### PR TITLE
Allow negative offset

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -191,11 +191,18 @@ def get_host_list(display_name=None, fqdn=None,
 
 def _paginate_host_list_query(query, limit, offset):
     total = query.count()
+
     max_offset = max(0, total - 1)  # Zero offset is always allowed
-    if offset > max_offset:
+    min_offset = -max_offset
+    if offset > max_offset or offset < min_offset:
         raise IndexError
 
-    query = query.order_by(Host.created_on, Host.id).limit(limit).offset(offset)
+    db_offset = max(offset, 0)
+    db_limit = limit if offset >= 0 else limit + offset
+    if not db_limit:
+        raise IndexError
+
+    query = query.order_by(Host.created_on, Host.id).limit(db_limit).offset(db_offset)
     query_results = query.all()
     logger.debug(f"Found hosts: {query_results}")
     return total, query_results

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -267,7 +267,6 @@ components:
       required: false
       schema:
         type: integer
-        minimum: 0
         default: 0
   schemas:
     BulkHostOut:


### PR DESCRIPTION
When using _LIMIT/OFFSET_ pagination together with **consistent** first/next/previous/last links, it’s necessary to allow negative offsets. Otherwise, it wouldn’t be possible to keep the _LIMIT_ value across the pages.

Added support for negative _OFFSET_, converting the API _LIMIT/OFFSET_ values to the PostgreSQL ones, keeping the pagination cursor consistent. Any offset that would return no records yields _404 Not Found_. In case of having no records at all, 0 is the only allowed _OFFSET_.

Please see a [Gist](https://gist.github.com/Glutexo/54efb5601b837f533953a5b2c390bfd3#file-pagination-example-md) with examples that illustrate this graphically. I put quite some thought into this, consulted with co-workers and concluded that this is the only way how to do it without arbitrary decisions that would only lead to inconsistencies.