### PR TITLE
Move the external_id length checks out of the openapi interface definition.

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -329,7 +329,7 @@ class HostSchema(Schema):
     bios_uuid = fields.Str(validate=verify_uuid_format)
     ip_addresses = fields.List(fields.Str())
     mac_addresses = fields.List(fields.Str())
-    external_id = fields.Str()
+    external_id = fields.Str(validate=validate.Length(min=1, max=500))
     facts = fields.List(fields.Nested(FactsSchema))
     system_profile = fields.Nested(SystemProfileSchema)
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -403,8 +403,6 @@ components:
             OpenStack, etc. This field is considered to be a canonical fact.
           type: string
           example: i-05d2313e6b9a42b16
-          minLength: 1
-          maxLength: 255
         facts:
           description: A set of facts belonging to the host.
           type: array

--- a/test_api.py
+++ b/test_api.py
@@ -593,6 +593,34 @@ class CreateHostsTestCase(DBAPITestCase):
         self.verify_error_response(response,
                                    expected_title="Bad Request")
 
+    def test_create_host_with_invalid_external_id(self):
+        host_data = HostWrapper(test_data(facts=None))
+
+        invalid_external_ids = ["", "a"*501]
+
+        for external_id in invalid_external_ids:
+            with self.subTest(external_id=external_id):
+                host_data.external_id = external_id
+
+                response = self.post(HOST_URL, [host_data.data()], 207)
+
+                error_host = response["data"][0]
+
+                self.assertEqual(error_host["status"], 400)
+
+                self.verify_error_response(error_host,
+                                           expected_title="Bad Request")
+
+    def test_create_host_with_external_id_as_None(self):
+        host_data = HostWrapper(test_data(facts=None))
+
+        host_data.external_id = None
+
+        response = self.post(HOST_URL, [host_data.data()], 400)
+
+        self.verify_error_response(response,
+                                   expected_title="Bad Request")
+
 
 class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):
 


### PR DESCRIPTION
Use marshmallow to validate the external_id.