### PR TITLE
Require identity header by API specs – now without unittest.mock

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -4,7 +4,7 @@ from enum import Enum
 from flask import current_app
 
 from app.models import Host
-from app.auth import current_identity, requires_identity
+from app.auth import current_identity
 from app import db
 from api import metrics
 
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 @metrics.api_request_time.time()
-@requires_identity
 def addHost(host):
     """
     Add or update a host
@@ -72,7 +71,6 @@ def addHost(host):
 
 
 @metrics.api_request_time.time()
-@requires_identity
 def getHostList(tag=None, display_name=None, page=1, per_page=100):
     """
     Get the list of hosts.  Filtering can be done by the tag or display_name.
@@ -140,7 +138,6 @@ def findHostsByDisplayName(account, display_name, page, per_page):
 
 
 @metrics.api_request_time.time()
-@requires_identity
 def getHostById(hostId, page=1, per_page=100):
     current_app.logger.debug("getHostById(%s, %d, %d)" % (hostId, page, per_page))
     query_results = Host.query.filter(
@@ -153,7 +150,6 @@ def getHostById(hostId, page=1, per_page=100):
 
 
 @metrics.api_request_time.time()
-@requires_identity
 def replaceFacts(hostId, namespace, fact_dict):
     current_app.logger.debug(
         "replaceFacts(%s, %s, %s)" % (hostId, namespace, fact_dict)
@@ -163,7 +159,6 @@ def replaceFacts(hostId, namespace, fact_dict):
 
 
 @metrics.api_request_time.time()
-@requires_identity
 def mergeFacts(hostId, namespace, fact_dict):
     current_app.logger.debug("mergeFacts(%s, %s, %s)" % (hostId, namespace, fact_dict))
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,9 +2,11 @@ import os
 import connexion
 import yaml
 
+from connexion import Api
 from connexion.resolver import RestyResolver
 from flask import jsonify
 
+from app.auth import init_api as auth_init_api
 from api.mgmt import monitoring_blueprint
 from app.config import Config
 from app.models import db
@@ -22,13 +24,16 @@ def create_app(config_name):
 
     app_config = Config(config_name)
 
-    connexion_app = connexion.App(
-        "inventory", specification_dir="./swagger/", options=connexion_options
-    )
-
     # Read the swagger.yml file to configure the endpoints
     with open("swagger/api.spec.yaml", "rb") as fp:
         spec = yaml.safe_load(fp)
+
+    api = Api(spec)
+    auth_init_api(api)
+
+    connexion_app = connexion.App(
+        "inventory", specification_dir="./swagger/", options=connexion_options
+    )
 
     # If we want to disable auth we first make the header not required
     if os.getenv("FLASK_DEBUG") and os.getenv("NOAUTH"):

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,11 +1,13 @@
 import os
 from functools import wraps
+from app.auth.connexion import get_authenticated_views
 from app.auth.identity import from_encoded, validate, Identity
 from flask import abort, request, _request_ctx_stack
+from app.utils import decorate
 from werkzeug.local import LocalProxy
 from werkzeug.exceptions import Forbidden
 
-__all__ = ["init_app", "current_identity", "NoIdentityError", "requires_identity"]
+__all__ = ["init_api", "current_identity", "NoIdentityError", "requires_identity"]
 
 _IDENTITY_HEADER = "x-rh-identity"
 
@@ -54,6 +56,14 @@ def _get_identity():
         return ctx.identity
     except AttributeError:
         raise NoIdentityError
+
+
+def init_api(api):
+    """
+    Decorate functions that require the identity header.
+    """
+    for view_func in get_authenticated_views(api.specification):
+        decorate(view_func, requires_identity)
 
 
 current_identity = LocalProxy(_get_identity)

--- a/app/auth/connexion.py
+++ b/app/auth/connexion.py
@@ -1,0 +1,47 @@
+from connexion.utils import get_function_from_name
+
+
+__all__ = ["get_authenticated_views"]
+
+
+def _is_requires_identity_param(param):
+    """
+    Determines whether the parameter means that the identity header is required.
+    """
+    return (
+        param["in"] == "header"
+        and param["name"] == "x-rh-identity"
+        and param.get("required", False)
+    )  # For header fields, "required" is optional and its default is false.
+
+
+def _requires_identity(item):
+    """
+    Finds out whether the identity header is required by the item’s parameters.
+    """
+    params = item.get("parameters", [])
+    return any(map(_is_requires_identity_param, params))
+
+
+def _methods(path):
+    """
+    List all method action specifications from a path specification.
+    """
+    for key, value in path.items():
+        if key == "parameters":
+            continue
+        yield value
+
+
+def get_authenticated_views(api_spec):
+    """
+    Go through the API specification and get every view function with an information
+    whether it requires the identity header.
+    """
+    paths = api_spec.get("paths", {})
+    for path in paths.values():
+        if not _requires_identity(path):
+            continue
+
+        for method in _methods(path):
+            yield get_function_from_name(method["operationId"])

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,5 @@
 import json
+from importlib import import_module
 
 
 class HostWrapper:
@@ -116,3 +117,10 @@ class HostWrapper:
     @classmethod
     def from_json(cls, d):
         return cls(json.loads(d))
+
+
+def decorate(func, decorator):
+    decorated = decorator(func)
+    module = import_module(func.__module__)
+    setattr(module, func.__name__, decorated)
+    return decorated


### PR DESCRIPTION
Some operations require the identity header authentication and some don’t. This is described by the [OpenAPI specification](https://github.com/RedHatInsights/insights-host-inventory/blob/e56670337bb84a9bc1368e8f0a8018223c051faf/swagger/api.spec.yaml). [Parse](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:auth_by_spec_simple_without_mocking?expand=1#diff-928a71ff2d667396888de19dbef2c2c5R36) this spec to populate the authenticated paths. The [_requires_identity_](https://github.com/RedHatInsights/insights-host-inventory/blob/e56670337bb84a9bc1368e8f0a8018223c051faf/app/auth/__init__.py#L39) decorator is applied to all operations in paths that require the identity header. These decorated view functions are then picked by Connexion.

Caveats/TODO:

* Doesn’t support overriding the parameter by the method specification.
* Doesn’t use the _RestyResolver_, but the default Connexions way of describing the exact module.function.

This is a version of #57, but without using [_unittest.mock_](https://docs.python.org/3.7/library/unittest.mock.html) in tests. Asking @dehort for a review – pick whichever version you like better.