### PR TITLE
Introduce an identity model module

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -1,0 +1,46 @@
+from base64 import b64decode
+from collections import namedtuple
+from json import loads
+
+
+__all__ = ["Identity",
+           "from_dict",
+           "from_json",
+           "from_encoded",
+           "validate"]
+
+
+Identity = namedtuple("Identity", ("account_number", "org_id"))
+
+
+def from_dict(dict_):
+    """
+    Build an Identity from a dictionary of values.
+    """
+    return Identity(**dict_)
+
+
+def from_json(json):
+    """
+    Build an Identity from a JSON string.
+    """
+    dict_ = loads(json)
+    return from_dict(dict_)
+
+
+def from_encoded(base64):
+    """
+    Build an Identity from the raw HTTP header value – a Base64-encoded
+    JSON.
+    """
+    json = b64decode(base64)
+    return from_json(json)
+
+
+def validate(identity):
+    """
+    Ensure both values are present.
+    """
+    dict_ = identity._asdict()
+    if not all(dict_.values()):
+        raise ValueError("Both account_number and org_id are mandatory.")

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,0 +1,127 @@
+from app.auth.identity import from_dict, from_encoded, from_json, Identity, validate
+from base64 import b64encode
+from json import dumps
+from unittest import main, TestCase
+
+
+class IdentityConstructorTestCase(TestCase):
+    """
+    Test the Identity module: the named tuple, its constructors and validation.
+    """
+
+    @staticmethod
+    def _identity():
+        return Identity(account_number="some number", org_id="some org id")
+
+    def test_from_dict_valid(self):
+        """
+        Initialize the Identity object with a valid dictionary.
+        """
+        identity = self._identity()
+
+        dict_ = {"account_number": identity.account_number, "org_id": identity.org_id}
+
+        self.assertEqual(identity, from_dict(dict_))
+
+    def test_from_dict_invalid(self):
+        """
+        Initializing the Identity object with a dictionary with missing values or with
+        anything else should raise TypeError.
+        """
+        dicts = [
+            {},
+            {"account_number": "some account number"},
+            {"org_id": "some org id"},
+            "some string",
+            ["some", "list"],
+        ]
+        for dict_ in dicts:
+            with self.assertRaises(TypeError):
+                from_dict(dict_)
+
+    def test_from_json_valid(self):
+        """
+        Initialize the Identity object with a valid JSON string.
+        """
+        identity = self._identity()
+
+        dict_ = identity._asdict()
+        json = dumps(dict_)
+
+        try:
+            self.assertEqual(identity, from_json(json))
+        except (TypeError, ValueError):
+            self.fail()
+
+    def test_from_json_invalid_type(self):
+        """
+        Initializing the Identity object with an invalid type that can’t be JSON should
+        raise a TypeError.
+        """
+        with self.assertRaises(TypeError):
+            from_json(["not", "a", "string"])
+
+    def test_from_json_invalid_value(self):
+        """
+        Initializing the Identity object with an invalid JSON string should raise a
+        ValueError.
+        """
+        with self.assertRaises(ValueError):
+            from_json("invalid JSON")
+
+    def test_from_encoded_valid(self):
+        """
+        Initialize the Identity object with an encoded payload – a base64-encoded JSON.
+        That would typically be a raw HTTP header content.
+        """
+        identity = self._identity()
+
+        dict_ = identity._asdict()
+        json = dumps(dict_)
+        base64 = b64encode(json.encode())
+
+        try:
+            self.assertEqual(identity, from_encoded(base64))
+        except (TypeError, ValueError):
+            self.fail()
+
+    def test_from_encoded_invalid_type(self):
+        """
+        Initializing the Identity object with an invalid type that can’t be a Base64
+        encoded payload should raise a TypeError.
+        """
+        with self.assertRaises(TypeError):
+            from_encoded(["not", "a", "string"])
+
+    def test_from_encoded_invalid_value(self):
+        """
+        Initializing the Identity object with an invalid Base6č encoded payload should
+        raise a ValueError.
+        """
+        with self.assertRaises(ValueError):
+            from_encoded("invalid Base64")
+
+
+class IdentityValidateTestCase(TestCase):
+    def test_validate_valid(self):
+        try:
+            identity = Identity(account_number="some number", org_id="some org id")
+            validate(identity)
+            self.assertTrue(True)
+        except ValueError:
+            self.fail()
+
+    def test_validate_invalid(self):
+        identities = [
+            Identity(account_number=None, org_id=None),
+            Identity(account_number=None, org_id="some org_id"),
+            Identity(account_number="some account_number", org_id=None),
+        ]
+        for identity in identities:
+            with self.subTest(identity=identity):
+                with self.assertRaises(ValueError):
+                    validate(identity)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from app.auth.identity import from_dict, from_encoded, from_json, Identity, validate
 from base64 import b64encode
 from json import dumps

--- a/test_unit.py
+++ b/test_unit.py
@@ -6,16 +6,22 @@ from json import dumps
 from unittest import main, TestCase
 
 
-class IdentityConstructorTestCase(TestCase):
+class AuthIdentityConstructorTestCase(TestCase):
     """
-    Test the Identity module: the named tuple, its constructors and validation.
+    Tests the Identity module constructors.
     """
 
     @staticmethod
     def _identity():
         return Identity(account_number="some number", org_id="some org id")
 
-    def test_from_dict_valid(self):
+
+class AuthIdentityFromDictTest(AuthIdentityConstructorTestCase):
+    """
+    Tests creating an Identity from a dictionary.
+    """
+
+    def test_valid(self):
         """
         Initialize the Identity object with a valid dictionary.
         """
@@ -25,7 +31,7 @@ class IdentityConstructorTestCase(TestCase):
 
         self.assertEqual(identity, from_dict(dict_))
 
-    def test_from_dict_invalid(self):
+    def test_invalid(self):
         """
         Initializing the Identity object with a dictionary with missing values or with
         anything else should raise TypeError.
@@ -41,7 +47,13 @@ class IdentityConstructorTestCase(TestCase):
             with self.assertRaises(TypeError):
                 from_dict(dict_)
 
-    def test_from_json_valid(self):
+
+class AuthIdentityFromJsonTest(AuthIdentityConstructorTestCase):
+    """
+    Tests creating an Identity from a JSON string.
+    """
+
+    def test_valid(self):
         """
         Initialize the Identity object with a valid JSON string.
         """
@@ -55,7 +67,7 @@ class IdentityConstructorTestCase(TestCase):
         except (TypeError, ValueError):
             self.fail()
 
-    def test_from_json_invalid_type(self):
+    def test_invalid_type(self):
         """
         Initializing the Identity object with an invalid type that can’t be JSON should
         raise a TypeError.
@@ -63,7 +75,7 @@ class IdentityConstructorTestCase(TestCase):
         with self.assertRaises(TypeError):
             from_json(["not", "a", "string"])
 
-    def test_from_json_invalid_value(self):
+    def test_invalid_value(self):
         """
         Initializing the Identity object with an invalid JSON string should raise a
         ValueError.
@@ -71,7 +83,14 @@ class IdentityConstructorTestCase(TestCase):
         with self.assertRaises(ValueError):
             from_json("invalid JSON")
 
-    def test_from_encoded_valid(self):
+
+class AuthIdentityFromEncodedTest(AuthIdentityConstructorTestCase):
+    """
+    Tests creating an Identity from a Base64 encoded JSON string, which is what is in
+    the HTTP header.
+    """
+
+    def test_valid(self):
         """
         Initialize the Identity object with an encoded payload – a base64-encoded JSON.
         That would typically be a raw HTTP header content.
@@ -87,7 +106,7 @@ class IdentityConstructorTestCase(TestCase):
         except (TypeError, ValueError):
             self.fail()
 
-    def test_from_encoded_invalid_type(self):
+    def test_invalid_type(self):
         """
         Initializing the Identity object with an invalid type that can’t be a Base64
         encoded payload should raise a TypeError.
@@ -95,7 +114,7 @@ class IdentityConstructorTestCase(TestCase):
         with self.assertRaises(TypeError):
             from_encoded(["not", "a", "string"])
 
-    def test_from_encoded_invalid_value(self):
+    def test_invalid_value(self):
         """
         Initializing the Identity object with an invalid Base6č encoded payload should
         raise a ValueError.
@@ -104,8 +123,8 @@ class IdentityConstructorTestCase(TestCase):
             from_encoded("invalid Base64")
 
 
-class IdentityValidateTestCase(TestCase):
-    def test_validate_valid(self):
+class AuthIdentityValidateTestCase(TestCase):
+    def test_valid(self):
         try:
             identity = Identity(account_number="some number", org_id="some org id")
             validate(identity)
@@ -113,11 +132,14 @@ class IdentityValidateTestCase(TestCase):
         except ValueError:
             self.fail()
 
-    def test_validate_invalid(self):
+    def test_invalid(self):
         identities = [
             Identity(account_number=None, org_id=None),
+            Identity(account_number="", org_id=""),
             Identity(account_number=None, org_id="some org_id"),
+            Identity(account_number="", org_id="some org_id"),
             Identity(account_number="some account_number", org_id=None),
+            Identity(account_number="some account_number", org_id=""),
         ]
         for identity in identities:
             with self.subTest(identity=identity):


### PR DESCRIPTION
Created an authentication [module](
https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:auth_identity_module?expand=1#diff-aaeb53fba2b4225a7fde4430b4b26033) that [parses](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:auth_identity_module?expand=1#diff-aaeb53fba2b4225a7fde4430b4b26033R31) and [validates](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:auth_identity_module?expand=1#diff-aaeb53fba2b4225a7fde4430b4b26033R40) the identity header data injected by 3Scale. The [validation](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:auth_identity_module?expand=1#diff-aaeb53fba2b4225a7fde4430b4b26033R40) itself is pretty dummy as it only checks whether the fields are present and not empty.

The [module](
https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:auth_identity_module?expand=1#diff-aaeb53fba2b4225a7fde4430b4b26033) is not used anywhere as this is not based on the [_dummy_http_auth_ branch](https://github.com/Glutexo/insights-host-inventory/tree/dummy_http_auth) from #30.

Replaces #8.

I’d like to ask @dehort for a review.