### PR TITLE
Use underscores rather than dashes as property name separators

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -6,14 +6,14 @@ from sqlalchemy import orm
 import uuid
 
 
-CANONICAL_FACTS = ("insights-id",
-                   "rhel-machine-id",
-                   "subscription-manager-id",
-                   "satellite-id",
-                   "bios-uuid",
-                   "ip-addresses",
+CANONICAL_FACTS = ("insights_id",
+                   "rhel_machine_id",
+                   "subscription_manager_id",
+                   "satellite_id",
+                   "bios_uuid",
+                   "ip_addresses",
                    "fqdn",
-                   "mac-addresses")
+                   "mac_addresses")
 
 
 def convert_fields_to_canonical_facts(json_dict):

--- a/app/utils.py
+++ b/app/utils.py
@@ -19,43 +19,43 @@ class HostWrapper:
 
     @property
     def insights_id(self):
-        return self.__data.get("insights-id", None)
+        return self.__data.get("insights_id", None)
 
     @insights_id.setter
     def insights_id(self, cf):
-        self.__data["insights-id"] = cf
+        self.__data["insights_id"] = cf
 
     @property
     def rhel_machine_id(self):
-        return self.__data.get("rhel-machine-id", None)
+        return self.__data.get("rhel_machine_id", None)
 
     @rhel_machine_id.setter
     def rhel_machine_id(self, cf):
-        self.__data["rhel-machine-id"] = cf
+        self.__data["rhel_machine_id"] = cf
 
     @property
     def subscription_manager_id(self):
-        return self.__data.get("subscription-manager-id", None)
+        return self.__data.get("subscription_manager_id", None)
 
     @subscription_manager_id.setter
     def subscription_manager_id(self, cf):
-        self.__data["subscription-manager-id"] = cf
+        self.__data["subscription_manager_id"] = cf
 
     @property
     def bios_uuid(self):
-        return self.__data.get("bios-uuid", None)
+        return self.__data.get("bios_uuid", None)
 
     @bios_uuid.setter
     def bios_uuid(self, cf):
-        self.__data["bios-uuid"] = cf
+        self.__data["bios_uuid"] = cf
 
     @property
     def ip_addresses(self):
-        return self.__data.get("ip-addresses", None)
+        return self.__data.get("ip_addresses", None)
 
     @ip_addresses.setter
     def ip_addresses(self, cf):
-        self.__data["ip-addresses"] = cf
+        self.__data["ip_addresses"] = cf
 
     @property
     def fqdn(self):
@@ -67,11 +67,11 @@ class HostWrapper:
 
     @property
     def mac_addresses(self):
-        return self.__data.get("mac-addresses", None)
+        return self.__data.get("mac_addresses", None)
 
     @mac_addresses.setter
     def mac_addresses(self, cf):
-        self.__data["mac-addresses"] = cf
+        self.__data["mac_addresses"] = cf
 
     @property
     def facts(self):

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -251,27 +251,27 @@ definitions:
       account:
         type: string
         example: "000102"
-      insights-id:
+      insights_id:
         type: string
         format: uuid
         example: 3f01b55457674041b75e41829bcee1dc
-      rhel-machine-id:
+      rhel_machine_id:
         type: string
         format: uuid
         example: 3f01b55457674041b75e41829bcee1dc
-      subscription-manager-id:
+      subscription_manager_id:
         type: string
         format: uuid
         example: 3f01b55457674041b75e41829bcee1dc
-      satellite-id:
+      satellite_id:
         type: string
         format: uuid
         example: 3f01b55457674041b75e41829bcee1dc
-      bios-uuid:
+      bios_uuid:
         type: string
         format: uuid
         example: 3f01b55457674041b75e41829bcee1dc
-      ip-addresses:
+      ip_addresses:
         type: array
         items:
           type: string
@@ -281,7 +281,7 @@ definitions:
       fqdn:
         type: string
         example: my.host.example.com
-      mac-addresses:
+      mac_addresses:
         type: array
         items:
           type: string


### PR DESCRIPTION
This allows the output JSON structure to be read in Javascript and used as an object.  It also makes it compatible with Django-rest-framework's serializers.