### PR TITLE
Allow to send request without canonical facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ want to destroy that data do the following:
 docker-compose down
 ```
 
+## Basic testing
+
+To test creating a sample host, you may simply send a simple JSON request like
+this:
+
+```
+curl -H 'X_RH_IDENTITY: foobar' -H 'Content-Type: application/json' -X POST localhost:8000/api/hosts/ -d '{ "display_name": "foo", "account": "bar" }'
+```
+
+After that, you can run the following command to ensure the test host 'foo' was
+registered and appears in the list of hosts.
+
+
+```
+curl -H 'X_RH_IDENTITY: foobar' -v http://localhost:8000/api/hosts/?format=json
+```
+
+All requests are authenticated by the user in the header 'X_RH_IDENTITY'
+
+
 ## Running the Tests
 
 Running the tests is quite simple:

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -13,9 +13,8 @@ class HostViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        cf = serializer.validated_data["canonical_facts"]
-
         try:
+            cf = serializer.validated_data["canonical_facts"]
             found_host = Host.objects.get(
                 Q(canonical_facts__contained_by=cf) | Q(canonical_facts__contains=cf),
                 account=serializer.validated_data["account"],
@@ -33,7 +32,7 @@ class HostViewSet(viewsets.ModelViewSet):
             )
 
         except Exception as e:
-            print(f"Couldn't find the {cf}, creating: {e}")
+            print(f"Couldn't find the canonical facts, creating: {e}")
             self.perform_create(serializer)
             headers = self.get_success_headers(serializer.validated_data)
             return Response(


### PR DESCRIPTION
At the moment, the try block doesn't catch the possibility that the user
is not sending the canonical facts on the first request to create the
host. In that case, 'validated_data' will not contain the key, and an
KeyError will be thrown.

```

File "/code/inventory/views.py" in create
  16.         cf = serializer.validated_data["canonical_facts"]

Exception Type: KeyError at /api/hosts/
Exception Value: 'canonical_facts'

```