### PR TITLE
[wip] Test operations with and without authentication

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -2,7 +2,7 @@ import os
 import logging
 from enum import Enum
 from app.models import Host
-from app.auth import current_identity
+from app.auth import current_identity, requires_identity
 from app import db
 from flask import current_app
 
@@ -12,6 +12,7 @@ FactOperations = Enum("FactOperations", ["merge", "replace"])
 logger = logging.getLogger(__name__)
 
 
+@requires_identity
 def addHost(host):
     """
     Add or update a host
@@ -56,6 +57,7 @@ def addHost(host):
         return found_host.to_json(), 200
 
 
+@requires_identity
 def getHostList(tag=None, display_name=None, page=1, per_page=100):
     """
     Get the list of hosts.  Filtering can be done by the tag or display_name.
@@ -119,6 +121,7 @@ def findHostsByDisplayName(account, display_name, page, per_page):
     return (total, found_host_list)
 
 
+@requires_identity
 def getHostById(hostId, page=1, per_page=100):
     current_app.logger.debug("getHostById(%s, %d, %d)" % (hostId, page, per_page))
     query_results = Host.query.filter(
@@ -130,6 +133,7 @@ def getHostById(hostId, page=1, per_page=100):
     return _buildPaginatedHostListResponse(total, page, per_page, found_host_list)
 
 
+@requires_identity
 def replaceFacts(hostId, namespace, fact_dict):
     current_app.logger.debug("replaceFacts(%s, %s, %s)" % (hostId, namespace, fact_dict))
 
@@ -139,6 +143,7 @@ def replaceFacts(hostId, namespace, fact_dict):
                                   fact_dict)
 
 
+@requires_identity
 def mergeFacts(hostId, namespace, fact_dict):
     current_app.logger.debug("mergeFacts(%s, %s, %s)" % (hostId, namespace, fact_dict))
 
@@ -185,6 +190,7 @@ def updateFactsByNamespace(operation, host_id_list, namespace, fact_dict):
     return 200
 
 
+@requires_identity
 def handleTagOperation(hostId, tag_op):
     current_app.logger.debug("handleTagOperation(%s, %s)" % (hostId, tag_op))
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,4 +58,4 @@ def create_app(config_name):
 
     db.init_app(flask_app)
 
-    return flask_app
+    return connexion_app

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -3,9 +3,13 @@ from flask import abort, current_app, request, _request_ctx_stack
 from werkzeug.local import LocalProxy
 from werkzeug.exceptions import Forbidden
 
-__all__ = ["init_app", "current_identity", "requires_identity"]
+__all__ = ["init_app", "current_identity", "NoIdentityError", "requires_identity"]
 
 _IDENTITY_HEADER = "x-rh-identity"
+
+
+class NoIdentityError(RuntimeError):
+    pass
 
 
 def _validate_identity(payload):
@@ -50,7 +54,10 @@ def requires_identity(view_func):
 
 def _get_identity():
     ctx = _request_ctx_stack.top
-    return ctx.identity
+    try:
+        return ctx.identity
+    except AttributeError:
+        raise NoIdentityError
 
 
 def _current_view_requires_identity():

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,9 +1,9 @@
 from app.auth.identity import from_encoded, validate
-from flask import abort, request, _request_ctx_stack
+from flask import abort, current_app, request, _request_ctx_stack
 from werkzeug.local import LocalProxy
 from werkzeug.exceptions import Forbidden
 
-__all__ = ["init_app", "current_identity"]
+__all__ = ["init_app", "current_identity", "requires_identity"]
 
 _IDENTITY_HEADER = "x-rh-identity"
 
@@ -17,6 +17,9 @@ def _validate_identity(payload):
 
 
 def _before_request():
+    if not _current_view_requires_identity():
+        return  # This function does not require authentication.
+
     try:
         payload = request.headers[_IDENTITY_HEADER]
     except KeyError:
@@ -40,9 +43,27 @@ def init_app(flask_app):
     flask_app.before_request(_before_request)
 
 
+def requires_identity(view_func):
+    view_func.requires_identity = True
+    return view_func
+
+
 def _get_identity():
     ctx = _request_ctx_stack.top
     return ctx.identity
+
+
+def _current_view_requires_identity():
+    return _view_requires_identity(_get_current_view_func())
+
+
+def _view_requires_identity(view_func):
+    return hasattr(view_func, "requires_identity") and view_func.requires_identity
+
+
+def _get_current_view_func():
+    endpoint = request.url_rule.endpoint
+    return current_app.view_functions[endpoint]
 
 
 current_identity = LocalProxy(_get_identity)

--- a/manage.py
+++ b/manage.py
@@ -7,9 +7,11 @@ from app import models
 # import models
 
 
-app = create_app(config_name=os.getenv('APP_SETTINGS'))
-migrate = Migrate(app, db)
-manager = Manager(app)
+connexion_app = create_app(config_name=os.getenv('APP_SETTINGS'))
+flask_app = connexion_app.app
+
+migrate = Migrate(flask_app.app, db)
+manager = Manager(flask_app.app)
 
 manager.add_command('db', MigrateCommand)
 

--- a/run.py
+++ b/run.py
@@ -6,14 +6,15 @@ import logging
 from app import create_app
 
 config_name = os.getenv('APP_SETTINGS', "development")
-application = create_app(config_name)
+connexion_app = create_app(config_name)
+flask_app = connexion_app.app
 listen_port = os.getenv('LISTEN_PORT', 8080)
 
 if __name__ == '__main__':
-    application.run(host="0.0.0.0", port=listen_port)
+    flask_app.run(host="0.0.0.0", port=listen_port)
 else:
     # Running within gunicorn...tie the flask_app logging
     # into the gunicorn loggging
     gunicorn_logger = logging.getLogger("gunicorn.error")
-    application.logger.handlers = gunicorn_logger.handlers
-    application.logger.setLevel(gunicorn_logger.level)
+    flask_app.logger.handlers = gunicorn_logger.handlers
+    flask_app.logger.setLevel(gunicorn_logger.level)

--- a/test_api.py
+++ b/test_api.py
@@ -55,17 +55,21 @@ class BaseAPITestCase(unittest.TestCase):
         auth_header = {"x-rh-identity": b64encode(json_doc.encode())}
         return auth_header
 
+    @property
+    def flask_app(self):
+        return self.connexion_app.app
+
     def setUp(self):
-        self.app = create_app(config_name="testing")
-        self.client = self.app.test_client
+        self.connexion_app = create_app(config_name="testing")
+        self.client = self.flask_app.test_client
 
         # binds the app to the current context
-        with self.app.app_context():
+        with self.flask_app.app_context():
             # create all tables
             db.create_all()
 
     def tearDown(self):
-        with self.app.app_context():
+        with self.flask_app.app_context():
             # drop all tables
             db.session.remove()
             db.drop_all()
@@ -678,10 +682,10 @@ class AuthTestCase(BaseAPITestCase):
         The identity payload is available by the request context = in the views.
         """
         payload = self._valid_payload()
-        with self.app.test_request_context(HOST_URL,
-                                           method="GET",
-                                           headers={"x-rh-identity": payload}):
-            self.app.preprocess_request()
+        with self.flask_app.test_request_context(HOST_URL,
+                                                     method="GET",
+                                                     headers={"x-rh-identity": payload}):
+            self.flask_app.preprocess_request()
             self.assertEqual(self._valid_identity(), current_identity)
 
 

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python
 
-from app.auth import _before_request, current_identity, _get_identity, init_app
+from app.auth import (
+    _before_request,
+    current_identity,
+    _current_view_requires_identity,
+    _get_current_view_func,
+    _get_identity,
+    init_app,
+    requires_identity,
+    _view_requires_identity
+)
 from app.auth.identity import from_dict, from_encoded, from_json, Identity, validate
 from base64 import b64encode
 from json import dumps
@@ -11,6 +20,28 @@ from werkzeug.local import LocalProxy
 
 class Abort(Exception):
     pass
+
+
+class ViewFunc:
+    """
+    A view function func that may have the requires_identity attribute.
+    """
+    def __init__(self, **kwargs):
+        """
+        Sets the requires_identity attribute if passed as a keyword argument.
+        """
+        if "requires_identity" in kwargs:
+            self.requires_identity = kwargs["requires_identity"]
+
+    def __repr__(self):
+        """
+        Describes how the stub has been constructed.
+        """
+        if hasattr(self, "requires_identity"):
+            kwargs = f"requires_identity={self.requires_identity}"
+        else:
+            kwargs = ""
+        return f"ViewFunc({kwargs})"
 
 
 class AuthInitAppTestCase(TestCase):
@@ -60,11 +91,26 @@ class AuthBeforeRequestTestCase(TestCase):
     Tests the before request hook that passes the HTTP header to the parser/validator.
     """
 
+    @patch("app.auth.request", **{"headers": {}})
+    @patch("app.auth._current_view_requires_identity", return_value=False)
+    def test_no_authentication(self, current_view_requires_identity, request):
+        """
+        The request is not authenticated: the identity header is not retrieved.
+        """
+        _before_request()
+
+        current_view_requires_identity.assert_called_once_with()
+        request.assert_not_called()
+
+
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded")
     @patch("app.auth.abort", side_effect=Abort)
     @patch("app.auth.request", **{"headers": {}})
-    def test_missing_header(self, request, abort, from_encoded, validate):
+    @patch("app.auth._current_view_requires_identity", return_value=True)
+    def test_missing_header(
+        self, current_view_requires_identity, request, abort, from_encoded, validate
+    ):
         """
         The identity HTTP header is missing. Fails with 403 (Forbidden).
         """
@@ -84,7 +130,8 @@ class AuthBeforeRequestTestCase(TestCase):
 
         @patch("app.auth.abort", side_effect=Abort)
         @patch("app.auth.validate")
-        def _test(validate, abort):
+        @patch("app.auth._current_view_requires_identity", return_value=True)
+        def _test(current_view_requires_identity, validate, abort):
             with patch("app.auth.request", **{"headers": {"x-rh-identity": payload}}):
                 with self.assertRaises(Abort):
                     _before_request()
@@ -104,8 +151,9 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort")
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded", side_effect=RuntimeError)
+    @patch("app.auth._current_view_requires_identity", return_value=True)
     def test_from_encoded_error_not_caught(
-        self, from_encoded_mock, validate_mock, abort
+        self, current_view_requires_identity, from_encoded_mock, validate_mock, abort
     ):
         """
         Any other error during the parsing is not caught and does not result in a
@@ -124,7 +172,10 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort", side_effect=Abort)
     @patch("app.auth.validate", side_effect=ValueError)
     @patch("app.auth.from_encoded")
-    def test_identity_invalid(self, from_encoded_mock, validate_mock, abort):
+    @patch("app.auth._current_view_requires_identity", return_value=True)
+    def test_identity_invalid(
+        self, current_view_requires_identity, from_encoded_mock, validate_mock, abort
+    ):
         """
         The identity payload is validated. Fails with 403 (Forbidden) if not valid.
         """
@@ -141,7 +192,10 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort")
     @patch("app.auth.validate", side_effect=RuntimeError)
     @patch("app.auth.from_encoded")
-    def test_validate_error_not_caught(self, from_encoded_mock, validate_mock, abort):
+    @patch("app.auth._current_view_requires_identity", return_value=True)
+    def test_validate_error_not_caught(
+        self, current_view_requires_identity, from_encoded_mock, validate_mock, abort
+    ):
         """
         Any other error during the validation is not caught and does not result in a
         controlled abort.
@@ -160,8 +214,14 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.abort", side_effect=Abort)
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded")
+    @patch("app.auth._current_view_requires_identity", return_value=True)
     def test_everything_ok(
-        self, from_encoded_mock, validate_mock, abort, request_ctx_stack
+        self,
+        current_view_requires_identity,
+        from_encoded_mock,
+        validate_mock,
+        abort,
+        request_ctx_stack
     ):
         """
         The identity payload is decoded and validated. Doesn’t fail if valid.
@@ -170,6 +230,7 @@ class AuthBeforeRequestTestCase(TestCase):
         with patch("app.auth.request", **{"headers": {"x-rh-identity": payload}}):
             _before_request()
 
+        current_view_requires_identity.assert_called_once_with()
         from_encoded_mock.assert_called_once_with(payload)
         validate_mock.assert_called_once_with(from_encoded_mock.return_value)
         abort.assert_not_called()
@@ -178,14 +239,106 @@ class AuthBeforeRequestTestCase(TestCase):
     @patch("app.auth.validate")
     @patch("app.auth.from_encoded")
     @patch("app.auth.request")
+    @patch("app.auth._current_view_requires_identity", return_value=True)
     def test_store_identity(
-        self, request, from_encoded_mock, validate_mock, request_ctx_stack
+        self,
+        current_view_requires_identity,
+        request,
+        from_encoded_mock,
+        validate_mock,
+        request_ctx_stack
     ):
         """
         The identity payload is stored by the current request context.
         """
         _before_request()
         self.assertEqual(from_encoded_mock.return_value, request_ctx_stack.top.identity)
+
+
+class AuthRequiresIdentityTestCase(TestCase):
+    """
+    Tests the marking function used to enable identity validation and usage in views.
+    """
+
+    def test_mark(self):
+        """
+        The requires_identity mark is assigned to the view function.
+        """
+        view_func = ViewFunc()
+        requires_identity(view_func)
+        self.assertTrue(hasattr(view_func, "requires_identity"))
+
+    def test_decorator(self):
+        """
+        The function works as a decorator returning the original view function.
+        """
+        view_func = ViewFunc()
+        decorated = requires_identity(view_func)
+        self.assertIs(view_func, decorated)
+
+
+class AuthCurrentViewRequiresIdentityTestCase(TestCase):
+    """
+    Tests checking whether an authentication is required for the current request.
+    """
+
+    @patch("app.auth._view_requires_identity")
+    @patch("app.auth._get_current_view_func")
+    def test_current_view_requires_identity(
+        self, get_current_view_func, view_requires_identity
+    ):
+        """
+        The view inferred from the current request is checked for the authentication
+        flag.
+        """
+        self.assertEqual(
+            view_requires_identity.return_value, _current_view_requires_identity()
+        )
+        get_current_view_func.assert_called_once_with()
+        view_requires_identity.assert_called_once_with(
+            get_current_view_func.return_value
+        )
+
+
+class AuthViewRequiresIdentityTestCase(TestCase):
+    """
+    Tests checking whether the given view function requires authentication.
+    """
+
+    def test_not_marked(self):
+        """
+        The view function is not marked at all, it is considered not requiring an
+        authentication.
+        """
+        view_func = ViewFunc()
+        self.assertEqual(False, _view_requires_identity(view_func))
+
+    def test_marked(self):
+        """
+        The view function is marked whether it requires an authentication.
+        """
+        requires_identity_values = [True, False]
+        for requires_identity_value in requires_identity_values:
+            with self.subTest(requires_identity=requires_identity_value):
+                view_func = ViewFunc(requires_identity=requires_identity)
+                self.assertEqual(requires_identity, _view_requires_identity(view_func))
+
+
+class AuthGetCurrentViewFuncTestCase(TestCase):
+    """
+    Tests retrieving the view function of the current request.
+    """
+
+    @patch("app.auth.current_app")
+    @patch("app.auth.request")
+    def test_get_current_view_func(self, request, current_app):
+        """
+        The view function is found in the view functions map of the Flask app by the
+        endpoint of the current request.
+        """
+        expected = current_app.view_functions[request.url_rule.endpoint]
+        actual = _get_current_view_func()
+        self.assertEqual(expected, actual)
 
 
 class AuthIdentityConstructorTestCase(TestCase):


### PR DESCRIPTION
Added a new [API specification](
https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:requires_identity_functional_tests?expand=1#diff-2b12b514b8cc8a8dbe7883281c5ea68d) that is used only in [tests](
https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:requires_identity_functional_tests?expand=1#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2). This [specification](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:requires_identity_functional_tests?expand=1#diff-2b12b514b8cc8a8dbe7883281c5ea68d) contains [an operation](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:requires_identity_functional_tests?expand=1#diff-2b12b514b8cc8a8dbe7883281c5ea68dR13) that does require the identity header and [an operation](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:requires_identity_functional_tests?expand=1#diff-2b12b514b8cc8a8dbe7883281c5ea68dR19) that doesn’t. It is used in [the new tests](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:requires_identity_functional_tests?expand=1#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2R66) that
verify that authentication is required only for marked views.

This provides test for #50 and is based on [that branch](https://github.com/Glutexo/insights-host-inventory/tree/requires_identity). Contains merged #45 that allows to write the functional tests. Replaces #47 that tested the original authentication approach. Asking @dehort for a review after the dependent PRs get reviewed and merged.