### PR TITLE
Serialization: Improve host (de)serialization tests

### DIFF
--- a/test_unit.py
+++ b/test_unit.py
@@ -327,14 +327,22 @@ class HostParamsToOrderByErrorsTestCase(TestCase):
             _params_to_order_by(Mock(), order_how="ASC")
 
 
-class SerializationHostFromJsonCompoundTestCase(TestCase):
+class SerializationBaseTestCase(TestCase):
+    def _format_uuid_without_hyphens(self, uuid_):
+        return uuid_.hex
+
+    def _format_uuid_with_hyphens(self, uuid_):
+        return str(uuid_)
+
+
+class SerializationHostFromJsonCompoundTestCase(SerializationBaseTestCase):
     def test_with_all_fields(self):
         canonical_facts = {
-            "insights_id": str(uuid4()),
-            "rhel_machine_id": str(uuid4()),
-            "subscription_manager_id": str(uuid4()),
-            "satellite_id": str(uuid4()),
-            "bios_uuid": str(uuid4()),
+            "insights_id": self._format_uuid_with_hyphens(uuid4()),
+            "rhel_machine_id": self._format_uuid_with_hyphens(uuid4()),
+            "subscription_manager_id": self._format_uuid_with_hyphens(uuid4()),
+            "satellite_id": self._format_uuid_with_hyphens(uuid4()),
+            "bios_uuid": self._format_uuid_with_hyphens(uuid4()),
             "ip_addresses": ["10.10.0.1", "10.0.0.2"],
             "fqdn": "some fqdn",
             "mac_addresses": ["c2:00:d0:c8:61:01"],
@@ -388,17 +396,17 @@ class SerializationHostFromJsonCompoundTestCase(TestCase):
 @patch("app.serialization.ModelsHost")
 @patch("app.serialization.Facts.from_json")
 @patch("app.serialization.CanonicalFacts.from_json")
-class SerializationHostFromJsonMockedTestCase(TestCase):
+class SerializationHostFromJsonMockedTestCase(SerializationBaseTestCase):
     def test_with_all_fields(self, canonical_facts_from_json, facts_from_json, models_host):
         input = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
             "account": "some account",
-            "insights_id": str(uuid4()),
-            "rhel_machine_id": str(uuid4()),
-            "subscription_manager_id": str(uuid4()),
-            "satellite_id": str(uuid4()),
-            "bios_uuid": str(uuid4()),
+            "insights_id": self._format_uuid_with_hyphens(uuid4()),
+            "rhel_machine_id": self._format_uuid_with_hyphens(uuid4()),
+            "subscription_manager_id": self._format_uuid_with_hyphens(uuid4()),
+            "satellite_id": self._format_uuid_with_hyphens(uuid4()),
+            "bios_uuid": self._format_uuid_with_hyphens(uuid4()),
             "ip_addresses": ["10.10.0.1", "10.0.0.2"],
             "fqdn": "some fqdn",
             "mac_addresses": ["c2:00:d0:c8:61:01"],
@@ -518,14 +526,14 @@ class SerializationHostToJsonBaseTestCase(TestCase):
         return f"{formatted}Z"
 
 
-class SerializationHostToJsonCompoundTestCase(SerializationHostToJsonBaseTestCase):
+class SerializationHostToJsonCompoundTestCase(SerializationHostToJsonBaseTestCase, SerializationBaseTestCase):
     def test_with_all_fields(self):
         canonical_facts = {
-            "insights_id": str(uuid4()),
-            "rhel_machine_id": str(uuid4()),
-            "subscription_manager_id": str(uuid4()),
-            "satellite_id": str(uuid4()),
-            "bios_uuid": str(uuid4()),
+            "insights_id": self._format_uuid_with_hyphens(uuid4()),
+            "rhel_machine_id": self._format_uuid_with_hyphens(uuid4()),
+            "subscription_manager_id": self._format_uuid_with_hyphens(uuid4()),
+            "satellite_id": self._format_uuid_with_hyphens(uuid4()),
+            "bios_uuid": self._format_uuid_with_hyphens(uuid4()),
             "ip_addresses": ["10.10.0.1", "10.0.0.2"],
             "fqdn": "some fqdn",
             "mac_addresses": ["c2:00:d0:c8:61:01"],
@@ -557,7 +565,7 @@ class SerializationHostToJsonCompoundTestCase(SerializationHostToJsonBaseTestCas
             "facts": [
                 {"namespace": namespace, "facts": facts} for namespace, facts in host_init_data["facts"].items()
             ],
-            "id": str(host_attr_data["id"]),
+            "id": self._format_uuid_with_hyphens(host_attr_data["id"]),
             "created": self._timestamp_to_str(host_attr_data["created_on"]),
             "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
         }
@@ -586,7 +594,7 @@ class SerializationHostToJsonCompoundTestCase(SerializationHostToJsonBaseTestCas
             "ansible_host": None,
             **unchanged_data,
             "facts": [],
-            "id": str(host_attr_data["id"]),
+            "id": self._format_uuid_with_hyphens(host_attr_data["id"]),
             "created": self._timestamp_to_str(host_attr_data["created_on"]),
             "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
         }
@@ -595,9 +603,9 @@ class SerializationHostToJsonCompoundTestCase(SerializationHostToJsonBaseTestCas
 
 @patch("app.serialization.Facts.to_json")
 @patch("app.serialization.CanonicalFacts.to_json")
-class SerializationHostToJsonMockedTestCase(SerializationHostToJsonBaseTestCase):
+class SerializationHostToJsonMockedTestCase(SerializationHostToJsonBaseTestCase, SerializationBaseTestCase):
     def test_with_all_fields(self, canonical_facts_to_json, facts_to_json):
-        canonical_facts = {"insights_id": str(uuid4()), "fqdn": "some fqdn"}
+        canonical_facts = {"insights_id": self._format_uuid_with_hyphens(uuid4()), "fqdn": "some fqdn"}
         canonical_facts_to_json.return_value = canonical_facts
         facts = [
             {"namespace": "some namespace", "facts": {"some key": "some value"}},
@@ -622,7 +630,7 @@ class SerializationHostToJsonMockedTestCase(SerializationHostToJsonBaseTestCase)
             **canonical_facts,
             **unchanged_data,
             "facts": facts_to_json.return_value,
-            "id": str(host_attr_data["id"]),
+            "id": self._format_uuid_with_hyphens(host_attr_data["id"]),
             "created": self._timestamp_to_str(host_attr_data["created_on"]),
             "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
         }
@@ -632,7 +640,7 @@ class SerializationHostToJsonMockedTestCase(SerializationHostToJsonBaseTestCase)
         facts_to_json.assert_called_once_with(host_init_data["facts"])
 
 
-class SerializationHostToSystemProfileJsonTestCase(TestCase):
+class SerializationHostToSystemProfileJsonTestCase(SerializationBaseTestCase):
     def test_non_empty_profile_is_not_changed(self):
         system_profile_facts = {
             "number_of_cpus": 1,
@@ -648,7 +656,7 @@ class SerializationHostToSystemProfileJsonTestCase(TestCase):
         host.id = uuid4()
 
         actual = SerializationHost.to_system_profile_json(host)
-        expected = {"id": str(host.id), "system_profile": system_profile_facts}
+        expected = {"id": self._format_uuid_with_hyphens(host.id), "system_profile": system_profile_facts}
         self.assertEqual(expected, actual)
 
     def test_empty_profile_is_empty_dict(self):
@@ -657,17 +665,11 @@ class SerializationHostToSystemProfileJsonTestCase(TestCase):
         host.system_profile_facts = None
 
         actual = SerializationHost.to_system_profile_json(host)
-        expected = {"id": str(host.id), "system_profile": {}}
+        expected = {"id": self._format_uuid_with_hyphens(host.id), "system_profile": {}}
         self.assertEqual(expected, actual)
 
 
-class SerializationCanonicalFactsFromJson(TestCase):
-    def _format_uuid_without_hyphens(self, uuid_):
-        return uuid_.hex
-
-    def _format_uuid_with_hyphens(self, uuid_):
-        return str(uuid_)
-
+class SerializationCanonicalFactsFromJson(SerializationBaseTestCase):
     def _randomly_formatted_uuid(self, uuid_):
         transformation = choice((self._format_uuid_without_hyphens, self._format_uuid_with_hyphens))
         return transformation(uuid_)
@@ -693,11 +695,11 @@ class SerializationCanonicalFactsFromJson(TestCase):
 
     def test_unknown_fields_are_rejected(self):
         canonical_facts = {
-            "insights_id": str(uuid4()),
-            "rhel_machine_id": str(uuid4()),
-            "subscription_manager_id": str(uuid4()),
-            "satellite_id": str(uuid4()),
-            "bios_uuid": str(uuid4()),
+            "insights_id": self._format_uuid_with_hyphens(uuid4()),
+            "rhel_machine_id": self._format_uuid_with_hyphens(uuid4()),
+            "subscription_manager_id": self._format_uuid_with_hyphens(uuid4()),
+            "satellite_id": self._format_uuid_with_hyphens(uuid4()),
+            "bios_uuid": self._format_uuid_with_hyphens(uuid4()),
             "ip_addresses": ("10.10.0.1", "10.10.0.2"),
             "fqdn": "some fqdn",
             "mac_addresses": ["c2:00:d0:c8:61:01"],
@@ -720,14 +722,14 @@ class SerializationCanonicalFactsFromJson(TestCase):
         self.assertEqual(result, canonical_facts)
 
 
-class SerializationCanonicalFactsToJsonTestCase(TestCase):
+class SerializationCanonicalFactsToJsonTestCase(SerializationBaseTestCase):
     def test_contains_all_values_unchanged(self):
         canonical_facts = {
-            "insights_id": str(uuid4()),
-            "rhel_machine_id": str(uuid4()),
-            "subscription_manager_id": str(uuid4()),
-            "satellite_id": str(uuid4()),
-            "bios_uuid": str(uuid4()),
+            "insights_id": self._format_uuid_with_hyphens(uuid4()),
+            "rhel_machine_id": self._format_uuid_with_hyphens(uuid4()),
+            "subscription_manager_id": self._format_uuid_with_hyphens(uuid4()),
+            "satellite_id": self._format_uuid_with_hyphens(uuid4()),
+            "bios_uuid": self._format_uuid_with_hyphens(uuid4()),
             "ip_addresses": ("10.10.0.1", "10.10.0.2"),
             "fqdn": "some fqdn",
             "mac_addresses": ("c2:00:d0:c8:61:01",),

--- a/test_unit.py
+++ b/test_unit.py
@@ -348,14 +348,14 @@ class SerializationHostFromJsonCompoundTestCase(SerializationBaseTestCase):
             "mac_addresses": ["c2:00:d0:c8:61:01"],
             "external_id": "i-05d2313e6b9a42b16",
         }
-        unchanged_input = {
+        unchanged_data = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
             "account": "some account",
         }
-        input = {
+        host_init_data = {
             **canonical_facts,
-            **unchanged_input,
+            **unchanged_data,
             "facts": [
                 {"namespace": "some namespace", "facts": {"some key": "some value"}},
                 {"namespace": "another namespace", "facts": {"another key": "another value"}},
@@ -368,12 +368,12 @@ class SerializationHostFromJsonCompoundTestCase(SerializationBaseTestCase):
             },
         }
 
-        actual = SerializationHost.from_json(input)
+        actual = SerializationHost.from_json(host_init_data)
         expected = {
             "canonical_facts": canonical_facts,
-            **unchanged_input,
-            "facts": {item["namespace"]: item["facts"] for item in input["facts"]},
-            "system_profile_facts": input["system_profile"],
+            **unchanged_data,
+            "facts": {item["namespace"]: item["facts"] for item in host_init_data["facts"]},
+            "system_profile_facts": host_init_data["system_profile"],
         }
 
         self.assertIs(ModelsHost, type(actual))
@@ -398,7 +398,7 @@ class SerializationHostFromJsonCompoundTestCase(SerializationBaseTestCase):
 @patch("app.serialization.CanonicalFacts.from_json")
 class SerializationHostFromJsonMockedTestCase(SerializationBaseTestCase):
     def test_with_all_fields(self, canonical_facts_from_json, facts_from_json, models_host):
-        input = {
+        host_data = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
             "account": "some account",
@@ -423,22 +423,22 @@ class SerializationHostFromJsonMockedTestCase(SerializationBaseTestCase):
             },
         }
 
-        result = SerializationHost.from_json(input)
+        result = SerializationHost.from_json(host_data)
         self.assertEqual(models_host.return_value, result)
 
-        canonical_facts_from_json.assert_called_once_with(input)
-        facts_from_json.assert_called_once_with(input["facts"])
+        canonical_facts_from_json.assert_called_once_with(host_data)
+        facts_from_json.assert_called_once_with(host_data["facts"])
         models_host.assert_called_once_with(
             canonical_facts_from_json.return_value,
-            input["display_name"],
-            input["ansible_host"],
-            input["account"],
+            host_data["display_name"],
+            host_data["ansible_host"],
+            host_data["account"],
             facts_from_json.return_value,
-            input["system_profile"],
+            host_data["system_profile"],
         )
 
     def test_without_facts(self, canonical_facts_from_json, facts_from_json, models_host):
-        input = {
+        host_data = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
             "account": "some account",
@@ -450,22 +450,22 @@ class SerializationHostFromJsonMockedTestCase(SerializationBaseTestCase):
             },
         }
 
-        result = SerializationHost.from_json(input)
+        result = SerializationHost.from_json(host_data)
         self.assertEqual(models_host.return_value, result)
 
-        canonical_facts_from_json.assert_called_once_with(input)
+        canonical_facts_from_json.assert_called_once_with(host_data)
         facts_from_json.assert_called_once_with(None)
         models_host.assert_called_once_with(
             canonical_facts_from_json.return_value,
-            input["display_name"],
-            input["ansible_host"],
-            input["account"],
+            host_data["display_name"],
+            host_data["ansible_host"],
+            host_data["account"],
             facts_from_json.return_value,
-            input["system_profile"],
+            host_data["system_profile"],
         )
 
     def test_without_display_name(self, canonical_facts_from_json, facts_from_json, models_host):
-        input = {
+        host_data = {
             "ansible_host": "some ansible host",
             "account": "some account",
             "facts": {
@@ -480,22 +480,22 @@ class SerializationHostFromJsonMockedTestCase(SerializationBaseTestCase):
             },
         }
 
-        result = SerializationHost.from_json(input)
+        result = SerializationHost.from_json(host_data)
         self.assertEqual(models_host.return_value, result)
 
-        canonical_facts_from_json.assert_called_once_with(input)
-        facts_from_json.assert_called_once_with(input["facts"])
+        canonical_facts_from_json.assert_called_once_with(host_data)
+        facts_from_json.assert_called_once_with(host_data["facts"])
         models_host.assert_called_once_with(
             canonical_facts_from_json.return_value,
             None,
-            input["ansible_host"],
-            input["account"],
+            host_data["ansible_host"],
+            host_data["account"],
             facts_from_json.return_value,
-            input["system_profile"],
+            host_data["system_profile"],
         )
 
     def test_without_system_profile(self, canonical_facts_from_json, facts_from_json, models_host):
-        input = {
+        host_data = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
             "account": "some account",
@@ -505,16 +505,16 @@ class SerializationHostFromJsonMockedTestCase(SerializationBaseTestCase):
             },
         }
 
-        result = SerializationHost.from_json(input)
+        result = SerializationHost.from_json(host_data)
         self.assertEqual(models_host.return_value, result)
 
-        canonical_facts_from_json.assert_called_once_with(input)
-        facts_from_json.assert_called_once_with(input["facts"])
+        canonical_facts_from_json.assert_called_once_with(host_data)
+        facts_from_json.assert_called_once_with(host_data["facts"])
         models_host.assert_called_once_with(
             canonical_facts_from_json.return_value,
-            input["display_name"],
-            input["ansible_host"],
-            input["account"],
+            host_data["display_name"],
+            host_data["ansible_host"],
+            host_data["account"],
             facts_from_json.return_value,
             {},
         )
@@ -676,8 +676,8 @@ class SerializationHostFromToJsonCompoundTestCase(SerializationHostToJsonBaseTes
             ],
         }
 
-        input = {**unchanged_data, **system_profile}
-        host = SerializationHost.from_json(input)
+        host_init_data = {**unchanged_data, **system_profile}
+        host = SerializationHost.from_json(host_init_data)
         self._add_saved_fields_to_host(host)
 
         actual = SerializationHost.to_json(host)
@@ -740,7 +740,7 @@ class SerializationCanonicalFactsFromJson(SerializationBaseTestCase):
         return transformation(seq)
 
     def test_values_are_stored_unchanged(self):
-        input = {
+        canonical_facts_data = {
             "insights_id": self._randomly_formatted_uuid(uuid4()),
             "rhel_machine_id": self._randomly_formatted_uuid(uuid4()),
             "subscription_manager_id": self._randomly_formatted_uuid(uuid4()),
@@ -751,8 +751,8 @@ class SerializationCanonicalFactsFromJson(SerializationBaseTestCase):
             "mac_addresses": self._randomly_formatted_sequence(("c2:00:d0:c8:61:01",)),
             "external_id": "i-05d2313e6b9a42b16",
         }
-        result = CanonicalFacts.from_json(input)
-        self.assertEqual(result, input)
+        result = CanonicalFacts.from_json(canonical_facts_data)
+        self.assertEqual(result, canonical_facts_data)
 
     def test_unknown_fields_are_rejected(self):
         canonical_facts = {
@@ -766,20 +766,20 @@ class SerializationCanonicalFactsFromJson(SerializationBaseTestCase):
             "mac_addresses": ["c2:00:d0:c8:61:01"],
             "external_id": "i-05d2313e6b9a42b16",
         }
-        input = {**canonical_facts, "unknown": "something"}
-        result = CanonicalFacts.from_json(input)
+        canonical_facts_init_data = {**canonical_facts, "unknown": "something"}
+        result = CanonicalFacts.from_json(canonical_facts_init_data)
         self.assertEqual(result, canonical_facts)
 
     def test_empty_fields_are_rejected(self):
         canonical_facts = {"fqdn": "some fqdn"}
-        input = {
+        canonical_facts_init_data = {
             **canonical_facts,
             "insights_id": "",
             "rhel_machine_id": None,
             "ip_addresses": [],
             "mac_addresses": tuple(),
         }
-        result = CanonicalFacts.from_json(input)
+        result = CanonicalFacts.from_json(canonical_facts_init_data)
         self.assertEqual(result, canonical_facts)
 
 
@@ -815,28 +815,30 @@ class SerializationCanonicalFactsToJsonTestCase(SerializationBaseTestCase):
 
 class SerializationFactsFromJsonTestCase(TestCase):
     def test_non_empty_namespaces_become_dict_items(self):
-        input = [
+        facts_data = [
             {"namespace": "first namespace", "facts": {"first key": "first value", "second key": "second value"}},
             {"namespace": "second namespace", "facts": {"third key": "third value"}},
         ]
-        self.assertEqual({item["namespace"]: item["facts"] for item in input}, Facts.from_json(input))
+        self.assertEqual({item["namespace"]: item["facts"] for item in facts_data}, Facts.from_json(facts_data))
 
     def test_empty_namespaces_remain_unchanged(self):
         for empty_facts in ({}, None):
             with self.subTest(empty_facts=empty_facts):
-                input = [
+                facts_data = [
                     {"namespace": "first namespace", "facts": {"first key": "first value"}},
                     {"namespace": "second namespace", "facts": empty_facts},
                 ]
-                self.assertEqual({item["namespace"]: item["facts"] for item in input}, Facts.from_json(input))
+                self.assertEqual(
+                    {item["namespace"]: item["facts"] for item in facts_data}, Facts.from_json(facts_data)
+                )
 
     def test_duplicate_namespaces_are_merged(self):
-        input = [
+        facts_data = [
             {"namespace": "first namespace", "facts": {"first key": "first value", "second key": "second value"}},
             {"namespace": "second namespace", "facts": {"third key": "third value"}},
             {"namespace": "first namespace", "facts": {"first key": "fourth value"}},
         ]
-        actual = Facts.from_json(input)
+        actual = Facts.from_json(facts_data)
         expected = {
             "first namespace": {"first key": "fourth value", "second key": "second value"},
             "second namespace": {"third key": "third value"},
@@ -855,9 +857,9 @@ class SerializationFactsFromJsonTestCase(TestCase):
         )
         for invalid_item in invalid_items:
             with self.subTest(invalid_item=invalid_item):
-                input = [{"namespace": "first namespace", "facts": {"first key": "first value"}}, invalid_item]
+                facts_data = [{"namespace": "first namespace", "facts": {"first key": "first value"}}, invalid_item]
                 with self.assertRaises(InputFormatException):
-                    Facts.from_json(input)
+                    Facts.from_json(facts_data)
 
 
 class SerializationFactsToJsonTestCase(TestCase):


### PR DESCRIPTION
Added a few improvements to the (de)serialization tests.

* Used methods with expressive names to format UUIDs. https://github.com/RedHatInsights/insights-host-inventory/commit/a36ba687670c460e7576f0d7c800f45b5a6ba4d7
* Renamed variables, whose names were clashing with built-in functions. https://github.com/RedHatInsights/insights-host-inventory/commit/692bc358e95b396e008e8348f88de3a659377811
* Added compound tests verifying that deserialization and serialization work well together. https://github.com/RedHatInsights/insights-host-inventory/commit/7403e1f496416cb4aa515170d922142c8878be3d

See the respective commit messages for further info.