### PR TITLE
Change query request format

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -203,12 +203,15 @@ def _paginate_host_list_query(query, limit, offset):
 
 def _build_paginated_host_list_response(total, limit, offset, host_list):
     json_host_list = [host.to_json() for host in host_list]
-    json_output = {"total": total,
-                   "count": len(host_list),
-                   "limit": limit,
-                   "offset": offset,
-                   "results": json_host_list,
-                   }
+    json_output = {
+        "meta": {
+            "count": len(host_list),
+            "limit": limit,
+            "offset": offset,
+            "total": total,
+        },
+        "data": json_host_list,
+    }
     return _build_json_response(json_output, status=200)
 
 
@@ -288,12 +291,15 @@ def get_host_system_profile_by_id(host_id_list, limit=100, offset=0):
         response_list = [host.to_system_profile_json()
                          for host in query_results]
 
-        json_output = {"total": total,
-                       "count": len(response_list),
-                       "limit": limit,
-                       "offset": offset,
-                       "results": response_list,
-                       }
+        json_output = {
+            "meta": {
+                "count": len(response_list),
+                "limit": limit,
+                "offset": offset,
+                "total": total,
+            },
+            "data": response_list
+        }
 
         return _build_json_response(json_output, status=200)
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -537,25 +537,12 @@ components:
         Inventory metadata.
       type: object
       required:
-        - count
-        - limit
-        - offset
-        - total
-        - results
+        - meta
+        - data
       properties:
-        count:
-          description: A number of entries on the current page.
-          type: integer
-        limit:
-          description: A page size – a number of retrieved entries.
-          type: integer
-        offset:
-          description: A dataset offset – a number of skipped records.
-          type: integer
-        total:
-          description: A total count of the found entries.
-          type: integer
-        results:
+        meta:
+          $ref: '#/components/schemas/QueryMeta'
+        data:
           description: Actual host search query result entries.
           type: array
           items:
@@ -565,11 +552,24 @@ components:
       description: Structure of the output of the host system profile query
       type: object
       required:
+        - meta
+        - data
+      properties:
+        meta:
+          $ref: '#/components/schemas/QueryMeta'
+        data:
+          description: Actual host search query result entries.
+          type: array
+          items:
+            $ref: '#/components/schemas/HostSystemProfileOut'
+    QueryMeta:
+      description: Result count and paging metadata
+      type: object
+      required:
         - count
         - limit
         - offset
         - total
-        - results
       properties:
         count:
           description: A number of entries on the current page.
@@ -583,11 +583,6 @@ components:
         total:
           description: A total count of the found entries.
           type: integer
-        results:
-          description: Actual host search query result entries.
-          type: array
-          items:
-            $ref: '#/components/schemas/HostSystemProfileOut'
     HostSystemProfileOut:
       title: Structure of an individual host system profile output
       description: Individual host record that contains only the host id and system profile

--- a/test_api.py
+++ b/test_api.py
@@ -262,9 +262,9 @@ class CreateHostsTestCase(DBAPITestCase):
         host_lookup_results = self.get("%s/%s" % (HOST_URL, original_id), 200)
 
         # sanity check
-        # host_lookup_results["results"][0]["facts"][0]["facts"]["key2"] = "blah"
-        # host_lookup_results["results"][0]["insights_id"] = "1.2.3.4"
-        self._validate_host(host_lookup_results["results"][0],
+        # host_lookup_results["data"][0]["facts"][0]["facts"]["key2"] = "blah"
+        # host_lookup_results["data"][0]["insights_id"] = "1.2.3.4"
+        self._validate_host(host_lookup_results["data"][0],
                             host_data,
                             expected_id=original_id)
 
@@ -317,7 +317,7 @@ class CreateHostsTestCase(DBAPITestCase):
         # Retrieve the host using the id that we first received
         data = self.get("%s/%s" % (HOST_URL, original_id), 200)
 
-        self._validate_host(data["results"][0],
+        self._validate_host(data["data"][0],
                             host_data,
                             expected_id=original_id)
 
@@ -348,7 +348,7 @@ class CreateHostsTestCase(DBAPITestCase):
 
         host_lookup_results = self.get("%s/%s" % (HOST_URL, original_id), 200)
 
-        self._validate_host(host_lookup_results["results"][0],
+        self._validate_host(host_lookup_results["data"][0],
                             host_data,
                             expected_id=original_id)
 
@@ -628,7 +628,7 @@ class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):
         # Explicitly set the display_name to the be id...this is expected here
         host_data.display_name = created_host["id"]
 
-        self._validate_host(host_lookup_results["results"][0],
+        self._validate_host(host_lookup_results["data"][0],
                             host_data,
                             expected_id=original_id)
 
@@ -657,7 +657,7 @@ class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):
         # Explicitly set the display_name ...this is expected here
         host_data.display_name = expected_display_name
 
-        self._validate_host(host_lookup_results["results"][0],
+        self._validate_host(host_lookup_results["data"][0],
                             host_data,
                             expected_id=original_id)
 
@@ -727,9 +727,9 @@ class PaginationTestCase(BaseAPITestCase):
             test_url = inject_qs(url, offset=offset, limit="1")
             response = self.get(test_url, 200)
 
-            self.assertEqual(len(response["results"]), expected_count)
-            self.assertEqual(response["count"], expected_count)
-            self.assertEqual(response["total"], expected_number_of_hosts)
+            self.assertEqual(len(response["data"]), expected_count)
+            self.assertEqual(response["meta"]["count"], expected_count)
+            self.assertEqual(response["meta"]["total"], expected_number_of_hosts)
 
         if expected_number_of_hosts == 0:
             _test_get_page(0, expected_count=0)
@@ -823,7 +823,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
         self.assertNotIn("system_profile", created_host)
 
         host_lookup_results = self.get("%s/%s/system_profile" % (HOST_URL, original_id), 200)
-        actual_host = host_lookup_results["results"][0]
+        actual_host = host_lookup_results["data"][0]
 
         self.assertEqual(original_id, actual_host["id"])
 
@@ -887,7 +887,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
                 self.assertNotIn("system_profile", created_host)
 
                 host_lookup_results = self.get("%s/%s/system_profile" % (HOST_URL, original_id), 200)
-                actual_host = host_lookup_results["results"][0]
+                actual_host = host_lookup_results["data"][0]
 
                 self.assertEqual(original_id, actual_host["id"])
 
@@ -950,7 +950,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
         original_id = created_host["id"]
 
         host_lookup_results = self.get("%s/%s/system_profile" % (HOST_URL, original_id), 200)
-        actual_host = host_lookup_results["results"][0]
+        actual_host = host_lookup_results["data"][0]
 
         self.assertEqual(original_id, actual_host["id"])
 
@@ -986,10 +986,10 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
         host_lookup_results = self.get(test_url, 200)
 
         self.assertEqual(
-            len(expected_system_profiles), len(host_lookup_results["results"])
+            len(expected_system_profiles), len(host_lookup_results["data"])
         )
         for expected_system_profile in expected_system_profiles:
-            self.assertIn(expected_system_profile, host_lookup_results["results"])
+            self.assertIn(expected_system_profile, host_lookup_results["data"])
 
         self._base_paging_test(test_url, len(expected_system_profiles))
 
@@ -998,8 +998,8 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
         expected_total = 0
         host_id = str(uuid.uuid4())
         results = self.get("%s/%s/system_profile" % (HOST_URL, host_id), 200)
-        self.assertEqual(results["count"], expected_count)
-        self.assertEqual(results["total"], expected_total)
+        self.assertEqual(results["meta"]["count"], expected_count)
+        self.assertEqual(results["meta"]["total"], expected_total)
 
     def test_get_system_profile_with_invalid_host_id(self):
         invalid_host_ids = ["notauuid", "%s,notuuid" % str(uuid.uuid4())]
@@ -1043,7 +1043,7 @@ class QueryTestCase(PreCreatedHostsBaseTestCase):
         response = self.get(HOST_URL, 200)
 
         expected_host_list = [h.data() for h in self.added_hosts]
-        self.assertEqual(response["results"], expected_host_list)
+        self.assertEqual(response["data"], expected_host_list)
 
         self._base_paging_test(HOST_URL, len(self.added_hosts))
 
@@ -1062,7 +1062,7 @@ class QueryTestCase(PreCreatedHostsBaseTestCase):
 
         response = self.get(test_url, 200)
 
-        self.assertEqual(response["results"], expected_host_list)
+        self.assertEqual(response["data"], expected_host_list)
 
     def test_query_all_with_invalid_paging_parameters(self):
         invalid_limit_parameters = ["-1", "0", "notanumber"]
@@ -1081,7 +1081,7 @@ class QueryTestCase(PreCreatedHostsBaseTestCase):
         response = self.get(test_url, 200)
 
         expected_host_list = [h.data() for h in host_list]
-        self.assertEqual(response["results"], expected_host_list)
+        self.assertEqual(response["data"], expected_host_list)
 
         self._base_paging_test(test_url, len(self.added_hosts))
 
@@ -1110,7 +1110,7 @@ class QueryTestCase(PreCreatedHostsBaseTestCase):
         response = self.get(HOST_URL + "/" + url_host_id_list, 200)
 
         expected_host_list = [h.data() for h in host_list]
-        self.assertEqual(response["results"], expected_host_list)
+        self.assertEqual(response["data"], expected_host_list)
 
     def test_query_using_host_id_list_include_badly_formatted_host_ids(self):
         host_list = self.added_hosts
@@ -1136,18 +1136,18 @@ class QueryTestCase(PreCreatedHostsBaseTestCase):
 
         response = self.get(HOST_URL + "?display_name=" + host_list[0].display_name)
 
-        self.assertEqual(len(response["results"]), 1)
-        self.assertEqual(response["results"][0]["fqdn"], host_list[0].fqdn)
-        self.assertEqual(response["results"][0]["insights_id"], host_list[0].insights_id)
-        self.assertEqual(response["results"][0]["display_name"], host_list[0].display_name)
+        self.assertEqual(len(response["data"]), 1)
+        self.assertEqual(response["data"][0]["fqdn"], host_list[0].fqdn)
+        self.assertEqual(response["data"][0]["insights_id"], host_list[0].insights_id)
+        self.assertEqual(response["data"][0]["display_name"], host_list[0].display_name)
 
     def test_query_using_fqdn_two_results(self):
         expected_host_list = [self.added_hosts[0], self.added_hosts[1]]
 
         response = self.get(HOST_URL + "?fqdn=" + expected_host_list[0].fqdn)
 
-        self.assertEqual(len(response["results"]), 2)
-        for result in response["results"]:
+        self.assertEqual(len(response["data"]), 2)
+        for result in response["data"]:
             self.assertEqual(result["fqdn"], expected_host_list[0].fqdn)
             assert any(result["insights_id"] == host.insights_id for host in expected_host_list)
             assert any(result["display_name"] == host.display_name for host in expected_host_list)
@@ -1157,8 +1157,8 @@ class QueryTestCase(PreCreatedHostsBaseTestCase):
 
         response = self.get(HOST_URL + "?fqdn=" + expected_host_list[0].fqdn)
 
-        self.assertEqual(len(response["results"]), 1)
-        for result in response["results"]:
+        self.assertEqual(len(response["data"]), 1)
+        for result in response["data"]:
             self.assertEqual(result["fqdn"], expected_host_list[0].fqdn)
             assert any(result["insights_id"] == host.insights_id for host in expected_host_list)
             assert any(result["display_name"] == host.display_name for host in expected_host_list)
@@ -1168,7 +1168,7 @@ class QueryTestCase(PreCreatedHostsBaseTestCase):
 
         response = self.get(HOST_URL + "?fqdn=ROFLSAUCE.com")
 
-        self.assertEqual(len(response["results"]), 0)
+        self.assertEqual(len(response["data"]), 0)
 
     def test_query_using_display_name_substring(self):
         host_list = self.added_hosts
@@ -1180,7 +1180,7 @@ class QueryTestCase(PreCreatedHostsBaseTestCase):
         response = self.get(test_url)
 
         expected_host_list = [h.data() for h in host_list]
-        self.assertEqual(response["results"], expected_host_list)
+        self.assertEqual(response["data"], expected_host_list)
 
         self._base_paging_test(test_url, len(self.added_hosts))
 
@@ -1192,7 +1192,7 @@ class QueryByHostnameOrIdTestCase(PreCreatedHostsBaseTestCase):
 
         response = self.get(test_url)
 
-        self.assertEqual(len(response["results"]), expected_number_of_hosts)
+        self.assertEqual(len(response["data"]), expected_number_of_hosts)
 
         self._base_paging_test(test_url, expected_number_of_hosts)
 
@@ -1225,7 +1225,7 @@ class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
 
         response = self.get(test_url)
 
-        self.assertEqual(len(response["results"]), expected_number_of_hosts)
+        self.assertEqual(len(response["data"]), expected_number_of_hosts)
 
         self._base_paging_test(test_url, expected_number_of_hosts)
 
@@ -1270,9 +1270,9 @@ class FactsTestCase(PreCreatedHostsBaseTestCase):
 
         response = self.get(f"{HOST_URL}/{url_host_id_list}", 200)
 
-        self.assertEqual(len(response["results"]), len(host_list))
+        self.assertEqual(len(response["data"]), len(host_list))
 
-        for response_host in response["results"]:
+        for response_host in response["data"]:
             host_to_verify = HostWrapper(response_host)
 
             self.assertEqual(host_to_verify.facts[0]["facts"], expected_facts)


### PR DESCRIPTION
Made the query results more compliant with the Platform API documentation.

* Moved count and pagination metadata to its own dictionary key _"meta"_.
* Renamed the _"results"_ key to _"data"_.

The switch from the _page/per_page_ parameters to _limit/offset_ is in #172. The _"links"_ field will be added by another pull request.

Steps to reproduce:

1. Run a _/hosts_ or _/hosts/{}/system_profile_ query.
2. See that the count and paging metadata is under the _"meta"_ key.
3. See that the results are under the "data" key.

```
GET http://localhost:8080/api/inventory/v1/hosts/47363ef2-720c-4c88-89be-11983bda65e6,337a287f-e2d9-4692-856d-19efc548a04d,e6e717fb-eba2-47c7-ac00-a37532e33ce2/system_profile

HTTP/1.1 200 OK
Server: gunicorn/19.9.0
Date: Wed, 10 Apr 2019 14:15:15 GMT
Connection: close
Content-Type: application/json
Content-Length: 2726
```
```json
{
  "data": [
    {
      "id": "47363ef2-720c-4c88-89be-11983bda65e6",
      "system_profile": {}
    },
    {
      "id": "337a287f-e2d9-4692-856d-19efc548a04d",
      "system_profile": {}
    },
    {
      "id": "e6e717fb-eba2-47c7-ac00-a37532e33ce2",
      "system_profile": {
        "arch": "x86-64",
        "bios_release_date": "10/31/2013",
        "bios_vendor": "AMI",
        "bios_version": "1.0.0uhoh",
        "cores_per_socket": 4,
        "cpu_flags": [
          "flag1",
          "flag2"
        ],
        "disk_devices": [
          {
            "device": "/dev/sdb1",
            "label": "home drive",
            "mount_point": "/home",
            "options": {
              "ro": true,
              "uid": "0"
            },
            "type": "ext3"
          }
        ],
        "enabled_services": [
          "ndb",
          "krb5"
        ],
        "infrastructure_type": "massive cpu",
        "infrastructure_vendor": "dell",
        "insights_client_version": "12.0.12",
        "insights_egg_version": "120.0.1",
        "installed_packages": [
          "rpm1",
          "rpm2"
        ],
        "installed_products": [
          {
            "id": "123",
            "name": "eap",
            "status": "UP"
          },
          {
            "id": "321",
            "name": "jbws",
            "status": "DOWN"
          }
        ],
        "installed_services": [
          "ndb",
          "krb5"
        ],
        "katello_agent_running": false,
        "kernel_modules": [
          "i915",
          "e1000e"
        ],
        "last_boot_time": "12:25 Mar 19, 2019",
        "network_interfaces": [
          {
            "ipv4_addresses": [
              "10.10.10.1"
            ],
            "ipv6_addresses": [
              "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
            ],
            "mac_address": "aa:bb:cc:dd:ee:ff",
            "mtu": 1500,
            "name": "eth0",
            "state": "UP",
            "type": "loopback"
          }
        ],
        "number_of_cpus": 1,
        "number_of_sockets": 2,
        "os_kernel_version": "Linux 2.0.1",
        "os_release": "Red Hat EL 7.0.1",
        "running_processes": [
          "vim",
          "gcc",
          "python"
        ],
        "satellite_managed": false,
        "subscription_auto_attach": "yes",
        "subscription_status": "valid",
        "system_memory_bytes": 1024,
        "yum_repos": [
          {
            "base_url": "http://rpms.redhat.com",
            "enabled": true,
            "gpgcheck": true,
            "name": "repo1"
          }
        ]
      }
    }
  ],
  "meta": {
    "count": 3,
    "page": 1,
    "per_page": 50,
    "total": 3
  }
}
```
```
Response code: 200 (OK); Time: 21ms; Content length: 2726 bytes
```

