### PR TITLE
Remove missed _base_paging_test

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1298,8 +1298,6 @@ class QueryTestCase(PreCreatedHostsBaseTestCase):
         expected_host_list = [h.data() for h in host_list]
         self.assertEqual(response["data"], expected_host_list)
 
-        self._base_paging_test(test_url, len(self.added_hosts))
-
     def test_query_using_host_id_list_with_invalid_limit_parameters(self):
         host_list = self.added_hosts
 


### PR DESCRIPTION
The __base_paging_test_ method has been [removed](https://github.com/RedHatInsights/insights-host-inventory/commit/939991b2439f13646a9f9de4f87648ee6c938490#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2L830) in favor of explicit pagination tests. One method call was however forgotten in the [_test_query_using_host_id_list_](https://github.com/RedHatInsights/insights-host-inventory/compare/pagination...Glutexo:fix_host_id_list_test?expand=1#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2R1289) test. Fixed by removing this [call](https://github.com/RedHatInsights/insights-host-inventory/compare/pagination...Glutexo:fix_host_id_list_test?expand=1#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2L1301).

The tests are now 🍏 again.