### PR TITLE
Add index on hosts.created_on

### DIFF
--- a/migrations/versions/cefbc157e084_add_created_on_index.py
+++ b/migrations/versions/cefbc157e084_add_created_on_index.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: cefbc157e084
+Revises: 2d1cdfe3208d
+Create Date: 2019-04-01 16:25:05.494229
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'cefbc157e084'
+down_revision = '2d1cdfe3208d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index("hosts_created_on", "hosts", ("created_on",))
+
+
+def downgrade():
+    op.drop_index("hosts_created_on")


### PR DESCRIPTION
Created a new [migration](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:created_on_index?expand=1#diff-97c2ce4322aad2668ca9c5f50f147783) that [adds](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:created_on_index?expand=1#diff-97c2ce4322aad2668ca9c5f50f147783R20) an index to the _created_on_ column in the _hosts_ table. This is going to be used by marker pagination introduced in #143. The timestamp of creation is a part of the marker. Without the index, the ordering may become slow.