### PR TITLE
Simplify display_name default

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -68,12 +68,9 @@ def _set_display_name_on_save(context):
     This logic happens during the saving of the host record so that
     the id exists and can be used as the display_name if necessary.
     """
-    if not context.get_current_parameters()['display_name']:
-        fqdn = context.get_current_parameters()["canonical_facts"].get("fqdn", None)
-        if fqdn:
-            return fqdn
-        else:
-            return context.get_current_parameters()['id']
+    params = context.get_current_parameters()
+    if not params['display_name']:
+        return params["canonical_facts"].get("fqdn") or params['id']
 
 
 class Host(db.Model):


### PR DESCRIPTION
Simplified the function determining the default value for the _display_name_ field. It’s now more concise.

Arose from an earlier [discussion](https://github.com/RedHatInsights/insights-host-inventory/pull/121#discussion_r262115538). The `context.get_current_parameters()` call is now no longer repeated. Also used _or_ instead of _if/else_ statement to improve expressiveness.