### PR TITLE
Fixed an issue where extra data in the x-rh-identity header can cause an authentication failure.

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -10,7 +10,7 @@ __all__ = ["Identity", "from_auth_header", "from_bearer_token", "validate"]
 def from_auth_header(base64):
     json = b64decode(base64)
     identity_dict = loads(json)
-    return Identity(**identity_dict["identity"])
+    return Identity(identity_dict["identity"]["account_number"])
 
 
 def from_bearer_token(token):

--- a/test_unit.py
+++ b/test_unit.py
@@ -84,12 +84,13 @@ class AuthIdentityFromAuthHeaderTest(AuthIdentityConstructorTestCase):
 
         identity_data = expected_identity._asdict()
 
-        identities = [{"identity": identity_data},
-                      {"identity": {**identity_data, **{"extra_data": "value"}}},
-                     ]
+        identity_data_dicts = [identity_data,
+                               # Test with extra data in the identity dict
+                               {**identity_data, **{"extra_data": "value"}}, ]
 
-        for identity in identities:
-            with self.subTest(identity=identity):
+        for identity_data in identity_data_dicts:
+            with self.subTest(identity_data=identity_data):
+                identity = {"identity": identity_data}
                 json = dumps(identity)
                 base64 = b64encode(json.encode())
 

--- a/test_unit.py
+++ b/test_unit.py
@@ -82,17 +82,24 @@ class AuthIdentityFromAuthHeaderTest(AuthIdentityConstructorTestCase):
         """
         expected_identity = self._identity()
 
-        dict_ = {"identity": expected_identity._asdict()}
-        json = dumps(dict_)
-        base64 = b64encode(json.encode())
+        identity_data = expected_identity._asdict()
 
-        try:
-            actual_identity = from_auth_header(base64)
-            self.assertEqual(expected_identity, actual_identity)
-        except (TypeError, ValueError):
-            self.fail()
+        identities = [{"identity": identity_data},
+                      {"identity": {**identity_data, **{"extra_data": "value"}}},
+                     ]
 
-        self.assertEqual(actual_identity.is_trusted_system, False)
+        for identity in identities:
+            with self.subTest(identity=identity):
+                json = dumps(identity)
+                base64 = b64encode(json.encode())
+
+                try:
+                    actual_identity = from_auth_header(base64)
+                    self.assertEqual(expected_identity, actual_identity)
+                except (TypeError, ValueError):
+                    self.fail()
+
+                self.assertEqual(actual_identity.is_trusted_system, False)
 
     def test_invalid_type(self):
         """


### PR DESCRIPTION
Added a test to make sure the issue doesn't come back.