### PR TITLE
Change URL defaults to match the deployments

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -25,8 +25,8 @@ class Config:
         self._log_configuration()
 
     def _build_base_url_path(self):
-        app_name = os.getenv("APP_NAME", "inventory/api")
-        path_prefix = os.getenv("PATH_PREFIX", "r/insights/platform")
+        app_name = os.getenv("APP_NAME", "inventory")
+        path_prefix = os.getenv("PATH_PREFIX", "api")
         base_url_path = f"/{path_prefix}/{app_name}"
         return base_url_path
 


### PR DESCRIPTION
Update [_APP_NAME_](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:url_defaults?expand=1#diff-4b1fc3357c304348032d92a3c42978d0R28) and [_PATH_PREFIX_](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:url_defaults?expand=1#diff-4b1fc3357c304348032d92a3c42978d0R29) environment configuration defaults so they match the new deployments. The inventory API will be available at _/api/inventory/v1_.