### PR TITLE
Normalize insights_id when searching

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,14 @@
 import json
 
 
+def uuid_with_hyphens(uuid):
+    return str(uuid)
+
+
+def uuid_without_hyphens(uuid):
+    return uuid.hex
+
+
 class HostWrapper:
     def __init__(self, data=None):
         self.__data = data or {}

--- a/test_api.py
+++ b/test_api.py
@@ -20,6 +20,8 @@ from app import create_app
 from app import db
 from app.auth.identity import Identity
 from app.utils import HostWrapper
+from app.utils import uuid_with_hyphens
+from app.utils import uuid_without_hyphens
 from tasks import msg_handler
 from test_utils import rename_host_table_and_indexes
 from test_utils import set_environment
@@ -38,8 +40,12 @@ ACCOUNT = "000501"
 SHARED_SECRET = "SuperSecretStuff"
 
 
-def generate_uuid():
-    return str(uuid.uuid4())
+def generate_uuid(with_hyphens=True):
+    generated_uuid = uuid.uuid4()
+    if with_hyphens:
+        return uuid_with_hyphens(generated_uuid)
+    else:
+        return uuid_without_hyphens(generated_uuid)
 
 
 def test_data(display_name="hi", facts=None):
@@ -1099,9 +1105,9 @@ class PreCreatedHostsBaseTestCase(DBAPITestCase, PaginationBaseTestCase):
 
     def create_hosts(self):
         hosts_to_create = [
-            ("host1", generate_uuid(), "host1.domain.test"),
-            ("host2", generate_uuid(), "host1.domain.test"),  # the same fqdn is intentional
-            ("host3", generate_uuid(), "host2.domain.test"),  # the same display_name is intentional
+            ("host1", generate_uuid(True), "host1.domain.test"),
+            ("host2", generate_uuid(True), "host1.domain.test"),  # the same fqdn is intentional
+            ("host3", generate_uuid(False), "host2.domain.test"),  # the same display_name is intentional
         ]
         host_list = []
 
@@ -1441,10 +1447,25 @@ class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
 
         self._base_paging_test(test_url, expected_number_of_hosts)
 
-    def test_query_with_matching_insights_id(self):
+    def test_query_with_exact_matching_insights_id_with_hyphens(self):
         host_list = self.added_hosts
 
         self._base_query_test(host_list[0].insights_id, 1)
+
+    def test_query_with_normalized_matching_insights_id_with_hyphens(self):
+        host_list = self.added_hosts
+        insights_id = uuid.UUID(host_list[0].insights_id)
+        self._base_query_test(uuid_without_hyphens(insights_id), 1)
+
+    def test_query_with_exact_matching_insights_id_without_hyphens(self):
+        host_list = self.added_hosts
+
+        self._base_query_test(host_list[0].insights_id, 1)
+
+    def test_query_with_normalized_matching_insights_id_without_hyphens(self):
+        host_list = self.added_hosts
+        insights_id = uuid.UUID(host_list[2].insights_id)
+        self._base_query_test(uuid_with_hyphens(insights_id), 1)
 
     def test_query_with_no_matching_insights_id(self):
         uuid_that_does_not_exist_in_db = generate_uuid()

--- a/test_api.py
+++ b/test_api.py
@@ -20,8 +20,8 @@ from app import create_app
 from app import db
 from app.auth.identity import Identity
 from app.utils import HostWrapper
-from app.utils import uuid_with_hyphens
-from app.utils import uuid_without_hyphens
+from app.utils import uuid_with_hyphens as with_hyphens
+from app.utils import uuid_without_hyphens as without_hyphens
 from tasks import msg_handler
 from test_utils import rename_host_table_and_indexes
 from test_utils import set_environment
@@ -40,12 +40,8 @@ ACCOUNT = "000501"
 SHARED_SECRET = "SuperSecretStuff"
 
 
-def generate_uuid(with_hyphens=True):
-    generated_uuid = uuid.uuid4()
-    if with_hyphens:
-        return uuid_with_hyphens(generated_uuid)
-    else:
-        return uuid_without_hyphens(generated_uuid)
+def generate_uuid(format_func=with_hyphens):
+    return format_func(uuid.uuid4())
 
 
 def test_data(display_name="hi", facts=None):
@@ -1105,9 +1101,9 @@ class PreCreatedHostsBaseTestCase(DBAPITestCase, PaginationBaseTestCase):
 
     def create_hosts(self):
         hosts_to_create = [
-            ("host1", generate_uuid(True), "host1.domain.test"),
-            ("host2", generate_uuid(True), "host1.domain.test"),  # the same fqdn is intentional
-            ("host3", generate_uuid(False), "host2.domain.test"),  # the same display_name is intentional
+            ("host1", generate_uuid(with_hyphens), "host1.domain.test"),
+            ("host2", generate_uuid(with_hyphens), "host1.domain.test"),  # the same fqdn is intentional
+            ("host3", generate_uuid(without_hyphens), "host2.domain.test"),  # the same display_name is intentional
         ]
         host_list = []
 
@@ -1455,7 +1451,7 @@ class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
     def test_query_with_normalized_matching_insights_id_with_hyphens(self):
         host_list = self.added_hosts
         insights_id = uuid.UUID(host_list[0].insights_id)
-        self._base_query_test(uuid_without_hyphens(insights_id), 1)
+        self._base_query_test(without_hyphens(insights_id), 1)
 
     def test_query_with_exact_matching_insights_id_without_hyphens(self):
         host_list = self.added_hosts
@@ -1465,7 +1461,7 @@ class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
     def test_query_with_normalized_matching_insights_id_without_hyphens(self):
         host_list = self.added_hosts
         insights_id = uuid.UUID(host_list[2].insights_id)
-        self._base_query_test(uuid_with_hyphens(insights_id), 1)
+        self._base_query_test(with_hyphens(insights_id), 1)
 
     def test_query_with_no_matching_insights_id(self):
         uuid_that_does_not_exist_in_db = generate_uuid()

--- a/test_unit.py
+++ b/test_unit.py
@@ -5,6 +5,7 @@ from unittest import main
 from unittest import TestCase
 from unittest.mock import Mock
 from unittest.mock import patch
+from uuid import uuid4
 
 from api import api_operation
 from api.host import _order_how
@@ -15,6 +16,8 @@ from app.auth.identity import Identity
 from app.auth.identity import SHARED_SECRET_ENV_VAR
 from app.auth.identity import validate
 from app.config import Config
+from app.utils import uuid_with_hyphens
+from app.utils import uuid_without_hyphens
 from test_utils import set_environment
 
 
@@ -317,6 +320,22 @@ class HostParamsToOrderByErrorsTestCase(TestCase):
     def test_order_by_only_how_raises_error(self):
         with self.assertRaises(ValueError):
             _params_to_order_by(Mock(), order_how="ASC")
+
+
+class UtilsUuidTestCase(TestCase):
+    def _some_uuids(self):
+        for _ in range(5):
+            yield uuid4()
+
+    def test_uuid_with_hyphens(self):
+        for uuid in self._some_uuids():
+            result = uuid_with_hyphens(uuid)
+            self.assertEqual(result, str(uuid))
+
+    def test_without_hyphens(self):
+        for uuid in self._some_uuids():
+            result = uuid_without_hyphens(uuid)
+            self.assertEqual(result, uuid.hex)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If a host is queried by an insights ID, it is now found regardless of the UUID formats used. It doesn’t matter whether it is stored or queried with or without hyphens.

The _or_ [approach](https://github.com/Glutexo/insights-host-inventory/blob/0e8dabb3470f4391533e2342a1e90680d0886334/api/host.py#L142) used would not be viable if there were more values requiring normalization. But as this affects only _insights_id_, we can keep it this simple. Otherwise we’d need to store the normalized values along the original ones.

On my machine with about one million hosts in the database I didn’t see any difference in performance.