### PR TITLE
Modified the way the tasks module is initialized.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,7 +10,7 @@ from app.models import db
 from app.exceptions import InventoryException
 from app.logging import configure_logging, threadctx
 from app.validators import verify_uuid_format  # noqa: 401
-from tasks import start_consumer
+from tasks import init_tasks
 
 REQUEST_ID_HEADER = "x-rh-insights-request-id"
 UNKNOWN_REQUEST_ID_VALUE = "-1"
@@ -75,7 +75,6 @@ def create_app(config_name):
             REQUEST_ID_HEADER,
             UNKNOWN_REQUEST_ID_VALUE)
 
-    if app_config.kafka_enabled:
-        start_consumer(flask_app)
+    init_tasks(app_config, flask_app)
 
     return flask_app

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -6,27 +6,38 @@ from threading import Thread
 from api import metrics
 from app import db
 from app.logging import threadctx, get_logger
-from app.config import Config
 from app.models import Host, SystemProfileSchema
 
 logger = get_logger(__name__)
-
-cfg = Config()
 
 
 class NullProducer:
 
     def send(self, topic, value=None):
-        logger.debug("NullProducer - logging message:  topic (%s) - message: %s " %
+        logger.debug("NullProducer - logging message:  topic (%s) - message: %s" %
                      (topic, value))
 
 
-if cfg.kafka_enabled:
-    logger.info("Starting KafkaProducer()")
-    producer = KafkaProducer(bootstrap_servers=cfg.bootstrap_servers)
-else:
-    logger.info("Starting NullProducer()")
-    producer = NullProducer()
+producer = None
+cfg = None
+
+
+def init_tasks(config, flask_app):
+    global cfg
+    cfg = config
+
+    _init_event_producer(config)
+    _init_system_profile_consumer(config, flask_app)
+
+
+def _init_event_producer(config):
+    global producer
+    if config.kafka_enabled:
+        logger.info("Starting KafkaProducer()")
+        producer = KafkaProducer(bootstrap_servers=config.bootstrap_servers)
+    else:
+        logger.info("Starting NullProducer()")
+        producer = NullProducer()
 
 
 def emit_event(e):
@@ -50,15 +61,19 @@ def msg_handler(parsed):
     db.session.commit()
 
 
-def start_consumer(flask_app, handler=msg_handler, consumer=None):
+def _init_system_profile_consumer(config, flask_app, handler=msg_handler, consumer=None):
+
+    if not config.kafka_enabled:
+        logger.info("System profile consumer has been disabled")
+        return
 
     logger.info("Starting system profile queue consumer.")
 
     if consumer is None:
         consumer = KafkaConsumer(
-            cfg.system_profile_topic,
-            group_id=cfg.consumer_group,
-            bootstrap_servers=cfg.bootstrap_servers)
+            config.system_profile_topic,
+            group_id=config.consumer_group,
+            bootstrap_servers=config.bootstrap_servers)
 
     def _f():
         with flask_app.app_context():

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -24,20 +24,21 @@ cfg = None
 
 def init_tasks(config, flask_app):
     global cfg
+    global producer
+
     cfg = config
 
-    _init_event_producer(config)
+    producer = _init_event_producer(config)
     _init_system_profile_consumer(config, flask_app)
 
 
 def _init_event_producer(config):
-    global producer
     if config.kafka_enabled:
         logger.info("Starting KafkaProducer()")
-        producer = KafkaProducer(bootstrap_servers=config.bootstrap_servers)
+        return KafkaProducer(bootstrap_servers=config.bootstrap_servers)
     else:
         logger.info("Starting NullProducer()")
-        producer = NullProducer()
+        return NullProducer()
 
 
 def emit_event(e):


### PR DESCRIPTION
This is an attempt to make the initialization of the event producer more explicit.  Instead of initializing the event producer when the tasks module is loaded, the event producer (and system profile consumer) is initialized/started when the init_tasks() method is called from app.create_app().

The config object is passed down into the tasks module and a reference is stored there as a global (see the cfg global).  The global is needed because the emit_event() method needs to get the topic from the configuration object.  I'm not too happy with the use of a global here, but I think this is a step in the right direction.