### PR TITLE
Allow the "tasks" to be disabled

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,7 +22,7 @@ def render_exception(exception):
     return response
 
 
-def create_app(config_name):
+def create_app(config_name, start_tasks=True):
     connexion_options = {"swagger_ui": True}
 
     # This feels like a hack but it is needed.  The logging configuration
@@ -75,6 +75,7 @@ def create_app(config_name):
             REQUEST_ID_HEADER,
             UNKNOWN_REQUEST_ID_VALUE)
 
-    init_tasks(app_config, flask_app)
+    if start_tasks:
+        init_tasks(app_config, flask_app)
 
     return flask_app

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -53,7 +53,7 @@ def initialize_thread_local_storage(host):
 
 def main():
     config_name = os.getenv('APP_SETTINGS', "development")
-    application = create_app(config_name)
+    application = create_app(config_name, start_tasks=False)
 
     config = Config()
 


### PR DESCRIPTION
Allow the "tasks" (threads, system profile kafka consumers, delete host event kafka producers to be disabled.  The tasks stuff should likely be injected in.