### PR TITLE
Formatting: fix Flake8 imports

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,4 +1,3 @@
-import logging
 import time
 
 from functools import wraps

--- a/api/mgmt.py
+++ b/api/mgmt.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, current_app, jsonify
+from flask import Blueprint, jsonify
 from prometheus_client import (CollectorRegistry,
                                multiprocess,
                                generate_latest,

--- a/app/models.py
+++ b/app/models.py
@@ -308,7 +308,6 @@ class NetworkInterfaceSchema(Schema):
     name = fields.Str(validate=validate.Length(min=1, max=50))
     type = fields.Str(validate=validate.Length(max=18))
 
-
 class SystemProfileSchema(Schema):
     number_of_cpus = fields.Int()
     number_of_sockets = fields.Int()

--- a/host_dumper.py
+++ b/host_dumper.py
@@ -2,7 +2,6 @@
 
 import argparse
 import pprint
-import os
 
 from app import create_app
 from app.models import Host

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,5 +1,6 @@
 from __future__ import with_statement
 from alembic import context
+from flask import current_app
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig
 import logging
@@ -17,7 +18,6 @@ logger = logging.getLogger('alembic.env')
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-from flask import current_app
 
 config.set_main_option(
     'sqlalchemy.url', current_app.config.get('SQLALCHEMY_DATABASE_URI')

--- a/run.py
+++ b/run.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import logging
 
 from app import create_app
 

--- a/test_api.py
+++ b/test_api.py
@@ -8,7 +8,7 @@ import uuid
 import copy
 import tempfile
 
-from app import create_app, db, events
+from app import create_app, db
 from app.auth.identity import Identity
 from app.utils import HostWrapper
 from tasks import msg_handler

--- a/test_db_model.py
+++ b/test_db_model.py
@@ -2,7 +2,7 @@ import uuid
 
 from app import db
 from app.models import Host
-from test_utils import flask_app_fixture
+from test_utils import flask_app_fixture  # noqa: 401
 
 """
 These tests are for testing the db model classes outside of the api.

--- a/test_host_dedup_logic.py
+++ b/test_host_dedup_logic.py
@@ -4,7 +4,7 @@ from api.host import find_existing_host
 from app import db
 from app.models import Host
 from pytest import mark
-from test_utils import flask_app_fixture
+from test_utils import flask_app_fixture  # noqa: 401
 
 ACCOUNT_NUMBER = "000102"
 


### PR DESCRIPTION
Fixed the Flake8 rules related to imports:

- [_E402_](https://github.com/RedHatInsights/insights-host-inventory/commit/103d3245228f3b976fc1e788cd67804897ad36c7) for imports not being on top of the file
- [_F401_](https://github.com/RedHatInsights/insights-host-inventory/commit/068c2d7a024189e02ccb1a59e70f66b4a3214d0d) for unused imports

**Внимание, внимание!**

Removing unused imports is potentially risky, because it doesn’t touch only formatting. Imports _can_ have side effects and one such [case](https://github.com/RedHatInsights/insights-host-inventory/blob/c91e5e03d8405f1b73fac8fc81b4aadae45ad066/app/__init__.py#L12) is already documented in the code by a _#noqa_ comment. The API [tests](https://github.com/RedHatInsights/insights-host-inventory/blob/master/test_api.py) are still passing, so there are hopefully no other import side effects. That one mentioned case should be fixed.