### PR TITLE
Use more universal run_simple instead of run

### DIFF
--- a/run.py
+++ b/run.py
@@ -4,13 +4,14 @@ import os
 import logging
 
 from app import create_app
+from werkzeug.serving import run_simple
 
 config_name = os.getenv('APP_SETTINGS', "development")
 application = create_app(config_name)
 listen_port = os.getenv('LISTEN_PORT', 8080)
 
 if __name__ == '__main__':
-    application.run(host="0.0.0.0", port=listen_port)
+    run_simple("0.0.0.0", listen_port, application)
 else:
     # Running within gunicorn...tie the flask_app logging
     # into the gunicorn loggging


### PR DESCRIPTION
Change the [serving call](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:run_simple?expand=1#diff-6e38f16215ae91c11fc5c54b74c66d54R14) to launch the development server: use Werkzeug’s _run_simple_ instead of Flask’s _run_ to start the server. This way it’s possible to launch any WSGI application including Flask apps, Connexion apps and most importantly dispatched apps. That will be necessary to expose metrics via Prometheus.

There is no change in the usage of the [run script](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:run_simple?expand=1#diff-6e38f16215ae91c11fc5c54b74c66d54).

How to test:

* Launch the development server with `python run.py`
* Issue a request to _http://localhost:8080/r/insights/platform/inventory/api/v1/hosts_ with a valid identity header, verify that an API response is returned with a status code 200.
* Launch the production server with `gunicorn --bind=0.0.0.0:8080 run`.
* Issue the same request as above and verify the results.

Asking @dehort for a review. Wouldn't this break something, including Flask’s or other customary rules?