### PR TITLE
Adding a couple of metrics for the host delete operation

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -274,7 +274,9 @@ def delete_by_id(host_id_list):
     hosts = _get_host_list_by_id_list(
         current_identity.account_number, host_id_list, order=False
     )
-    hosts.delete(synchronize_session="fetch")
+    with metrics.delete_host_processing_time.time():
+        hosts.delete(synchronize_session="fetch")
+    metrics.delete_host_count.inc(hosts.count())
     for id_ in host_id_list:
         emit_event(events.delete(id_))
 

--- a/api/host.py
+++ b/api/host.py
@@ -276,9 +276,10 @@ def delete_by_id(host_id_list):
     )
     with metrics.delete_host_processing_time.time():
         hosts.delete(synchronize_session="fetch")
+    db.session.commit()
     metrics.delete_host_count.inc(hosts.count())
-    for id_ in host_id_list:
-        emit_event(events.delete(id_))
+    for deleted_host in hosts:
+        emit_event(events.delete(deleted_host.id))
 
 
 @api_operation

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -14,6 +14,10 @@ create_host_count = Counter("inventory_create_host_count",
                             "The total amount of hosts created")
 update_host_count = Counter("inventory_update_host_count",
                             "The total amount of hosts updated")
+delete_host_count = Counter("inventory_delete_host_count",
+                            "The total amount of hosts deleted")
+delete_host_processing_time = Summary("inventory_delete_host_commit_seconds",
+                                      "Time spent deleting hosts from the database")
 login_failure_count = Counter("inventory_login_failure_count",
                               "The total amount of failed login attempts")
 system_profile_deserialization_time = Summary("system_profile_deserialization_time",

--- a/test_api.py
+++ b/test_api.py
@@ -242,6 +242,9 @@ class DeleteHostsTestCase(DBAPITestCase):
         # Try to get the host again
         response = self.get(HOST_URL + "/" + original_id, 200)
 
+        self.assertEqual(response["count"], 0)
+        self.assertEqual(response["total"], 0)
+        self.assertEqual(response["results"], [])
 
 class CreateHostsTestCase(DBAPITestCase):
     def test_create_and_update(self):


### PR DESCRIPTION
Adding a couple of metrics for the host delete operation
Commit the deleted hosts
Only emit events for hosts that were actually deleted
Verify the host is deleted in the test case