### PR TITLE
Count login failures, now without mocking

### DIFF
--- a/api/metrics.py
+++ b/api/metrics.py
@@ -4,3 +4,4 @@ api_request_time = Summary("inventory_request_processing_seconds", "Time spent p
 api_request_count = Counter("inventory_request_count", "The total amount of API requests")
 create_host_count = Counter("inventory_create_host_count", "The total amount of hosts created")
 update_host_count = Counter("inventory_update_host_count", "The total amount of hosts updated")
+login_failure_count = Counter("inventory_login_failure_count", "The total amount of failed login attempts")

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,5 +1,6 @@
 import os
 from functools import wraps
+from api.metrics import login_failure_count
 from app.auth.identity import from_encoded, validate, Identity
 from flask import abort, request, _request_ctx_stack
 from werkzeug.local import LocalProxy
@@ -21,19 +22,28 @@ def _pick_identity():
         try:
             payload = request.headers[_IDENTITY_HEADER]
         except KeyError:
-            abort(Forbidden.code)
+            _login_failed()
 
         try:
             return from_encoded(payload)
-        except (KeyError, TypeError, ValueError):
-            abort(Forbidden.code)
+        except (KeyError, TypeError, ValueError) as e:
+            print(type(e))
+            _login_failed()
 
 
 def _validate(identity):
     try:
         validate(identity)
     except Exception:
-        abort(Forbidden.code)
+        _login_failed()
+
+
+def _login_failed():
+    """
+    The identity header is either missing or invalid, login failed – aborting.
+    """
+    login_failure_count.inc()
+    abort(Forbidden.code)
 
 
 def requires_identity(view_func):

--- a/test_unit.py
+++ b/test_unit.py
@@ -3,18 +3,29 @@
 import os
 
 from api import api_operation
-from app.auth import (
-    _validate,
-    _pick_identity,
-)
+from app import create_app
+from app.auth import _IDENTITY_HEADER, _login_failed, _validate, _pick_identity
 from app.config import Config
 from app.auth.identity import from_dict, from_encoded, from_json, Identity, validate
 from base64 import b64encode
+from contextlib import contextmanager
 from json import dumps
 from unittest import main, TestCase
 from unittest.mock import Mock, patch
 import pytest
 from werkzeug.exceptions import Forbidden
+
+
+def _encode_header(dict_):
+    """
+    Encode the header payload dictionary.
+    """
+    json = dumps(dict_)
+    return b64encode(json.encode())
+
+
+def _identity():
+    return Identity(account_number="some number")
 
 
 class ApiOperationTestCase(TestCase):
@@ -47,17 +58,7 @@ class ApiOperationTestCase(TestCase):
         self.assertEqual(old_func.return_value, new_func())
 
 
-class AuthIdentityConstructorTestCase(TestCase):
-    """
-    Tests the Identity module constructors.
-    """
-
-    @staticmethod
-    def _identity():
-        return Identity(account_number="some number")
-
-
-class AuthIdentityFromDictTest(AuthIdentityConstructorTestCase):
+class AuthIdentityFromDictTest(TestCase):
     """
     Tests creating an Identity from a dictionary.
     """
@@ -66,7 +67,7 @@ class AuthIdentityFromDictTest(AuthIdentityConstructorTestCase):
         """
         Initialize the Identity object with a valid dictionary.
         """
-        identity = self._identity()
+        identity = _identity()
 
         dict_ = {
             "account_number": identity.account_number,
@@ -86,7 +87,7 @@ class AuthIdentityFromDictTest(AuthIdentityConstructorTestCase):
                 from_dict(dict_)
 
 
-class AuthIdentityFromJsonTest(AuthIdentityConstructorTestCase):
+class AuthIdentityFromJsonTest(TestCase):
     """
     Tests creating an Identity from a JSON string.
     """
@@ -95,7 +96,7 @@ class AuthIdentityFromJsonTest(AuthIdentityConstructorTestCase):
         """
         Initialize the Identity object with a valid JSON string.
         """
-        identity = self._identity()
+        identity = _identity()
 
         dict_ = {"identity": identity._asdict()}
         json = dumps(dict_)
@@ -126,7 +127,7 @@ class AuthIdentityFromJsonTest(AuthIdentityConstructorTestCase):
         Initializing the Identity object with a JSON string that is not
         formatted correctly.
         """
-        identity = self._identity()
+        identity = _identity()
 
         dict_ = identity._asdict()
         json = dumps(dict_)
@@ -135,7 +136,7 @@ class AuthIdentityFromJsonTest(AuthIdentityConstructorTestCase):
             from_json(json)
 
 
-class AuthIdentityFromEncodedTest(AuthIdentityConstructorTestCase):
+class AuthIdentityFromEncodedTest(TestCase):
     """
     Tests creating an Identity from a Base64 encoded JSON string, which is what is in
     the HTTP header.
@@ -146,11 +147,8 @@ class AuthIdentityFromEncodedTest(AuthIdentityConstructorTestCase):
         Initialize the Identity object with an encoded payload – a base64-encoded JSON.
         That would typically be a raw HTTP header content.
         """
-        identity = self._identity()
-
-        dict_ = {"identity": identity._asdict()}
-        json = dumps(dict_)
-        base64 = b64encode(json.encode())
+        identity = _identity()
+        base64 = _encode_header({"identity": identity._asdict()})
 
         try:
             self.assertEqual(identity, from_encoded(base64))
@@ -167,7 +165,7 @@ class AuthIdentityFromEncodedTest(AuthIdentityConstructorTestCase):
 
     def test_invalid_value(self):
         """
-        Initializing the Identity object with an invalid Base6č encoded payload should
+        Initializing the Identity object with an invalid Base64 encoded payload should
         raise a ValueError.
         """
         with self.assertRaises(ValueError):
@@ -175,13 +173,10 @@ class AuthIdentityFromEncodedTest(AuthIdentityConstructorTestCase):
 
     def test_invalid_format(self):
         """
-        Initializing the Identity object with an valid Base64 encoded payload
-        that does not contain the "identity" field.
+        Initializing the Identity object with a valid Base64 encoded payload that does
+        not contain the "identity" field.
         """
-        identity = self._identity()
-
-        dict_ = identity._asdict()
-        json = dumps(dict_)
+        json = dumps({})
         base64 = b64encode(json.encode())
 
         with self.assertRaises(KeyError):
@@ -201,8 +196,6 @@ class AuthIdentityValidateTestCase(TestCase):
         identities = [
             Identity(account_number=None),
             Identity(account_number=""),
-            Identity(account_number=None),
-            Identity(account_number=""),
         ]
         for identity in identities:
             with self.subTest(identity=identity):
@@ -216,6 +209,108 @@ class AuthIdentityValidateTestCase(TestCase):
             _validate("")
         with self.assertRaises(Forbidden):
             _validate({})
+
+
+class AuthPickIdentityTestCase(TestCase):
+    """
+    The identity is read and decoded from the header.
+    """
+
+    def setUp(self):
+        self.app = create_app(config_name="testing")
+
+    @contextmanager
+    def _request(self, headers):
+        with self.app.test_request_context(headers=headers) as context:
+            yield context
+
+    def test_header_missing(self):
+        """
+        If the identity header is missing, the login attempt is considered failed.
+        """
+        with self._request({}):
+            with self.assertRaises(Forbidden):
+                _pick_identity()
+
+    def test_decode_fail_invalid_payload(self):
+        """
+        If the identity header decode fails, the login attempt is considered failed.
+        """
+        payload = "invalid"
+        with self._request({_IDENTITY_HEADER: payload}):
+            with self.assertRaises(Forbidden):
+                # b64decode raises ValueError.
+                _pick_identity()
+
+    def test_decode_fail_missing_identity(self):
+        """
+        If the identity header doesn’t contain the "identity" key, the login attempt is
+        considered failed.
+        """
+        payload = _encode_header({})
+        with self._request({_IDENTITY_HEADER: payload}):
+            with self.assertRaises(Forbidden):
+                # dict["_identity"] raises KeyError.
+                _pick_identity()
+
+    def test_decode_fail_missing_account_number(self):
+        """
+        If the identity header doesn’t contain the "identity.account_number" key, the
+        login attempt is considered failed.
+        """
+        payload = _encode_header({"identity": {}})
+        with self._request({_IDENTITY_HEADER: payload}):
+            with self.assertRaises(Forbidden):
+                # Failed "account_number" in dict check raises TypeError.
+                _pick_identity()
+
+    def test_return(self):
+        """
+        The decoded identity is returned.
+        """
+        identity = _identity()
+        payload = _encode_header({"identity": identity._asdict()})
+        with self._request({_IDENTITY_HEADER: payload}):
+            result = _pick_identity()
+        self.assertEqual(identity, result)
+
+
+class AuthValidateTestCase(TestCase):
+    """
+    The retrieved identity is validated and if it’s not valid, the login attempt is
+    considered failed – the request is aborted.
+    """
+
+    def test_valid(self):
+        """
+        If the identity is valid, the login attempt is not considered failed.
+        """
+        identity = Identity(account_number="some account")
+        try:
+            _validate(identity)
+            self.assertTrue(True)
+        except Forbidden:
+            self.fail()
+
+    def test_login_failed(self):
+        """
+        If the identity is invalid, the login attempt is considered failed.
+        """
+        with self.assertRaises(Forbidden):
+            _validate(Identity(account_number=None))
+
+
+class AuthLoginFailedTestCase(TestCase):
+    """
+    The request is aborted with a Forbidden status.
+    """
+
+    def test_abort(self):
+        """
+        The current request is aborted with a Forbidden status.
+        """
+        with self.assertRaises(Forbidden):
+            _login_failed()
 
 
 @pytest.mark.usefixtures("monkeypatch")


### PR DESCRIPTION
Add a new Prometheus [Counter](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count_without_mocking?expand=1#diff-09a4c1f30c5458aa77651a6d5b4d2d2fR6) for login failures. [Increment](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count_without_mocking?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41R45) the counter whenever an authentication fails: either if the header is [undecodable](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count_without_mocking?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41R31) or [invalid](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count_without_mocking?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41R38).

This doesn’t cover the case when the header is completely [missing](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count_without_mocking?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41R25). Such case is [caught](https://github.com/RedHatInsights/insights-host-inventory/blob/e56670337bb84a9bc1368e8f0a8018223c051faf/swagger/api.spec.yaml#L16) by Connexion and doesn’t get to the authentication [module](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:login_failure_count_without_mocking?expand=1#diff-3b16d374ef08532ca6b01246c5f0fa41) at all.

This is a version of #77, but without any mocking in the tests. Otherwise, the code is identical. I made this in response to @dehort’s [review](
https://github.com/RedHatInsights/insights-host-inventory/pull/70#issuecomment-44808645) of #70. Please review and pick either this or the original PR #77 depending on which approach you like better.