### PR TITLE
Create a run script with temporary directory

### DIFF
--- a/run_gunicorn.py
+++ b/run_gunicorn.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+from contextlib import contextmanager
+from subprocess import run
+from os import getenv, putenv
+from tempfile import TemporaryDirectory
+
+
+PROMETHEUS_ENV_VAR = "prometheus_multiproc_dir"
+LISTEN_PORT = getenv('LISTEN_PORT', 8080)
+
+
+@contextmanager
+def prometheus_temp_dir():
+    """
+    Creates a new temporary folder and sets it to the Prometheus’ environment variable.
+    """
+    with TemporaryDirectory() as temp_dir:
+        orig = getenv(PROMETHEUS_ENV_VAR)
+        putenv(PROMETHEUS_ENV_VAR, temp_dir)
+        try:
+            yield
+        finally:
+            putenv(PROMETHEUS_ENV_VAR, orig)
+
+
+def run_server():
+    """
+    Runs the Gunicorn server in a new subprocess. This way it gets the new environment
+    variables.
+    """
+    bind = f"0.0.0.0:{LISTEN_PORT}"
+    run(("gunicorn", "--log-level=debug", f"--bind={bind}", "run"))
+
+
+if __name__ == "__main__":
+    with prometheus_temp_dir():
+        run_server()


### PR DESCRIPTION
Introduce a new [run script](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:prometheus_temp_dir?expand=1#diff-297b2ac7e7abfacd1d2c7aefe0c8b500) that creates [a temporary directory](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:prometheus_temp_dir?expand=1#diff-297b2ac7e7abfacd1d2c7aefe0c8b500R16) for
Prometheus and [runs](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:prometheus_temp_dir?expand=1#diff-297b2ac7e7abfacd1d2c7aefe0c8b500R31) Gunicorn in a subprocess with this directory path
set. This makes it easier to run the service locally for development without paying attention to Prometheus configuration and cleanup.

The server is [run](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:prometheus_temp_dir?expand=1#diff-297b2ac7e7abfacd1d2c7aefe0c8b500R31) in a subprocess, because the changes in the environment apply only for new processes. Thus, the original variable value [backup](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:prometheus_temp_dir?expand=1#diff-297b2ac7e7abfacd1d2c7aefe0c8b500R17) is essentially not necessary, but it looked more semantically clean to me with it.

This pull request will start to make sense only once #58 gets merged. Asking @dehort for a review.