### PR TITLE
Add ability to filter by fqdn

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -71,15 +71,22 @@ def find_host_by_insights_id(account_number, insights_id):
         ).first()
 
 
-def find_host_by_canonical_facts(account_number, canonical_facts):
-    current_app.logger.debug("find_host_by_canonical_facts(%s)", canonical_facts)
-    host = Host.query.filter(
+def _canonical_facts_host_query(account_number, canonical_facts):
+    return Host.query.filter(
         (Host.account == account_number)
         & (
             Host.canonical_facts.comparator.contains(canonical_facts)
             | Host.canonical_facts.comparator.contained_by(canonical_facts)
         )
-    ).first()
+    )
+
+
+def find_host_by_canonical_facts(account_number, canonical_facts):
+    """
+    Returns first match for a host containing given canonical facts
+    """
+    current_app.logger.debug("find_host_by_canonical_facts(%s)", canonical_facts)
+    host = _canonical_facts_host_query(account_number, canonical_facts).first()    
     current_app.logger.debug("found_host:%s", host)
     return host
 
@@ -117,13 +124,9 @@ def get_host_list(tag=None, display_name=None, fqdn=None, page=1, per_page=100):
     )
 
     if fqdn:
-        host = find_host_by_canonical_facts(current_identity.account_number, {"fqdn": fqdn})
-        if host:
-            total = 1
-            host_list = [host]
-        else:
-            total = 0
-            host_list = []
+        (total, host_list) = find_hosts_by_canonical_facts(
+            current_identity.account_number, {"fqdn": fqdn}, page, per_page
+        )
     elif tag:
         (total, host_list) = find_hosts_by_tag(
             current_identity.account_number, tag, page, per_page
@@ -139,8 +142,7 @@ def get_host_list(tag=None, display_name=None, fqdn=None, page=1, per_page=100):
         total = query_results.total
         host_list = query_results.items
 
-    return _build_paginated_host_list_response(total, page,
-                                               per_page, host_list)
+    return _build_paginated_host_list_response(total, page, per_page, host_list)
 
 
 def _build_paginated_host_list_response(total, page, per_page, host_list):
@@ -177,6 +179,18 @@ def find_hosts_by_display_name(account, display_name, page, per_page):
     total = query_results.total
     found_host_list = query_results.items
     current_app.logger.debug("found_host_list:%s" % found_host_list)
+    return (total, found_host_list)
+
+
+def find_hosts_by_canonical_facts(account_number, canonical_facts, page, per_page):
+    """
+    Returns paginated results for all hosts containing given canonical facts
+    """
+    current_app.logger.debug("find_hosts_by_canonical_facts(%s)", canonical_facts)
+    query_results = _canonical_facts_host_query(account_number, canonical_facts).paginate(page, per_page, True)
+    total = query_results.total
+    found_host_list = query_results.items
+    current_app.logger.debug("found_host_list:%s", found_host_list)
     return (total, found_host_list)
 
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -64,6 +64,11 @@ paths:
           description: A part of a searched host’s display name. Doesn’t apply
             if a search by tag query is provided.
           required: false
+        - name: fqdn
+          in: query
+          type: string
+          description: Filter by a host's FQDN
+          required: false
         - $ref: '#/parameters/perPageParam'
         - $ref: '#/parameters/pageParam'
       responses:

--- a/test_api.py
+++ b/test_api.py
@@ -396,7 +396,10 @@ class PreCreatedHostsBaseTestCase(DBAPITestCase):
         self.added_hosts = self.create_hosts()
 
     def create_hosts(self):
-        hosts_to_create = [("host1", "12345"), ("host2", "54321")]
+        hosts_to_create = [
+            ("host1", "12345", "host1.domain.test"),
+            ("host2", "54321", "host2.domain.test")
+        ]
         host_list = []
 
         for host in hosts_to_create:
@@ -405,6 +408,7 @@ class PreCreatedHostsBaseTestCase(DBAPITestCase):
             host_wrapper.tags = copy.deepcopy(TAGS)
             host_wrapper.display_name = host[0]
             host_wrapper.insights_id = host[1]
+            host_wrapper.fqdn = host[2]
             host_wrapper.facts = [{"namespace": "ns1", "facts": {"key1": "value1"}}]
 
             response_data = self.post(HOST_URL, host_wrapper.data(), 201)
@@ -493,8 +497,27 @@ class QueryTestCase(PreCreatedHostsBaseTestCase):
 
         response = self.get(HOST_URL + "?display_name=" + host_list[0].display_name)
 
-        # FIXME: check the results
         self.assertEqual(len(response["results"]), 1)
+        self.assertEqual(response["results"][0]["fqdn"], host_list[0].fqdn)
+        self.assertEqual(response["results"][0]["insights_id"], host_list[0].insights_id)
+        self.assertEqual(response["results"][0]["display_name"], host_list[0].display_name)
+
+    def test_query_using_fqdn(self):
+        host_list = self.added_hosts
+
+        response = self.get(HOST_URL + "?fqdn=" + host_list[0].fqdn)
+
+        self.assertEqual(len(response["results"]), 1)
+        self.assertEqual(response["results"][0]["fqdn"], host_list[0].fqdn)
+        self.assertEqual(response["results"][0]["insights_id"], host_list[0].insights_id)
+        self.assertEqual(response["results"][0]["display_name"], host_list[0].display_name)
+
+    def test_query_using_non_existant_fqdn(self):
+        host_list = self.added_hosts
+
+        response = self.get(HOST_URL + "?fqdn=ROFLSAUCE.com")
+
+        self.assertEqual(len(response["results"]), 0)
 
     def test_query_using_display_name_substring(self):
         host_list = self.added_hosts


### PR DESCRIPTION
Can now query with GET /hosts?fqdn="something.com" -- `get_host_by_canonical_facts` will be used. If the host exists, a list of 1 host is returned. Otherwise, empty list is returned.