### PR TITLE
Use DispatcherMiddleware to run the app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ import yaml
 
 from flask_sqlalchemy import SQLAlchemy
 from connexion.resolver import RestyResolver
+from werkzeug.wsgi import DispatcherMiddleware
 
 
 db = SQLAlchemy()
@@ -75,3 +76,10 @@ def create_app(config_name):
     db.init_app(flask_app)
 
     return flask_app
+
+
+def dispatch(flask_app):
+    """
+    Create a combined app that allows to mount other WSGI apps.
+    """
+    return DispatcherMiddleware(flask_app)

--- a/run.py
+++ b/run.py
@@ -3,7 +3,7 @@
 import os
 import logging
 
-from app import create_app
+from app import create_app, dispatch
 
 config_name = os.getenv('APP_SETTINGS', "development")
 application = create_app(config_name)
@@ -17,3 +17,5 @@ else:
     gunicorn_logger = logging.getLogger("gunicorn.error")
     application.logger.handlers = gunicorn_logger.handlers
     application.logger.setLevel(gunicorn_logger.level)
+
+    application = dispatch(application)


### PR DESCRIPTION
[Packed](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:dispatch?expand=1#diff-1f9f743421417fb2794c88447083a031R86) the application in the [Werkzeug’s _DispatcherMiddleware_](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:dispatch?expand=1#diff-1f9f743421417fb2794c88447083a031R7) when [run](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:dispatch?expand=1#diff-6e38f16215ae91c11fc5c54b74c66d54R21) with gUnicorn. This allows to combine more WSGI applications which will be necessary to add Prometheus.

This applies only when the gUnicorn server is [used](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:dispatch?expand=1#diff-6e38f16215ae91c11fc5c54b74c66d54R14). For the [development server](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:dispatch?expand=1#diff-6e38f16215ae91c11fc5c54b74c66d54R12) to support this, #59 will have to be used. One does not simply `.run()` a dispatched application.

Asking @dehort for a review.