### PR TITLE
Extract (de)serialization methods

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -17,7 +17,8 @@ from app.exceptions import ValidationException
 from app.logging import get_logger
 from app.models import Host
 from app.models import PatchHostSchema
-from app.serialization import Host as SerializationHost
+from app.serialization import serialize_host
+from app.serialization import serialize_host_system_profile
 from lib.host_repository import _canonical_facts_host_query
 from lib.host_repository import add_host
 from lib.host_repository import AddHostResults
@@ -152,7 +153,7 @@ def _params_to_order_by(order_by=None, order_how=None):
 
 
 def _build_paginated_host_list_response(total, page, per_page, host_list):
-    json_host_list = [SerializationHost.to_json(host) for host in host_list]
+    json_host_list = [serialize_host(host) for host in host_list]
     json_output = {
         "total": total,
         "count": len(host_list),
@@ -264,7 +265,7 @@ def get_host_system_profile_by_id(host_id_list, page=1, per_page=100, order_by=N
         query = query.order_by(*order_by)
     query_results = query.paginate(page, per_page, True)
 
-    response_list = [SerializationHost.to_system_profile_json(host) for host in query_results.items]
+    response_list = [serialize_host_system_profile(host) for host in query_results.items]
 
     json_output = {
         "total": query_results.total,

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -1,114 +1,89 @@
 from app.exceptions import InputFormatException
-from app.models import Host as ModelsHost
+from app.models import Host as Host
 
 
-__all__ = ("Host", "CanonicalFacts", "Facts")
+__all__ = ("deserialize_host", "serialize_host", "serialize_host_system_profile")
 
 
-class Host:
-    @classmethod
-    def from_json(cls, d):
-        canonical_facts = CanonicalFacts.from_json(d)
-        facts = Facts.from_json(d.get("facts"))
-        return ModelsHost(
-            canonical_facts,
-            d.get("display_name", None),
-            d.get("ansible_host"),
-            d.get("account"),
-            facts,
-            d.get("system_profile", {}),
-        )
-
-    @classmethod
-    def to_json(cls, host):
-        json_dict = CanonicalFacts.to_json(host.canonical_facts)
-        json_dict["id"] = str(host.id)
-        json_dict["account"] = host.account
-        json_dict["display_name"] = host.display_name
-        json_dict["ansible_host"] = host.ansible_host
-        json_dict["facts"] = Facts.to_json(host.facts)
-        json_dict["created"] = host.created_on.isoformat() + "Z"
-        json_dict["updated"] = host.modified_on.isoformat() + "Z"
-        return json_dict
-
-    @classmethod
-    def to_system_profile_json(cls, host):
-        json_dict = {"id": str(host.id), "system_profile": host.system_profile_facts or {}}
-        return json_dict
+_CANONICAL_FACTS_FIELDS = (
+    "insights_id",
+    "rhel_machine_id",
+    "subscription_manager_id",
+    "satellite_id",
+    "bios_uuid",
+    "ip_addresses",
+    "fqdn",
+    "mac_addresses",
+    "external_id",
+)
 
 
-class CanonicalFacts:
-    """
-    There is a mismatch between how the canonical facts are sent as JSON
-    and how the canonical facts are stored in the DB.  This class contains
-    the logic that is responsible for performing the conversion.
-
-    The canonical facts will be stored as a dict in a single json column
-    in the DB.
-    """
-
-    field_names = (
-        "insights_id",
-        "rhel_machine_id",
-        "subscription_manager_id",
-        "satellite_id",
-        "bios_uuid",
-        "ip_addresses",
-        "fqdn",
-        "mac_addresses",
-        "external_id",
+def deserialize_host(data):
+    canonical_facts = _deserialize_canonical_facts(data)
+    facts = _deserialize_facts(data.get("facts"))
+    return Host(
+        canonical_facts,
+        data.get("display_name", None),
+        data.get("ansible_host"),
+        data.get("account"),
+        facts,
+        data.get("system_profile", {}),
     )
 
-    @staticmethod
-    def from_json(json_dict):
-        canonical_fact_list = {}
-        for cf in CanonicalFacts.field_names:
-            # Do not allow the incoming canonical facts to be None or ''
-            if cf in json_dict and json_dict[cf]:
-                canonical_fact_list[cf] = json_dict[cf]
-        return canonical_fact_list
 
-    @staticmethod
-    def to_json(internal_dict):
-        canonical_fact_dict = dict.fromkeys(CanonicalFacts.field_names, None)
-        for cf in CanonicalFacts.field_names:
-            if cf in internal_dict:
-                canonical_fact_dict[cf] = internal_dict[cf]
-        return canonical_fact_dict
+def serialize_host(host):
+    json_dict = _serialize_canonical_facts(host.canonical_facts)
+    json_dict["id"] = str(host.id)
+    json_dict["account"] = host.account
+    json_dict["display_name"] = host.display_name
+    json_dict["ansible_host"] = host.ansible_host
+    json_dict["facts"] = _serialize_facts(host.facts)
+    json_dict["created"] = host.created_on.isoformat() + "Z"
+    json_dict["updated"] = host.modified_on.isoformat() + "Z"
+    return json_dict
 
 
-class Facts:
-    """
-    There is a mismatch between how the facts are sent as JSON
-    and how the facts are stored in the DB.  This class contains
-    the logic that is responsible for performing the conversion.
+def serialize_host_system_profile(host):
+    json_dict = {"id": str(host.id), "system_profile": host.system_profile_facts or {}}
+    return json_dict
 
-    The facts will be stored as a dict in a single json column
-    in the DB.
-    """
 
-    @staticmethod
-    def from_json(fact_list):
-        if fact_list is None:
-            fact_list = []
+def _deserialize_canonical_facts(data):
+    canonical_fact_list = {}
+    for cf in _CANONICAL_FACTS_FIELDS:
+        # Do not allow the incoming canonical facts to be None or ''
+        if cf in data and data[cf]:
+            canonical_fact_list[cf] = data[cf]
+    return canonical_fact_list
 
-        fact_dict = {}
-        for fact in fact_list:
-            if "namespace" in fact and "facts" in fact:
-                if fact["namespace"] in fact_dict:
-                    fact_dict[fact["namespace"]].update(fact["facts"])
-                else:
-                    fact_dict[fact["namespace"]] = fact["facts"]
+
+def _serialize_canonical_facts(canonical_facts):
+    canonical_fact_dict = dict.fromkeys(_CANONICAL_FACTS_FIELDS, None)
+    for cf in _CANONICAL_FACTS_FIELDS:
+        if cf in canonical_facts:
+            canonical_fact_dict[cf] = canonical_facts[cf]
+    return canonical_fact_dict
+
+
+def _deserialize_facts(data):
+    if data is None:
+        data = []
+
+    fact_dict = {}
+    for fact in data:
+        if "namespace" in fact and "facts" in fact:
+            if fact["namespace"] in fact_dict:
+                fact_dict[fact["namespace"]].update(fact["facts"])
             else:
-                # The facts from the request are formatted incorrectly
-                raise InputFormatException(
-                    "Invalid format of Fact object.  Fact must contain 'namespace' and 'facts' keys."
-                )
-        return fact_dict
+                fact_dict[fact["namespace"]] = fact["facts"]
+        else:
+            # The facts from the request are formatted incorrectly
+            raise InputFormatException(
+                "Invalid format of Fact object.  Fact must contain 'namespace' and 'facts' keys."
+            )
+    return fact_dict
 
-    @staticmethod
-    def to_json(fact_dict):
-        fact_list = [
-            {"namespace": namespace, "facts": facts if facts else {}} for namespace, facts in fact_dict.items()
-        ]
-        return fact_list
+
+def _serialize_facts(facts):
+    fact_list = [{"namespace": namespace, "facts": facts if facts else {}} for namespace, facts in facts.items()]
+    return fact_list

--- a/host_dumper.py
+++ b/host_dumper.py
@@ -3,8 +3,8 @@ import argparse
 import pprint
 
 from app import create_app
-from app.models import Host as ModelsHost
-from app.serialization import Host as SerializationHost
+from app.models import Host
+from app.serialization import serialize_host
 
 application = create_app("cli")
 
@@ -26,22 +26,22 @@ with application.app_context():
     if args.id:
         host_id_list = [args.id]
         print("looking up host using id")
-        query_results = ModelsHost.query.filter(ModelsHost.id.in_(host_id_list)).all()
+        query_results = Host.query.filter(Host.id.in_(host_id_list)).all()
     elif args.hostname:
         print("looking up host using display_name, fqdn")
-        query_results = ModelsHost.query.filter(
-            ModelsHost.display_name.comparator.contains(args.hostname)
-            | ModelsHost.canonical_facts["fqdn"].astext.contains(args.hostname)
+        query_results = Host.query.filter(
+            Host.display_name.comparator.contains(args.hostname)
+            | Host.canonical_facts["fqdn"].astext.contains(args.hostname)
         ).all()
     elif args.insights_id:
         print("looking up host using insights_id")
-        query_results = ModelsHost.query.filter(
-            ModelsHost.canonical_facts.comparator.contains({"insights_id": args.insights_id})
+        query_results = Host.query.filter(
+            Host.canonical_facts.comparator.contains({"insights_id": args.insights_id})
         ).all()
     elif args.account_number:
-        query_results = ModelsHost.query.filter(ModelsHost.account == args.account_number).all()
+        query_results = Host.query.filter(Host.account == args.account_number).all()
 
-    json_host_list = [SerializationHost.to_json(host) for host in query_results]
+    json_host_list = [serialize_host(host) for host in query_results]
 
     if args.no_pp:
         print(json_host_list)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -7,7 +7,8 @@ from app.logging import get_logger
 from app.models import db
 from app.models import Host
 from app.models import HostSchema
-from app.serialization import Host as SerializationHost
+from app.serialization import deserialize_host
+from app.serialization import serialize_host
 from lib import metrics
 
 # FIXME:  rename this
@@ -36,7 +37,7 @@ def add_host(host, update_system_profile=True):
     except ValidationError as e:
         raise ValidationException(str(e.messages)) from None
 
-    input_host = SerializationHost.from_json(validated_input_host_dict.data)
+    input_host = deserialize_host(validated_input_host_dict.data)
 
     existing_host = find_existing_host(input_host.account, input_host.canonical_facts)
 
@@ -99,7 +100,7 @@ def create_new_host(input_host):
     db.session.commit()
     metrics.create_host_count.inc()
     logger.debug("Created host:%s", input_host)
-    return SerializationHost.to_json(input_host), AddHostResults.created
+    return serialize_host(input_host), AddHostResults.created
 
 
 @metrics.update_host_commit_processing_time.time()
@@ -109,4 +110,4 @@ def update_existing_host(existing_host, input_host, update_system_profile):
     db.session.commit()
     metrics.update_host_count.inc()
     logger.debug("Updated host:%s", existing_host)
-    return SerializationHost.to_json(existing_host), AddHostResults.updated
+    return serialize_host(existing_host), AddHostResults.updated

--- a/test_db_model.py
+++ b/test_db_model.py
@@ -2,7 +2,7 @@ import uuid
 
 from app import db
 from app.models import Host
-from app.serialization import Host as SerializationHost
+from app.serialization import deserialize_host
 
 """
 These tests are for testing the db model classes outside of the api.
@@ -29,7 +29,7 @@ def test_create_host_with_canonical_facts_as_None(flask_app_fixture):
 
     host_dict = {**invalid_canonical_facts, **valid_canonical_facts}
 
-    host = SerializationHost.from_json(host_dict)
+    host = deserialize_host(host_dict)
 
     assert valid_canonical_facts == host.canonical_facts
 


### PR DESCRIPTION
Moved all the [_Host_](https://github.com/Glutexo/insights-host-inventory/blob/c455dafbd4c0ad3a36218c011047b9319ccb1011/app/models.py#L33), [_CanonicalFacts_](https://github.com/Glutexo/insights-hostinventory/blob/c455dafbd4c0ad3a36218c011047b9319ccb1011/app/models.py#L76) and [_Facts_](https://github.com/Glutexo/insights-host-inventory/blob/c455dafbd4c0ad3a36218c011047b9319ccb1011/app/models.py#L93) (de)serialization methods from the classes to bare functions. The _CanonicalFacts_ and _Facts_ were mere containers for static methods. The [_Host_](https://github.com/Glutexo/insights-host-inventory/blob/c455dafbd4c0ad3a36218c011047b9319ccb1011/app/models.py#L119) is a database model, which should not be concerned about serialization.

The new bare methods can be easily extracted to a separate module (#324). They have unified naming including the argument names.