### PR TITLE
Formatting: fix Flake8 whitespace violations

### DIFF
--- a/host_dumper.py
+++ b/host_dumper.py
@@ -44,7 +44,7 @@ with application.app_context():
     elif args.insights_id:
         print("looking up host using insights_id")
         query_results = Host.query.filter(
-                Host.canonical_facts.comparator.contains({'insights_id':args.insights_id})
+                Host.canonical_facts.comparator.contains({'insights_id': args.insights_id})
                     ).all()
     elif args.account_number:
         query_results = Host.query.filter(

--- a/test_api.py
+++ b/test_api.py
@@ -870,7 +870,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
                 "infrastructure_vendor": "dell",
                 "network_interfaces": [{"ipv4_addresses": ["10.10.10.1"],
                                         "state": "UP",
-                                        "ipv6_addresses": ["2001:0db8:85a3:0000:0000:8a2e:0370:7334",],
+                                        "ipv6_addresses": ["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
                                         "mtu": 1500,
                                         "mac_address": "aa:bb:cc:dd:ee:ff",
                                         "type": "loopback",


### PR DESCRIPTION
Fixed the E231 Flake8 rule that targets whitespace around operators and control characters. In case of the [removed comma](https://github.com/RedHatInsights/insights-host-inventory/pull/334/files#diff-dc4308fba8c70f6d0b9ab17c57fb8ab2R873), the actual fix would be to add a space, but since this is not a multi-line expression, the trailing comma is redundant.

This is a part of the way to ultimately fixed formatting. #189 #335 Related to #331.