### PR TITLE
Fix F811 rule, move fixtures to conftest.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,22 @@
+from pytest import fixture
+
+from app import create_app, db
+from test_utils import rename_host_table_and_indexes
+
+
+@fixture
+def flask_app_fixture():
+    rename_host_table_and_indexes()
+
+    app = create_app(config_name="testing")
+
+    # binds the app to the current context
+    with app.app_context() as ctx:
+        # create all tables
+        db.create_all()
+        ctx.push()
+        yield app
+        ctx.pop
+
+        db.session.remove()
+        db.drop_all()

--- a/test_db_model.py
+++ b/test_db_model.py
@@ -2,7 +2,6 @@ import uuid
 
 from app import db
 from app.models import Host
-from test_utils import flask_app_fixture
 
 """
 These tests are for testing the db model classes outside of the api.

--- a/test_host_dedup_logic.py
+++ b/test_host_dedup_logic.py
@@ -4,7 +4,7 @@ from api.host import find_existing_host
 from app import db
 from app.models import Host
 from pytest import mark
-from test_utils import flask_app_fixture
+
 
 ACCOUNT_NUMBER = "000102"
 

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,9 +1,7 @@
 import contextlib
 import os
-import pytest
 import unittest.mock
 
-from app import create_app, db
 from app.models import Host
 
 
@@ -33,21 +31,3 @@ def rename_host_table_and_indexes():
     for index in Host.__table_args__:
         if temp_table_name_suffix not in index.name:
             index.name = index.name + temp_table_name_suffix
-
-
-@pytest.fixture
-def flask_app_fixture():
-    rename_host_table_and_indexes()
-
-    app = create_app(config_name="testing")
-
-    # binds the app to the current context
-    with app.app_context() as ctx:
-        # create all tables
-        db.create_all()
-        ctx.push()
-        yield app
-        ctx.pop
-
-        db.session.remove()
-        db.drop_all()


### PR DESCRIPTION
Moved fixtures from the [_test_utils_](https://github.com/Glutexo/insights-host-inventory/blob/74a7bbbfdc049abcd978ae631d3e73749086a196/test_utils.py) module to a special [_conftest.py_](https://github.com/Glutexo/insights-host-inventory/blob/74a7bbbfdc049abcd978ae631d3e73749086a196/conftest.py) file that is grabbed automatically by pytest. This fixes the _F811_ Flake8 rule complaining about test function argument names clashing with the pytest fixture function name.