### PR TITLE
Create a primitive health probe

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,5 @@
+__all__ = ["health"]
+
+
+def health():
+    return "", 200

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -233,6 +233,16 @@ paths:
       responses:
         "200":
           description: Successfully added or removed a tag
+  /health:
+    get:
+      operationId: api.health
+      tags:
+        - health
+      summary: Respond to a health check
+      description: Respond to a health check
+      responses:
+        '200':
+          description: The application is able to respond to requests
 definitions:
   Facts:
     type: object

--- a/test_api.py
+++ b/test_api.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from urllib.parse import urlsplit, urlencode, parse_qs, urlunsplit
 
 HOST_URL = "/api/hosts"
+HEALTH_URL = "/api/health"
 
 NS = "testns"
 ID = "whoabuddy"
@@ -56,19 +57,11 @@ class BaseAPITestCase(unittest.TestCase):
         return auth_header
 
     def setUp(self):
+        """
+        Creates the application and a test client to make requests.
+        """
         self.app = create_app(config_name="testing")
         self.client = self.app.test_client
-
-        # binds the app to the current context
-        with self.app.app_context():
-            # create all tables
-            db.create_all()
-
-    def tearDown(self):
-        with self.app.app_context():
-            # drop all tables
-            db.session.remove()
-            db.drop_all()
 
     def get(self, path, status=200, return_response_as_json=True):
         return self._response_check(
@@ -113,13 +106,36 @@ class BaseAPITestCase(unittest.TestCase):
         else:
             return response
 
+
+class DBAPITestCase(BaseAPITestCase):
+
+    def setUp(self):
+        """
+        Initializes the database by creating all tables.
+        """
+        super(DBAPITestCase, self).setUp()
+
+        # binds the app to the current context
+        with self.app.app_context():
+            # create all tables
+            db.create_all()
+
+    def tearDown(self):
+        """
+        Cleans up the database by dropping all tables.
+        """
+        with self.app.app_context():
+            # drop all tables
+            db.session.remove()
+            db.drop_all()
+
     def _build_host_id_list_for_url(self, host_list):
         host_id_list = [str(h.id) for h in host_list]
 
         return ",".join(host_id_list)
 
 
-class CreateHostsTestCase(BaseAPITestCase):
+class CreateHostsTestCase(DBAPITestCase):
 
     def test_create_and_update(self):
         facts = None
@@ -245,7 +261,7 @@ class CreateHostsTestCase(BaseAPITestCase):
         response_data = self.post(HOST_URL, host_data.data(), 400)
 
 
-class PreCreatedHostsBaseTestCase(BaseAPITestCase):
+class PreCreatedHostsBaseTestCase(DBAPITestCase):
 
     def setUp(self):
         super(PreCreatedHostsBaseTestCase, self).setUp()
@@ -619,7 +635,7 @@ class TagsTestCase(PreCreatedHostsBaseTestCase):
 
 
 
-class AuthTestCase(BaseAPITestCase):
+class AuthTestCase(DBAPITestCase):
     @staticmethod
     def _valid_identity():
         """
@@ -675,6 +691,21 @@ class AuthTestCase(BaseAPITestCase):
                                            headers={"x-rh-identity": payload}):
             self.app.preprocess_request()
             self.assertEqual(self._valid_identity(), current_identity)
+
+
+class HealthTestCase(BaseAPITestCase):
+    """
+    Tests the health check endpoint.
+    """
+
+    def test_heath(self):
+        """
+        The health check simply returns 200 to any GET request. The response body is
+        irrelevant.
+        """
+        headers = self._get_valid_auth_header()
+        response = self.client().get(HEALTH_URL, headers=headers)
+        self.assertEqual(200, response.status_code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added a new view [_/health_](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:health_probe?expand=1#diff-b5704d15302288389d3aef6d5ab2a4f3R210) that simply responds with 200. This can serve as a responder for a health probe. It still requires the request to be authenticated though.

~~I didn’t write tests for this yet. Pushing here so it’s ready for you to use.~~

After #38 gets merged, the health probe can be modified so it won’t require authentication:

```python
from app.auth import bypass_auth

@bypass_auth
def health():
    …
```