### PR TITLE
Fix test failing by unittest.mock import

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import unittest
+import unittest.mock
 import json
 import dateutil.parser
 import test.support


### PR DESCRIPTION
[_DeleteHostsTestCase.test_create_then_delete_](https://github.com/RedHatInsights/insights-host-inventory/blob/af65dea5c62211083f301db800a1d126acba4372/test_api.py#L1318) fails, because unittest.mock is not imported. [Added](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:fix_tests_unittest_mock?expand=1#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2R4) missing import.

Still I don’t like the usage of _unittest.mock_ here. Please see #280 for more details.