### PR TITLE
Mention the health check in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,9 @@ Configuration system properties:
  INVENTORY_DB_POOL_TIMEOUT="5"
  INVENTORY_DB_POOL_SIZE="5"
 ```
+
+## Deployment
+
+There is a health check endpoint at _/api/health_ responding with_200_ to any
+GET request. Point your OpenShift or whatever health probe there, so your pods
+are replaced once they stop responding.


### PR DESCRIPTION
Add a new [Deployment section](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:health_docs?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R70) to the [README file](
https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:health_docs?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8). Mentioned the existence of the health check endpoint there. Nothing special, just decreasing the number of undocumented features.

~~This is based on #41. Please do not merge before that pull request gets merged.~~