### PR TITLE
Formatting: fix Flake8 newlines

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,4 +1,5 @@
 from prometheus_client import multiprocess
 
+
 def child_exit(server, worker):
     multiprocess.mark_process_dead(worker.pid)

--- a/test_api.py
+++ b/test_api.py
@@ -715,6 +715,7 @@ class CreateHostsTestCase(DBAPITestCase):
                 self.verify_error_response(error_host,
                                            expected_title="Bad Request")
 
+
 class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):
 
     def test_create_host_without_display_name_and_without_fqdn(self):
@@ -772,6 +773,7 @@ class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):
         self._validate_host(host_lookup_results["results"][0],
                             host_data,
                             expected_id=original_id)
+
 
 class BulkCreateHostsTestCase(DBAPITestCase):
 

--- a/test_api.py
+++ b/test_api.py
@@ -1717,7 +1717,6 @@ class QueryOrderBadRequestsTestCase(QueryOrderTestCase):
                 response = self._get(url, None, "ASC", 400)
 
 
-
 class FactsTestCase(PreCreatedHostsBaseTestCase):
     def _valid_fact_doc(self):
         return {"newfact1": "newvalue1", "newfact2": "newvalue2"}

--- a/test_db_model.py
+++ b/test_db_model.py
@@ -8,6 +8,7 @@ from test_utils import flask_app_fixture
 These tests are for testing the db model classes outside of the api.
 """
 
+
 def _create_host(insights_id=None, fqdn=None, display_name=None):
     if not insights_id:
         insights_id = str(uuid.uuid4())


### PR DESCRIPTION
Fixed missing and redundant newlines triggering Flake8 _E3_ rules.

This is a part of the first step to fix all the formatting. See #335, #189 and #331.