### PR TITLE
Fix UUID validation on facts operations

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -220,6 +220,7 @@ paths:
             type: array
             items:
               type: string
+              format: uuid
         - in: path
           name: namespace
           description: A namespace of the merged facts.
@@ -258,6 +259,7 @@ paths:
             type: array
             items:
               type: string
+              format: uuid
         - in: path
           name: namespace
           description: A namespace of the merged facts.

--- a/test_api.py
+++ b/test_api.py
@@ -1755,6 +1755,23 @@ class FactsTestCase(PreCreatedHostsBaseTestCase):
 
         self._basic_fact_test(new_facts, expected_facts, True)
 
+    def test_invalid_host_id(self):
+        bad_id_list = ["notauuid", "1234blahblahinvalid"]
+        only_bad_id = bad_id_list.copy()
+
+        # Can’t have empty string as an only ID, that results in 404 Not Found.
+        more_bad_id_list = bad_id_list + [""]
+        valid_id = self.added_hosts[0].id
+        with_bad_id = [f"{valid_id},{bad_id}" for bad_id in more_bad_id_list]
+
+        operations = (self.patch, self.put)
+        fact_doc = self._valid_fact_doc()
+        for operation in operations:
+            for host_id_list in chain(only_bad_id, with_bad_id):
+                url = self._build_facts_url(host_id_list, "ns1")
+                with self.subTest(operation=operation, host_id_list=host_id_list):
+                    operation(url, fact_doc, 400)
+
 
 class HeaderAuthTestCase(DBAPITestCase):
     @staticmethod


### PR DESCRIPTION
Invalid UUIDs were causing facts operations (PUT, PATCH) to crash with 500 Internal Server Error. Fixed this so it now fails properly with 400 Bad Request.

The problem was in that the [_host_id_list_](https://github.com/RedHatInsights/insights-host-inventory/blob/1dab76aaaab5f77aeaf866efbd075b31022ad738/swagger/api.spec.yaml#L215) parameter didn’t have the _uuid_ format specified. Connexion thus didn’t validate it and any arbitrary string value was passed to a SQL query for a UUID field.

This’d be better fixed by unifying the _host_id_list_ parameter in the OpenAPI [spec](https://github.com/RedHatInsights/insights-host-inventory/blob/1dab76aaaab5f77aeaf866efbd075b31022ad738/swagger/api.spec.yaml) file. I’ll do this in a separate pull request.