### PR TITLE
Accept database URI details from environment for flexibility

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,7 +36,7 @@ def create_app(config_name):
     password = os.getenv('INVENTORY_DB_PASS', 'insights')
     host = os.getenv('INVENTORY_DB_HOST', 'localhost')
     db_name = os.getenv('INVENTORY_DB_NAME', 'test_db')
-    flask_app.config['SQLALCHEMY_DATABASE_URI'] = f'postgresql://{user}:{pass}@{host}/{db_name}'
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = f'postgresql://{user}:{password}@{host}/{db_name}'
     flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
     print("Calling db.init_app()")

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,8 @@ from flask_sqlalchemy import SQLAlchemy
 from connexion.resolver import RestyResolver
 import connexion
 
+import os
+
 # local import
 #from instance.config import app_config
 
@@ -30,7 +32,11 @@ def create_app(config_name):
     flask_app = connexion_app.app
 
     flask_app.config['SQLALCHEMY_ECHO'] = True 
-    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://insights:insights@localhost/test_db'
+    user = os.getenv('INVENTORY_DB_USER', 'insights')
+    password = os.getenv('INVENTORY_DB_PASS', 'insights')
+    host = os.getenv('INVENTORY_DB_HOST', 'localhost')
+    db_name = os.getenv('INVENTORY_DB_NAME', 'test_db')
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = f'postgresql://{user}:{pass}@{host}/{db_name}'
     flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
     print("Calling db.init_app()")


### PR DESCRIPTION
This picks up the database connection configuration from the following four environment variables:

- `INVENTORY_DB_USER` - the username to connect as - defaults to `insights`
- `INVENTORY_DB_PASS` - the password to use when connecting - defaults to `insights`
- `INVENTORY_DB_HOST` - the host address to connect to - defaults to `localhost`
- `INVENTORY_DB_NAME` - the database name to connect to - defaults to `test_db`

This allows e.g. docker systems, developer systems and other environments to set the database connection without disturbing the code.