### PR TITLE
Count login failures

### DIFF
--- a/api/metrics.py
+++ b/api/metrics.py
@@ -4,3 +4,4 @@ api_request_time = Summary("inventory_request_processing_seconds", "Time spent p
 api_request_count = Counter("inventory_request_count", "The total amount of API requests")
 create_host_count = Counter("inventory_create_host_count", "The total amount of hosts created")
 update_host_count = Counter("inventory_update_host_count", "The total amount of hosts updated")
+login_failure_count = Counter("inventory_login_failure_count", "The total amount of failed login attempts")


### PR DESCRIPTION
Add a new Prometheus [Counter](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count?expand=1#diff-09a4c1f30c5458aa77651a6d5b4d2d2fR6) for login failures. [Increment](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41R44) the counter whenever authentication fails: either if the header is [undecodeable](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41R29) or [invalid](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41R36).

This doesn’t cover the case when the header is completely [missing](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41R24). Such case is [caught](https://github.com/RedHatInsights/insights-host-inventory/blob/dc3d424bbe873f9598958f9e53ac6181518e884d/swagger/api.spec.yaml#L16) by Connexion and doesn’t get to the authentication [module](
https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41) at all.

Asking @dehort for a review.