### PR TITLE
Openapi 3 conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,21 +82,6 @@ _prometheus_multiproc_dir_ environment variable. This is done automatically.
 python run_gunicorn.py 
 ```
 
-#### Disable authentication checks
-
-It is also possible to disable authentication (mainly useful for developement).
-This is accomplished by setting the FLASK_DEBUG=1 and NOAUTH=1 environment 
-variables.
-
-```
-FLASK_DEBUG=1 NOAUTH=1 gunicorn -c gunicorn.conf.py --log-config=$INVENTORY_LOGGING_CONFIG_FILE run
-```
-
-By default, the the auth header usually contains the account number.
-When adding/updating a host, the account
-number from the auth header is checked against what is provided along with the host.
-When running in disabled authentication mode, the account number passed along with
-the hosts should be "0000001".
 
 ## Configuration environment variables
 
@@ -170,3 +155,15 @@ will be added to the existing host entry.
 
 If the canonical facts based lookup does not locate an existing host, then
 a new host entry is created.
+
+#### Testing API Calls
+
+It is necessary to pass an authentication header along on each call to the
+service.  For testing purposes, it is possible to set the required identity
+header to the following:
+
+  x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjAwMDAwMDEifX0=
+
+This is the base64 encoding of the following json doc:
+
+  '{"identity":{"account_number":"0000001"}}'

--- a/api/host.py
+++ b/api/host.py
@@ -6,7 +6,7 @@ from enum import Enum
 
 from app import db
 from app.models import Host
-from app.auth import current_identity, requires_identity
+from app.auth import current_identity
 from app.exceptions import InventoryException
 from api import api_operation, metrics
 
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 @api_operation
 @metrics.api_request_time.time()
-@requires_identity
 def add_host(host):
     """
     Add or update a host
@@ -115,7 +114,6 @@ def update_existing_host(existing_host, input_host):
 
 @api_operation
 @metrics.api_request_time.time()
-@requires_identity
 def get_host_list(tag=None, display_name=None, fqdn=None,
         hostname_or_id=None, insights_id=None,
         page=1, per_page=100):
@@ -232,7 +230,6 @@ def find_hosts_by_hostname_or_id(account_number, hostname, page, per_page):
 
 @api_operation
 @metrics.api_request_time.time()
-@requires_identity
 def get_host_by_id(host_id_list, page=1, per_page=100):
     query_results = Host.query.filter(
         (Host.account == current_identity.account_number)
@@ -247,7 +244,6 @@ def get_host_by_id(host_id_list, page=1, per_page=100):
 
 @api_operation
 @metrics.api_request_time.time()
-@requires_identity
 def replace_facts(host_id_list, namespace, fact_dict):
     return update_facts_by_namespace(FactOperations.replace, host_id_list,
                                      namespace, fact_dict)
@@ -255,7 +251,6 @@ def replace_facts(host_id_list, namespace, fact_dict):
 
 @api_operation
 @metrics.api_request_time.time()
-@requires_identity
 def merge_facts(host_id_list, namespace, fact_dict):
     if not fact_dict:
         error_msg = "ERROR: Invalid request.  Merging empty facts into existing facts is a no-op."

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,10 +36,6 @@ def create_app(config_name):
     with open("swagger/api.spec.yaml", "rb") as fp:
         spec = yaml.safe_load(fp)
 
-    # If we want to disable auth we first make the header not required
-    if os.getenv("FLASK_DEBUG") and os.getenv("NOAUTH"):
-        spec["parameters"]["rhIdentityHeader"]["required"] = False
-
     connexion_app.add_api(
         spec,
         arguments={"title": "RestyResolver Example"},

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,66 +1,28 @@
+import connexion
 import logging
-import os
 
-from functools import wraps
-from app.auth.identity import from_encoded, validate, Identity
-from flask import abort, request, _request_ctx_stack
+from app.auth.identity import from_encoded, validate
 from werkzeug.local import LocalProxy
-from werkzeug.exceptions import Forbidden
 
-__all__ = ["init_app", "current_identity", "NoIdentityError", "requires_identity"]
-
-_IDENTITY_HEADER = "x-rh-identity"
+__all__ = ["current_identity"]
 
 logger = logging.getLogger(__name__)
 
 
-class NoIdentityError(RuntimeError):
-    pass
-
-
-def _pick_identity():
-    if os.getenv("FLASK_DEBUG") and os.getenv("NOAUTH"):
-        return Identity(account_number="0000001")
-    else:
-        try:
-            payload = request.headers[_IDENTITY_HEADER]
-        except KeyError:
-            logger.debug("Unable to retrieve identity header from request")
-            abort(Forbidden.code)
-
-        try:
-            return from_encoded(payload)
-        except (KeyError, TypeError, ValueError):
-            logger.debug("Unable to decode identity header")
-            abort(Forbidden.code)
-
-
-def _validate(identity):
+def authentication_header_handler(header_payload, required_scopes=None):
     try:
+        identity = from_encoded(header_payload)
         validate(identity)
-    except Exception:
-        logger.debug("Failed to validate identity header value")
-        abort(Forbidden.code)
+    except (KeyError, TypeError, ValueError):
+        logger.debug("Unable to decode identity header",
+                     exc_info=True)
+        return None
 
-
-def requires_identity(view_func):
-    @wraps(view_func)
-    def _wrapper(*args, **kwargs):
-        identity = _pick_identity()
-        _validate(identity)
-        ctx = _request_ctx_stack.top
-        ctx.identity = identity
-        return view_func(*args, **kwargs)
-
-    return _wrapper
+    return {"uid": identity}
 
 
 def _get_identity():
-    ctx = _request_ctx_stack.top
-    try:
-        return ctx.identity
-    except AttributeError:
-        raise NoIdentityError
+    return connexion.context["user"]
 
 
 current_identity = LocalProxy(_get_identity)

--- a/logconfig.ini
+++ b/logconfig.ini
@@ -38,8 +38,8 @@ qualname=api
 [handler_logstash]
 class=StreamHandler
 level=NOTSET
-formatter=logstash
-#formatter=human_readable
+#formatter=logstash
+formatter=human_readable
 args=(sys.stdout, )
 
 [formatter_logstash]

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -206,10 +206,6 @@ paths:
           description: Host or namespace not found.
 components:
   securitySchemes:
-    BearerAuth:
-      type: http
-      scheme: bearer
-      x-bearerInfoFunc: app.auth.bearer_token_handler
     ApiKeyAuth:
       type: apiKey
       in: header

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1,382 +1,445 @@
-swagger: "2.0"
+openapi: 3.0.0
 info:
   description: REST interface for the Insights Platform Host Inventory application.
   version: 1.0.0
   title: Insights Host Inventory REST Interface
-consumes:
-- application/json
-produces:
-- application/json
-basePath: /r/insights/platform/inventory/api/v1
-
-parameters:
-  rhIdentityHeader:
-    in: header
-    name: x-rh-identity
-    required: true
-    type: string
-    format: byte
-    description: 'Base64-encoded JSON identity header provided by 3Scale.
-      Contains an account number of the user issuing the request. Format of the
-      JSON: {"identity": {"account_number": "12345678"}}'
-  pageParam:
-    in: query
-    name: page
-    required: false
-    type: integer
-    minimum: 1
-    default: 1
-    description: A page number of the items to return.
-  perPageParam:
-    in: query
-    name: per_page
-    required: false
-    type: integer
-    minimum: 1
-    maximum: 100
-    default: 50
-    description: A number of items to return per page.
-
 paths:
   /hosts:
-    parameters:
-      - $ref: '#/parameters/rhIdentityHeader'
     get:
       operationId: api.host.get_host_list
       tags:
-      - hosts
+        - hosts
       summary: Read the entire list of hosts
-      description: Read the entire list of all hosts available to the account.
-        The list can be filtered either by tags or by a display name.
+      description: >-
+        Read the entire list of all hosts available to the account. The list can
+        be filtered either by tags or by a display name.
+      security:
+        - ApiKeyAuth: []
       parameters:
-        - name: tag
-          in: query
-          type: array
-          items:
+        - in: query
+          name: tag
+          schema:
+            type: array
+            items:
+              type: string
+          description: >-
+            A comma separated list of all tags that a matched host must own.
+            Example: namespace/tag:value,somens/sometag:someval
+          required: false
+        - in: query
+          name: display_name
+          schema:
             type: string
-          description: 'A comma separated list of all tags that a matched host
-            must own. Example: namespace/tag:value,somens/sometag:someval'
+          description: >-
+            A part of a searched host’s display name. Doesn’t apply if a search
+            by tag query is provided.
           required: false
-          collectionFormat: multi
-        - name: display_name
-          in: query
-          type: string
-          description: A part of a searched host’s display name. Doesn’t apply
-            if a search by tag query is provided.
-          required: false
-        - name: fqdn
-          in: query
-          type: string
+        - in: query
+          name: fqdn
+          schema:
+            type: string
           description: Filter by a host's FQDN
           required: false
-        - name: hostname_or_id
-          in: query
-          type: string
-          description: Search for a host by display_name, fqdn, id
+        - in: query
+          name: hostname_or_id
+          schema:
+            type: string
+          description: 'Search for a host by display_name, fqdn, id'
           required: false
-        - name: insights_id
-          in: query
-          type: string
-          format: uuid
+        - in: query
+          name: insights_id
+          schema:
+            type: string
+            format: uuid
           description: Search for a host by insights_id
           required: false
-        - $ref: '#/parameters/perPageParam'
-        - $ref: '#/parameters/pageParam'
+        - $ref: '#/components/parameters/perPageParam'
+        - $ref: '#/components/parameters/pageParam'
       responses:
-        "200":
+        '200':
           description: Successfully read the hosts list.
-          schema:
-            $ref: '#/definitions/HostQueryOutput'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HostQueryOutput'
     post:
       operationId: api.host.add_host
       tags:
-      - hosts
-      summary: Create/update a host and add it to the host list
-      description: Create a new host and add it to the host list or update an
-        existing hosts. A host is updated if there is already one with the same
+        - hosts
+      summary: Add or create a host
+      description: >-
+        Create a new host and add it to the host list or update an existing
+        hosts. A host is updated if there is already one with the same
         canonicals facts and belonging to the same account.
-      parameters:
-      - in: body
-        name: host
+      security:
+        - ApiKeyAuth: []
+      requestBody:
         description: A host object to be added to the host list
         required: true
-        schema:
-          $ref: '#/definitions/Host'
+        content:
+          application/json:
+            schema:
+              x-body-name: host
+              $ref: '#/components/schemas/Host'
       responses:
-        "201":
-          description: Successfully created a host.
-          schema:
-            $ref: '#/definitions/HostOut'
-        "200":
+        '200':
           description: Successfully updated a host.
-          schema:
-            $ref: '#/definitions/HostOut'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HostOut'
+        '201':
+          description: Successfully created a host.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HostOut'
+        '400':
+          description: Invalid request.
   '/hosts/{host_id_list}':
-    parameters:
-      - $ref: '#/parameters/rhIdentityHeader'
     get:
       tags:
-      - hosts
+        - hosts
       summary: Find hosts by their IDs
       description: Find one or more hosts by their ID.
       operationId: api.host.get_host_by_id
-      produces:
-      - application/json
+      security:
+        - ApiKeyAuth: []
       parameters:
-        - name: host_id_list
-          in: path
+        - in: path
+          name: host_id_list
           description: A comma separated list of host IDs.
           required: true
-          type: array
-          collectionFormat: csv
-          items:
-            type: string
-        - $ref: '#/parameters/perPageParam'
-        - $ref: '#/parameters/pageParam'
-      responses:
-        "200":
-          description: Successfully searched for hosts.
           schema:
-            $ref: '#/definitions/HostQueryOutput'
+            type: array
+            items:
+              type: string
+        - $ref: '#/components/parameters/perPageParam'
+        - $ref: '#/components/parameters/pageParam'
+      responses:
+        '200':
+          description: Successfully searched for hosts.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HostQueryOutput'
         '400':
           description: Invalid request.
-        "404":
+        '404':
           description: Host not found.
   '/hosts/{host_id_list}/facts/{namespace}':
-    parameters:
-      - $ref: '#/parameters/rhIdentityHeader'
     patch:
       tags:
-      - hosts
+        - hosts
       summary: Merge facts under a namespace
       description: Merge one or multiple hosts facts under a namespace.
       operationId: api.host.merge_facts
-      produces:
-      - application/json
+      security:
+        - ApiKeyAuth: []
       parameters:
-      - name: host_id_list
-        in: path
-        description: IDs of the hosts that own the facts to be merged.
+        - in: path
+          name: host_id_list
+          description: IDs of the hosts that own the facts to be merged.
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+        - in: path
+          name: namespace
+          description: A namespace of the merged facts.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: A dictionary with the new facts to merge with the original ones.
         required: true
-        type: array
-        collectionFormat: csv
-        items:
-          type: string
-      - name: namespace
-        in: path
-        description: A namespace of the merged facts.
-        required: true
-        type: string
-      - in: body
-        name: fact_dict
-        description: A dictionary with the new facts to merge with the original
-          ones.
-        required: true
-        schema:
-          $ref: '#/definitions/Facts'
+        content:
+          application/json:
+            schema:
+              x-body-name: fact_dict
+              $ref: '#/components/schemas/Facts'
       responses:
-        "200":
+        '200':
           description: Successfully merged facts.
-        "400":
+        '400':
           description: Invalid request.
-        "404":
+        '404':
           description: Host or namespace not found.
     put:
       tags:
-      - hosts
+        - hosts
       summary: Replace facts under a namespace
       description: Replace facts under a namespace
+      security:
+        - ApiKeyAuth: []
       operationId: api.host.replace_facts
-      produces:
-      - application/json
       parameters:
-      - name: host_id_list
-        in: path
-        description: IDs of the hosts that own the facts to be replaced.
+        - in: path
+          name: host_id_list
+          description: IDs of the hosts that own the facts to be replaced.
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+        - in: path
+          name: namespace
+          description: A namespace of the merged facts.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: A dictionary with the new facts to replace the original ones.
         required: true
-        type: array
-        collectionFormat: csv
-        items:
-          type: string
-      - name: namespace
-        in: path
-        description: A namespace of the merged facts.
-        required: true
-        type: string
-      - in: body
-        name: fact_dict
-        description: A dictionary with the new facts to replace the original
-          ones.
-        required: true
-        schema:
-          $ref: '#/definitions/Facts'
+        content:
+          application/json:
+            schema:
+              x-body-name: fact_dict
+              $ref: '#/components/schemas/Facts'
       responses:
-        "200":
+        '200':
           description: Successfully replaced facts.
-        "400":
+        '400':
           description: Invalid request.
-        "404":
+        '404':
           description: Host or namespace not found.
-definitions:
-  Facts:
-    title: Host facts
-    description: A set of string facts about a host.
-    type: object
-    additionalProperties:
-      type: string
-    example:
-      fact1: value1
-      fact2: value2
-  FactSet:
-    title: Host facts under a namespace
-    description: A set of string facts belonging to a single namespace.
-    properties:
-      namespace:
-        type: string
-        description: A namespace the facts belong to.
-      facts:
-        type: object
-        description: The facts themselves.
-  Host:
-    title: Host data
-    description: Data of a single host belonging to an account. Represents the
-      hosts without its Inventory metadata.
-    type: object
-    required:
-    - account
-    properties:
-      display_name:
-        description: A host’s human-readable display name, e.g. in a form of a
-          domain name.
-        type: string
-        example: host1.mydomain.com
-        x-nullable: true
-      account:
-        description: A Red Hat Account number that owns the host.
-        type: string
-        example: "000102"
-      insights_id:
-        description: An ID defined in /etc/insights-client/machine-id. This field is
-          considered a canonical fact.
-        type: string
-        format: uuid
-        example: 3f01b55457674041b75e41829bcee1dc
-        x-nullable: true
-      rhel_machine_id:
-        description: A Machine ID of a RHEL host.  This field is considered
-          to be a canonical fact.
-        type: string
-        format: uuid
-        example: 3f01b55457674041b75e41829bcee1dc
-        x-nullable: true
-      subscription_manager_id:
-        description: A Red Hat Subcription Manager ID of a RHEL host.  This
-          field is considered to be a canonical fact.
-        type: string
-        format: uuid
-        example: 3f01b55457674041b75e41829bcee1dc
-        x-nullable: true
-      satellite_id:
-        description: A Red Hat Satellite ID of a RHEL host.  This field is
-          considered to be a canonical fact.
-        type: string
-        format: uuid
-        example: 3f01b55457674041b75e41829bcee1dc
-        x-nullable: true
-      bios_uuid:
-        description: A UUID of the host machine BIOS.  This field is considered
-          to be a canonical fact.
-        type: string
-        format: uuid
-        example: 3f01b55457674041b75e41829bcee1dc
-        x-nullable: true
-      ip_addresses:
-        description: Host’s network IP addresses.  This field is considered
-          to be a canonical fact.
-        type: array
-        items:
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      x-bearerInfoFunc: app.auth.bearer_token_handler
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-rh-identity
+      description: >-
+        Base64-encoded JSON identity header provided by 3Scale. Contains an
+        account number of the user issuing the request. Format of the JSON:
+        {"identity": {"account_number": "12345678"}}
+      x-apikeyInfoFunc: app.auth.authentication_header_handler
+  parameters:
+    pageParam:
+      name: page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+      description: A page number of the items to return.
+    perPageParam:
+      name: per_page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 50
+      description: A number of items to return per page.
+  schemas:
+    BulkHostOut:
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Total number of items in the "data" list.
+        errors:
+          type: integer
+          description: Number of items in the "data" list that contain errors.
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkHostOutDetails'
+          description: 'List of hosts that were created, updated or failed to be processed.'
+    BulkHostOutDetails:
+      type: object
+      properties:
+        status:
+          type: integer
+          description: HTTP status code of the results of the host create/update process
+        host:
+          $ref: '#/components/schemas/HostOut'
+        title:
           type: string
-        x-nullable: true
-        example:
-        - 10.10.0.1
-        - 10.0.0.2
-      fqdn:
-        description: A host’s Fully Qualified Domain Name.  This field is
-          considered to be a canonical fact.
-        type: string
-        example: my.host.example.com
-        x-nullable: true
-      mac_addresses:
-        description: Host’s network interfaces MAC addresses.  This field
-          is considered to be a canonical fact.
-        type: array
-        items:
+          description: Short description of why a host failed to be created or updated.
+        detail:
           type: string
-        x-nullable: true
-        example:
-        - c2:00:d0:c8:61:01
-      external_id:
-        description: Host’s reference in the external source e.g. AWS EC2, Azure,
-          OpenStack, etc. This field is considered to be a canonical fact.
+          description: Details about why a host failed to be created or updated.
+    Facts:
+      title: Host facts
+      description: A set of string facts about a host.
+      type: object
+      additionalProperties:
         type: string
-        x-nullable: true
-        example: i-05d2313e6b9a42b16
-      facts:
-        description: A set of facts belonging to the host.
-        type: array
-        items:
-          $ref: '#/definitions/FactSet'
-      tags:
-        description: A set of tags assigned to the host.
-        type: array
-        items:
+      example:
+        fact1: value1
+        fact2: value2
+    FactSet:
+      title: Host facts under a namespace
+      description: A set of string facts belonging to a single namespace.
+      properties:
+        namespace:
           type: string
-  HostOut:
-    title: A Host Inventory entry
-    description: A database entry representing a single host with its Inventory
-      metadata.
-    allOf:
-      - $ref: '#/definitions/Host'
-      - type: object
-        properties:
-          id:
-            description: A durable and reliable platform-wide host identifier. Applications should use this identifier to reference hosts.
+          description: A namespace the facts belong to.
+        facts:
+          type: object
+          description: The facts themselves.
+    Host:
+      title: Host data
+      description: >-
+        Data of a single host belonging to an account. Represents the hosts
+        without its Inventory metadata.
+      type: object
+      required:
+        - account
+      properties:
+        display_name:
+          description: >-
+            A host’s human-readable display name, e.g. in a form of a domain
+            name.
+          type: string
+          example: host1.mydomain.com
+          nullable: true
+        account:
+          description: A Red Hat Account number that owns the host.
+          type: string
+          example: '000102'
+        insights_id:
+          description: >-
+            An ID defined in /etc/insights-client/machine-id. This field is
+            considered a canonical fact.
+          type: string
+          format: uuid
+          example: 3f01b55457674041b75e41829bcee1dc
+          nullable: true
+        rhel_machine_id:
+          description: >-
+            A Machine ID of a RHEL host.  This field is considered to be a
+            canonical fact.
+          type: string
+          format: uuid
+          example: 3f01b55457674041b75e41829bcee1dc
+          nullable: true
+        subscription_manager_id:
+          description: >-
+            A Red Hat Subcription Manager ID of a RHEL host.  This field is
+            considered to be a canonical fact.
+          type: string
+          format: uuid
+          example: 3f01b55457674041b75e41829bcee1dc
+          nullable: true
+        satellite_id:
+          description: >-
+            A Red Hat Satellite ID of a RHEL host.  This field is considered to
+            be a canonical fact.
+          type: string
+          format: uuid
+          example: 3f01b55457674041b75e41829bcee1dc
+          nullable: true
+        bios_uuid:
+          description: >-
+            A UUID of the host machine BIOS.  This field is considered to be a
+            canonical fact.
+          type: string
+          format: uuid
+          example: 3f01b55457674041b75e41829bcee1dc
+          nullable: true
+        ip_addresses:
+          description: >-
+            Host’s network IP addresses.  This field is considered to be a
+            canonical fact.
+          type: array
+          items:
             type: string
-            format: uuid
-          created:
-            description: A timestamp when the entry was created.
+          nullable: true
+          example:
+            - 10.10.0.1
+            - 10.0.0.2
+        fqdn:
+          description: >-
+            A host’s Fully Qualified Domain Name.  This field is considered to
+            be a canonical fact.
+          type: string
+          example: my.host.example.com
+          nullable: true
+        mac_addresses:
+          description: >-
+            Host’s network interfaces MAC addresses.  This field is considered
+            to be a canonical fact.
+          type: array
+          items:
             type: string
-            format: date-time
-          updated:
-            description: A timestamp when the entry was last updated.
+          nullable: true
+          example:
+            - 'c2:00:d0:c8:61:01'
+        external_id:
+          description: >-
+            Host’s reference in the external source e.g. AWS EC2, Azure,
+            OpenStack, etc. This field is considered to be a canonical fact.
+          type: string
+          nullable: true
+          example: i-05d2313e6b9a42b16
+        facts:
+          description: A set of facts belonging to the host.
+          type: array
+          items:
+            $ref: '#/components/schemas/FactSet'
+        tags:
+          description: A set of tags assigned to the host.
+          type: array
+          items:
             type: string
-            format: date-time
-  HostQueryOutput:
-    title: A Host Inventory query result
-    description: A paginated host search query result with host entries and
-      their Inventory metadata.
-    type: object
-    required:
-      - count
-      - page
-      - per_page
-      - total
-      - results
-    properties:
-      count:
-        description: A number of entries on the current page.
-        type: integer
-      page:
-        description: A current page number.
-        type: integer
-      per_page:
-        description: A page size – a number of entries per single page.
-        type: integer
-      total:
-        description: A total count of the found entries.
-        type: integer
-      results:
-        description: Actual host search query result entries.
-        type: array
-        items:
-          $ref: '#/definitions/HostOut'
+    HostOut:
+      title: A Host Inventory entry
+      description: A database entry representing a single host with its Inventory metadata.
+      allOf:
+        - $ref: '#/components/schemas/Host'
+        - type: object
+          properties:
+            id:
+              description: >-
+                A durable and reliable platform-wide host identifier.
+                Applications should use this identifier to reference hosts.
+              type: string
+              format: uuid
+            created:
+              description: A timestamp when the entry was created.
+              type: string
+              format: date-time
+            updated:
+              description: A timestamp when the entry was last updated.
+              type: string
+              format: date-time
+    HostQueryOutput:
+      title: A Host Inventory query result
+      description: >-
+        A paginated host search query result with host entries and their
+        Inventory metadata.
+      type: object
+      required:
+        - count
+        - page
+        - per_page
+        - total
+        - results
+      properties:
+        count:
+          description: A number of entries on the current page.
+          type: integer
+        page:
+          description: A current page number.
+          type: integer
+        per_page:
+          description: A page size – a number of entries per single page.
+          type: integer
+        total:
+          description: A total count of the found entries.
+          type: integer
+        results:
+          description: Actual host search query result entries.
+          type: array
+          items:
+            $ref: '#/components/schemas/HostOut'

--- a/test_api.py
+++ b/test_api.py
@@ -856,17 +856,17 @@ class AuthTestCase(DBAPITestCase):
 
     def test_validate_missing_identity(self):
         """
-        Identity header is not present, 400 Bad Request is returned.
+        Identity header is not present, 401 Unauthorized is returned.
         """
         response = self._get_hosts({})
-        self.assertEqual(400, response.status_code)  # Bad Request
+        self.assertEqual(401, response.status_code)
 
     def test_validate_invalid_identity(self):
         """
-        Identity header is not valid – empty in this case, 403 Forbidden is returned.
+        Identity header is not valid – empty in this case, 401 Unauthorized is returned.
         """
         response = self._get_hosts({"x-rh-identity": ""})
-        self.assertEqual(403, response.status_code)  # Forbidden
+        self.assertEqual(401, response.status_code)
 
     def test_validate_valid_identity(self):
         """

--- a/test_unit.py
+++ b/test_unit.py
@@ -3,10 +3,6 @@
 import os
 
 from api import api_operation, REQUEST_ID_HEADER
-from app.auth import (
-    _validate,
-    _pick_identity,
-)
 from app.config import Config
 from app.auth.identity import from_dict, from_encoded, from_json, Identity, validate
 from base64 import b64encode
@@ -220,22 +216,6 @@ class AuthIdentityValidateTestCase(TestCase):
             with self.subTest(identity=identity):
                 with self.assertRaises(ValueError):
                     validate(identity)
-
-    def test__validate_identity(self):
-        with self.assertRaises(Forbidden):
-            _validate(None)
-        with self.assertRaises(Forbidden):
-            _validate("")
-        with self.assertRaises(Forbidden):
-            _validate({})
-
-
-@pytest.mark.usefixtures("monkeypatch")
-def test_noauthmode(monkeypatch):
-    with monkeypatch.context() as m:
-        m.setenv("FLASK_DEBUG", "1")
-        m.setenv("NOAUTH", "1")
-        assert _pick_identity() == Identity(account_number="0000001")
 
 
 @pytest.mark.usefixtures("monkeypatch")


### PR DESCRIPTION
Converted the swagger 2 interface doc to openapi 3.

Removed the more manual approach to x-rh-identity header authentication.

https://projects.engineering.redhat.com/browse/RHCLOUD-146