### PR TITLE
 Extract host (de)serialization

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -12,6 +12,7 @@ from app.models import Host, HostSchema, PatchHostSchema
 from app.auth import current_identity
 from app.exceptions import InventoryException
 from app.logging import get_logger
+from app.serialization import Host as SerializationHost
 from api import api_operation, metrics
 from lib.host import add_host, AddHostResults, _canonical_facts_host_query
 from tasks import emit_event
@@ -153,7 +154,7 @@ def _params_to_order_by(order_by=None, order_how=None):
 
 
 def _build_paginated_host_list_response(total, page, per_page, host_list):
-    json_host_list = [host.to_json() for host in host_list]
+    json_host_list = [SerializationHost.to_json(host) for host in host_list]
     json_output = {"total": total,
                    "count": len(host_list),
                    "page": page,
@@ -278,7 +279,7 @@ def get_host_system_profile_by_id(
         query = query.order_by(*order_by)
     query_results = query.paginate(page, per_page, True)
 
-    response_list = [host.to_system_profile_json()
+    response_list = [SerializationHost.to_system_profile_json(host)
                      for host in query_results.items]
 
     json_output = {"total": query_results.total,

--- a/app/models.py
+++ b/app/models.py
@@ -75,36 +75,6 @@ class Host(db.Model):
         self.facts = facts
         self.system_profile_facts = system_profile_facts or {}
 
-    @classmethod
-    def from_json(cls, d):
-        canonical_facts = CanonicalFacts.from_json(d)
-        facts = Facts.from_json(d.get("facts"))
-        return cls(
-            canonical_facts,
-            d.get("display_name", None),
-            d.get("ansible_host"),
-            d.get("account"),
-            facts,
-            d.get("system_profile", {}),
-        )
-
-    def to_json(self):
-        json_dict = CanonicalFacts.to_json(self.canonical_facts)
-        json_dict["id"] = str(self.id)
-        json_dict["account"] = self.account
-        json_dict["display_name"] = self.display_name
-        json_dict["ansible_host"] = self.ansible_host
-        json_dict["facts"] = Facts.to_json(self.facts)
-        json_dict["created"] = self.created_on.isoformat()+"Z"
-        json_dict["updated"] = self.modified_on.isoformat()+"Z"
-        return json_dict
-
-    def to_system_profile_json(self):
-        json_dict = {"id": str(self.id),
-                     "system_profile": self.system_profile_facts or {}
-                     }
-        return json_dict
-
     def save(self):
         db.session.add(self)
 
@@ -196,83 +166,6 @@ class Host(db.Model):
             self.display_name,
             self.canonical_facts,
         )
-
-
-class CanonicalFacts:
-    """
-    There is a mismatch between how the canonical facts are sent as JSON
-    and how the canonical facts are stored in the DB.  This class contains
-    the logic that is responsible for performing the conversion.
-
-    The canonical facts will be stored as a dict in a single json column
-    in the DB.
-    """
-
-    field_names = (
-        "insights_id",
-        "rhel_machine_id",
-        "subscription_manager_id",
-        "satellite_id",
-        "bios_uuid",
-        "ip_addresses",
-        "fqdn",
-        "mac_addresses",
-        "external_id",
-    )
-
-    @staticmethod
-    def from_json(json_dict):
-        canonical_fact_list = {}
-        for cf in CanonicalFacts.field_names:
-            # Do not allow the incoming canonical facts to be None or ''
-            if cf in json_dict and json_dict[cf]:
-                canonical_fact_list[cf] = json_dict[cf]
-        return canonical_fact_list
-
-    @staticmethod
-    def to_json(internal_dict):
-        canonical_fact_dict = dict.fromkeys(CanonicalFacts.field_names, None)
-        for cf in CanonicalFacts.field_names:
-            if cf in internal_dict:
-                canonical_fact_dict[cf] = internal_dict[cf]
-        return canonical_fact_dict
-
-
-class Facts:
-    """
-    There is a mismatch between how the facts are sent as JSON
-    and how the facts are stored in the DB.  This class contains
-    the logic that is responsible for performing the conversion.
-
-    The facts will be stored as a dict in a single json column
-    in the DB.
-    """
-
-    @staticmethod
-    def from_json(fact_list):
-        if fact_list is None:
-            fact_list = []
-
-        fact_dict = {}
-        for fact in fact_list:
-            if "namespace" in fact and "facts" in fact:
-                if fact["namespace"] in fact_dict:
-                    fact_dict[fact["namespace"]].update(fact["facts"])
-                else:
-                    fact_dict[fact["namespace"]] = fact["facts"]
-            else:
-                # The facts from the request are formatted incorrectly
-                raise InputFormatException("Invalid format of Fact object.  Fact "
-                                           "must contain 'namespace' and 'facts' keys.")
-        return fact_dict
-
-    @staticmethod
-    def to_json(fact_dict):
-        fact_list = [
-            {"namespace": namespace, "facts": facts if facts else {}}
-            for namespace, facts in fact_dict.items()
-        ]
-        return fact_list
 
 
 class DiskDeviceSchema(Schema):

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -1,0 +1,117 @@
+from app.models import Host as ModelsHost
+from app.exceptions import InputFormatException
+
+
+__all__ = ("Host", "CanonicalFacts", "Facts")
+
+
+class Host:
+
+    @classmethod
+    def from_json(cls, d):
+        canonical_facts = CanonicalFacts.from_json(d)
+        facts = Facts.from_json(d.get("facts"))
+        return ModelsHost(
+            canonical_facts,
+            d.get("display_name", None),
+            d.get("ansible_host"),
+            d.get("account"),
+            facts,
+            d.get("system_profile", {}),
+        )
+
+    @classmethod
+    def to_json(cls, host):
+        json_dict = CanonicalFacts.to_json(host.canonical_facts)
+        json_dict["id"] = str(host.id)
+        json_dict["account"] = host.account
+        json_dict["display_name"] = host.display_name
+        json_dict["ansible_host"] = host.ansible_host
+        json_dict["facts"] = Facts.to_json(host.facts)
+        json_dict["created"] = host.created_on.isoformat() + "Z"
+        json_dict["updated"] = host.modified_on.isoformat() + "Z"
+        return json_dict
+
+    @classmethod
+    def to_system_profile_json(cls, host):
+        json_dict = {"id": str(host.id),
+            "system_profile": host.system_profile_facts or {}
+        }
+        return json_dict
+
+
+class CanonicalFacts:
+    """
+    There is a mismatch between how the canonical facts are sent as JSON
+    and how the canonical facts are stored in the DB.  This class contains
+    the logic that is responsible for performing the conversion.
+
+    The canonical facts will be stored as a dict in a single json column
+    in the DB.
+    """
+
+    field_names = (
+        "insights_id",
+        "rhel_machine_id",
+        "subscription_manager_id",
+        "satellite_id",
+        "bios_uuid",
+        "ip_addresses",
+        "fqdn",
+        "mac_addresses",
+        "external_id",
+    )
+
+    @staticmethod
+    def from_json(json_dict):
+        canonical_fact_list = {}
+        for cf in CanonicalFacts.field_names:
+            # Do not allow the incoming canonical facts to be None or ''
+            if cf in json_dict and json_dict[cf]:
+                canonical_fact_list[cf] = json_dict[cf]
+        return canonical_fact_list
+
+    @staticmethod
+    def to_json(internal_dict):
+        canonical_fact_dict = dict.fromkeys(CanonicalFacts.field_names, None)
+        for cf in CanonicalFacts.field_names:
+            if cf in internal_dict:
+                canonical_fact_dict[cf] = internal_dict[cf]
+        return canonical_fact_dict
+
+
+class Facts:
+    """
+    There is a mismatch between how the facts are sent as JSON
+    and how the facts are stored in the DB.  This class contains
+    the logic that is responsible for performing the conversion.
+
+    The facts will be stored as a dict in a single json column
+    in the DB.
+    """
+
+    @staticmethod
+    def from_json(fact_list):
+        if fact_list is None:
+            fact_list = []
+
+        fact_dict = {}
+        for fact in fact_list:
+            if "namespace" in fact and "facts" in fact:
+                if fact["namespace"] in fact_dict:
+                    fact_dict[fact["namespace"]].update(fact["facts"])
+                else:
+                    fact_dict[fact["namespace"]] = fact["facts"]
+            else:
+                # The facts from the request are formatted incorrectly
+                raise InputFormatException("Invalid format of Fact object.  Fact "
+                                           "must contain 'namespace' and 'facts' keys.")
+        return fact_dict
+
+    @staticmethod
+    def to_json(fact_dict):
+        fact_list = [
+            {"namespace": namespace, "facts": facts if facts else {}}
+            for namespace, facts in fact_dict.items()
+        ]
+        return fact_list

--- a/host_dumper.py
+++ b/host_dumper.py
@@ -5,7 +5,8 @@ import pprint
 import os
 
 from app import create_app
-from app.models import Host
+from app.models import Host as ModelsHost
+from app.serialization import Host as SerializationHost
 
 application = create_app("cli")
 
@@ -32,26 +33,26 @@ with application.app_context():
     if args.id:
         host_id_list = [args.id]
         print("looking up host using id")
-        query_results = Host.query.filter(
-                Host.id.in_(host_id_list)
+        query_results = ModelsHost.query.filter(
+                ModelsHost.id.in_(host_id_list)
                     ).all()
     elif args.hostname:
         print("looking up host using display_name, fqdn")
-        query_results = Host.query.filter(
-                Host.display_name.comparator.contains(args.hostname)
-                | Host.canonical_facts['fqdn'].astext.contains(args.hostname)
+        query_results = ModelsHost.query.filter(
+            ModelsHost.display_name.comparator.contains(args.hostname)
+            | ModelsHost.canonical_facts['fqdn'].astext.contains(args.hostname)
                     ).all()
     elif args.insights_id:
         print("looking up host using insights_id")
-        query_results = Host.query.filter(
-                Host.canonical_facts.comparator.contains({'insights_id':args.insights_id})
+        query_results = ModelsHost.query.filter(
+                ModelsHost.canonical_facts.comparator.contains({'insights_id':args.insights_id})
                     ).all()
     elif args.account_number:
-        query_results = Host.query.filter(
-                Host.account == args.account_number
+        query_results = ModelsHost.query.filter(
+            ModelsHost.account == args.account_number
                 ).all()
 
-    json_host_list = [host.to_json() for host in query_results]
+    json_host_list = [SerializationHost.to_json(host) for host in query_results]
 
     if args.no_pp:
         print(json_host_list)


### PR DESCRIPTION
Created a new module [app.serialization](https://github.com/Glutexo/insights-host-inventory/blob/b8d9e8b8334fe33f054448499f3ede9245e3fbd3/app/serialization.py). Extracted all Host serialization and deserialization logic into that module. Used the existing paradigm from [_CanonicalFacts_](https://github.com/Glutexo/insights-host-inventory/blob/b8d9e8b8334fe33f054448499f3ede9245e3fbd3/app/serialization.py#L43) and [_Facts_](https://github.com/Glutexo/insights-host-inventory/blob/b8d9e8b8334fe33f054448499f3ede9245e3fbd3/app/serialization.py#L83) classes for the [_Host_](https://github.com/Glutexo/insights-host-inventory/blob/b8d9e8b8334fe33f054448499f3ede9245e3fbd3/app/serialization.py#L8) itself too. All the logic and behavior remained unchanged.

This is a part of the bigger picture of extracting the host import/export to a single place. See #323. The [_Host_](https://github.com/Glutexo/insights-host-inventory/blob/b8d9e8b8334fe33f054448499f3ede9245e3fbd3/app/serialization.py#L8) class name clash is not the nicest thing, but it’s valid as it’s in a different module. Still this is just a temporary state, since I plan to ditch the classes and rename the functions as one of the further steps.