### PR TITLE
Stop using test.support.EnvironmentVarGuard

### DIFF
--- a/test_utils.py
+++ b/test_utils.py
@@ -1,0 +1,14 @@
+import contextlib
+import os
+import unittest.mock
+
+
+@contextlib.contextmanager
+def set_environment(new_env=None):
+    new_env = new_env or {}
+    patched_dict = unittest.mock.patch.dict(os.environ, new_env)
+    patched_dict.start()
+    os.environ.clear()
+    os.environ.update(new_env)
+    yield
+    patched_dict.stop()


### PR DESCRIPTION
test.support.EnvironmentVarGuard is an internal python api.  Its usage is causing issues for setting up automated tests.  Replaced the usage of test.support.EnvironmentVarGuard with a custom contextmanager.

The test_utils.py module needs to be moved to tests/utils.py later on.