### PR TITLE
[waiting] Bypass authentication for the health probe

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,5 @@
+__all__ = ["health"]
+
+
+def health():
+    return "", 200

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,5 +1,9 @@
+from app.auth import bypass_auth
+
+
 __all__ = ["health"]
 
 
+@bypass_auth
 def health():
     return "", 200

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,11 +1,15 @@
 from app.auth.identity import from_encoded, validate
-from flask import abort, request, _request_ctx_stack
+from flask import abort, current_app, request, _request_ctx_stack
 from werkzeug.local import LocalProxy
 from werkzeug.exceptions import Forbidden
 
-__all__ = ["init_app", "current_identity"]
+__all__ = ["bypass_auth", "init_app", "current_identity"]
 
 _IDENTITY_HEADER = "x-rh-identity"
+
+
+class NoIdentityError(RuntimeError):
+    pass
 
 
 def _validate_identity(payload):
@@ -17,6 +21,10 @@ def _validate_identity(payload):
 
 
 def _before_request():
+    view_func = _get_view_func()
+    if hasattr(view_func, "bypass_auth") and view_func.bypass_auth:
+        return  # This function does not require authentication.
+
     try:
         payload = request.headers[_IDENTITY_HEADER]
     except KeyError:
@@ -40,9 +48,26 @@ def init_app(flask_app):
     flask_app.before_request(_before_request)
 
 
+def bypass_auth(view_func):
+    """
+    Decorates the given view function as not requiring the authentication HTTP header.
+    """
+    view_func.bypass_auth = True
+    return view_func
+
+
 def _get_identity():
     ctx = _request_ctx_stack.top
-    return ctx.identity
+
+    try:
+        return ctx.identity
+    except AttributeError:
+        raise NoIdentityError
+
+
+def _get_view_func():
+    endpoint = request.url_rule.endpoint
+    return current_app.view_functions[endpoint]
 
 
 current_identity = LocalProxy(_get_identity)

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -233,6 +233,16 @@ paths:
       responses:
         "200":
           description: Successfully added or removed a tag
+  /health:
+    get:
+      operationId: api.health
+      tags:
+        - health
+      summary: Respond to a health check
+      description: Respond to a health check
+      responses:
+        '200':
+          description: The application is able to respond to requests
 definitions:
   Facts:
     type: object

--- a/test_api.py
+++ b/test_api.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from urllib.parse import urlsplit, urlencode, parse_qs, urlunsplit
 
 HOST_URL = "/api/hosts"
+HEALTH_URL = "/api/health"
 
 NS = "testns"
 ID = "whoabuddy"
@@ -56,19 +57,11 @@ class BaseAPITestCase(unittest.TestCase):
         return auth_header
 
     def setUp(self):
+        """
+        Creates the application and a test client to make requests.
+        """
         self.app = create_app(config_name="testing")
         self.client = self.app.test_client
-
-        # binds the app to the current context
-        with self.app.app_context():
-            # create all tables
-            db.create_all()
-
-    def tearDown(self):
-        with self.app.app_context():
-            # drop all tables
-            db.session.remove()
-            db.drop_all()
 
     def get(self, path, status=200, return_response_as_json=True):
         return self._response_check(
@@ -113,13 +106,36 @@ class BaseAPITestCase(unittest.TestCase):
         else:
             return response
 
+
+class DBAPITestCase(BaseAPITestCase):
+
+    def setUp(self):
+        """
+        Initializes the database by creating all tables.
+        """
+        super(DBAPITestCase, self).setUp()
+
+        # binds the app to the current context
+        with self.app.app_context():
+            # create all tables
+            db.create_all()
+
+    def tearDown(self):
+        """
+        Cleans up the database by dropping all tables.
+        """
+        with self.app.app_context():
+            # drop all tables
+            db.session.remove()
+            db.drop_all()
+
     def _build_host_id_list_for_url(self, host_list):
         host_id_list = [str(h.id) for h in host_list]
 
         return ",".join(host_id_list)
 
 
-class CreateHostsTestCase(BaseAPITestCase):
+class CreateHostsTestCase(DBAPITestCase):
 
     def test_create_and_update(self):
         facts = None
@@ -245,7 +261,7 @@ class CreateHostsTestCase(BaseAPITestCase):
         response_data = self.post(HOST_URL, host_data.data(), 400)
 
 
-class PreCreatedHostsBaseTestCase(BaseAPITestCase):
+class PreCreatedHostsBaseTestCase(DBAPITestCase):
 
     def setUp(self):
         super(PreCreatedHostsBaseTestCase, self).setUp()
@@ -619,7 +635,7 @@ class TagsTestCase(PreCreatedHostsBaseTestCase):
 
 
 
-class AuthTestCase(BaseAPITestCase):
+class AuthTestCase(DBAPITestCase):
     @staticmethod
     def _valid_identity():
         """
@@ -675,6 +691,21 @@ class AuthTestCase(BaseAPITestCase):
                                            headers={"x-rh-identity": payload}):
             self.app.preprocess_request()
             self.assertEqual(self._valid_identity(), current_identity)
+
+
+class HealthTestCase(BaseAPITestCase):
+    """
+    Tests the health check endpoint.
+    """
+
+    def test_heath(self):
+        """
+        The health check simply returns 200 to any GET request. The response body is
+        irrelevant.
+        """
+        headers = self._get_valid_auth_header()
+        response = self.client().get(HEALTH_URL, headers=headers)
+        self.assertEqual(200, response.status_code)
 
 
 if __name__ == "__main__":

--- a/test_api.py
+++ b/test_api.py
@@ -695,16 +695,15 @@ class AuthTestCase(DBAPITestCase):
 
 class HealthTestCase(BaseAPITestCase):
     """
-    Tests the health check endpoint.
+    Tests the health check endpoint, that must be available without authentication.
     """
 
     def test_heath(self):
         """
         The health check simply returns 200 to any GET request. The response body is
-        irrelevant.
+        irrelevant. There need not to be an identity header.
         """
-        headers = self._get_valid_auth_header()
-        response = self.client().get(HEALTH_URL, headers=headers)
+        response = self.client().get(HEALTH_URL)  # No identity header.
         self.assertEqual(200, response.status_code)
 
 

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 
-from app.auth import _before_request, current_identity, _get_identity, init_app
+from app.auth import (
+    _before_request,
+    bypass_auth,
+    current_identity,
+    _get_identity,
+    _get_view_func,
+    init_app,
+    NoIdentityError
+)
 from app.auth.identity import from_dict, from_encoded, from_json, Identity, validate
 from base64 import b64encode
 from json import dumps
@@ -11,6 +19,35 @@ from werkzeug.local import LocalProxy
 
 class Abort(Exception):
     pass
+
+
+class EmptyRequest:
+    """
+    A request stub that doesn’t have the identity attribute.
+    """
+    pass
+
+
+class ViewFunc:
+    """
+    A view function func that may have the bypass_auth attribute.
+    """
+    def __init__(self, **kwargs):
+        """
+        Sets the bypass_auth attribute if passed as a keyword argument.
+        """
+        if "bypass_auth" in kwargs:
+            self.bypass_auth = kwargs["bypass_auth"]
+
+    def __repr__(self):
+        """
+        Describes how the stub has been constructed.
+        """
+        if hasattr(self, "bypass_auth"):
+            kwargs = f"bypass_auth={self.bypass_auth}"
+        else:
+            kwargs = ""
+        return f"ViewFunc({kwargs})"
 
 
 class AuthInitAppTestCase(TestCase):
@@ -32,10 +69,20 @@ class AuthGetIdentityTestCase(TestCase):
     Tests retrieving the identity from the request context.
     """
 
-    @patch("app.auth._request_ctx_stack")
-    def test_get_identity(self, request_ctx_stack):
+    @patch("app.auth._request_ctx_stack", top=EmptyRequest())
+    def test_no_identity(self, request_ctx_stack):
         """
-        The Authentication Manager request hook is bound to every request.
+        A specific error is raised if there is no identity in the current request
+        context = if the authentication is bypassed for the request.
+        """
+        with self.assertRaises(NoIdentityError):
+            _get_identity()
+
+    @patch("app.auth._request_ctx_stack")
+    def test_return(self, request_ctx_stack):
+        """
+        The Authentication Manager request hook is bound to every request that doesn’t
+        have bypassed authentication.
         """
         self.assertEqual(request_ctx_stack.top.identity, _get_identity())
 
@@ -55,16 +102,107 @@ class AuthCurrentIdentityTestCase(TestCase):
         self.assertEqual(request_ctx_stack.top.identity, current_identity)
 
 
+class BypassAuthTestCase(TestCase):
+    """
+    Tests the bypass_auth decorator that marks the view functions not to require the
+    identity header.
+    """
+
+    def test_decorator(self):
+        """
+        The decorated view function is marked with a bypass_auth attribute set to True.
+        """
+
+        @bypass_auth
+        def view_func():
+            """
+            Dummy function being decorated.
+            """
+            pass
+
+        self.assertTrue(hasattr(view_func, "bypass_auth"))
+        self.assertTrue(view_func.bypass_auth)
+
+
+class GetViewFuncTestCase(TestCase):
+    """
+    Tests retrieving the view of the current request.
+    """
+
+    @patch("app.auth.current_app")
+    @patch("app.auth.request")
+    def test_get_view_func(self, request, current_app):
+        """
+        The view function is found in the view functions map of the Flask app by the
+        endpoint of the current request.
+        """
+        self.assertEqual(
+            current_app.view_functions[request.url_rule.endpoint],
+            _get_view_func()
+        )
+
+
 class AuthBeforeRequestTestCase(TestCase):
     """
     Tests the before request hook that passes the HTTP header to the parser/validator.
     """
 
+    @patch("app.auth._request_ctx_stack", top=EmptyRequest())
+    @patch("app.auth.validate")
+    @patch("app.auth.from_encoded")
+    @patch("app.auth.request")
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=True))
+    def test_auth_bypassed(
+        self, get_view_func, request, from_encoded, validate, request_ctx_stack
+    ):
+        """
+        The request headers are not accessed at all if the authentication is bypassed
+        for the current view.
+        """
+        _before_request()
+
+        get_view_func.assert_called_once_with()
+
+        # Nothing else happens.
+        request.headers.__getitem__.assert_not_called()
+        from_encoded.assert_not_called()
+        validate.assert_not_called()
+        self.assertFalse(hasattr(request_ctx_stack.top, "identity"))
+
+    def test_auth_not_bypassed(self):
+        """
+        The identity HTTP header is parsed and validated if the function is explicitly
+        marked as not having bypased auth or if not marked at all.
+        """
+        @patch("app.auth._request_ctx_stack")
+        @patch("app.auth.validate")
+        @patch("app.auth.from_encoded")
+        @patch("app.auth.request")
+        def test(request, from_encoded, validate, request_ctx_stack):
+            """
+            The HTTP header is normally parsed, validated and assigned to the request.
+            """
+            _before_request()
+
+            # Once we got here, we’re verified. Everything else is covered by other
+            # tests.
+            request.headers.__getitem__.assert_called_once_with("x-rh-identity")
+
+        view_funcs = [ViewFunc(bypass_auth=False), ViewFunc()]
+        for view_func in view_funcs:
+            with self.subTest(view_func=view_func):
+                with patch(
+                    "app.auth._get_view_func", return_value=view_func
+                ) as get_view_func:
+                    test()
+                    get_view_func.assert_called_once_with()
+
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded")
     @patch("app.auth.abort", side_effect=Abort)
     @patch("app.auth.request", **{"headers": {}})
-    def test_missing_header(self, request, abort, from_encoded, validate):
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
+    def test_missing_header(self, get_view_func, request, abort, from_encoded, validate):
         """
         The identity HTTP header is missing. Fails with 403 (Forbidden).
         """
@@ -84,7 +222,8 @@ class AuthBeforeRequestTestCase(TestCase):
 
         @patch("app.auth.abort", side_effect=Abort)
         @patch("app.auth.validate")
-        def _test(validate, abort):
+        @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
+        def _test(get_view_func, validate, abort):
             with patch("app.auth.request", **{"headers": {"x-rh-identity": payload}}):
                 with self.assertRaises(Abort):
                     _before_request()
@@ -104,8 +243,9 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort")
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded", side_effect=RuntimeError)
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
     def test_from_encoded_error_not_caught(
-        self, from_encoded_mock, validate_mock, abort
+        self, get_view_func, from_encoded_mock, validate_mock, abort
     ):
         """
         Any other error during the parsing is not caught and does not result in a
@@ -124,7 +264,10 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort", side_effect=Abort)
     @patch("app.auth.validate", side_effect=ValueError)
     @patch("app.auth.from_encoded")
-    def test_identity_invalid(self, from_encoded_mock, validate_mock, abort):
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
+    def test_identity_invalid(
+        self, get_view_func, from_encoded_mock, validate_mock, abort
+    ):
         """
         The identity payload is validated. Fails with 403 (Forbidden) if not valid.
         """
@@ -141,7 +284,10 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort")
     @patch("app.auth.validate", side_effect=RuntimeError)
     @patch("app.auth.from_encoded")
-    def test_validate_error_not_caught(self, from_encoded_mock, validate_mock, abort):
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
+    def test_validate_error_not_caught(
+        self, get_view_func, from_encoded_mock, validate_mock, abort
+    ):
         """
         Any other error during the validation is not caught and does not result in a
         controlled abort.
@@ -160,8 +306,9 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort", side_effect=Abort)
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded")
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
     def test_everything_ok(
-        self, from_encoded_mock, validate_mock, abort, request_ctx_stack
+        self, get_view_func, from_encoded_mock, validate_mock, abort, request_ctx_stack
     ):
         """
         The identity payload is decoded and validated. Doesn’t fail if valid.
@@ -178,8 +325,14 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded")
     @patch("app.auth.request")
+    @patch("app.auth._get_view_func", return_value=ViewFunc(bypass_auth=False))
     def test_store_identity(
-        self, request, from_encoded_mock, validate_mock, request_ctx_stack
+        self,
+        get_view_func,
+        request,
+        from_encoded_mock,
+        validate_mock,
+        request_ctx_stack
     ):
         """
         The identity payload is stored by the current request context.


### PR DESCRIPTION
The health probe is the reason why disabling the authentication for specific operations is needed. Merged #38 and #39 and bypassed the health check operation.

~~Again, this doesn’t have tests written yet.~~ Will be ready for a review and merge after #38 and #39 get merged.