### PR TITLE
Allow having views without authentication

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -8,6 +8,10 @@ __all__ = ["bypass_auth", "init_app", "current_identity"]
 _IDENTITY_HEADER = "x-rh-identity"
 
 
+class NoIdentityError(RuntimeError):
+    pass
+
+
 def _validate_identity(payload):
     """
     Identity payload validation dummy. Fails if the data is empty.
@@ -54,7 +58,11 @@ def bypass_auth(view_func):
 
 def _get_identity():
     ctx = _request_ctx_stack.top
-    return ctx.identity
+
+    try:
+        return ctx.identity
+    except AttributeError:
+        raise NoIdentityError
 
 
 def _get_view_func():

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,9 +1,9 @@
 from app.auth.identity import from_encoded, validate
-from flask import abort, request, _request_ctx_stack
+from flask import abort, current_app, request, _request_ctx_stack
 from werkzeug.local import LocalProxy
 from werkzeug.exceptions import Forbidden
 
-__all__ = ["init_app", "current_identity"]
+__all__ = ["bypass_auth", "init_app", "current_identity"]
 
 _IDENTITY_HEADER = "x-rh-identity"
 
@@ -17,6 +17,10 @@ def _validate_identity(payload):
 
 
 def _before_request():
+    view_func = _get_view_func()
+    if hasattr(view_func, "bypass_auth") and view_func.bypass_auth:
+        return  # This function does not require authentication.
+
     try:
         payload = request.headers[_IDENTITY_HEADER]
     except KeyError:
@@ -40,9 +44,22 @@ def init_app(flask_app):
     flask_app.before_request(_before_request)
 
 
+def bypass_auth(view_func):
+    """
+    Decorates the given view function as not requiring the authentication HTTP header.
+    """
+    view_func.bypass_auth = True
+    return view_func
+
+
 def _get_identity():
     ctx = _request_ctx_stack.top
     return ctx.identity
+
+
+def _get_view_func():
+    endpoint = request.url_rule.endpoint
+    return current_app.view_functions[endpoint]
 
 
 current_identity = LocalProxy(_get_identity)

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
 
-from app.auth import _before_request, current_identity, _get_identity, init_app
+from app.auth import (
+    _before_request,
+    bypass_auth,
+    current_identity,
+    _get_identity,
+    _get_view_func,
+    init_app
+)
 from app.auth.identity import from_dict, from_encoded, from_json, Identity, validate
 from base64 import b64encode
 from json import dumps
@@ -11,6 +18,35 @@ from werkzeug.local import LocalProxy
 
 class Abort(Exception):
     pass
+
+
+class EmptyRequest:
+    """
+    A request stub that doesn’t have the identity attribute.
+    """
+    pass
+
+
+class ViewFunc:
+    """
+    A view function func that may have the bypass_auth attribute.
+    """
+    def __init__(self, **kwargs):
+        """
+        Sets the bypass_auth attribute if passed as a keyword argument.
+        """
+        if "bypass_auth" in kwargs:
+            self.bypass_auth = kwargs["bypass_auth"]
+
+    def __repr__(self):
+        """
+        Describes how the stub has been constructed.
+        """
+        if hasattr(self, "bypass_auth"):
+            kwargs = f"bypass_auth={self.bypass_auth}"
+        else:
+            kwargs = ""
+        return f"ViewFunc({kwargs})"
 
 
 class AuthInitAppTestCase(TestCase):
@@ -32,10 +68,21 @@ class AuthGetIdentityTestCase(TestCase):
     Tests retrieving the identity from the request context.
     """
 
-    @patch("app.auth._request_ctx_stack")
-    def test_get_identity(self, request_ctx_stack):
+    @patch("app.auth._request_ctx_stack", top=EmptyRequest())
+    def test_no_identity(self, request_ctx_stack):
         """
-        The Authentication Manager request hook is bound to every request.
+        An error is raised if there is no identity in the current request context = if
+        the authentication is bypassed for the request. The identity attribute is not
+        present.
+        """
+        with self.assertRaises(AttributeError):
+            _get_identity()
+
+    @patch("app.auth._request_ctx_stack")
+    def test_return(self, request_ctx_stack):
+        """
+        The Authentication Manager request hook is bound to every request that doesn’t
+        have bypassed authentication.
         """
         self.assertEqual(request_ctx_stack.top.identity, _get_identity())
 
@@ -55,16 +102,107 @@ class AuthCurrentIdentityTestCase(TestCase):
         self.assertEqual(request_ctx_stack.top.identity, current_identity)
 
 
+class BypassAuthTestCase(TestCase):
+    """
+    Tests the bypass_auth decorator that marks the view functions not to require the
+    identity header.
+    """
+
+    def test_decorator(self):
+        """
+        The decorated view function is marked with a bypass_auth attribute set to True.
+        """
+
+        @bypass_auth
+        def view_func():
+            """
+            Dummy function being decorated.
+            """
+            pass
+
+        self.assertTrue(hasattr(view_func, "bypass_auth"))
+        self.assertTrue(view_func.bypass_auth)
+
+
+class GetViewFuncTestCase(TestCase):
+    """
+    Tests retrieving the view of the current request.
+    """
+
+    @patch("app.auth.current_app")
+    @patch("app.auth.request")
+    def test_get_view_func(self, request, current_app):
+        """
+        The view function is found in the view functions map of the Flask app by the
+        endpoint of the current request.
+        """
+        self.assertEqual(
+            current_app.view_functions[request.url_rule.endpoint],
+            _get_view_func()
+        )
+
+
 class AuthBeforeRequestTestCase(TestCase):
     """
     Tests the before request hook that passes the HTTP header to the parser/validator.
     """
 
+    @patch("app.auth._request_ctx_stack", top=EmptyRequest())
+    @patch("app.auth.validate")
+    @patch("app.auth.from_encoded")
+    @patch("app.auth.request")
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=True))
+    def test_auth_bypassed(
+        self, get_view_func, request, from_encoded, validate, request_ctx_stack
+    ):
+        """
+        The request headers are not accessed at all if the authentication is bypassed
+        for the current view.
+        """
+        _before_request()
+
+        get_view_func.assert_called_once_with()
+
+        # Nothing else happens.
+        request.headers.__getitem__.assert_not_called()
+        from_encoded.assert_not_called()
+        validate.assert_not_called()
+        self.assertFalse(hasattr(request_ctx_stack.top, "identity"))
+
+    def test_auth_not_bypassed(self):
+        """
+        The identity HTTP header is parsed and validated if the function is explicitly
+        marked as not having bypased auth or if not marked at all.
+        """
+        @patch("app.auth._request_ctx_stack")
+        @patch("app.auth.validate")
+        @patch("app.auth.from_encoded")
+        @patch("app.auth.request")
+        def test(request, from_encoded, validate, request_ctx_stack):
+            """
+            The HTTP header is normally parsed, validated and assigned to the request.
+            """
+            _before_request()
+
+            # Once we got here, we’re verified. Everything else is covered by other
+            # tests.
+            request.headers.__getitem__.assert_called_once_with("x-rh-identity")
+
+        view_funcs = [ViewFunc(bypass_auth=False), ViewFunc()]
+        for view_func in view_funcs:
+            with self.subTest(view_func=view_func):
+                with patch(
+                    "app.auth._get_view_func", return_value=view_func
+                ) as get_view_func:
+                    test()
+                    get_view_func.assert_called_once_with()
+
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded")
     @patch("app.auth.abort", side_effect=Abort)
     @patch("app.auth.request", **{"headers": {}})
-    def test_missing_header(self, request, abort, from_encoded, validate):
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
+    def test_missing_header(self, get_view_func, request, abort, from_encoded, validate):
         """
         The identity HTTP header is missing. Fails with 403 (Forbidden).
         """
@@ -84,7 +222,8 @@ class AuthBeforeRequestTestCase(TestCase):
 
         @patch("app.auth.abort", side_effect=Abort)
         @patch("app.auth.validate")
-        def _test(validate, abort):
+        @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
+        def _test(get_view_func, validate, abort):
             with patch("app.auth.request", **{"headers": {"x-rh-identity": payload}}):
                 with self.assertRaises(Abort):
                     _before_request()
@@ -104,8 +243,9 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort")
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded", side_effect=RuntimeError)
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
     def test_from_encoded_error_not_caught(
-        self, from_encoded_mock, validate_mock, abort
+        self, get_view_func, from_encoded_mock, validate_mock, abort
     ):
         """
         Any other error during the parsing is not caught and does not result in a
@@ -124,7 +264,10 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort", side_effect=Abort)
     @patch("app.auth.validate", side_effect=ValueError)
     @patch("app.auth.from_encoded")
-    def test_identity_invalid(self, from_encoded_mock, validate_mock, abort):
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
+    def test_identity_invalid(
+        self, get_view_func, from_encoded_mock, validate_mock, abort
+    ):
         """
         The identity payload is validated. Fails with 403 (Forbidden) if not valid.
         """
@@ -141,7 +284,10 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort")
     @patch("app.auth.validate", side_effect=RuntimeError)
     @patch("app.auth.from_encoded")
-    def test_validate_error_not_caught(self, from_encoded_mock, validate_mock, abort):
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
+    def test_validate_error_not_caught(
+        self, get_view_func, from_encoded_mock, validate_mock, abort
+    ):
         """
         Any other error during the validation is not caught and does not result in a
         controlled abort.
@@ -160,8 +306,9 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort", side_effect=Abort)
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded")
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
     def test_everything_ok(
-        self, from_encoded_mock, validate_mock, abort, request_ctx_stack
+        self, get_view_func, from_encoded_mock, validate_mock, abort, request_ctx_stack
     ):
         """
         The identity payload is decoded and validated. Doesn’t fail if valid.
@@ -178,8 +325,14 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded")
     @patch("app.auth.request")
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
     def test_store_identity(
-        self, request, from_encoded_mock, validate_mock, request_ctx_stack
+        self,
+        get_view_func,
+        request,
+        from_encoded_mock,
+        validate_mock,
+        request_ctx_stack
     ):
         """
         The identity payload is stored by the current request context.

--- a/test_unit.py
+++ b/test_unit.py
@@ -6,7 +6,8 @@ from app.auth import (
     current_identity,
     _get_identity,
     _get_view_func,
-    init_app
+    init_app,
+    NoIdentityError
 )
 from app.auth.identity import from_dict, from_encoded, from_json, Identity, validate
 from base64 import b64encode
@@ -71,11 +72,10 @@ class AuthGetIdentityTestCase(TestCase):
     @patch("app.auth._request_ctx_stack", top=EmptyRequest())
     def test_no_identity(self, request_ctx_stack):
         """
-        An error is raised if there is no identity in the current request context = if
-        the authentication is bypassed for the request. The identity attribute is not
-        present.
+        A specific error is raised if there is no identity in the current request
+        context = if the authentication is bypassed for the request.
         """
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(NoIdentityError):
             _get_identity()
 
     @patch("app.auth._request_ctx_stack")


### PR DESCRIPTION
Created a [_bypass_auth_](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:bypass_auth?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41R47) decorator. Marked views won’t require having the identity HTTP header. This is useful for diagnostic requests that don’t touch the database, e.g. **a health probe**.

~~I’ve not written tests for this yet. Pushing here in case I wouldn’t make it before my departure.~~ There are currently only [unit tests](https://github.com/RedHatInsights/insights-host-inventory/pull/38/files#diff-13729a38e16bcaf94b928e33e5dd468a), because it’s not possible to test it functionally without an actual unauthenticated route. I’ll prepare another PR that allows to test this even before making the actual health check endpoint.