### PR TITLE
Mention the run script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,18 @@ environment needs to point to this directory.  The
 contents of this directory need to be removed between
 runs.
 
-Running the server:
+A command to run the server in a cluster.
 
 ```
-mkdir /path/to/prometheus_dir
-gunicorn --log-level=debug -c gunicorn.conf.py run
-rm /path/to/prometheus_dir/*
+gunicorn -c gunicorn.conf.py run
+```
+
+Running the server locally for development. In this case it’s not necessary to
+care about the Prometheus temp directory or to set the
+_prometheus_multiproc_dir_ environment variable. This is done automatically.
+
+```
+python run_gunicorn.py 
 ```
 
 Configuration system properties:


### PR DESCRIPTION
Split the running the server [instructions](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:server_readme?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R44) in [README](
https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:server_readme?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8) to those that apply to [a cluster](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:server_readme?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R58) and those that apply to a local instance. There is a run script for running the server [locally](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:server_readme?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R64) without having to pay attention to the Prometheus temp dir configuration.

Asking @dehort for a review.