### PR TITLE
Fix Django REST framework static files

### DIFF
--- a/insights/urls.py
+++ b/insights/urls.py
@@ -54,5 +54,7 @@ urlpatterns = [
 
 if settings.DEBUG:
     import debug_toolbar
-
     urlpatterns = [path("__debug__", include(debug_toolbar.urls))] + urlpatterns
+
+    from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+    urlpatterns = staticfiles_urlpatterns() + urlpatterns


### PR DESCRIPTION
The [_dango.contrib.staticfiles_](https://github.com/RedHatInsights/insights-host-inventory/blob/master/insights/settings.py#L53) app works automatically only when using the runserver command. With Gunicorn its necessary to [register](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:fix_staticfiles?expand=1#diff-726597a51dcd6dcecba84610e48540ceR59) its handler for the static assets manually.

This fixes JavaScript and CSS in the REST API UI, making it work again.