### PR TITLE
Allow access from any host

### DIFF
--- a/run.py
+++ b/run.py
@@ -8,4 +8,4 @@ config_name = os.getenv('APP_SETTINGS', "development")
 application = create_app(config_name)
 
 if __name__ == '__main__':
-    application.run()
+    application.run(host="0.0.0.0")


### PR DESCRIPTION
[Set](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:openshift#diff-6e38f16215ae91c11fc5c54b74c66d54R11) Flask’s _host_ variable to accept connections from everywhere. This is probably not the best thing to do. Using an IP provided by OpenShift would be better. Unfortunately I don’t know how to do that. 

This would at least allow for now to deploy to OpenShift from [_master_](https://github.com/RedHatInsights/insights-host-inventory/tree/master), even though there are many issues with the current configuration.