### PR TITLE
Add the API request count metric – simpler version

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -26,6 +26,7 @@ def addHost(host):
      - account number
     """
     current_app.logger.debug("addHost(%s)" % host)
+    metrics.api_request_count.inc()
 
     account_number = host.get("account", None)
 
@@ -84,6 +85,7 @@ def getHostList(tag=None, display_name=None, page=1, per_page=100):
     current_app.logger.debug(
         "getHostList(tag=%s, display_name=%s)" % (tag, display_name)
     )
+    metrics.api_request_count.inc()
 
     if tag:
         (total, host_list) = findHostsByTag(
@@ -143,6 +145,8 @@ def findHostsByDisplayName(account, display_name, page, per_page):
 @requires_identity
 def getHostById(hostId, page=1, per_page=100):
     current_app.logger.debug("getHostById(%s, %d, %d)" % (hostId, page, per_page))
+    metrics.api_request_count.inc()
+
     query_results = Host.query.filter(
         (Host.account == current_identity.account_number) & Host.id.in_(hostId)
     ).paginate(page, per_page, True)
@@ -158,6 +162,7 @@ def replaceFacts(hostId, namespace, fact_dict):
     current_app.logger.debug(
         "replaceFacts(%s, %s, %s)" % (hostId, namespace, fact_dict)
     )
+    metrics.api_request_count.inc()
 
     return updateFactsByNamespace(FactOperations.replace, hostId, namespace, fact_dict)
 
@@ -166,6 +171,7 @@ def replaceFacts(hostId, namespace, fact_dict):
 @requires_identity
 def mergeFacts(hostId, namespace, fact_dict):
     current_app.logger.debug("mergeFacts(%s, %s, %s)" % (hostId, namespace, fact_dict))
+    metrics.api_request_count.inc()
 
     if not fact_dict:
         error_msg = "ERROR: Invalid request.  Merging empty facts into " "existing facts is a no-op."

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -1,5 +1,6 @@
 from prometheus_client import Counter, Summary
 
 api_request_time = Summary("inventory_request_processing_seconds", "Time spent processing request")
+api_request_count = Counter("inventory_request_count", "The total amount of API requests")
 create_host_count = Counter("inventory_create_host_count", "The total amount of hosts created")
 update_host_count = Counter("inventory_update_host_count", "The total amount of hosts updated")


### PR DESCRIPTION
Added a new [_inventory_request_count_](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:inventory_request_count_simpler?expand=1#diff-09a4c1f30c5458aa77651a6d5b4d2d2fR4) metric that counts the total amount of API requests. It doesn’t include management (_health_ and _metrics_) requests. It increments on succeeded requests as well as on failures.

This is a simpler version of #70. It doesn’t introduce a new [decorator](https://github.com/RedHatInsights/insights-host-inventory/pull/70/files#diff-09a4c1f30c5458aa77651a6d5b4d2d2fR10) and doesn’t use mocking in tests. That means though that the counting is untested in this PR.

Asking @dehort to review. Please consider whether you like this more than the original #70. I [elaborated](
https://github.com/RedHatInsights/insights-host-inventory/pull/70#issuecomment-450862079) a bit both on the decorator and on the mocking [there](
https://github.com/RedHatInsights/insights-host-inventory/pull/70#issuecomment-450862079). Thanks!