### PR TITLE
Allow authentication in debug mode

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -53,8 +53,7 @@ def create_app(config_name):
     flask_app.config['SQLALCHEMY_POOL_SIZE'] = _get_db_pool_size()
     flask_app.config['SQLALCHEMY_POOL_TIMEOUT'] = _get_db_pool_timeout()
 
-    if not flask_app.debug:
-        auth_init_app(flask_app)
+    auth_init_app(flask_app)
 
     db.init_app(flask_app)
 


### PR DESCRIPTION
Removed the [authentication bypass](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:auth_in_debug_mode?expand=1#diff-1f9f743421417fb2794c88447083a031R56) in the debug mode. It caused errors on every operation, because the account number was not available.

Asking @dehort for a review.