### PR TITLE
Update python_version according to docker-compose

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,4 +23,4 @@ request = "*"
 pytest = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7.1"


### PR DESCRIPTION
Currently, 'FROM python:3' in docker-compose.yml is installing the app in 
a container which only has python 3.7.1 available, so the mismatch between
that and the version in Pipfile throw a warning and make it unable to start.