### PR TITLE
Formatting: bypass linter on a non-deprecated method

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -430,7 +430,7 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
     hosts_to_update = Host.query.filter(
         (Host.account == current_identity.account_number)
         & Host.id.in_(host_id_list)
-        & Host.facts.has_key(namespace)
+        & Host.facts.has_key(namespace)  # noqa: W601 JSONB query filter, not a dict
     ).all()
 
     logger.debug("hosts_to_update:%s" % hosts_to_update)


### PR DESCRIPTION
Fixed the _W601_ Flake8 rule complaining about a deprecated method usage. This time resolved by adding a _#noqa_ comment. This is the only valid usage of the linter bypass in the whole repository. The object is not a Python collection, but a SQLAlchemy column. The object does not support using the _in_ keyword. Its _has_key_ method is a userspace method and is not deprecated. It builds a SQL filter on a _JSONB_ column.

This is a part of the first step towards a cleanly formatted codebase. See #189, #335 and #331.