### PR TITLE
Count merge and replace facts

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -257,13 +257,20 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
         current_app.logger.debug(error_msg)
         return error_msg, 400
 
+    replaced_count = 0
+    merged_count = 0
     for host in hosts_to_update:
         if operation is FactOperations.replace:
             host.replace_facts_in_namespace(namespace, fact_dict)
+            replaced_count += 1
         else:
             host.merge_facts_in_namespace(namespace, fact_dict)
+            merged_count += 1
 
     db.session.commit()
+
+    metrics.replace_facts_count.inc(replaced_count)
+    metrics.merge_facts_count.inc(merged_count)
 
     current_app.logger.debug("hosts_to_update:%s" % hosts_to_update)
 

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -4,3 +4,5 @@ api_request_time = Summary("inventory_request_processing_seconds", "Time spent p
 api_request_count = Counter("inventory_request_count", "The total amount of API requests")
 create_host_count = Counter("inventory_create_host_count", "The total amount of hosts created")
 update_host_count = Counter("inventory_update_host_count", "The total amount of hosts updated")
+merge_facts_count = Counter("inventory_merge_facts_count", "The total amount of facts merged")
+replace_facts_count = Counter("inventory_replace_facts_count", "The total amount of facts replaced")


### PR DESCRIPTION
Every [merged](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:merge_facts_count?expand=1#diff-a5c55b46cc9c536070cb56798c97adfaR198) and [replaced](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:merge_facts_count?expand=1#diff-a5c55b46cc9c536070cb56798c97adfaR195) fact set of a host is tallied. The respective counter increments for every host after the changes are committed.

Asking @dehort for a review.

Related to #70.