### PR TITLE
Add pagination links to query outputs

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -581,10 +581,13 @@ components:
       type: object
       required:
         - meta
+        - links
         - data
       properties:
         meta:
           $ref: '#/components/schemas/QueryMeta'
+        links:
+          $ref: '#/components/schemas/PaginationLinks'
         data:
           description: Actual host search query result entries.
           type: array
@@ -596,10 +599,13 @@ components:
       type: object
       required:
         - meta
+        - links
         - data
       properties:
         meta:
           $ref: '#/components/schemas/QueryMeta'
+        links:
+          $ref: '#/components/schemas/PaginationLinks'
         data:
           description: Actual host search query result entries.
           type: array
@@ -626,6 +632,33 @@ components:
         total:
           description: A total count of the found entries.
           type: integer
+    PaginationLinks:
+      description: Pagination links
+      type: object
+      required:
+        - first
+        - next
+        - previous
+        - last
+      properties:
+        first:
+          description: Link to the first page
+          type: string
+          format: path
+        next:
+          description: Link to the next page if exists
+          type: string
+          format: path
+          nullable: true
+        previous:
+          description: Link to the previous page if exists
+          type: string
+          format: path
+          nullable: true
+        last:
+          description: Link to the last page
+          type: string
+          format: path
     HostSystemProfileOut:
       title: Structure of an individual host system profile output
       description: Individual host record that contains only the host id and system profile


### PR DESCRIPTION
Added [pagination links](https://github.com/RedHatInsights/insights-host-inventory/compare/pagination...Glutexo:pagination_links?expand=1#diff-b5704d15302288389d3aef6d5ab2a4f3R598) ([_first_](https://github.com/RedHatInsights/insights-host-inventory/compare/pagination...Glutexo:pagination_links?expand=1#diff-b5704d15302288389d3aef6d5ab2a4f3R607), [_next_](https://github.com/RedHatInsights/insights-host-inventory/compare/pagination...Glutexo:pagination_links?expand=1#diff-b5704d15302288389d3aef6d5ab2a4f3R611), [_previous_](https://github.com/RedHatInsights/insights-host-inventory/compare/pagination...Glutexo:pagination_links?expand=1#diff-b5704d15302288389d3aef6d5ab2a4f3R616), [_last_](https://github.com/RedHatInsights/insights-host-inventory/compare/pagination...Glutexo:pagination_links?expand=1#diff-b5704d15302288389d3aef6d5ab2a4f3R621)) to query outputs: hosts and system profiles. The links are absolute paths, but not URLs. The [_next_](https://github.com/RedHatInsights/insights-host-inventory/compare/pagination...Glutexo:pagination_links?expand=1#diff-b5704d15302288389d3aef6d5ab2a4f3R611) and [_previous_](https://github.com/RedHatInsights/insights-host-inventory/compare/pagination...Glutexo:pagination_links?expand=1#diff-b5704d15302288389d3aef6d5ab2a4f3R616) links can be missing if the page doesn’t exist. The path and its query are preserved, only the _page_ and _per_page_ parameters are filled. If not provided, parameters are filled with their default values.

I tried to preserve as much code as possible, reserving any refactorings to further pull requests. I reused the URL and query string [building](https://github.com/RedHatInsights/insights-host-inventory/blob/aa7727d7d80689bd77d06b018028679faf1696ec/test_api.py#L59) from the tests. Otherwise, I continued to build and check URLs by simple string composition and comparison. This is not a good thing and carries some possible troubles like [relying](https://github.com/RedHatInsights/insights-host-inventory/compare/pagination...Glutexo:pagination_links?expand=1#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2R1304) on Python’s internal dictionary ordering (present since Python 3.5). I’d like to fix this as a separate issue.

Steps to reproduce:

1. Query a hosts list.
   ```
   GET http://localhost:8080/api/inventory/v1/hosts
   ```
2. See that there is a _links_ key in the response with _first_, _next_, _previous_ and _last_ links.
   ```
   {
     "total": 20,
     "count": 20,
     "page": 1,
     "per_page": 50,
     "results": [
       …
     ],
     "links": {
       "first": "\/api\/inventory\/v1\/hosts?page=1&per_page=50",
       "next": null,
       "previous": null,
       "last": "\/api\/inventory\/v1\/hosts?page=1&per_page=50"
     }
   }
3. See that if it’s the first page, the _previous_ link is _null_.
4. See that if it’s the last page, the _next_ link is _null_.
5. See that the links are absolute paths, but not full URIs.
6. Check that with other queries too.
   ```
   GET http://localhost:8080/api/inventory/v1/hosts/47363ef2-720c-4c88-89be-11983bda65e6,337a287f-e2d9-4692-856d-19efc548a04d,e6e717fb-eba2-47c7-ac00-a37532e33ce2
   GET http://localhost:8080/api/inventory/v1/hosts/47363ef2-720c-4c88-89be-11983bda65e6/system_profile
   ```
