### PR TITLE
Use a dummy authentication middleware

### DIFF
--- a/insights/settings.py
+++ b/insights/settings.py
@@ -71,6 +71,8 @@ MIDDLEWARE = [
 if DEBUG:
     INSTALLED_APPS.append("debug_toolbar")
     MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+    # Must be at least before clickjacking.
+    MIDDLEWARE.insert(0, "inventory.auth.header_auth_middleware")
 
 ROOT_URLCONF = "insights.urls"
 

--- a/inventory/auth.py
+++ b/inventory/auth.py
@@ -1,0 +1,17 @@
+from django.http import JsonResponse, HttpResponseForbidden
+
+
+__all__ = ['header_auth_middleware']
+
+
+HEADER = "HTTP_X_RH_IDENTITY"
+
+
+def header_auth_middleware(get_response):
+    def middleware(request):
+        auth_data = request.META.get(HEADER)
+        if not auth_data:
+            return JsonResponse({}, status=HttpResponseForbidden.status_code)
+
+        return get_response(request)
+    return middleware


### PR DESCRIPTION
Created an authentication [middleware](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:dummy_http_auth?expand=1#diff-03dda6e671f3e8c6185e73dd813c5446R10), that rejects every request that doesn’t contain the _x-rh-identity_ header. This header can currently contain anything for it to pass the validation. This is a stub for an actual header parsing and verification.

The authentication applies to the Django REST API UI too, so I made this to be used only outside the _DEBUG_ mode.


Steps to reproduce:

```bash
$ curl -I 'http://localhost:8000/api/' 
HTTP/1.1 403 Forbidden
…
```

```bash
$ curl -I -H 'x-rh-identity: something' 'http://localhost:8000/api/'
HTTP/1.1 200 OK
…
```

I’d like to ask @dehort for a review.