### PR TITLE
Use limit/offset pagination in /hosts

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -3,6 +3,8 @@ import sqlalchemy
 import uuid
 
 from enum import Enum
+from flask import abort
+from flask_api.status import HTTP_404_NOT_FOUND
 from marshmallow import ValidationError
 
 from app import db
@@ -158,7 +160,7 @@ def update_existing_host(existing_host, input_host):
 @metrics.api_request_time.time()
 def get_host_list(display_name=None, fqdn=None,
         hostname_or_id=None, insights_id=None,
-        page=1, per_page=100):
+        limit=100, offset=0):
     if fqdn:
         query = find_hosts_by_canonical_facts(
             current_identity.account_number, {"fqdn": fqdn}
@@ -178,22 +180,34 @@ def get_host_list(display_name=None, fqdn=None,
             Host.account == current_identity.account_number
         )
 
-    query_results = query.paginate(page, per_page, True)
-    logger.debug(f"Found hosts: {query_results.items}")
+    try:
+        total, query_results = _paginate_host_list_query(query, limit, offset)
+    except IndexError:
+        abort(HTTP_404_NOT_FOUND)
+    else:
+        return _build_paginated_host_list_response(total, limit, offset, query_results)
 
-    return _build_paginated_host_list_response(
-        query_results.total, page, per_page, query_results.items
-    )
+
+def _paginate_host_list_query(query, limit, offset):
+    total = query.count()
+    max_offset = max(0, total - 1)  # Zero offset is always allowed
+    if offset > max_offset:
+        raise IndexError
+
+    query = query.order_by(Host.created_on, Host.id).limit(limit).offset(offset)
+    query_results = query.all()
+    logger.debug(f"Found hosts: {query_results}")
+    return total, query_results
 
 
-def _build_paginated_host_list_response(total, page, per_page, host_list):
-    json_host_list = [host.to_json() for host in host_list]
+def _build_paginated_host_list_response(total, limit, offset, query_results):
+    json_host_list = [host.to_json() for host in query_results]
     return (
         {
             "total": total,
-            "count": len(host_list),
-            "page": page,
-            "per_page": per_page,
+            "count": len(query_results),
+            "limit": limit,
+            "offset": offset,
             "results": json_host_list,
         },
         200,
@@ -238,17 +252,15 @@ def find_hosts_by_hostname_or_id(account_number, hostname):
 
 @api_operation
 @metrics.api_request_time.time()
-def get_host_by_id(host_id_list, page=1, per_page=100):
+def get_host_by_id(host_id_list, limit=100, offset=0):
     query = _get_host_list_by_id_list(current_identity.account_number,
                                       host_id_list)
-
-    query_results = query.paginate(page, per_page, True)
-
-    logger.debug(f"Found hosts: {query_results.items}")
-
-    return _build_paginated_host_list_response(
-        query_results.total, page, per_page, query_results.items
-    )
+    try:
+        total, query_results = _paginate_host_list_query(query, limit, offset)
+    except IndexError:
+        abort(HTTP_404_NOT_FOUND)
+    else:
+        return _build_paginated_host_list_response(total, limit, offset, query_results)
 
 
 def _get_host_list_by_id_list(account_number, host_id_list):
@@ -260,25 +272,26 @@ def _get_host_list_by_id_list(account_number, host_id_list):
 
 @api_operation
 @metrics.api_request_time.time()
-def get_host_system_profile_by_id(host_id_list, page=1, per_page=100):
+def get_host_system_profile_by_id(host_id_list, limit=100, offset=0):
     query = _get_host_list_by_id_list(current_identity.account_number,
                                       host_id_list)
 
-    query_results = query.paginate(page, per_page, True)
-
-    response_list = [host.to_system_profile_json()
-                     for host in query_results.items]
-
-    return (
-        {
-            "total": query_results.total,
-            "count": len(response_list),
-            "page": page,
-            "per_page": per_page,
-            "results": response_list,
-        },
-        200,
-    )
+    try:
+        total, query_results = _paginate_host_list_query(query, limit, offset)
+    except IndexError:
+        abort(HTTP_404_NOT_FOUND)
+    else:
+        response_list = [host.to_system_profile_json() for host in query_results]
+        return (
+            {
+                "total": total,
+                "count": len(query_results),
+                "limit": limit,
+                "offset": offset,
+                "results": response_list,
+            },
+            200,
+        )
 
 
 @api_operation

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -39,8 +39,8 @@ paths:
             format: uuid
           description: Search for a host by insights_id
           required: false
-        - $ref: '#/components/parameters/perPageParam'
-        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
       responses:
         '200':
           description: Successfully read the hosts list.
@@ -113,8 +113,8 @@ paths:
             items:
               type: string
               format: uuid
-        - $ref: '#/components/parameters/perPageParam'
-        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
       responses:
         '200':
           description: Successfully searched for hosts.
@@ -222,8 +222,8 @@ paths:
             items:
               type: string
               format: uuid
-        - $ref: '#/components/parameters/perPageParam'
-        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/offsetParam'
       responses:
         '200':
           description: Successfully searched for hosts.
@@ -251,17 +251,8 @@ components:
         {"identity": {"account_number": "12345678"}}
       x-apikeyInfoFunc: app.auth.authentication_header_handler
   parameters:
-    pageParam:
-      name: page
-      in: query
-      required: false
-      schema:
-        type: integer
-        minimum: 1
-        default: 1
-      description: A page number of the items to return.
-    perPageParam:
-      name: per_page
+    limitParam:
+      name: limit
       in: query
       required: false
       schema:
@@ -270,6 +261,14 @@ components:
         maximum: 100
         default: 50
       description: A number of items to return per page.
+    offsetParam:
+      name: offset
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
   schemas:
     BulkHostOut:
       type: object
@@ -539,19 +538,19 @@ components:
       type: object
       required:
         - count
-        - page
-        - per_page
+        - limit
+        - offset
         - total
         - results
       properties:
         count:
           description: A number of entries on the current page.
           type: integer
-        page:
-          description: A current page number.
+        limit:
+          description: A page size – a number of retrieved entries.
           type: integer
-        per_page:
-          description: A page size – a number of entries per single page.
+        offset:
+          description: A dataset offset – a number of skipped records.
           type: integer
         total:
           description: A total count of the found entries.
@@ -567,19 +566,19 @@ components:
       type: object
       required:
         - count
-        - page
-        - per_page
+        - limit
+        - offset
         - total
         - results
       properties:
         count:
           description: A number of entries on the current page.
           type: integer
-        page:
-          description: A current page number.
+        limit:
+          description: A page size – a number of retrieved entries.
           type: integer
-        per_page:
-          description: A page size – a number of entries per single page.
+        offset:
+          description: A dataset offset – a number of skipped records.
           type: integer
         total:
           description: A total count of the found entries.

--- a/test_api.py
+++ b/test_api.py
@@ -723,8 +723,8 @@ class BulkCreateHostsTestCase(DBAPITestCase):
 
 class PaginationTestCase(BaseAPITestCase):
     def _base_paging_test(self, url, expected_number_of_hosts):
-        def _test_get_page(page, expected_count=1):
-            test_url = inject_qs(url, page=page, per_page="1")
+        def _test_get_page(offset, expected_count=1):
+            test_url = inject_qs(url, offset=offset, limit="1")
             response = self.get(test_url, 200)
 
             self.assertEqual(len(response["results"]), expected_count)
@@ -732,20 +732,20 @@ class PaginationTestCase(BaseAPITestCase):
             self.assertEqual(response["total"], expected_number_of_hosts)
 
         if expected_number_of_hosts == 0:
-            _test_get_page(1, expected_count=0)
+            _test_get_page(0, expected_count=0)
             return
 
         i = 0
 
         # Iterate through the pages
-        for i in range(1, expected_number_of_hosts + 1):
+        for i in range( expected_number_of_hosts):
             with self.subTest(pagination_test=i):
                 _test_get_page(str(i))
 
         # Go one page past the last page and look for an error
         i = i + 1
         with self.subTest(pagination_test=i):
-            test_url = inject_qs(url, page=str(i), per_page="1")
+            test_url = inject_qs(url, offset=str(i), limit="1")
             self.get(test_url, 404)
 
 


### PR DESCRIPTION
Changed the pagination parameters from _page/per_page_ to standard _limit/offset_. The _offset_ starts with 0 and that’s also the default. The _limit_ is capped at 100 and its default is 50, just as with the former _per_page_ parameter. If the offset is out of bound, error _404 Not Found_ is raised.

This pull request doesn’t aim to completely implement the complete standard pagination as described in the Cloud Services Platform [documentation](https://platform-docs.cloud.paas.upshift.redhat.com/rest/pagination.html). It’s rather the first step towards it.

I generally only transformed the existing pagination to the new one, without any major changes to the architecture. As a result,

* There are some untested calls. [\[1\]](https://github.com/RedHatInsights/insights-host-inventory/blob/5f1a55e9c103de462140b5b8aa9ef9a7c74c409c/test_api.py#L1014) [\[2\]](https://github.com/RedHatInsights/insights-host-inventory/blob/5f1a55e9c103de462140b5b8aa9ef9a7c74c409c/test_api.py#L933) Those were already untested before my changes.
* The [_api.host_](https://github.com/RedHatInsights/insights-host-inventory/blob/master/api/host.py) module would utilize a bit refactoring to DRY the code building the response.

I‘d do both right away as new, independent PRs. The tests are definitely more important. These are not needed for the ticket to be closed.

Solves [RHCLOUD-344](https://projects.engineering.redhat.com/browse/RHCLOUD-344).