### PR TITLE
Add external_id canonical fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The canonical facts are:
 * ip_addresses
 * fqdn
 * mac_addresses
-* source_ref
+* external_id
 
 Hosts are added and updated by sending a POST to the /hosts endpoint.
 (See the API Documentation for more details on the POST method).

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The canonical facts are:
 * ip_addresses
 * fqdn
 * mac_addresses
+* source_ref
 
 Hosts are added and updated by sending a POST to the /hosts endpoint.
 (See the API Documentation for more details on the POST method).

--- a/app/models.py
+++ b/app/models.py
@@ -20,7 +20,7 @@ CANONICAL_FACTS = (
     "ip_addresses",
     "fqdn",
     "mac_addresses",
-    "source_ref",
+    "external_id",
 )
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -20,6 +20,7 @@ CANONICAL_FACTS = (
     "ip_addresses",
     "fqdn",
     "mac_addresses",
+    "source_ref",
 )
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -79,6 +79,14 @@ class HostWrapper:
         self.__data["mac_addresses"] = cf
 
     @property
+    def source_ref(self):
+        return self.__data.get("source_ref")
+
+    @source_ref.setter
+    def source_ref(self, cf):
+        self.__data["source_ref"] = cf
+
+    @property
     def facts(self):
         return self.__data.get("facts", None)
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -79,12 +79,12 @@ class HostWrapper:
         self.__data["mac_addresses"] = cf
 
     @property
-    def source_ref(self):
-        return self.__data.get("source_ref")
+    def external_id(self):
+        return self.__data.get("external_id")
 
-    @source_ref.setter
-    def source_ref(self, cf):
-        self.__data["source_ref"] = cf
+    @external_id.setter
+    def external_id(self, cf):
+        self.__data["external_id"] = cf
 
     @property
     def facts(self):

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -315,6 +315,12 @@ definitions:
         x-nullable: true
         example:
         - c2:00:d0:c8:61:01
+      source_ref:
+        description: Host’s reference in the external source e.g. AWS EC2, Azure,
+          OpenStack, etc. This field is considered to be a canonical fact.
+        type: string
+        x-nullable: true
+        example: i-05d2313e6b9a42b16
       facts:
         description: A set of facts belonging to the host.
         type: array

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -315,7 +315,7 @@ definitions:
         x-nullable: true
         example:
         - c2:00:d0:c8:61:01
-      source_ref:
+      external_id:
         description: Host’s reference in the external source e.g. AWS EC2, Azure,
           OpenStack, etc. This field is considered to be a canonical fact.
         type: string

--- a/test_api.py
+++ b/test_api.py
@@ -36,7 +36,7 @@ def test_data(display_name="hi", tags=None, facts=None):
         # "ip_addresses": ["10.10.0.1", "10.0.0.2"],
         "ip_addresses": ["10.10.0.1"],
         # "mac_addresses": ["c2:00:d0:c8:61:01"],
-        # "source_ref": "i-05d2313e6b9a42b16"
+        # "external_id": "i-05d2313e6b9a42b16"
         "tags": tags if tags else [],
         "facts": facts if facts else FACTS,
     }
@@ -177,7 +177,7 @@ class CreateHostsTestCase(DBAPITestCase):
         host_data.rhel_machine_id = "1234-56-789"
         host_data.ip_addresses = ["10.10.0.1", "10.0.0.2"]
         host_data.mac_addresses = ["c2:00:d0:c8:61:01"]
-        host_data.source_ref = "i-05d2313e6b9a42b16"
+        host_data.external_id = "i-05d2313e6b9a42b16"
         host_data.insights_id = "0987-65-4321"
 
         # Update the host with the new data
@@ -211,7 +211,7 @@ class CreateHostsTestCase(DBAPITestCase):
         host_data.bios_uuid = "123456"
         host_data.fqdn = "original_fqdn"
         host_data.mac_addresses = ["aa:bb:cc:dd:ee:ff"]
-        host_data.source_ref = "abcdef"
+        host_data.external_id = "abcdef"
 
         # Create the host
         created_host = self.post(HOST_URL, host_data.data(), 201)
@@ -228,7 +228,7 @@ class CreateHostsTestCase(DBAPITestCase):
         host_data.bios_uuid = "654321"
         host_data.fqdn = "expected_fqdn"
         host_data.mac_addresses = ["ff:ee:dd:cc:bb:aa"]
-        host_data.source_ref = "fedcba"
+        host_data.external_id = "fedcba"
         host_data.facts = [{"namespace": "ns1",
                             "facts": {"newkey": "newvalue"}}]
 
@@ -293,7 +293,7 @@ class CreateHostsTestCase(DBAPITestCase):
         del host_data.ip_addresses
         del host_data.fqdn
         del host_data.mac_addresses
-        del host_data.source_ref
+        del host_data.external_id
 
         response_data = self.post(HOST_URL, host_data.data(), 400)
 
@@ -365,8 +365,8 @@ class CreateHostsTestCase(DBAPITestCase):
         self.assertEqual(received_host["fqdn"], expected_host.fqdn)
         self.assertEqual(received_host["mac_addresses"],
                          expected_host.mac_addresses)
-        self.assertEqual(received_host["source_ref"],
-                         expected_host.source_ref)
+        self.assertEqual(received_host["external_id"],
+                         expected_host.external_id)
         self.assertEqual(received_host["ip_addresses"],
                          expected_host.ip_addresses)
         self.assertEqual(received_host["display_name"],

--- a/test_api.py
+++ b/test_api.py
@@ -36,6 +36,7 @@ def test_data(display_name="hi", tags=None, facts=None):
         # "ip_addresses": ["10.10.0.1", "10.0.0.2"],
         "ip_addresses": ["10.10.0.1"],
         # "mac_addresses": ["c2:00:d0:c8:61:01"],
+        # "source_ref": "i-05d2313e6b9a42b16"
         "tags": tags if tags else [],
         "facts": facts if facts else FACTS,
     }
@@ -176,6 +177,7 @@ class CreateHostsTestCase(DBAPITestCase):
         host_data.rhel_machine_id = "1234-56-789"
         host_data.ip_addresses = ["10.10.0.1", "10.0.0.2"]
         host_data.mac_addresses = ["c2:00:d0:c8:61:01"]
+        host_data.source_ref = "i-05d2313e6b9a42b16"
         host_data.insights_id = "0987-65-4321"
 
         # Update the host with the new data
@@ -209,6 +211,7 @@ class CreateHostsTestCase(DBAPITestCase):
         host_data.bios_uuid = "123456"
         host_data.fqdn = "original_fqdn"
         host_data.mac_addresses = ["aa:bb:cc:dd:ee:ff"]
+        host_data.source_ref = "abcdef"
 
         # Create the host
         created_host = self.post(HOST_URL, host_data.data(), 201)
@@ -225,6 +228,7 @@ class CreateHostsTestCase(DBAPITestCase):
         host_data.bios_uuid = "654321"
         host_data.fqdn = "expected_fqdn"
         host_data.mac_addresses = ["ff:ee:dd:cc:bb:aa"]
+        host_data.source_ref = "fedcba"
         host_data.facts = [{"namespace": "ns1",
                             "facts": {"newkey": "newvalue"}}]
 
@@ -289,6 +293,7 @@ class CreateHostsTestCase(DBAPITestCase):
         del host_data.ip_addresses
         del host_data.fqdn
         del host_data.mac_addresses
+        del host_data.source_ref
 
         response_data = self.post(HOST_URL, host_data.data(), 400)
 
@@ -360,6 +365,8 @@ class CreateHostsTestCase(DBAPITestCase):
         self.assertEqual(received_host["fqdn"], expected_host.fqdn)
         self.assertEqual(received_host["mac_addresses"],
                          expected_host.mac_addresses)
+        self.assertEqual(received_host["source_ref"],
+                         expected_host.source_ref)
         self.assertEqual(received_host["ip_addresses"],
                          expected_host.ip_addresses)
         self.assertEqual(received_host["display_name"],


### PR DESCRIPTION
source_ref is a host’s reference in the external source e.g.
AWS EC2, Azure, OpenStack, etc.

For AWS EC2, source_ref maps to 'instance-id' attribute
(e.g. i-1234567890abcdef0), which can be discovered by insights
client by e.g. using:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html

Topological Inventory '/vms' API endpoint has a source_ref
attribute that maps to this value.