### PR TITLE
Dedup hosts using subscription manager

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -90,9 +90,26 @@ def _add_host(host):
 def find_existing_host(account_number, canonical_facts):
     existing_host = None
 
+    input_elevated_canonical_facts = _pluck_elevated_canonical_facts(
+            canonical_facts
+            )
+
+    if input_elevated_canonical_facts:
+        # There is at least one "elevated" canonical fact passed in
+        # Search for an existing host using the "elevated" canonical facts
+        existing_host = _find_host_by_elevated_ids(account_number,
+                **input_elevated_canonical_facts)
+
+    if not existing_host:
+        existing_host = find_host_by_canonical_facts(account_number,
+                                                     canonical_facts)
+
+    return existing_host
+
+
+def _pluck_elevated_canonical_facts(canonical_facts):
     elevated_canonical_fact_fields = ("insights_id",
                                       "subscription_manager_id",
-                                      "external_id",
                                       )
 
     id_dict = {}
@@ -100,18 +117,7 @@ def find_existing_host(account_number, canonical_facts):
         cf_value = canonical_facts.get(cf)
         if cf_value:
             id_dict[cf] = cf_value
-
-    print("id_dict:", id_dict)
-
-    if id_dict:
-        # There is at least one "elevated" cf passed in
-        existing_host = _find_host_by_elevated_ids(account_number, **id_dict)
-
-    if not existing_host:
-        existing_host = find_host_by_canonical_facts(account_number,
-                                                     canonical_facts)
-
-    return existing_host
+    return id_dict
 
 
 @metrics.find_host_using_elevated_ids.time()

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -4,6 +4,8 @@ api_request_time = Summary("inventory_request_processing_seconds",
                            "Time spent processing request")
 host_dedup_processing_time = Summary("inventory_dedup_processing_seconds",
                                      "Time spent looking for existing host (dedup logic)")
+find_host_using_elevated_ids = Summary("inventory_find_host_using_elevated_ids_processing_seconds",
+                                     "Time spent looking for existing host using the elevated ids")
 new_host_commit_processing_time = Summary("inventory_new_host_commit_seconds",
                                           "Time spent committing a new host to the database")
 update_host_commit_processing_time = Summary("inventory_update_host_commit_seconds",

--- a/app/models.py
+++ b/app/models.py
@@ -33,7 +33,10 @@ class Host(db.Model):
     # alembic autogenerate functionality does not try to remove the indexes
     __table_args__ = (Index("idxinsightsid", text("(canonical_facts ->> 'insights_id')")),
                       Index("idxgincanonicalfacts", "canonical_facts"),
-                      Index("idxaccount", "account"),)
+                      Index("idxaccount", "account"),
+                      Index("hosts_subscription_manager_id_index",
+                          text("(canonical_facts ->> 'subscription_manager_id')")),
+                      )
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     account = db.Column(db.String(10))

--- a/migrations/versions/76b7bc1d1d12_add_subscription_manager_id_index.py
+++ b/migrations/versions/76b7bc1d1d12_add_subscription_manager_id_index.py
@@ -1,0 +1,27 @@
+"""add_host_subscription_manager_id_index
+
+Revision ID: 76b7bc1d1d12
+Revises: 5dbbd56ce006
+Create Date: 2019-06-24 16:41:54.754856
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '76b7bc1d1d12'
+down_revision = '5dbbd56ce006'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('hosts_subscription_manager_id_index',
+                    'hosts',
+                    [sa.text("(canonical_facts ->> 'subscription_manager_id')")]
+                    )
+
+
+def downgrade():
+    op.drop_index('hosts_subscription_manager_id_index', table_name='hosts')

--- a/test_host_dedup_logic.py
+++ b/test_host_dedup_logic.py
@@ -79,3 +79,16 @@ def test_find_host_using_subscription_manager_id_match(flask_app_fixture):
     search_canonical_facts[sub_mgr_id_key] = canonical_facts[sub_mgr_id_key]
 
     basic_host_dedup_test(canonical_facts, search_canonical_facts)
+
+
+def test_find_host_using_elevated_ids_match(flask_app_fixture):
+    first_canonical_facts = {"subscription_manager_id": generate_uuid()}
+    create_host(first_canonical_facts)
+
+    second_canonical_facts = {"insights_id": generate_uuid()}
+    expected_host = create_host(second_canonical_facts)
+
+    search_canonical_facts = {**first_canonical_facts, **second_canonical_facts}
+    found_host = find_existing_host(ACCOUNT_NUMBER, search_canonical_facts)
+
+    assert expected_host.id == found_host.id

--- a/test_host_dedup_logic.py
+++ b/test_host_dedup_logic.py
@@ -68,15 +68,14 @@ def test_find_host_using_insights_id_match(flask_app_fixture):
     basic_host_dedup_test(canonical_facts, search_canonical_facts)
 
 def test_find_host_using_subscription_manager_id_match(flask_app_fixture):
-    sub_mgr_id_key = "subscription_manager_id"
     canonical_facts = {"fqdn": "fred",
                        "bios_uuid": generate_uuid(),
-                       sub_mgr_id_key: generate_uuid(),
+                       "subscription_manager_id": generate_uuid(),
                        }
 
     # Change the bios_uuid so that falling back to subset match will fail
     search_canonical_facts = {"bios_uuid": generate_uuid(), }
-    search_canonical_facts[sub_mgr_id_key] = canonical_facts[sub_mgr_id_key]
+    search_canonical_facts["subscription_manager_id"] = canonical_facts["subscription_manager_id"]
 
     basic_host_dedup_test(canonical_facts, search_canonical_facts)
 

--- a/test_host_dedup_logic.py
+++ b/test_host_dedup_logic.py
@@ -66,3 +66,16 @@ def test_find_host_using_insights_id_match(flask_app_fixture):
                               }
 
     basic_host_dedup_test(canonical_facts, search_canonical_facts)
+
+def test_find_host_using_subscription_manager_id_match(flask_app_fixture):
+    sub_mgr_id_key = "subscription_manager_id"
+    canonical_facts = {"fqdn": "fred",
+                       "bios_uuid": generate_uuid(),
+                       sub_mgr_id_key: generate_uuid(),
+                       }
+
+    # Change the bios_uuid so that falling back to subset match will fail
+    search_canonical_facts = {"bios_uuid": generate_uuid(), }
+    search_canonical_facts[sub_mgr_id_key] = canonical_facts[sub_mgr_id_key]
+
+    basic_host_dedup_test(canonical_facts, search_canonical_facts)

--- a/test_host_dedup_logic.py
+++ b/test_host_dedup_logic.py
@@ -75,8 +75,10 @@ def test_find_host_using_subscription_manager_id_match(flask_app_fixture):
                        }
 
     # Change the bios_uuid so that falling back to subset match will fail
-    search_canonical_facts = {"bios_uuid": generate_uuid(), }
-    search_canonical_facts["subscription_manager_id"] = canonical_facts["subscription_manager_id"]
+    search_canonical_facts = {
+        "bios_uuid": generate_uuid(),
+        "subscription_manager_id": canonical_facts["subscription_manager_id"]
+    }
 
     basic_host_dedup_test(canonical_facts, search_canonical_facts)
 


### PR DESCRIPTION
This change uses subscription_manager_id as well as insights_id as an "elevated" id for deduplication. 

RHCLOUD-149