### PR TITLE
Adding account_number to logstash log message

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -37,6 +37,7 @@ class Identity:
         if token:
             self.token = token
             self.is_trusted_system = True
+            self.account_number = "<<TRUSTED IDENTITY>>"
 
     def _asdict(self):
         return {"account_number": self.account_number}

--- a/app/logging.py
+++ b/app/logging.py
@@ -6,6 +6,8 @@ import os
 from gunicorn import glogging
 from flask import request
 
+from app.auth import current_identity
+
 REQUEST_ID_HEADER = "x-rh-insights-request-id"
 UNKNOWN_REQUEST_ID_VALUE = "-1"
 
@@ -48,6 +50,8 @@ class ContextualFilter(logging.Filter):
     def filter(self, log_record):
         log_record.request_id = request.headers.get(REQUEST_ID_HEADER,
                                                     UNKNOWN_REQUEST_ID_VALUE)
+
+        log_record.account_number = current_identity.account_number
         return True
 
 

--- a/test_unit.py
+++ b/test_unit.py
@@ -183,6 +183,11 @@ class TrustedIdentityTestCase(TestCase):
         identity = self._build_id()
 
         self.assertEqual(identity.is_trusted_system, True)
+    
+    def test_is_account_number_valid_on_trusted_system(self):
+        identity = self._build_id()
+
+        self.assertEqual(identity.account_number, "<<TRUSTED IDENTITY>>")
 
 
 class ConfigTestCase(TestCase):


### PR DESCRIPTION
Adding the account_number to the logstash message (similar to request_id). Account number is defaulted when using token auth.