### PR TITLE
Do not start the tasks subsystem unless explicitly asked to

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,10 +7,13 @@ from flask import jsonify, request
 from api.mgmt import monitoring_blueprint
 from app.config import Config
 from app.models import db
+from app.logging import get_logger
 from app.exceptions import InventoryException
 from app.logging import configure_logging, threadctx
 from app.validators import verify_uuid_format  # noqa: 401
 from tasks import init_tasks
+
+logger = get_logger(__name__)
 
 REQUEST_ID_HEADER = "x-rh-insights-request-id"
 UNKNOWN_REQUEST_ID_VALUE = "-1"
@@ -22,7 +25,7 @@ def render_exception(exception):
     return response
 
 
-def create_app(config_name, start_tasks=True):
+def create_app(config_name, start_tasks=False):
     connexion_options = {"swagger_ui": True}
 
     # This feels like a hack but it is needed.  The logging configuration
@@ -77,5 +80,9 @@ def create_app(config_name, start_tasks=True):
 
     if start_tasks:
         init_tasks(app_config, flask_app)
+    else:
+        logger.warn("WARNING: The \"tasks\" subsystem has been disabled.  "
+                    "The message queue based system_profile consumer "
+                    "and message queue based event notifications have been disabled.")
 
     return flask_app

--- a/run.py
+++ b/run.py
@@ -6,7 +6,7 @@ import logging
 from app import create_app
 
 config_name = os.getenv('APP_SETTINGS', "development")
-application = create_app(config_name)
+application = create_app(config_name, start_tasks=True)
 listen_port = os.getenv('LISTEN_PORT', 8080)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The create_app() method is used in various areas of the code (tests, db migrations, host_dumper, etc) where tasks (threads, kafka producer, kafka consumer, etc) are not required.  For now, make it so that the tasks are only started when explicitly asked to.