### PR TITLE
Formatting: fix trailing whitespace

### DIFF
--- a/migrations/versions/2d951983fa89_.py
+++ b/migrations/versions/2d951983fa89_.py
@@ -1,7 +1,7 @@
 """empty message
 
 Revision ID: 2d951983fa89
-Revises: 
+Revises:
 Create Date: 2018-10-31 21:23:07.038176
 
 """


### PR DESCRIPTION
Fixed the W291 Flake8 rule complaning about trailing whitespace.

This is a part of a big formatting fix. See #335, #189 and #331.