### PR TITLE
Add support for custom ordering ✨

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -42,6 +42,8 @@ paths:
         - $ref: '#/components/parameters/branchId'
         - $ref: '#/components/parameters/perPageParam'
         - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/orderByParam'
+        - $ref: '#/components/parameters/orderHowParam'
       responses:
         '200':
           description: Successfully read the hosts list.
@@ -109,6 +111,8 @@ paths:
         - $ref: '#/components/parameters/branchId'
         - $ref: '#/components/parameters/perPageParam'
         - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/orderByParam'
+        - $ref: '#/components/parameters/orderHowParam'
       responses:
         '200':
           description: Successfully searched for hosts.
@@ -229,6 +233,8 @@ paths:
         - $ref: '#/components/parameters/hostIdList'
         - $ref: '#/components/parameters/perPageParam'
         - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/orderByParam'
+        - $ref: '#/components/parameters/orderHowParam'
       responses:
         '200':
           description: Successfully searched for hosts.
@@ -299,6 +305,28 @@ components:
       required: true
       schema:
         type: string
+    orderByParam:
+      name: order_by
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - display_name
+          - updated
+      description: Ordering field name
+    orderHowParam:
+      name: order_how
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - ASC
+          - DESC
+      description: >-
+        Direction of the ordering, defaults to ASC for display_name and to DESC for
+        updated
   schemas:
     BulkHostOut:
       type: object

--- a/test_unit.py
+++ b/test_unit.py
@@ -261,46 +261,46 @@ class HostParamsToOrderByTestCase(TestCase):
     def test_default_is_updated_desc(self, modified_on, order_how):
         actual = _params_to_order_by(None, None)
         expected = (modified_on.desc.return_value,)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
         order_how.assert_not_called()
 
     def test_default_for_updated_is_desc(self, modified_on, order_how):
         actual = _params_to_order_by("updated", None)
         expected = (modified_on.desc.return_value,)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
         order_how.assert_not_called()
 
     def test_order_by_updated_asc(self, modified_on, order_how):
         actual = _params_to_order_by("updated", "ASC")
         expected = (order_how.return_value,)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
         order_how.assert_called_once_with(modified_on, "ASC")
 
     def test_order_by_updated_desc(self, modified_on, order_how):
         actual = _params_to_order_by("updated", "DESC")
         expected = (order_how.return_value,)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
         order_how.assert_called_once_with(modified_on, "DESC")
 
     @patch("api.host.Host.display_name")
     def test_default_for_display_name_is_asc(self, display_name, modified_on, order_how):
         actual = _params_to_order_by("display_name",)
         expected = (display_name.asc.return_value, modified_on.desc.return_value)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
         order_how.assert_not_called()
 
     @patch("api.host.Host.display_name")
     def test_order_by_display_name_asc(self, display_name, modified_on, order_how):
         actual = _params_to_order_by("display_name", "ASC")
         expected = (order_how.return_value, modified_on.desc.return_value)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
         order_how.assert_called_once_with(display_name, "ASC")
 
     @patch("api.host.Host.display_name")
     def test_order_by_display_name_desc(self, display_name, modified_on, order_how):
         actual = _params_to_order_by("display_name", "DESC")
         expected = (order_how.return_value, modified_on.desc.return_value)
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
         order_how.assert_called_once_with(display_name, "DESC")
 
 


### PR DESCRIPTION
Added ordering query parameters ([_order_by_](https://github.com/Glutexo/insights-host-inventory/blob/64d83729ff4ff1120e089fca4bbd975313e6a953/swagger/api.spec.yaml#L357) and [_order_how_](https://github.com/Glutexo/insights-host-inventory/blob/64d83729ff4ff1120e089fca4bbd975313e6a953/swagger/api.spec.yaml#L367)) to all three query operations ([_/hosts_](https://github.com/Glutexo/insights-host-inventory/blob/64d83729ff4ff1120e089fca4bbd975313e6a953/swagger/api.spec.yaml#L7), [_/hosts/{host_id_list}_](https://github.com/Glutexo/insights-host-inventory/blob/64d83729ff4ff1120e089fca4bbd975313e6a953/swagger/api.spec.yaml#L105), [_/hosts/{host_id_list}/system_profile_](https://github.com/Glutexo/insights-host-inventory/blob/64d83729ff4ff1120e089fca4bbd975313e6a953/swagger/api.spec.yaml#L209)). This allows to request the items ordered by one of the two fields ([_display_name_](https://github.com/Glutexo/insights-host-inventory/blob/64d83729ff4ff1120e089fca4bbd975313e6a953/swagger/api.spec.yaml#L364), [_updated_](https://github.com/Glutexo/insights-host-inventory/blob/64d83729ff4ff1120e089fca4bbd975313e6a953/swagger/api.spec.yaml#L365)) available in the UI.

Default ordering is still _updated DESC_. Default direction for _updated_ is _DESC_, for _display_name_ it’s _ASC_. When ordering by _display_name_, an _ordering_ by _updated DESC_ is added to the end. It’s not possible to specify only an ordering direction.

There is some repeating code around handling the query parameters. I didn’t want to DRY this single bit as it’s a part of a bigger functionality that is common to the queries – pagination, ordering, response formatting. There is already an issue for that: #147. At least the [__get_host_list_by_id_list_](https://github.com/Glutexo/insights-host-inventory/blob/64d83729ff4ff1120e089fca4bbd975313e6a953/api/host.py#L338) method is now a bit [simpler](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:custom_ordering?expand=1#diff-a5c55b46cc9c536070cb56798c97adfaL300).