### PR TITLE
Use dynamic-rest library to display models

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,8 +10,10 @@ gunicorn = "*"
 "psycopg2" = "*"
 drf-yasg = "*"
 logstash_formatter = "*"
+dynamic-rest = "*"
 
 [dev-packages]
+pip = "==18.0"
 django-debug-toolbar = "*"
 "flake8" = "*"
 black = "==18.6b4"

--- a/inventory/serializers.py
+++ b/inventory/serializers.py
@@ -1,9 +1,12 @@
-from rest_framework.serializers import HyperlinkedModelSerializer
+from dynamic_rest.serializers import DynamicModelSerializer
 from inventory.models import Host
 
 
-class HostSerializer(HyperlinkedModelSerializer):
+class HostSerializer(DynamicModelSerializer):
     class Meta:
         model = Host
         name = "host"
-        fields = ("canonical_facts", "facts", "tags", "display_name", "account")
+        fields = (
+            "id", "account", "display_name", "created_on", "modified_on",
+            "canonical_facts", "facts", "tags"
+        )

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1,11 +1,12 @@
 from django.db.models import Q
-from rest_framework import viewsets, status
+from rest_framework import status
 from rest_framework.response import Response
 from inventory.models import Host
 from inventory.serializers import HostSerializer
+from dynamic_rest.viewsets import DynamicModelViewSet
 
 
-class HostViewSet(viewsets.ModelViewSet):
+class HostViewSet(DynamicModelViewSet):
     serializer_class = HostSerializer
     queryset = Host.objects.all()
 


### PR DESCRIPTION
The `dynamic-rest` library allows more comprehensive query handling and consistent data serialisation across paging systems.

The insights-advisor-api would like to use the `django-rest-models` library to access the inventory API as if it were a native model in Django.  This requires the use of `dynamic-rest` views and serializers in the target API.