### PR TITLE
Make create_app return the connexion app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,4 +58,4 @@ def create_app(config_name):
 
     db.init_app(flask_app)
 
-    return flask_app
+    return connexion_app

--- a/manage.py
+++ b/manage.py
@@ -7,9 +7,11 @@ from app import models
 # import models
 
 
-app = create_app(config_name=os.getenv('APP_SETTINGS'))
-migrate = Migrate(app, db)
-manager = Manager(app)
+connexion_app = create_app(config_name=os.getenv('APP_SETTINGS'))
+flask_app = connexion_app.app
+
+migrate = Migrate(flask_app.app, db)
+manager = Manager(flask_app.app)
 
 manager.add_command('db', MigrateCommand)
 

--- a/run.py
+++ b/run.py
@@ -6,14 +6,15 @@ import logging
 from app import create_app
 
 config_name = os.getenv('APP_SETTINGS', "development")
-application = create_app(config_name)
+connexion_app = create_app(config_name)
+flask_app = connexion_app.app
 listen_port = os.getenv('LISTEN_PORT', 8080)
 
 if __name__ == '__main__':
-    application.run(host="0.0.0.0", port=listen_port)
+    flask_app.run(host="0.0.0.0", port=listen_port)
 else:
     # Running within gunicorn...tie the flask_app logging
     # into the gunicorn loggging
     gunicorn_logger = logging.getLogger("gunicorn.error")
-    application.logger.handlers = gunicorn_logger.handlers
-    application.logger.setLevel(gunicorn_logger.level)
+    flask_app.logger.handlers = gunicorn_logger.handlers
+    flask_app.logger.setLevel(gunicorn_logger.level)

--- a/test_api.py
+++ b/test_api.py
@@ -55,17 +55,21 @@ class BaseAPITestCase(unittest.TestCase):
         auth_header = {"x-rh-identity": b64encode(json_doc.encode())}
         return auth_header
 
+    @property
+    def flask_app(self):
+        return self.connexion_app.app
+
     def setUp(self):
-        self.app = create_app(config_name="testing")
-        self.client = self.app.test_client
+        self.connexion_app = create_app(config_name="testing")
+        self.client = self.flask_app.test_client
 
         # binds the app to the current context
-        with self.app.app_context():
+        with self.flask_app.app_context():
             # create all tables
             db.create_all()
 
     def tearDown(self):
-        with self.app.app_context():
+        with self.flask_app.app_context():
             # drop all tables
             db.session.remove()
             db.drop_all()
@@ -670,10 +674,10 @@ class AuthTestCase(BaseAPITestCase):
         The identity payload is available by the request context = in the views.
         """
         payload = self._valid_payload()
-        with self.app.test_request_context(HOST_URL,
-                                           method="GET",
-                                           headers={"x-rh-identity": payload}):
-            self.app.preprocess_request()
+        with self.flask_app.test_request_context(HOST_URL,
+                                                     method="GET",
+                                                     headers={"x-rh-identity": payload}):
+            self.flask_app.preprocess_request()
             self.assertEqual(self._valid_identity(), current_identity)
 
 


### PR DESCRIPTION
Change the return value of the [_app.create_app_](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:return_connexion_app?expand=1#diff-1f9f743421417fb2794c88447083a031R29) method to return the whole Connexion app and not only the Flask app inside. That makes possible to have control of the API specification in tests.

This will help #38, allowing to specify an unauthenticated operation in the tests and thus to make functional tests for the authentication bypassing.

Asking @dehort for a review.