### PR TITLE
Fix the test class inheritance tree

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1563,7 +1563,7 @@ class LimitOffsetBaseTestCase(unittest.TestCase):
         )
 
 
-class QueriesBaseTestCase(QueryBaseTestCase):
+class QueriesBaseTestCase(DBAPITestCase):
 
     def _queries_subtests(self, host_id_list):
         url_host_id_list = ",".join(host_id_list)
@@ -1577,9 +1577,7 @@ class QueriesBaseTestCase(QueryBaseTestCase):
                 yield url
 
 
-class QueriesWithPreCreatedHostsBaseTestCase(
-    QueriesBaseTestCase, PreCreatedHostsBaseTestCase
-):
+class QueriesWithPreCreatedHostsBaseTestCase(QueriesBaseTestCase, PreCreatedHostsBaseTestCase):
 
     def _queries_subtests_with_added_hosts(self):
         host_id_list = [host.id for host in self.added_hosts]
@@ -1600,7 +1598,7 @@ class QueryOrderTestCase(QueriesWithPreCreatedHostsBaseTestCase):
 
 
 class PaginatedQueryWithPreCreatedHostsTestCase(
-    QueriesWithPreCreatedHostsBaseTestCase, LimitOffsetBaseTestCase
+    QueryBaseTestCase, QueriesWithPreCreatedHostsBaseTestCase, LimitOffsetBaseTestCase
 ):
 
     def test_all_records_with_defaults(self):
@@ -1736,7 +1734,7 @@ class PaginatedParametrizedQueryWithPreCreatedHostTestCase(
 
 
 class PaginatedQueryWithMorePreCreatedHostsTestCase(
-    QueriesWithPreCreatedHostsBaseTestCase, LimitOffsetBaseTestCase
+    QueryBaseTestCase, QueriesWithPreCreatedHostsBaseTestCase, LimitOffsetBaseTestCase
 ):
 
     def create_hosts(self):
@@ -1834,9 +1832,7 @@ class PaginatedQueryWithNoHostsTestCase(QueryBaseTestCase, LimitOffsetBaseTestCa
         self._assert_limit_offset_error_detail(response)
 
 
-class PaginationLinksWithPreCreatedHostsTestCase(
-    QueriesWithPreCreatedHostsBaseTestCase
-):
+class PaginationLinksWithPreCreatedHostsTestCase(QueriesWithPreCreatedHostsBaseTestCase):
 
     def test_first_page(self):
         """


### PR DESCRIPTION
Made [_QueriesWithPreCreatedHostsBaseTestCase_](https://github.com/RedHatInsights/insights-host-inventory/blob/pagination/test_api.py#L1468) [not inherit](https://github.com/RedHatInsights/insights-host-inventory/compare/pagination...Glutexo:pagination_test_class_tree?expand=1#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2R1468) from [_QueryTestCase_](https://github.com/RedHatInsights/insights-host-inventory/blob/pagination/test_api.py#L1255). Despite the names (which are not so smart 🙁) they are not related and there are tests that use methods from [QueryTestCase](https://github.com/RedHatInsights/insights-host-inventory/blob/pagination/test_api.py#L1255), but don’t need the ones from [_QueriesWithPreCreatedHostsBaseTestCase_](https://github.com/RedHatInsights/insights-host-inventory/blob/pagination/test_api.py#L1468) ([_PaginatedQueryWithNoHostsTestCase_](https://github.com/RedHatInsights/insights-host-inventory/blob/pagination/test_api.py#L1696)), even those that actually use pre-created hosts ([_PaginatedParametrizedQueryWithPreCreatedHostTestCase_](https://github.com/RedHatInsights/insights-host-inventory/blob/1e673b3fcffcbc2eb69c610814f7fc6902bff90d/test_api.py#L1581)). Like this, the test class ancestor clearly tell what functionality is required and used.