### PR TITLE
Streamed download all hosts

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -46,7 +46,7 @@ def create_app(config_name):
                 spec,
                 arguments={"title": "RestyResolver Example"},
                 resolver=RestyResolver("api"),
-                validate_responses=True,
+                validate_responses=False,
                 strict_validation=True,
                 base_path=api_url,
             )

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -14,31 +14,10 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
-        - in: query
-          name: display_name
-          schema:
-            type: string
-          description: A part of a searched host’s display name.
-          required: false
-        - in: query
-          name: fqdn
-          schema:
-            type: string
-          description: Filter by a host's FQDN
-          required: false
-        - in: query
-          name: hostname_or_id
-          schema:
-            type: string
-          description: 'Search for a host by display_name, fqdn, id'
-          required: false
-        - in: query
-          name: insights_id
-          schema:
-            type: string
-            format: uuid
-          description: Search for a host by insights_id
-          required: false
+        - $ref: '#/components/parameters/displayName'
+        - $ref: '#/components/parameters/fqdn'
+        - $ref: '#/components/parameters/hostnameOrId'
+        - $ref: '#/components/parameters/insightsId'
         - $ref: '#/components/parameters/perPageParam'
         - $ref: '#/components/parameters/pageParam'
       responses:
@@ -94,6 +73,32 @@ paths:
                     host: Input host data
         '400':
           description: Invalid request.
+  /hosts/download:
+    get:
+      operationId: api.host.download_hosts
+      tags:
+        - hosts
+      summary: Download the entire list of hosts
+      description: >-
+        Download the entire list of all hosts available to the account. The
+        records are sent as a chunked response, one record per chunk, without
+        any result set or pagination metadata.
+
+        For now, it’s still using pagination and the chunking is used only only
+        exercise the purpose. The response is sent as plain text as it’s not
+        valid JSON – it’s a concatenated list of JSON documents.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/displayName'
+        - $ref: '#/components/parameters/fqdn'
+        - $ref: '#/components/parameters/hostnameOrId'
+        - $ref: '#/components/parameters/insightsId'
+      responses:
+        '200':
+          description: Successfully downloaded the hosts list.
+          content:
+            application/x-ndjson: {}
   '/hosts/{host_id_list}':
     get:
       tags:
@@ -302,6 +307,35 @@ components:
         maximum: 100
         default: 50
       description: A number of items to return per page.
+    displayName:
+      name: display_name
+      in: query
+      required: false
+      schema:
+        type: string
+      description: A part of a searched host’s display name.
+    fqdn:
+      name: fqdn
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Filter by a host's FQDN
+    hostnameOrId:
+      name: hostname_or_id
+      in: query
+      required: false
+      schema:
+        type: string
+      description: 'Search for a host by display_name, fqdn, id'
+    insightsId:
+      name: insights_id
+      in: query
+      required: false
+      schema:
+        type: string
+        format: uuid
+      description: Search for a host by insights_id
   schemas:
     BulkHostOut:
       type: object

--- a/test_api.py
+++ b/test_api.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from urllib.parse import urlsplit, urlencode, parse_qs, urlunsplit
 
 HOST_URL = "/api/inventory/v1/hosts"
+DOWNLOAD_URL = f"{HOST_URL}/download"
 HEALTH_URL = "/health"
 METRICS_URL = "/metrics"
 VERSION_URL = "/version"
@@ -1464,6 +1465,128 @@ class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
     def test_query_with_no_matching_insights_id(self):
         uuid_that_does_not_exist_in_db = generate_uuid()
         self._base_query_test(uuid_that_does_not_exist_in_db, 0)
+
+
+class DownloadHostsTestCase(PreCreatedHostsBaseTestCase):
+
+    def get_streamed(self, path, status=200):
+        response = self.client().get(path, headers=self._get_valid_auth_header())
+        response = self._response_check(response, status, False)
+
+        self.assertTrue(response.is_streamed)
+        self.assertEqual(response.mimetype, 'application/x-ndjson')
+
+        return [json.loads(chunk) for chunk in response.response]
+
+
+class DownloadHostsQueryTestCase(DownloadHostsTestCase):
+
+    def _download_url(self, query):
+        return f"{DOWNLOAD_URL}?{urlencode(query)}"
+
+    def test_query_all(self):
+        results = self.get_streamed(DOWNLOAD_URL, 200)
+        self.assertEqual(len(results), len(self.added_hosts))
+
+    def test_query_using_display_name(self):
+        first_added_host = self.added_hosts[0]
+
+        url = self._download_url({"display_name": first_added_host.display_name})
+        results = self.get_streamed(url, 200)
+
+        self.assertEqual(len(results), 1)
+
+        sole_result = results[0]
+        self.assertEqual(sole_result["fqdn"], first_added_host.fqdn)
+        self.assertEqual(sole_result["insights_id"], first_added_host.insights_id)
+        self.assertEqual(sole_result["display_name"], first_added_host.display_name)
+
+    def test_query_using_fqdn(self):
+        expected_hosts = [self.added_hosts[0], self.added_hosts[1]]
+        fqdn = self.added_hosts[0].fqdn
+
+        url = self._download_url({"fqdn": fqdn})
+        results = self.get_streamed(url, 200)
+
+        self.assertEqual(len(results), len(expected_hosts))
+        for result in results:
+            self.assertEqual(result["fqdn"], fqdn)
+            assert any(
+                result["insights_id"] == host.insights_id for host in expected_hosts
+            )
+            assert any(
+                result["display_name"] == host.display_name for host in expected_hosts
+            )
+
+    def test_query_using_insights_id(self):
+        expected_host = self.added_hosts[0]
+
+        url = self._download_url({"insights_id": expected_host.insights_id})
+        results = self.get_streamed(url, 200)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["insights_id"], expected_host.insights_id)
+
+    def test_query_using_display_name_as_hostname(self):
+        expected_host = self.added_hosts[2]
+
+        url = self._download_url({"hostname_or_id": expected_host.display_name})
+        results = self.get_streamed(url, 200)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["display_name"], expected_host.display_name)
+
+    def test_query_using_fqdn_as_hostname(self):
+        expected_host = self.added_hosts[2]
+
+        url = self._download_url({"hostname_or_id": expected_host.fqdn})
+        results = self.get_streamed(url, 200)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["fqdn"], expected_host.fqdn)
+
+    def test_query_using_id_as_hostname(self):
+        expected_host = self.added_hosts[0]
+
+        url = self._download_url({"hostname_or_id": expected_host.id})
+        results = self.get_streamed(url, 200)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], expected_host.id)
+
+
+class DownloadHostsPaginationTestCase(DownloadHostsTestCase):
+
+    def _create_more_hosts(self):
+        hosts = []
+        for _ in range(100):  # The total will be more than one page.
+            # The {} is a hack to prevent HostWrapper’s buggy behavior.
+            host_wrapper = HostWrapper({})
+            host_wrapper.account = ACCOUNT
+            host_wrapper.insights_id = generate_uuid()
+
+            hosts.append(host_wrapper.data())
+
+        response = self.post(HOST_URL, hosts, 207)
+
+        self.assertTrue(all(item["status"] == 201 for item in response["data"]))
+        return [HostWrapper(item["host"]) for item in response["data"]]
+
+    def setUp(self):
+        super().setUp()
+        self.added_hosts += self._create_more_hosts()
+
+    def test_no_missing_records(self):
+        results = self.get_streamed(DOWNLOAD_URL, 200)
+        self.assertEqual(len(self.added_hosts), len(results))
+
+    def test_no_duplicate_records(self):
+        results = self.get_streamed(DOWNLOAD_URL, 200)
+        for result in results:
+            self.assertEqual(results.count(result), 1)
+
+    # Order is untested, it’s there only for the marker pagination. Order is not
+    # guaranteed in the results.
 
 
 class FactsTestCase(PreCreatedHostsBaseTestCase):


### PR DESCRIPTION
Added a [_/hosts/download_](https://github.com/Glutexo/insights-host-inventory/blob/fe4d54a81743649b511c4c6f72973d12978b9bbd/swagger/api.spec.yaml#L76) endpoint that loads all hosts from the database and streams them per page as HTTP chunks. The stream is a [NDJSON](https://github.com/ndjson/ndjson-spec) and the items are in the same [_HostOut_](https://github.com/RedHatInsights/insights-host-inventory/blob/f8d9c018dfc2372e804f321bd190afb5d2fe261f/swagger/api.spec.yaml#L519) format as the other get hosts actions.

Same querying parameters are available as for the [_/hosts_](https://github.com/Glutexo/insights-host-inventory/blob/fe4d54a81743649b511c4c6f72973d12978b9bbd/swagger/api.spec.yaml#L7) operation, but not the [pagination](https://github.com/RedHatInsights/insights-host-inventory/blob/f8d9c018dfc2372e804f321bd190afb5d2fe261f/swagger/api.spec.yaml#L42) parameters.

I am aware that the [marker pagination](https://github.com/RedHatInsights/insights-host-inventory/pull/143/files#diff-a5c55b46cc9c536070cb56798c97adfaR163) is an obvious adept for extraction to a generic class. I’ve consciously taken the tactical way as I didn’t want to postpone the delivery. I’ll gladly refactor that as a next step.