### PR TITLE
Formatting: fix long lines

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,10 +21,9 @@ extend-ignore =
     E303,
     E305,
     E402,
-    E501,
     F401,
     F811,
     F841,
     W291,
     W601
-max-line-length = 100
+max-line-length = 119

--- a/api/host.py
+++ b/api/host.py
@@ -447,7 +447,12 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
     logger.debug("hosts_to_update:%s" % hosts_to_update)
 
     if len(hosts_to_update) != len(host_id_list):
-        error_msg = "ERROR: The number of hosts requested does not match the " "number of hosts found in the host database.  This could " " happen if the namespace " "does not exist or the account number associated with the " "call does not match the account number associated with " "one or more the hosts.  Rejecting the fact change request."
+        error_msg = (
+            "ERROR: The number of hosts requested does not match the number of hosts found in the "
+            "host database.  This could happen if the namespace does not exist or the account "
+            "number associated with the call does not match the account number associated with one "
+            "or more the hosts.  Rejecting the fact change request."
+        )
         logger.debug(error_msg)
         return error_msg, 400
 


### PR DESCRIPTION
Fixed the _E501_ Flake8 rule targetting too long lines. In most places, the code has been only reformatted. Sometimes a variable name has been shortened or another code-aware change has been made. I am not sure whether these changes don’t trigger another Flake8 rule. That should not be a big of an issue, since such cases should be rare and can be easily fixed.

I used a line length of 88 character, which is what Black uses by default.

In the [_app.config_](https://github.com/Glutexo/insights-host-inventory/blob/31ac6a483f9ab2cc33b69ce1e7fa948899d096f9/app/config.py) module I changed the [_import_](https://github.com/Glutexo/insights-host-inventory/blob/31ac6a483f9ab2cc33b69ce1e7fa948899d096f9/app/config.py#L1) statement and replaced _os.environ.get_ with an equivalent _os.getenv_.

In the [_api.metrics_](https://github.com/Glutexo/insights-host-inventory/blob/31ac6a483f9ab2cc33b69ce1e7fa948899d096f9/api/metrics.py) module I was targeting only the long lines, which results in not-unified code style. Improving the style and making it consistent would be a subject of another pull request.

This is a part of the first step towards a nicely formatted codebase. See #189, #335 and #331. It is currently the biggest pull request, but containing only trivial changes not affecting logic.