### PR TITLE
[waiting] Use Prometheus to gather metrics

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ request = "*"
 gunicorn = "*"
 connexion = {extras = ["swagger-ui"]}
 pyyaml = ">=3.13"
+prometheus-client = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "97e671154a7e58bdcef357c873f7ee83e7c4c7901ca0f355eb173be344bed2bd"
+            "sha256": "a1c53a3a5502bc3355669bd53ad47771a2a424dd8cc0149e0b88ceae4c203647"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,10 +31,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
-                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
             ],
-            "version": "==2018.10.15"
+            "version": "==2018.11.29"
         },
         "chardet": {
             "hashes": [
@@ -239,6 +239,13 @@
             ],
             "version": "==2018.11.20"
         },
+        "prometheus-client": {
+            "hashes": [
+                "sha256:e8c11ff5ca53de6c3d91e1510500611cafd1d247a937ec6c588a0a7cc3bef93c"
+            ],
+            "index": "pypi",
+            "version": "==0.5.0"
+        },
         "psycopg2-binary": {
             "hashes": [
                 "sha256:036bcb198a7cc4ce0fe43344f8c2c9a8155aefa411633f426c8c6ed58a6c0426",
@@ -344,10 +351,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         },
         "sqlalchemy": {
             "hashes": [
@@ -470,10 +477,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         }
     }
 }

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ import yaml
 
 from flask_sqlalchemy import SQLAlchemy
 from connexion.resolver import RestyResolver
+from prometheus_client import make_wsgi_app
 from werkzeug.wsgi import DispatcherMiddleware
 
 
@@ -82,4 +83,11 @@ def dispatch(flask_app):
     """
     Create a combined app that allows to mount other WSGI apps.
     """
-    return DispatcherMiddleware(flask_app)
+    app_name = os.getenv("APP_NAME", "inventory")
+    path_prefix = os.getenv("PATH_PREFIX", "/r/insights/platform")
+
+    prometheus_app = make_wsgi_app()
+
+    return DispatcherMiddleware(
+        flask_app, {f"{path_prefix}/{app_name}/metrics": prometheus_app}
+    )

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ import yaml
 
 from flask_sqlalchemy import SQLAlchemy
 from connexion.resolver import RestyResolver
+from werkzeug.wsgi import DispatcherMiddleware
 
 
 db = SQLAlchemy()
@@ -75,3 +76,10 @@ def create_app(config_name):
     db.init_app(flask_app)
 
     return flask_app
+
+
+def dispatch(flask_app):
+    """
+    Create a combined app that allows to mount other WSGI apps.
+    """
+    return DispatcherMiddleware(flask_app)

--- a/run.py
+++ b/run.py
@@ -3,7 +3,7 @@
 import os
 import logging
 
-from app import create_app
+from app import create_app, dispatch
 
 config_name = os.getenv('APP_SETTINGS', "development")
 application = create_app(config_name)
@@ -17,3 +17,5 @@ else:
     gunicorn_logger = logging.getLogger("gunicorn.error")
     application.logger.handlers = gunicorn_logger.handlers
     application.logger.setLevel(gunicorn_logger.level)
+
+    application = dispatch(application)


### PR DESCRIPTION
[Installed]((https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:prometheus?expand=1#diff-1e61a31bf9b94805f869dc4137ec1885R22)) the Prometheus client and [exposed](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:prometheus?expand=1#diff-1f9f743421417fb2794c88447083a031R91) its default metrics (Python information and statistics) to the new _/metrics_ endpoint.

This endpoint is not a part of the API and because of that it’s not under the _api/v1_ prefix. I’ll DRY this once #62 gets merged. The pull request is based on #60 that uses application dispatching to combine the Flask app with the Prometheus one.

Will ask @dehort for review once #60 gets merged.