### PR TITLE
Remove forgotten debug statements 🔥

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1783,12 +1783,6 @@ class PaginatedQueryWithMorePreCreatedHostsTestCase(
 
             expected_count = min(limit, total - offset)
 
-            from logging import DEBUG, getLogger
-
-            logger = getLogger(__name__)
-            logger.setLevel(DEBUG)
-            logger.debug(f"{HOST_URL}?limit={limit}&offset={offset}")
-            logger.debug(f"{response}, {expected_count}")
             self.assertEqual(len(response["data"]), expected_count)
             self.assertEqual(response["meta"]["count"], expected_count)
             self.assertEqual(response["meta"]["total"], total)


### PR DESCRIPTION
There was forgotten debugging [block](https://github.com/RedHatInsights/insights-host-inventory/blob/47426c49d8e6595cc703d7271f84269fb3dc9c2a/test_api.py#L1684) in one of the tests helper [methods](https://github.com/Glutexo/insights-host-inventory/blob/b853f860d1205ff86c92e2d14d1cfb96ccb0ed21/test_api.py#L1673). [Removed](https://github.com/RedHatInsights/insights-host-inventory/pull/299/files#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2L1682) those lines as they should not be there.