### PR TITLE
Test query hosts by invalid insights ID

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1489,8 +1489,11 @@ class QueryByHostnameOrIdTestCase(PreCreatedHostsBaseTestCase):
 
 class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
 
+    def _test_url(self, query_value):
+        return HOST_URL + "?insights_id=" + query_value
+
     def _base_query_test(self, query_value, expected_number_of_hosts):
-        test_url = HOST_URL + "?insights_id=" + query_value
+        test_url = self._test_url(query_value)
 
         response = self.get(test_url)
 
@@ -1506,6 +1509,10 @@ class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
     def test_query_with_no_matching_insights_id(self):
         uuid_that_does_not_exist_in_db = generate_uuid()
         self._base_query_test(uuid_that_does_not_exist_in_db, 0)
+
+    def test_query_with_invalid_insights_id(self):
+        test_url = self._test_url("notauuid")
+        self.get(test_url, 400)
 
     def test_query_with_maching_insights_id_and_branch_id(self):
         valid_insights_id = self.added_hosts[0].insights_id


### PR DESCRIPTION
There were no tests verifying that _400 Bad Request_ is raised if the [_insights_id_](https://github.com/RedHatInsights/insights-host-inventory/blob/c08633b7a93896f48b3a50e2269f0841f6c9f022/swagger/api.spec.yaml#L36) in the [query](https://github.com/RedHatInsights/insights-host-inventory/blob/c08633b7a93896f48b3a50e2269f0841f6c9f022/swagger/api.spec.yaml#L7) is not a valid UUID. Added such [test](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:query_by_insights_id_tests?expand=1#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2R1513).

This is a part of fixes for #265. Related to #92.