### PR TITLE
Add index on modified_on DESC, id DESC

### DIFF
--- a/migrations/versions/5dbbd56ce006_add_modified_on_id_index.py
+++ b/migrations/versions/5dbbd56ce006_add_modified_on_id_index.py
@@ -1,0 +1,26 @@
+"""add_modified_on_id_index
+
+Revision ID: 5dbbd56ce006
+Revises: a9f0e674cf52
+Create Date: 2019-05-24 20:53:01.426278
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5dbbd56ce006'
+down_revision = 'a9f0e674cf52'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    columns = (sa.desc("modified_on"), sa.desc("id"))
+    expressions = [sa.text(str(column)) for column in columns]
+    op.create_index("hosts_modified_on_id", "hosts", expressions)
+
+
+def downgrade():
+    op.drop_index("hosts_modified_on_id")


### PR DESCRIPTION
[Added](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:default_ordering_index?expand=1#diff-4136aafb770721d5b4cc452e6b4f0518R22) a new index that gets used by the default hosts ordering: `"modified_on" DESC, "id" DESC`.

This is a complement to #325.


- _EXPLAIN SELECT_ without the index:
   ```
   Limit  (cost=93366.28..93366.40 rows=50 width=685)
     ->  Sort  (cost=93366.28..95866.20 rows=999969 width=685)
           Sort Key: modified_on DESC, id DESC
           ->  Seq Scan on hosts  (cost=0.00..60148.03 rows=999969 width=685)
                 Filter: ((account)::text = 'abc123'::text)
   ```
- _EXPLAIN SELECT_ with the index:
   ```
   Limit  (cost=0.42..11.57 rows=50 width=685)
     ->  Index Scan using hosts_modified_on_id on hosts  (cost=0.42..222970.08 rows=999969 width=685)
           Filter: ((account)::text = 'abc123'::text)
   ```

Unfortunately I don’t know what all those numbers mean. But I see that the index gets actually used.
