### PR TITLE
Mention the API spec and UI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,9 @@ from inside of the deployment cluster.
 * _/metrics_ offers metrics and monitoring intended to be pulled by
   [Prometheus](https://prometheus.io). 
 
+## API Documentation
+
+The API is described by an OpenAPI specification file
+[_swagger/api/api.spec.yaml_](swagger/api.spec.yaml). The application exposes
+a browsable Swagger UI Console at
+[_/r/insights/platform/inventory/api/v1/ui/_](http://localhost:8080/r/insights/platform/inventory/api/v1/ui/).


### PR DESCRIPTION
Added a new [Documentation](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:documentation?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R97) section to the [README](
https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:documentation?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8). It contains [a link](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:documentation?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R100) to the API specification file, clickable on GitHub, and [a link](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:documentation?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R102) to the Swagger UI Console, clickable on localhost with a running app instance.

Asking @dehort for a review.