### PR TITLE
Hook a dummy auth validation to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Running the tests is quite simple:
 
 ```
 ./test_api.py
+./test_unit.py
 ```
 
 ## Running the server

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,8 @@
 import os
 import logging
 import connexion
+
+from app.auth import AuthManager
 from flask_api import FlaskAPI
 from flask_sqlalchemy import SQLAlchemy
 from connexion.resolver import RestyResolver
@@ -39,6 +41,10 @@ def create_app(config_name):
         'SQLALCHEMY_DATABASE_URI'
     ] = f'postgresql://{user}:{password}@{host}/{db_name}'
     flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+    if not flask_app.debug:
+        auth_manager = AuthManager()
+        auth_manager.init_app(flask_app)
 
     db.init_app(flask_app)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ import os
 import logging
 import connexion
 
-from app.auth import AuthManager
+from app.auth import init_app as auth_init_app
 from flask_api import FlaskAPI
 from flask_sqlalchemy import SQLAlchemy
 from connexion.resolver import RestyResolver
@@ -43,8 +43,7 @@ def create_app(config_name):
     flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
     if not flask_app.debug:
-        auth_manager = AuthManager()
-        auth_manager.init_app(flask_app)
+        auth_init_app(flask_app)
 
     db.init_app(flask_app)
 

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,0 +1,53 @@
+from flask import abort, request
+from werkzeug.exceptions import Forbidden
+
+__all__ = ["AuthManager"]
+
+_IDENTITY_HEADER = "x-rh-identity"
+
+
+def _validate_identity(payload):
+    """
+    Identity payload validation dummy. Fails if the data is empty.
+    """
+    if not payload:
+        raise ValueError
+
+
+class AuthManager:
+    """
+    Authentication manager for a Flask app. Hooks to a request, parses the identity HTTP
+    header and either raises an error or makes the identity data available to the views.
+    """
+
+    def __init__(self):
+        """
+        Identities are stored by a request context.
+        """
+        self.identities = {}
+
+    def _before_request(self):
+        """
+        Validates the identity HTTP header. Stores the value for it to be available in
+        the views. Fails with 403 otherwise.
+        """
+        try:
+            payload = request.headers[_IDENTITY_HEADER]
+            _validate_identity(payload)
+        except (KeyError, ValueError):
+            abort(Forbidden.code)
+        else:
+            self.identities[request] = payload
+
+    def identity(self):
+        """
+        Gets the identity data by the current request context.
+        """
+        return self.identities[request]
+
+    def init_app(self, flask_app):
+        """
+        Hooks the identity HTTP header parsing to every request.
+        """
+        flask_app.auth_manager = self
+        flask_app.before_request(self._before_request)

--- a/test_api.py
+++ b/test_api.py
@@ -443,17 +443,36 @@ class TagsTestCase(PreCreatedHostsBaseTestCase):
 
 class AuthTestCase(BaseAPITestCase):
     def _get_hosts(self, headers):
+        """
+        Issues a GET request to the /hosts URL, providing given headers.
+        """
         return self.client().get(HOST_URL, headers=headers)
 
-    def test_validate_invalid_identity(self):
+    def test_validate_missing_identity(self):
+        """
+        Identity header is not present, 403 Forbidden is returned.
+        """
         response = self._get_hosts({})
         self.assertEqual(403, response.status_code)  # Forbidden
 
+    def test_validate_invalid_identity(self):
+        """
+        Identity header is not valid – empty in this case, 403 Forbidden is returned.
+        """
+        response = self._get_hosts({"x-rh-identity": ""})
+        self.assertEqual(403, response.status_code)  # Forbidden
+
     def test_validate_valid_identity(self):
+        """
+        Identity header is valid – non-empty in this case, 200 is returned.
+        """
         response = self._get_hosts({"x-rh-identity": "some payload"})
         self.assertEqual(200, response.status_code)  # OK
 
     def test_get_identity(self):
+        """
+        The identity payload is available by the request context = in the views.
+        """
         payload = "some payload"
         with self.app.test_request_context(HOST_URL,
                                            method="GET",

--- a/test_api.py
+++ b/test_api.py
@@ -3,6 +3,7 @@
 import unittest
 import json
 from app import create_app, db
+from app.auth import current_identity
 from app.utils import HostWrapper
 
 HOST_URL = "/api/hosts"
@@ -17,7 +18,7 @@ from unittest.mock import patch
 
 
 class Request:
-    headers = {"x-rh-identity": None}
+    headers = {"x-rh-identity": ""}
 
 
 def validate_identity(payload):
@@ -478,7 +479,7 @@ class AuthTestCase(BaseAPITestCase):
                                            method="GET",
                                            headers={"x-rh-identity": payload}):
             self.app.preprocess_request()
-            self.assertEquals(payload, self.app.auth_manager.identity())
+            self.assertEquals(payload, current_identity)
 
 
 if __name__ == "__main__":

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,0 +1,106 @@
+from app.auth import AuthManager, _validate_identity
+from unittest import main, TestCase
+from unittest.mock import Mock, patch
+
+
+class AuthManagerTestCase(TestCase):
+    def setUp(self):
+        """
+        Instantiates the Authentication Manager.
+        """
+        self.auth_manager = AuthManager()
+
+    def test_init_app_access(self):
+        """
+        The Authentication Manager instance is accessible from the Flask Application.
+        """
+        app = Mock()
+        self.auth_manager.init_app(app)
+        self.assertEqual(self.auth_manager, app.auth_manager)
+
+    def test_init_app_before_request(self):
+        """
+        The Authentication Manager request hook is bound to every request.
+        """
+        app = Mock()
+        self.auth_manager.init_app(app)
+        app.before_request.assert_called_once_with(self.auth_manager._before_request)
+
+    def test_identity(self):
+        """
+        The identity method retrieves a stored identity by the current request context.
+        """
+        key = "some key"
+        value = "some value"
+        with patch("app.auth.request", key):
+            self.auth_manager.identities = {key: value}
+            self.assertEqual(value, self.auth_manager.identity())
+
+    @patch("app.auth.abort")
+    @patch("app.auth._validate_identity")
+    def test_before_request_validate_identity(self, validate_identity, abort):
+        """
+        The identity payload is validated. Doesn’t fail if valid.
+        """
+        payload = "some payload"
+        with patch("app.auth.request", **{"headers": {"x-rh-identity": payload}}):
+            self.auth_manager._before_request()
+
+        validate_identity.assert_called_once_with(payload)
+        abort.assert_not_called()
+
+    @patch("app.auth.abort")
+    @patch("app.auth._validate_identity", side_effect=ValueError)
+    @patch("app.auth.request")
+    def test_before_request_abort(self, request, validate_identity, abort):
+        """
+        The identity payload is validated. Fails with 403 (Forbidden) if not valid.
+        """
+        payload = "some payload"
+        with patch("app.auth.request", **{"headers": {"x-rh-identity": payload}}):
+            self.auth_manager._before_request()
+
+        validate_identity.assert_called_once_with(payload)
+        abort.assert_called_once_with(403)  # Forbidden
+
+    @patch("app.auth._validate_identity")
+    def test_before_request_identities(self, validate_identity):
+        """
+        The identity payload is stored by the current request context.
+        """
+        payload = "some payload"
+        with patch(
+            "app.auth.request", **dict(headers={"x-rh-identity": payload})
+        ) as request:
+            self.auth_manager._before_request()
+            self.assertIn(request, self.auth_manager.identities)
+            self.assertEqual(payload, self.auth_manager.identities[request])
+
+    @patch("app.auth._validate_identity")
+    def test_get_identity_from_header(self, validate_identity):
+        """
+        The identity payload is stored on request and retrieved by the identity method.
+        """
+        payload = "some payload"
+        with patch(
+            "app.auth.request", **{"headers": {"x-rh-identity": payload}}
+        ) as request:
+            self.auth_manager._before_request()
+            self.assertEqual(payload, self.auth_manager.identity())
+
+
+class ValidationTestCase(TestCase):
+    def test_valid(self):
+        _validate_identity("some payload")
+        self.assertTrue(True)
+
+    def test_invalid(self):
+        payloads = {None, ""}
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                with self.assertRaises(ValueError):
+                    _validate_identity(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from app.auth import (
     _before_request,
     current_identity,

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,86 +1,109 @@
-from app.auth import AuthManager, _validate_identity
+from app.auth import (
+    _before_request,
+    current_identity,
+    _get_identity,
+    init_app,
+    _validate_identity,
+)
 from unittest import main, TestCase
 from unittest.mock import Mock, patch
+from werkzeug.local import LocalProxy
 
 
-class AuthManagerTestCase(TestCase):
+class Abort(Exception):
+    pass
+
+
+class AuthInitAppTestCase(TestCase):
     """
-    Tests the Authentication Manager, the binding between the Flask app and the identity
-    HTTP header parser/validator.
+    Test the before request hook binding to the Flask app.
     """
 
-    def setUp(self):
+    def test_init_app(self):
         """
-        Instantiates the Authentication Manager.
-        """
-        self.auth_manager = AuthManager()
-
-    def test_init_app_access(self):
-        """
-        The Authentication Manager instance is accessible from the Flask Application.
+        The before request hook is bound to the Flask app.
         """
         app = Mock()
-        self.auth_manager.init_app(app)
-        self.assertEqual(self.auth_manager, app.auth_manager)
+        init_app(app)
+        app.before_request.assert_called_once_with(_before_request)
 
-    def test_init_app_before_request(self):
+
+class AuthGetIdentityTestCase(TestCase):
+    """
+    Tests retrieving the identity from the request context.
+    """
+
+    @patch("app.auth._request_ctx_stack")
+    def test_get_identity(self, request_ctx_stack):
         """
         The Authentication Manager request hook is bound to every request.
         """
-        app = Mock()
-        self.auth_manager.init_app(app)
-        app.before_request.assert_called_once_with(self.auth_manager._before_request)
+        self.assertEqual(request_ctx_stack.top.identity, _get_identity())
 
-    def test_identity(self):
-        """
-        The identity method retrieves a stored identity by the current request context.
-        """
-        key = "some key"
-        value = "some value"
-        with patch("app.auth.request", key):
-            self.auth_manager.identities = {key: value}
-            self.assertEqual(value, self.auth_manager.identity())
 
-    @patch("app.auth.abort")
+class AuthCurrentIdentityTestCase(TestCase):
+    """
+    Tests retrieving the identity from the request context through Werkzeug‘s local
+    proxy.
+    """
+
+    @patch("app.auth._request_ctx_stack")
+    def test_get_identity(self, request_ctx_stack):
+        """
+        The Authentication Manager request hook is bound to every request.
+        """
+        self.assertIsInstance(current_identity, LocalProxy)
+        self.assertEqual(request_ctx_stack.top.identity, current_identity)
+
+
+class AuthBeforeRequestTestCase(TestCase):
+    """
+    Tests the before request hook that passes the HTTP header to the parser/validator.
+    """
+
     @patch("app.auth._validate_identity")
-    def test_before_request_validate_identity(self, validate_identity, abort):
+    @patch("app.auth.abort", side_effect=Abort)
+    @patch("app.auth.request", **{"headers": {}})
+    def test_missing_header(self, request, abort, validate_identity):
+        """
+        The identity HTTP header is missing. Fails with 403 (Forbidden).
+        """
+        with self.assertRaises(Abort):
+            _before_request()
+
+        abort.assert_called_once_with(403)  # Forbidden
+        validate_identity.assert_not_called()
+
+    @patch("app.auth._request_ctx_stack")
+    @patch("app.auth.abort", side_effect=Abort)
+    @patch("app.auth._validate_identity")
+    def test_validate_identity_valid(self, validate_identity, abort, request_ctx_stack):
         """
         The identity payload is validated. Doesn’t fail if valid.
         """
         payload = "some payload"
         with patch("app.auth.request", **{"headers": {"x-rh-identity": payload}}):
-            self.auth_manager._before_request()
+            _before_request()
 
         validate_identity.assert_called_once_with(payload)
         abort.assert_not_called()
 
-    @patch("app.auth.abort")
-    @patch("app.auth._validate_identity")
-    def test_before_request_missing_abort(self, validate_identity, abort):
+    def test_validate_identity_invalid(self):
         """
-        The identity header is missing. Fails with 403 (Forbidden).
-        """
-        with patch("app.auth.request", **{"headers": {}}):
-            self.auth_manager._before_request()
-
-        validate_identity.assert_not_called()
-        abort.assert_called_once_with(403)  # Forbidden
-
-    def test_before_request_invalid_abort(self):
-        """
-        The identity payload is validated. Fails with 403 (Forbidden) if not valid,
-        assuming it can raise KeyError or ValueError.
+        The identity payload is validated. Fails with 403 (Forbidden) if not parsable or
+        otherwise invalid.
         """
         payload = "some payload"
 
-        @patch("app.auth.abort")
+        @patch("app.auth.abort", side_effect=Abort)
         def _test(abort):
             with patch("app.auth.request", **{"headers": {"x-rh-identity": payload}}):
-                self.auth_manager._before_request()
+                with self.assertRaises(Abort):
+                    _before_request()
 
             abort.assert_called_once_with(403)  # Forbidden
 
-        errors = [KeyError, ValueError]
+        errors = [TypeError, ValueError]
         for error in errors:
             with self.subTest(error=error):
                 with patch(
@@ -90,28 +113,27 @@ class AuthManagerTestCase(TestCase):
                     validate_identity.assert_called_once_with(payload)
 
     @patch("app.auth.abort")
-    def test_before_request_error_not_caught(self, abort):
+    def test_error_not_caught(self, abort):
         """
         Any other error during the validation is not caught and does not result in a
         controlled abort.
         """
         payload = "some payload"
         error = RuntimeError
-        with patch(
-            "app.auth.request", **{"headers": {"x-rh-identity": payload}}
-        ) as request:
+        with patch("app.auth.request", **{"headers": {"x-rh-identity": payload}}):
             with patch(
                 "app.auth._validate_identity", side_effect=error
             ) as validate_identity:
                 with self.assertRaises(error):
-                    self.auth_manager._before_request()
+                    _before_request()
 
                 validate_identity.assert_called_once_with(payload)
 
         abort.assert_not_called()
 
+    @patch("app.auth._request_ctx_stack")
     @patch("app.auth._validate_identity")
-    def test_before_request_identities(self, validate_identity):
+    def test_store_identity(self, validate_identity, request_ctx_stack):
         """
         The identity payload is stored by the current request context.
         """
@@ -119,24 +141,11 @@ class AuthManagerTestCase(TestCase):
         with patch(
             "app.auth.request", **dict(headers={"x-rh-identity": payload})
         ) as request:
-            self.auth_manager._before_request()
-            self.assertIn(request, self.auth_manager.identities)
-            self.assertEqual(payload, self.auth_manager.identities[request])
-
-    @patch("app.auth._validate_identity")
-    def test_get_identity_from_header(self, validate_identity):
-        """
-        The identity payload is stored on request and retrieved by the identity method.
-        """
-        payload = "some payload"
-        with patch(
-            "app.auth.request", **{"headers": {"x-rh-identity": payload}}
-        ) as request:
-            self.auth_manager._before_request()
-            self.assertEqual(payload, self.auth_manager.identity())
+            _before_request()
+            self.assertEqual(payload, request_ctx_stack.top.identity)
 
 
-class ValidationTestCase(TestCase):
+class AuthValidateIdentityTestCase(TestCase):
     """
     Tests the dummy identity validator.
     """


### PR DESCRIPTION
Created [an Authentication Manager](https://github.com/RedHatInsights/insights-host-inventory/pull/30/files#diff-3b16d374ef08532ca6b01246c5f0fa41R17) that hooks to every request. It parses and validates an identity HTTP header and makes the payload available to views. Currently the parsing and validation is only [a dummy stub](https://github.com/RedHatInsights/insights-host-inventory/pull/30/files#diff-3b16d374ef08532ca6b01246c5f0fa41R9): every request is valid if the header is present.

Replaces #7. Asking @dehort for a review.

I created [a new file](
https://github.com/RedHatInsights/insights-host-inventory/pull/30/files#diff-13729a38e16bcaf94b928e33e5dd468a) with unit tests, keeping [_test_api.py_](
https://github.com/RedHatInsights/insights-host-inventory/pull/30/files#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2) only for API calls. When writing new tests, please ensure that the new [_bypass_auth_](https://github.com/RedHatInsights/insights-host-inventory/pull/30/files#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2R27) patch is applied to every call that makes requests.