### PR TITLE
Fix some typos

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -36,6 +36,6 @@ class Config:
         if self._config_name != "testing":
             print("Insights Host Inventory Configuration:")
             print("API URL Path: %s" % self.api_url_path_prefix)
-            print("Management URL Path Preifx: %s" % self.mgmt_url_path_prefix)
+            print("Management URL Path Prefix: %s" % self.mgmt_url_path_prefix)
             print("DB Host: %s" % self._db_host)
             print("DB Name: %s" % self._db_name)

--- a/test_api.py
+++ b/test_api.py
@@ -705,7 +705,7 @@ class HealthTestCase(BaseAPITestCase):
     Tests the health check endpoint.
     """
 
-    def test_heath(self):
+    def test_health(self):
         """
         The health check simply returns 200 to any GET request. The response body is
         irrelevant.


### PR DESCRIPTION
There were some typos in test names and log messages. Fixed those.

Fixes #97 and #90. Review? @dehort 