### PR TITLE
Extract common query parameters

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -39,12 +39,7 @@ paths:
             format: uuid
           description: Search for a host by insights_id
           required: false
-        - in: query
-          name: branch_id
-          schema:
-            type: string
-          description: Filter by branch_id
-          required: false
+        - $ref: '#/components/parameters/branchId'
         - $ref: '#/components/parameters/perPageParam'
         - $ref: '#/components/parameters/pageParam'
       responses:
@@ -110,21 +105,8 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
-        - in: path
-          name: host_id_list
-          description: A comma separated list of host IDs.
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-              format: uuid
-        - in: query
-          name: branch_id
-          schema:
-            type: string
-          description: Filter by branch_id
-          required: false
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/branchId'
         - $ref: '#/components/parameters/perPageParam'
         - $ref: '#/components/parameters/pageParam'
       responses:
@@ -147,15 +129,7 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
-        - in: path
-          name: host_id_list
-          description: A comma separated list of host IDs.
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-              format: uuid
+        - $ref: '#/components/parameters/hostIdList'
       responses:
         '200':
           description: Successfully deleted hosts.
@@ -172,21 +146,8 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
-        - in: path
-          name: host_id_list
-          description: A host ID
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-              format: uuid
-        - in: query
-          name: branch_id
-          schema:
-            type: string
-          description: Filter by branch_id
-          required: false
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/branchId'
       requestBody:
         description: A group of fields to be updated on the host
         required: true
@@ -212,21 +173,8 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
-        - in: path
-          name: host_id_list
-          description: IDs of the hosts that own the facts to be merged.
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-              format: uuid
-        - in: path
-          name: namespace
-          description: A namespace of the merged facts.
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/factsNamespace'
       requestBody:
         description: A dictionary with the new facts to merge with the original ones.
         required: true
@@ -251,21 +199,8 @@ paths:
         - ApiKeyAuth: []
       operationId: api.host.replace_facts
       parameters:
-        - in: path
-          name: host_id_list
-          description: IDs of the hosts that own the facts to be replaced.
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-              format: uuid
-        - in: path
-          name: namespace
-          description: A namespace of the merged facts.
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/hostIdList'
+        - $ref: '#/components/parameters/factsNamespace'
       requestBody:
         description: A dictionary with the new facts to replace the original ones.
         required: true
@@ -291,15 +226,7 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
-        - in: path
-          name: host_id_list
-          description: A comma separated list of host IDs.
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-              format: uuid
+        - $ref: '#/components/parameters/hostIdList'
         - $ref: '#/components/parameters/perPageParam'
         - $ref: '#/components/parameters/pageParam'
       responses:
@@ -348,6 +275,30 @@ components:
         maximum: 100
         default: 50
       description: A number of items to return per page.
+    hostIdList:
+      in: path
+      name: host_id_list
+      description: A comma separated list of host IDs.
+      required: true
+      schema:
+        type: array
+        items:
+          type: string
+          format: uuid
+    branchId:
+      in: query
+      name: branch_id
+      schema:
+        type: string
+      description: Filter by branch_id
+      required: false
+    factsNamespace:
+      in: path
+      name: namespace
+      description: A namespace of the merged facts.
+      required: true
+      schema:
+        type: string
   schemas:
     BulkHostOut:
       type: object


### PR DESCRIPTION
The OpenAPI [specification](https://github.com/RedHatInsights/insights-host-inventory/blob/1dab76aaaab5f77aeaf866efbd075b31022ad738/swagger/api.spec.yaml) describes the same parameter multiple times for different operations. Extracted those the parameters sections and replaced the in-place definition with a reference.

This also solves an UUID validation bug (#289) for facts operations, as there was missing the string format key.