### PR TITLE
Add SQLAlchemy logging configuration

### DIFF
--- a/logconfig.ini
+++ b/logconfig.ini
@@ -1,5 +1,5 @@
 [loggers]
-keys=root, gunicorn.error, gunicorn.access, app, api
+keys=root, gunicorn.error, gunicorn.access, sqlalchemy.engine, app, api
 
 [handlers]
 keys=logstash
@@ -22,6 +22,12 @@ level=ERROR
 handlers=logstash
 propagate=1
 qualname=gunicorn.access
+
+[logger_sqlalchemy.engine]
+level=WARNING
+handlers=logstash
+propagate=1
+qualname=sqlalchemy.engine
 
 [logger_app]
 level=DEBUG


### PR DESCRIPTION
Added SQLAlchemy’s default logging [configuration](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:sqlalchemy_logging?expand=1#diff-b289960fa46262613513c74bcd6b9471R26) to the [_logconfig.ini_](
https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:sqlalchemy_logging?expand=1#diff-b289960fa46262613513c74bcd6b9471). With that it’s easy to change its loglevel to INFO to see the queries or to DEBUG to see even the results.

See [the docs](https://docs.sqlalchemy.org/en/latest/core/engines.html?highlight=log%20level#configuring-logging) for reference.