### PR TITLE
DRY getting the query results

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -143,27 +143,27 @@ def get_host_list(display_name=None, fqdn=None,
         hostname_or_id=None, insights_id=None,
         page=1, per_page=100):
     if fqdn:
-        (total, host_list) = find_hosts_by_canonical_facts(
+        query_results = find_hosts_by_canonical_facts(
             current_identity.account_number, {"fqdn": fqdn}, page, per_page
         )
     elif display_name:
-        (total, host_list) = find_hosts_by_display_name(
+        query_results = find_hosts_by_display_name(
             current_identity.account_number, display_name, page, per_page
         )
     elif hostname_or_id:
-        (total, host_list) = find_hosts_by_hostname_or_id(
+        query_results = find_hosts_by_hostname_or_id(
             current_identity.account_number, hostname_or_id, page, per_page)
     elif insights_id:
-        (total, host_list) = find_hosts_by_canonical_facts(
+        query_results = find_hosts_by_canonical_facts(
             current_identity.account_number, {"insights_id": insights_id}, page, per_page)
     else:
         query_results = Host.query.filter(
             Host.account == current_identity.account_number
         ).paginate(page, per_page, True)
-        total = query_results.total
-        host_list = query_results.items
 
-    return _build_paginated_host_list_response(total, page, per_page, host_list)
+    return _build_paginated_host_list_response(
+        query_results.total, page, per_page, query_results.items
+    )
 
 
 def _build_paginated_host_list_response(total, page, per_page, host_list):
@@ -186,10 +186,8 @@ def find_hosts_by_display_name(account, display_name, page, per_page):
         (Host.account == account)
         & Host.display_name.comparator.contains(display_name)
     ).paginate(page, per_page, True)
-    total = query_results.total
-    found_host_list = query_results.items
-    logger.debug("found_host_list:%s" % found_host_list)
-    return (total, found_host_list)
+    logger.debug("found_host_list:%s" % query_results.items)
+    return query_results
 
 
 def find_hosts_by_canonical_facts(account_number, canonical_facts, page, per_page):
@@ -198,10 +196,8 @@ def find_hosts_by_canonical_facts(account_number, canonical_facts, page, per_pag
     """
     logger.debug("find_hosts_by_canonical_facts(%s)", canonical_facts)
     query_results = _canonical_facts_host_query(account_number, canonical_facts).paginate(page, per_page, True)
-    total = query_results.total
-    found_host_list = query_results.items
-    logger.debug("found_host_list:%s", found_host_list)
-    return (total, found_host_list)
+    logger.debug("found_host_list:%s", query_results.items)
+    return query_results
 
 
 def find_hosts_by_hostname_or_id(account_number, hostname, page, per_page):
@@ -223,11 +219,9 @@ def find_hosts_by_hostname_or_id(account_number, hostname, page, per_page):
     query = Host.query.filter(sqlalchemy.or_(*filter_list))
 
     query_results = query.paginate(page, per_page, True)
-    total = query_results.total
-    found_host_list = query_results.items
-    logger.debug("found_host_list:%s", found_host_list)
+    logger.debug("found_host_list:%s", query_results.items)
 
-    return (total, found_host_list)
+    return query_results
 
 
 @api_operation


### PR DESCRIPTION
It’s not necessary to extract the total number of records and the records itself in each find function. Modified those to return the result set itself. The code is now more concise and expressive.