### PR TITLE
Fix style of the authentication header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ header to the following:
 x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjAwMDAwMDEifX0=
 ```
 
-This is the base64 encoding of the following json doc:
+This is the Base64 encoding of the following JSON document:
 
 ```json
 {"identity": {"account_number": "0000001"}}

--- a/README.md
+++ b/README.md
@@ -182,8 +182,12 @@ It is necessary to pass an authentication header along on each call to the
 service.  For testing purposes, it is possible to set the required identity
 header to the following:
 
-  x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjAwMDAwMDEifX0=
+```
+x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjAwMDAwMDEifX0=
+```
 
 This is the base64 encoding of the following json doc:
 
-  '{"identity":{"account_number":"0000001"}}'
+```json
+{"identity": {"account_number": "0000001"}}
+```


### PR DESCRIPTION
The [_Testing API Calls_](https://github.com/RedHatInsights/insights-host-inventory/blob/c08633b7a93896f48b3a50e2269f0841f6c9f022/README.md#testing-api-calls) section of the [_README_](https://github.com/RedHatInsights/insights-host-inventory/blob/c08633b7a93896f48b3a50e2269f0841f6c9f022/README.md) contains an example authentication HTTP header. These were printed as plain-text. Changed them to code so they are more distinguishable and readable. The JSON is even syntax-highlighted by GitHub.

Also changed the typography a bit.