### PR TITLE
Test health check does not require identity

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -711,8 +711,7 @@ class HealthTestCase(BaseAPITestCase):
         The health check simply returns 200 to any GET request. The response body is
         irrelevant.
         """
-        headers = self._get_valid_auth_header()
-        response = self.client().get(HEALTH_URL, headers=headers)
+        response = self.client().get(HEALTH_URL)  # No identity header.
         self.assertEqual(200, response.status_code)
 
 


### PR DESCRIPTION
Altered the health check endpoint [test](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:health_test_without_auth?expand=1#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2R709): the identity header is [no longer passed](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:health_test_without_auth?expand=1#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2L714). [The test](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:health_test_without_auth?expand=1#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2R709) now verifies that the operation works even when the identity header is not present. That is how it is going to be used.

This can effectively replaces #52 as I noted In my [comment](
https://github.com/RedHatInsights/insights-host-inventory/pull/52#issuecomment-442767584) there. Then, #45 should be no longer needed too.

Asking @dehort for review.