### PR TITLE
Require identity header by API specs

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -14,7 +14,6 @@ FactOperations = Enum("FactOperations", ["merge", "replace"])
 
 @api_operation
 @metrics.api_request_time.time()
-@requires_identity
 def add_host(host):
     """
     Add or update a host
@@ -112,7 +111,6 @@ def update_existing_host(existing_host, input_host):
 
 @api_operation
 @metrics.api_request_time.time()
-@requires_identity
 def get_host_list(tag=None, display_name=None, fqdn=None, page=1, per_page=100):
     """
     Get the list of hosts.  Filtering can be done by the tag, display_name, or fqdn.
@@ -198,7 +196,6 @@ def find_hosts_by_canonical_facts(account_number, canonical_facts, page, per_pag
 
 @api_operation
 @metrics.api_request_time.time()
-@requires_identity
 def get_host_by_id(host_id_list, page=1, per_page=100):
     current_app.logger.debug(
             "get_host_by_id(%s, %d, %d)" % (host_id_list, page, per_page)
@@ -216,7 +213,6 @@ def get_host_by_id(host_id_list, page=1, per_page=100):
 
 @api_operation
 @metrics.api_request_time.time()
-@requires_identity
 def replace_facts(host_id_list, namespace, fact_dict):
     current_app.logger.debug(
         "replace_facts(%s, %s, %s)" % (host_id_list, namespace, fact_dict)
@@ -228,7 +224,6 @@ def replace_facts(host_id_list, namespace, fact_dict):
 
 @api_operation
 @metrics.api_request_time.time()
-@requires_identity
 def merge_facts(host_id_list, namespace, fact_dict):
     current_app.logger.debug(
             "merge_facts(%s, %s, %s)" % (host_id_list, namespace, fact_dict)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,9 +2,11 @@ import os
 import connexion
 import yaml
 
+from connexion import Api
 from connexion.resolver import RestyResolver
 from flask import jsonify
 
+from app.auth import init_api as auth_init_api
 from api.mgmt import monitoring_blueprint
 from app.config import Config
 from app.models import db
@@ -22,13 +24,16 @@ def create_app(config_name):
 
     app_config = Config(config_name)
 
-    connexion_app = connexion.App(
-        "inventory", specification_dir="./swagger/", options=connexion_options
-    )
-
     # Read the swagger.yml file to configure the endpoints
     with open("swagger/api.spec.yaml", "rb") as fp:
         spec = yaml.safe_load(fp)
+
+    api = Api(spec)
+    auth_init_api(api)
+
+    connexion_app = connexion.App(
+        "inventory", specification_dir="./swagger/", options=connexion_options
+    )
 
     # If we want to disable auth we first make the header not required
     if os.getenv("FLASK_DEBUG") and os.getenv("NOAUTH"):

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,11 +1,13 @@
 import os
 from functools import wraps
+from app.auth.connexion import get_authenticated_views
 from app.auth.identity import from_encoded, validate, Identity
 from flask import abort, request, _request_ctx_stack
+from app.utils import decorate
 from werkzeug.local import LocalProxy
 from werkzeug.exceptions import Forbidden
 
-__all__ = ["init_app", "current_identity", "NoIdentityError", "requires_identity"]
+__all__ = ["init_api", "current_identity", "NoIdentityError", "requires_identity"]
 
 _IDENTITY_HEADER = "x-rh-identity"
 
@@ -54,6 +56,14 @@ def _get_identity():
         return ctx.identity
     except AttributeError:
         raise NoIdentityError
+
+
+def init_api(api):
+    """
+    Decorate functions that require the identity header.
+    """
+    for view_func in get_authenticated_views(api.specification):
+        decorate(view_func, requires_identity)
 
 
 current_identity = LocalProxy(_get_identity)

--- a/app/auth/connexion.py
+++ b/app/auth/connexion.py
@@ -1,0 +1,47 @@
+from connexion.utils import get_function_from_name
+
+
+__all__ = ["get_authenticated_views"]
+
+
+def _is_requires_identity_param(param):
+    """
+    Determines whether the parameter means that the identity header is required.
+    """
+    return (
+        param["in"] == "header"
+        and param["name"] == "x-rh-identity"
+        and param.get("required", False)
+    )  # For header fields, "required" is optional and its default is false.
+
+
+def _requires_identity(item):
+    """
+    Finds out whether the identity header is required by the item’s parameters.
+    """
+    params = item.get("parameters", [])
+    return any(map(_is_requires_identity_param, params))
+
+
+def _methods(path):
+    """
+    List all method action specifications from a path specification.
+    """
+    for key, value in path.items():
+        if key == "parameters":
+            continue
+        yield value
+
+
+def get_authenticated_views(api_spec):
+    """
+    Go through the API specification and get every view function with an information
+    whether it requires the identity header.
+    """
+    paths = api_spec.get("paths", {})
+    for path in paths.values():
+        if not _requires_identity(path):
+            continue
+
+        for method in _methods(path):
+            yield get_function_from_name(method["operationId"])

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,5 @@
 import json
+from importlib import import_module
 
 
 class HostWrapper:
@@ -124,3 +125,10 @@ class HostWrapper:
     @classmethod
     def from_json(cls, d):
         return cls(json.loads(d))
+
+
+def decorate(func, decorator):
+    decorated = decorator(func)
+    module = import_module(func.__module__)
+    setattr(module, func.__name__, decorated)
+    return decorated

--- a/test_unit.py
+++ b/test_unit.py
@@ -2,19 +2,29 @@
 
 import os
 
+import test_unit
 from api import api_operation
-from app.auth import (
-    _validate,
-    _pick_identity,
+from app import create_app
+from app.auth import init_api, _validate, _pick_identity
+from app.auth.connexion import (
+    _is_requires_identity_param,
+    _methods,
+    get_authenticated_views,
+    _requires_identity
 )
 from app.config import Config
 from app.auth.identity import from_dict, from_encoded, from_json, Identity, validate
+from app.utils import decorate
 from base64 import b64encode
 from json import dumps
 from unittest import main, TestCase
-from unittest.mock import Mock, patch
 import pytest
+from unittest.mock import call, Mock, patch
 from werkzeug.exceptions import Forbidden
+
+
+class Abort(Exception):
+    pass
 
 
 class ApiOperationTestCase(TestCase):
@@ -45,6 +55,381 @@ class ApiOperationTestCase(TestCase):
         old_func = Mock()
         new_func = api_operation(old_func)
         self.assertEqual(old_func.return_value, new_func())
+
+
+class CreateAppTestCase(TestCase):
+    """
+    Tests the Flask application initialization.
+    """
+
+    config_name = "production"
+
+    @patch("app.db")
+    @patch("app.RestyResolver")
+    @patch("app.connexion.App")
+    @patch("app.auth_init_api")
+    @patch("app.Api")
+    @patch("app.yaml.safe_load")
+    @patch("app.open")
+    def test_init_api(
+        self, open_mock, safe_load, api, auth_init_api, app, resty_resolver, db
+    ):
+        create_app(self.config_name)
+        api.assert_called_once_with(safe_load.return_value)
+        auth_init_api.assert_called_once_with(api.return_value)
+
+
+class AuthInitApiTestCase(TestCase):
+    """
+    Tests getting the specification from the API and decoration each operation that
+    requires the identity header.
+    """
+
+    @patch("app.auth.get_authenticated_views")
+    def test_specification(self, get_authenticated_views):
+        """
+        The specification is taken from the API and parsed.
+        """
+        api = Mock()
+        init_api(api)
+        get_authenticated_views.assert_called_once_with(api.specification)
+
+    @patch("app.auth.requires_identity")
+    @patch("app.auth.decorate")
+    def test_decorate(self, decorate, requires_identity):
+        """
+        The returned view functions are decorated.
+        """
+        view_funcs = [Mock(), Mock()]
+        with patch(
+            "app.auth.get_authenticated_views", return_value=view_funcs
+        ) as get_authenticated_views:
+            init_api(Mock())
+
+            decorate_calls = []
+            requires_identity_calls = []
+            for view_func in view_funcs:
+                decorate_calls.append(call(view_func, requires_identity))
+                requires_identity_calls.append(call(view_func))
+
+            self.assertEqual(decorate_calls, decorate.mock_calls)
+
+
+class AuthConnexionIsRequiresIdentityParamTestCase(TestCase):
+    """
+    Tests the check whether an OpenAPI parameter specification describes a required
+    x-rh-identity header.
+    """
+    def test_is(self):
+        """
+        The parameter dictionary is correctly recognized as a required identity header.
+        """
+        params = [
+            {"required": True, "in": "header", "name": "x-rh-identity"},
+            {
+                "in": "header",
+                "something": "else",
+                "name": "x-rh-identity",
+                "required": True
+            },
+            {
+                "in": "header",
+                "name": "x-rh-identity",
+                "required": True,
+                "type": "string",
+                "format": "byte"
+            }
+        ]
+        for param in params:
+            with self.subTest(params=param):
+                self.assertTrue(_is_requires_identity_param(param))
+
+    def test_is_not(self):
+        """
+        The parameter dictionary is correctly recognized as not a required identity
+        header.
+        """
+        params = [
+            {"required": False, "in": "header", "name": "x-rh-identity"},
+            {"required": True, "in": "query", "name": "x-rh-identity"},
+            {"required": True, "in": "header", "name": "identity"},
+            # For header fields, "required" is optional and its default is false.
+            {"in": "header", "name": "x-rh-identity"}
+        ]
+        for param in params:
+            with self.subTest(param=param):
+                self.assertFalse(_is_requires_identity_param(param))
+
+
+class AuthConnexionRequiresIdentityTestCase(TestCase):
+    """
+    Tests the check whether among the items parameter is (at least) one that says that
+    the identity header is required.
+    """
+
+    def _item(self, count):
+        """
+        Builds an item with a given number of parameters.
+        """
+        return {"parameters": [{}] * count}
+
+    @patch(
+        "app.auth.connexion._is_requires_identity_param",
+        side_effect=[False, True, False]
+    )
+    def test_one(self, is_requires_identity_param):
+        """
+        If one parameter is recognized as requiring the identity header, the request is
+        recognized as authenticated.
+        """
+        item = self._item(3)
+        self.assertTrue(_requires_identity(item))
+
+    @patch(
+        "app.auth.connexion._is_requires_identity_param",
+        side_effect=[False, True, True]
+    )
+    def test_more_than_one(self, is_requires_identity_param):
+        """
+        If more than one parameter is recognized as requiring the identity header, the
+        request is recognized as authenticated.
+        """
+        item = self._item(3)
+        self.assertTrue(_requires_identity(item))
+
+    @patch(
+        "app.auth.connexion._is_requires_identity_param",
+        side_effect=[False, False, False]
+    )
+    def test_none(self, is_requires_identity_param):
+        """
+        If no parameter is recognized as requiring the identity header, the request is
+        recognized as not authenticated.
+        """
+        item = self._item(3)
+        self.assertFalse(_requires_identity(item))
+
+    def test_empty(self):
+        """
+        If there is an empty parameter list, the request is recognized as not
+        authenticated.
+        """
+        item = self._item(0)
+        self.assertFalse(_requires_identity(item))
+
+
+    def test_missing(self):
+        """
+        If there is no parameter list at all, the request is recognized as not
+        authenticated.
+        """
+        self.assertFalse(_requires_identity({}))
+
+
+class AuthConnexionMethodsTestCase(TestCase):
+    """
+    Tests getting the method objects as a generator from a path specification,
+    omitting the parameters object and the keys.
+    """
+    def test_reject_parameters(self):
+        tests = [
+            (
+                {
+                    "get": {"some": "thing"},
+                    "parameters": {"a": "parameter"}
+                },
+                [{"some": "thing"}]
+            ),
+            (
+                {
+                    "get": {"some": "thing"},
+                    "parameters": {},
+                    "post": {"other": "stuff"}
+                },
+                [{"some": "thing"}, {"other": "stuff"}]
+            ),
+            ({"parameters": {"a": "parameter"}}, [])
+        ]
+        for original, filtered in tests:
+            with self.subTest(path=original):
+                self.assertEqual(filtered, list(_methods(original)))
+
+
+class AuthConnectionGetAuthenticatedViewsTestCase(TestCase):
+    """
+    Tests parsing the OpenAPI specification, finding all the operations view functions
+    with an information on whether it requires authentication.
+    """
+
+    @patch("app.auth.connexion.get_function_from_name")
+    @patch("app.auth.connexion._methods")
+    @patch("app.auth.connexion._requires_identity")
+    def test_no_paths(self, requires_identity, methods, get_function_from_name):
+        """
+        If there is no paths object at all, no view functions are found.
+        """
+        result = get_authenticated_views({})
+        self.assertEqual([], list(result))
+
+        requires_identity.assert_not_called()
+        methods.assert_not_called()
+        get_function_from_name.assert_not_called()
+
+
+    @patch("app.auth.connexion.get_function_from_name")
+    @patch("app.auth.connexion._methods")
+    @patch("app.auth.connexion._requires_identity")
+    def test_empty_paths(self, requires_identity, methods, get_function_from_name):
+        """
+        If there are no paths in the list, no view functions are found.
+        """
+        result = get_authenticated_views({"paths": {}})
+        self.assertEqual([], list(result))
+
+        requires_identity.assert_not_called()
+        methods.assert_not_called()
+        get_function_from_name.assert_not_called()
+
+    @patch("app.auth.connexion.get_function_from_name")
+    @patch("app.auth.connexion._methods")
+    @patch("app.auth.connexion._requires_identity")
+    def test_requires_identity_path(
+        self, requires_identity, methods, get_function_from_name
+    ):
+        """
+        Each path is tested on whether it requires the identity parameter.
+        """
+        paths = {
+            "/hosts": {"parameters": {"some": "parameters"}},
+            "/health": {"get": {"operationId": "some operation"}}
+        }
+        all(get_authenticated_views({"paths": paths}))
+
+        calls = []
+        for path in paths.values():
+            calls.append(call(path))
+        requires_identity.assert_has_calls(calls, True)
+
+    @patch("app.auth.connexion.get_function_from_name")
+    @patch("app.auth.connexion._methods")
+    def test_methods_iterator(self, methods, get_function_from_name):
+        """
+        Methods are retrieved for every path that requires the header identity
+        parameter.
+        """
+        def requires_identity(path):
+            return path["get"]["operationId"] == "first operation"
+
+        paths = {
+            "/hosts": {"get": {"operationId": "first operation"}},
+            "/health": {"get": {"operationId": "second operation"}}
+        }
+        with patch("app.auth.connexion._requires_identity", requires_identity):
+            all(get_authenticated_views({"paths": paths}))
+
+        self.assertIn(call(paths["/hosts"]), methods.mock_calls)
+        self.assertNotIn(call(paths["/health"]), methods.mock_calls)
+
+    @patch("app.auth.connexion.get_function_from_name")
+    @patch("app.auth.connexion._requires_identity")
+    def test_get_function_from_name(self, requires_identity, get_function_from_name):
+        """
+        View function is retrieved for every operation.
+        """
+        methods_return_values = [
+            [{"operationId": "first operation"}, {"operationId": "second operation"}],
+            [{"operationId": "third operation"}]
+        ]
+
+        with patch(
+            "app.auth.connexion._methods", side_effect=methods_return_values
+        ) as methods_mock:
+            for _ in get_authenticated_views({"paths": {"/hosts": {}, "/health": {}}}):
+                pass
+
+            calls = []
+            for methods in methods_return_values:
+                for method in methods:
+                    calls.append(call(method["operationId"]))
+
+            get_function_from_name.assert_has_calls(calls, True)
+            self.assertEqual(len(calls), len(get_function_from_name.mock_calls))
+
+    def test_return(self):
+        """
+        For every method that requires the identity header a view function is yielded.
+        """
+        def requires_identity(item):
+            return item["get"]["operationId"] == "first operation"
+
+        def get_function_from_name(name):
+            return view_funcs[name]
+
+        paths = {
+            "/hosts": {"get": {"operationId": "first operation"}},
+            "/health": {"get": {"operationId": "second operation"}}
+        }
+        methods_return_values = []
+        for path in paths.values():
+            methods_return_values.append(path.values())
+
+        view_funcs = {
+            "first operation": Mock(),
+            "second operation": Mock()
+        }
+
+        with patch(
+            "app.auth.connexion._requires_identity", wraps=requires_identity
+        ) as requires_identity_mock:
+            with patch(
+                "app.auth.connexion._methods", side_effect=methods_return_values
+            ) as methods_mock:
+                with patch(
+                    "app.auth.connexion.get_function_from_name", get_function_from_name
+                ) as get_function_from_name_mock:
+                    self.assertEqual(
+                        [view_funcs["first operation"]],
+                        list(get_authenticated_views({"paths": paths}))
+                    )
+
+    def test_whole(self):
+        def get_function_from_name(name):
+            return view_funcs[name]
+
+        view_funcs = {
+            "first operation": Mock(),
+            "second operation": Mock(),
+            "third operation": Mock(),
+            "fourth operation": Mock(),
+        }
+
+        spec = {
+            "paths": {
+                "/first_path": {
+                    "parameters": [
+                        {"in": "header", "name": "x-rh-identity", "required": True}
+                    ],
+                    "get": {"operationId": "first operation"}
+                },
+                "/second_path": {
+                    "parameters": [
+                        {"in": "header", "name": "x-rh-identity", "required": False}
+                    ],
+                    "get": {"operationId": "second operation"}
+                },
+                "/third_path": {
+                    "parameters": [{"in": "header", "name": "x-rh-identity"}],
+                    "get": {"operationId": "third operation"}
+                },
+                "/fourth_path": {"get": {"operationId": "fourth operation"}}
+            }
+        }
+
+        with patch(
+            "app.auth.connexion.get_function_from_name", get_function_from_name
+        ) as get_function_from_name_mock:
+            result = list(get_authenticated_views(spec))
+            self.assertEqual([view_funcs["first operation"]], result)
 
 
 class AuthIdentityConstructorTestCase(TestCase):
@@ -216,6 +601,53 @@ class AuthIdentityValidateTestCase(TestCase):
             _validate("")
         with self.assertRaises(Forbidden):
             _validate({})
+
+
+class UtilsDecorateTestCase(TestCase):
+    """
+    Tests decorating a function by reference.
+    """
+
+    def setUp(self):
+        """
+        Backup the original method that is being replaced.
+        """
+        self.backup = test_unit.Abort
+
+    def tearDown(self):
+        """
+        Restore the replaced method from the backup.
+        """
+        test_unit.Abort = self.backup
+
+    def test_decorate(self):
+        """
+        The decorator function is passed the original function.
+        """
+        def decorator(func):
+            return func
+
+        decorator_mock = Mock(wraps=decorator)
+
+        decorate(test_unit.Abort, decorator_mock)
+        decorator_mock.assert_called_once_with(test_unit.Abort)
+
+    def test_return(self):
+        """
+        The decorator return value is returned.
+        """
+        mock = Mock()
+        self.assertEqual(mock.return_value, decorate(test_unit.Abort, mock))
+
+    def test_replace(self):
+        """
+        The original module function is replaced by the decorated one.
+        """
+        mock = Mock()
+        decorate(test_unit.Abort, mock)
+
+        self.assertEqual(mock.return_value.return_value, test_unit.Abort("something"))
+        mock.return_value.assert_called_once_with("something")
 
 
 @pytest.mark.usefixtures("monkeypatch")


### PR DESCRIPTION
Some operations require the identity header authentication and some don’t. This is described by the [OpenAPI specification](
https://github.com/RedHatInsights/insights-host-inventory/blob/6662e113ddf55b175fcd01375374d2b1489512db/swagger/api.spec.yaml). [Parse](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:auth_by_spec_simple?expand=1#diff-928a71ff2d667396888de19dbef2c2c5R36) [this spec](
https://github.com/RedHatInsights/insights-host-inventory/blob/6662e113ddf55b175fcd01375374d2b1489512db/swagger/api.spec.yaml) to populate the authenticated paths. The [_requires_identity_](https://github.com/RedHatInsights/insights-host-inventory/blob/6662e113ddf55b175fcd01375374d2b1489512db/app/auth/__init__.py#L39) decorator is [applied](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:auth_by_spec_simple?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41R66) to the all operations in paths that require the identity
header. These decorated view functions are then picked by Connexion.

Caveats/TODO – will do in subsequent pull requests.

* Doesn’t support overriding the parameter by the method specification.
* Doesn’t use the RestyResolver, but the default Connexions way of describing the exact module.function.

There is some black magic going on with the [_decorate_](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:auth_by_spec_simple?expand=1#diff-5609c27c7d83fbaa57c74f5491ef464bR122) method. It patches the method in the module as if the decorator was applied at the time of its definition. I don’t like this _that much_ and it can be probably better done by using a custom resolver. We can decide later how much a refactor is worth it.