### PR TITLE
Describe the management endpoints in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,12 @@ Configuration system properties:
 
 ## Deployment
 
-There is a health check endpoint at _/health_ responding with_200_ to any
-GET request. Point your OpenShift or whatever health probe there, so your pods
-are replaced once they stop responding.
+The application provides some management information about itself. These
+endpoints are exposed at the root path _/_ and thus are accessible only
+from inside of the deployment cluster.
 
-There is a prometheus metrics endpoint at _/metrics_.  Point your Prometheus
-scraper there.
+* _/health_ responds with _200_ to any GET requests, point your liveness
+  or readiness probe here.
+* _/metrics_ offers metrics and monitoring intended to be pulled by
+  [Prometheus](https://prometheus.io). 
+


### PR DESCRIPTION
The [_README_](
https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:management_readme?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8) described only the _/health_ endpoint. Added information about [_/metrics_](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:management_readme?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R73) endpoint for [Prometheus](https://www.prometheus.io/) and edited the [_/health_](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:management_readme?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R71) one so it properly describes the new root path approach.

This new description will be true after #58 gets merged.