### PR TITLE
Move the metrics around.  Add the metrics back to the add_host logic.

### DIFF
--- a/api/metrics.py
+++ b/api/metrics.py
@@ -2,18 +2,8 @@ from prometheus_client import Counter, Summary
 
 api_request_time = Summary("inventory_request_processing_seconds",
                            "Time spent processing request")
-host_dedup_processing_time = Summary("inventory_dedup_processing_seconds",
-                                     "Time spent looking for existing host (dedup logic)")
-new_host_commit_processing_time = Summary("inventory_new_host_commit_seconds",
-                                          "Time spent committing a new host to the database")
-update_host_commit_processing_time = Summary("inventory_update_host_commit_seconds",
-                                             "Time spent committing a update host to the database")
 api_request_count = Counter("inventory_request_count",
                             "The total amount of API requests")
-create_host_count = Counter("inventory_create_host_count",
-                            "The total amount of hosts created")
-update_host_count = Counter("inventory_update_host_count",
-                            "The total amount of hosts updated")
 delete_host_count = Counter("inventory_delete_host_count",
                             "The total amount of hosts deleted")
 delete_host_processing_time = Summary("inventory_delete_host_commit_seconds",

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -1,0 +1,12 @@
+from prometheus_client import Counter, Summary
+
+host_dedup_processing_time = Summary("inventory_dedup_processing_seconds",
+                                     "Time spent looking for existing host (dedup logic)")
+new_host_commit_processing_time = Summary("inventory_new_host_commit_seconds",
+                                          "Time spent committing a new host to the database")
+update_host_commit_processing_time = Summary("inventory_update_host_commit_seconds",
+                                             "Time spent committing a update host to the database")
+create_host_count = Counter("inventory_create_host_count",
+                            "The total amount of hosts created")
+update_host_count = Counter("inventory_update_host_count",
+                            "The total amount of hosts updated")


### PR DESCRIPTION
This commit adds the prometheus metrics back to the add_host logic and moves the metrics out of the api module and into the (poorly named) lib module.