### PR TITLE
Add verbose message to bad offset error

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -22,6 +22,10 @@ FactOperations = Enum("FactOperations", ["merge", "replace"])
 logger = logging.getLogger(__name__)
 
 
+def _abort_bad_limit_offset():
+    abort(HTTP_404_NOT_FOUND, "No resources found with provided limit and offset")
+
+
 @api_operation
 @metrics.api_request_time.time()
 def add_host_list(host_list):
@@ -184,7 +188,7 @@ def get_host_list(display_name=None, fqdn=None,
     try:
         total, query_results = _paginate_host_list_query(query, limit, offset)
     except IndexError:
-        abort(HTTP_404_NOT_FOUND)
+        _abort_bad_limit_offset()
     else:
         return _build_paginated_host_list_response(total, limit, offset, query_results)
 
@@ -265,7 +269,7 @@ def get_host_by_id(host_id_list, limit=100, offset=0):
     try:
         total, query_results = _paginate_host_list_query(query, limit, offset)
     except IndexError:
-        abort(HTTP_404_NOT_FOUND)
+        _abort_bad_limit_offset()
     else:
         return _build_paginated_host_list_response(total, limit, offset, query_results)
 
@@ -286,7 +290,7 @@ def get_host_system_profile_by_id(host_id_list, limit=100, offset=0):
     try:
         total, query_results = _paginate_host_list_query(query, limit, offset)
     except IndexError:
-        abort(HTTP_404_NOT_FOUND)
+        _abort_bad_limit_offset()
     else:
         response_list = [host.to_system_profile_json()
                          for host in query_results]

--- a/test_api.py
+++ b/test_api.py
@@ -746,7 +746,11 @@ class PaginationTestCase(BaseAPITestCase):
         i = i + 1
         with self.subTest(pagination_test=i):
             test_url = inject_qs(url, offset=str(i), limit="1")
-            self.get(test_url, 404)
+            response = self.get(test_url, 404)
+            self.assertEqual(
+                response["detail"],
+                "No resources found with provided limit and offset"
+            )
 
 
 class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):


### PR DESCRIPTION
If a query is run with bad _LIMIT/OFFSET_ parameters, the 404 error message is not explanatory. It doesn’t say “Page Not Found” any more.

[Suggested](https://github.com/RedHatInsights/insights-host-inventory/pull/216#issuecomment-486225182) by @fijshion at #216.