### PR TITLE
Set Host id field to UUID, randomly generated by default

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -67,9 +67,7 @@ def findHostsByDisplayName(display_name):
 def getHostById(hostId):
     print(f"getHostById({hostId})")
 
-    host_id_list = [int(host_id) for host_id in hostId]
-
-    found_host_list = Host.query.filter(Host.id.in_(host_id_list)).all()
+    found_host_list = Host.query.filter(Host.id.in_(hostId)).all()
 
     json_host_list = [host.to_json() for host in found_host_list]
 
@@ -91,10 +89,8 @@ def replaceFacts(hostId, namespace, fact_dict):
 def mergeFacts(hostId, namespace, fact_dict):
     print(f"mergeFacts({hostId}, {namespace}, {fact_dict})")
 
-    host_id_list = [int(host_id) for host_id in hostId]
-
     hosts_to_update = Host.query.filter(
-            Host.id.in_(host_id_list) &
+            Host.id.in_(hostId) &
             Host.facts.has_key(namespace)).all()
 
     print("hosts_to_update:", hosts_to_update)

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,9 @@
 from app import db
 from datetime import datetime
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy import orm
+
+import uuid
 
 
 def convert_json_facts_to_dict(fact_list):
@@ -30,12 +32,12 @@ def convert_dict_to_json_facts(fact_dict):
 class Host(db.Model):
     __tablename__ = 'hosts'
 
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     account = db.Column(db.String(10))
     display_name = db.Column(db.String(200))
-    created_on = db.Column(db.DateTime, 
+    created_on = db.Column(db.DateTime,
                           default=datetime.utcnow)
-    modified_on = db.Column(db.DateTime, 
+    modified_on = db.Column(db.DateTime,
                           default=datetime.utcnow,
                           onupdate=datetime.utcnow)
     facts = db.Column(JSONB)

--- a/run.py
+++ b/run.py
@@ -4,7 +4,7 @@ import os
 
 from app import create_app
 
-config_name = os.getenv('APP_SETTINGS') # config_name = "development"
+config_name = os.getenv('APP_SETTINGS', "development")
 app = create_app(config_name)
 
 if __name__ == '__main__':

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -251,8 +251,8 @@ definitions:
       - type: object
         properties:
           id:
-            type: integer
-            format: int64
+            type: string
+            format: uuid
           created:
             type: string
             format: date-time

--- a/test_api.py
+++ b/test_api.py
@@ -124,7 +124,7 @@ class HostsTestCase(unittest.TestCase):
 
         self.assertEqual(results["id"], original_id)
 
-        data = self.get("%s/%d" % (HOST_URL, original_id), 200)
+        data = self.get("%s/%s" % (HOST_URL, original_id), 200)
         results = HostWrapper(data["results"][0])
 
         self.assertEqual(len(results.facts), 2)
@@ -166,7 +166,7 @@ class HostsTestCase(unittest.TestCase):
 
         self.post(HOST_URL, host_data.data(), 200)
 
-        data = self.get("%s/%d" % (HOST_URL, original_id), 200)
+        data = self.get("%s/%s" % (HOST_URL, original_id), 200)
         print(data["results"][0])
         results = HostWrapper(data["results"][0])
 


### PR DESCRIPTION
This corrects the definition of the Host's `id` field as an integer, when it is defined in the migration as a UUID.