### PR TITLE
Formatting: reorder python imports

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -36,6 +36,7 @@ pytest-cov = "*"
 coverage = "*"
 flake8 = "*"
 pyupgrade = "*"
+reorder-python-imports = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3d6a8a12a736dae80e5296827ff7956e94e86a0a31a09b02d9091e2031136a0d"
+            "sha256": "0fad5b19fbcf54fe6f614c24d55514836ee16a4ca1babe28f511f4b33119f330"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -45,18 +45,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:34a8ddb7247316be6ea94c7eeee41212312d250d99bf668fcd6748629b578622",
-                "sha256:71f3554cc69fa20be06cf20d6c9e0d8095d7c40695b48618676c3cd9a5ba0783"
+                "sha256:7cfb8b0989fc32cc9e18590348bbfe679704cd84adece20b20b359e0b0db7840",
+                "sha256:d01be3d0d8cd04fd30547917411a26715fe299d5b071a980ecaea6062d7c9b20"
             ],
             "index": "pypi",
-            "version": "==1.9.189"
+            "version": "==1.9.190"
         },
         "botocore": {
             "hashes": [
-                "sha256:4febbf206d1dc8b8299aa211d8e382d5bf3f22097855b9f98d5e8c401ef8192b",
-                "sha256:b62ab3e4e98e075fc9e8e8fd4e8f5b92ebf311a6dc9f7578650938c7bc94e592"
+                "sha256:10a88f73a4d3c88d4d807df4e0357120e30edbb037ad01f6e7457cf9cb2cc1a8",
+                "sha256:b04b9c9f49dd540fbcf1d1990382910d99926eedfb82eaff20527446240750a4"
             ],
-            "version": "==1.12.189"
+            "version": "==1.12.190"
         },
         "certifi": {
             "hashes": [
@@ -617,6 +617,13 @@
         }
     },
     "develop": {
+        "aspy.refactor-imports": {
+            "hashes": [
+                "sha256:6d465c18cadad7e5a87810ecf8e516cb6f78e91871f4f55d0f228c6c376bd16a",
+                "sha256:88418d9bd1a0d50b9d3836504469dce6f26ee8b2d78bd58b805d73dd8b381d55"
+            ],
+            "version": "==1.1.0"
+        },
         "atomicwrites": {
             "hashes": [
                 "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
@@ -630,6 +637,13 @@
                 "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
             "version": "==19.1.0"
+        },
+        "cached-property": {
+            "hashes": [
+                "sha256:3a026f1a54135677e7da5ce819b0c690f156f37976f3e30c5430740725203d7f",
+                "sha256:9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504"
+            ],
+            "version": "==1.5.1"
         },
         "coverage": {
             "hashes": [
@@ -768,6 +782,14 @@
             ],
             "index": "pypi",
             "version": "==1.21.0"
+        },
+        "reorder-python-imports": {
+            "hashes": [
+                "sha256:074df6e564ef9ef852eeb3f11733267775b366ac64e46506f5ad4f19687ac0fc",
+                "sha256:d5f294eb140129af00a2e31df8591f78c57815308553deb000ed854a4da7e885"
+            ],
+            "index": "pypi",
+            "version": "==1.6.0"
         },
         "six": {
             "hashes": [

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,5 +1,4 @@
 import time
-
 from functools import wraps
 
 from api.metrics import api_request_count

--- a/api/host.py
+++ b/api/host.py
@@ -1,18 +1,22 @@
+import uuid
+from enum import Enum
+
 import flask
 import sqlalchemy
 import ujson
-import uuid
-
-from enum import Enum
 from flask_api import status
 from marshmallow import ValidationError
 
-from app import db, events
-from app.models import Host, HostSchema, PatchHostSchema
+from api import api_operation
+from api import metrics
+from app import db
+from app import events
 from app.auth import current_identity
 from app.exceptions import InventoryException
 from app.logging import get_logger
-from api import api_operation, metrics
+from app.models import Host
+from app.models import HostSchema
+from app.models import PatchHostSchema
 from tasks import emit_event
 
 

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -1,4 +1,5 @@
-from prometheus_client import Counter, Summary
+from prometheus_client import Counter
+from prometheus_client import Summary
 
 api_request_time = Summary("inventory_request_processing_seconds",
                            "Time spent processing request")

--- a/api/mgmt.py
+++ b/api/mgmt.py
@@ -1,8 +1,9 @@
-from flask import Blueprint, jsonify
-from prometheus_client import (CollectorRegistry,
-                               multiprocess,
-                               generate_latest,
-                               CONTENT_TYPE_LATEST,)
+from flask import Blueprint
+from flask import jsonify
+from prometheus_client import CollectorRegistry
+from prometheus_client import CONTENT_TYPE_LATEST
+from prometheus_client import generate_latest
+from prometheus_client import multiprocess
 
 from app.common import get_build_version
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,14 +1,15 @@
 import connexion
 import yaml
-
 from connexion.resolver import RestyResolver
-from flask import jsonify, request
+from flask import jsonify
+from flask import request
 
 from api.mgmt import monitoring_blueprint
 from app.config import Config
-from app.models import db
 from app.exceptions import InventoryException
-from app.logging import configure_logging, threadctx
+from app.logging import configure_logging
+from app.logging import threadctx
+from app.models import db
 from app.validators import verify_uuid_format  # noqa: 401
 from tasks import init_tasks
 

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,9 +1,11 @@
 import connexion
+from werkzeug.local import LocalProxy
 
 from api.metrics import login_failure_count
-from app.auth.identity import from_bearer_token, from_auth_header, validate
+from app.auth.identity import from_auth_header
+from app.auth.identity import from_bearer_token
+from app.auth.identity import validate
 from app.logging import get_logger
-from werkzeug.local import LocalProxy
 
 __all__ = ["current_identity",
            "bearer_token_handler",

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -1,9 +1,9 @@
 import os
-
 from base64 import b64decode
 from json import loads
 
-from app.logging import get_logger, threadctx
+from app.logging import get_logger
+from app.logging import threadctx
 
 
 __all__ = ["Identity", "from_auth_header", "from_bearer_token", "validate"]

--- a/app/events.py
+++ b/app/events.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import datetime
-from marshmallow import Schema, fields
+
+from marshmallow import fields
+from marshmallow import Schema
 
 logger = logging.getLogger(__name__)
 

--- a/app/logging.py
+++ b/app/logging.py
@@ -1,10 +1,9 @@
-from threading import local
-import logging
 import logging.config
-import logstash_formatter
 import os
-import watchtower
+from threading import local
 
+import logstash_formatter
+import watchtower
 from boto3.session import Session
 from gunicorn import glogging
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,12 +1,20 @@
 import uuid
-
 from datetime import datetime
-from flask_sqlalchemy import SQLAlchemy
-from marshmallow import Schema, fields, validate, validates, ValidationError
-from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy import orm, Index, text
 
-from app.exceptions import InventoryException, InputFormatException
+from flask_sqlalchemy import SQLAlchemy
+from marshmallow import fields
+from marshmallow import Schema
+from marshmallow import validate
+from marshmallow import validates
+from marshmallow import ValidationError
+from sqlalchemy import Index
+from sqlalchemy import orm
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.exceptions import InputFormatException
+from app.exceptions import InventoryException
 from app.logging import get_logger
 from app.validators import verify_uuid_format
 

--- a/app/validators.py
+++ b/app/validators.py
@@ -1,6 +1,6 @@
 import uuid
-import validators
 
+import validators
 from jsonschema import draft4_format_checker
 
 

--- a/host_dumper.py
+++ b/host_dumper.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import argparse
 import pprint
 

--- a/manage.py
+++ b/manage.py
@@ -1,7 +1,11 @@
 import os
+
+from flask_migrate import Migrate
+from flask_migrate import MigrateCommand
 from flask_script import Manager  # class for handling a set of commands
-from flask_migrate import Migrate, MigrateCommand
-from app import db, create_app
+
+from app import create_app
+from app import db
 
 
 app = create_app(config_name=os.getenv('APP_SETTINGS'))

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,9 +1,12 @@
 from __future__ import with_statement
+
+import logging
+from logging.config import fileConfig
+
 from alembic import context
 from flask import current_app
-from sqlalchemy import engine_from_config, pool
-from logging.config import fileConfig
-import logging
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/migrations/versions/2d1cdfe3208d_add_system_profile_facts_column.py
+++ b/migrations/versions/2d1cdfe3208d_add_system_profile_facts_column.py
@@ -5,8 +5,8 @@ Revises: 2d951983fa89
 Create Date: 2019-03-22 10:52:29.024809
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.

--- a/migrations/versions/2d951983fa89_.py
+++ b/migrations/versions/2d951983fa89_.py
@@ -5,8 +5,8 @@ Revises:
 Create Date: 2018-10-31 21:23:07.038176
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.

--- a/migrations/versions/5dbbd56ce006_add_modified_on_id_index.py
+++ b/migrations/versions/5dbbd56ce006_add_modified_on_id_index.py
@@ -5,8 +5,8 @@ Revises: a9f0e674cf52
 Create Date: 2019-05-24 20:53:01.426278
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 # revision identifiers, used by Alembic.

--- a/migrations/versions/76b7bc1d1d12_add_subscription_manager_id_index.py
+++ b/migrations/versions/76b7bc1d1d12_add_subscription_manager_id_index.py
@@ -5,8 +5,8 @@ Revises: 5dbbd56ce006
 Create Date: 2019-06-24 16:41:54.754856
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 # revision identifiers, used by Alembic.

--- a/migrations/versions/a9f0e674cf52_add_ansible_host_column.py
+++ b/migrations/versions/a9f0e674cf52_add_ansible_host_column.py
@@ -5,8 +5,8 @@ Revises: 2d1cdfe3208d
 Create Date: 2019-04-10 10:07:05.401715
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 # revision identifiers, used by Alembic.

--- a/run.py
+++ b/run.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import os
 
 from app import create_app

--- a/run_gunicorn.py
+++ b/run_gunicorn.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-
 from contextlib import contextmanager
+from os import getenv
+from os import putenv
 from subprocess import run
-from os import getenv, putenv
 from tempfile import TemporaryDirectory
 
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,12 +1,15 @@
 import json
+from threading import Thread
+
 from kafka import KafkaConsumer
 from kafka import KafkaProducer
-from threading import Thread
 
 from api import metrics
 from app import db
-from app.logging import threadctx, get_logger
-from app.models import Host, SystemProfileSchema
+from app.logging import get_logger
+from app.logging import threadctx
+from app.models import Host
+from app.models import SystemProfileSchema
 
 logger = get_logger(__name__)
 

--- a/test_api.py
+++ b/test_api.py
@@ -1,24 +1,28 @@
 #!/usr/bin/env python
-
-import unittest
-import unittest.mock
-import json
-import dateutil.parser
-import uuid
 import copy
+import json
 import tempfile
+import unittest.mock
+import uuid
+from base64 import b64encode
+from datetime import datetime
+from datetime import timezone
+from itertools import chain
+from json import dumps
+from urllib.parse import parse_qs
+from urllib.parse import urlencode
+from urllib.parse import urlsplit
+from urllib.parse import urlunsplit
 
-from app import create_app, db
+import dateutil.parser
+
+from app import create_app
+from app import db
 from app.auth.identity import Identity
 from app.utils import HostWrapper
 from tasks import msg_handler
-from base64 import b64encode
-from itertools import chain
-from json import dumps
-from datetime import datetime, timezone
-from urllib.parse import urlsplit, urlencode, parse_qs, urlunsplit
-
-from test_utils import set_environment, rename_host_table_and_indexes
+from test_utils import rename_host_table_and_indexes
+from test_utils import set_environment
 
 HOST_URL = "/api/inventory/v1/hosts"
 HEALTH_URL = "/health"

--- a/test_host_dedup_logic.py
+++ b/test_host_dedup_logic.py
@@ -1,9 +1,10 @@
 import uuid
 
+from pytest import mark
+
 from api.host import find_existing_host
 from app import db
 from app.models import Host
-from pytest import mark
 
 
 ACCOUNT_NUMBER = "000102"

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python
-
-from api import api_operation
-from api.host import _params_to_order_by, _order_how
-from app.config import Config
-from app.auth.identity import (Identity,
-                               validate,
-                               from_auth_header,
-                               from_bearer_token,
-                               SHARED_SECRET_ENV_VAR)
 from base64 import b64encode
 from json import dumps
-from unittest import main, TestCase
-from unittest.mock import Mock, patch
+from unittest import main
+from unittest import TestCase
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from api import api_operation
+from api.host import _order_how
+from api.host import _params_to_order_by
+from app.auth.identity import from_auth_header
+from app.auth.identity import from_bearer_token
+from app.auth.identity import Identity
+from app.auth.identity import SHARED_SECRET_ENV_VAR
+from app.auth.identity import validate
+from app.config import Config
 from test_utils import set_environment
 
 

--- a/test_utils.py
+++ b/test_utils.py
@@ -2,6 +2,8 @@ import contextlib
 import os
 import unittest.mock
 
+import pytest
+
 from app.models import Host
 
 

--- a/test_validators.py
+++ b/test_validators.py
@@ -1,8 +1,8 @@
 import pytest
 
-from app.validators import (verify_uuid_format,
-                            verify_ip_address_format,
-                            verify_mac_address_format)
+from app.validators import verify_ip_address_format
+from app.validators import verify_mac_address_format
+from app.validators import verify_uuid_format
 
 
 @pytest.mark.parametrize("uuid", ["4a8fb994-57fe-4dbb-ad2a-9e922560b6c1",


### PR DESCRIPTION
Added the [_reorder-python-imports_](https://github.com/Glutexo/insights-host-inventory/blob/564c29512a1ac6fb924c049829d328ad85b62dc5/Pipfile#L31) package to the development dependencies. Used it to reorder imports in all Python files.

```bash
find . -type f -name '*.py' | xargs -L1 reorder-python-imports
```

The tool has split the imports into three groups, ordered them alphabetically and split multiple imports into separate lines. This will be later done automatically by a pre-commit hook. #331 

This is a part of the way to having the code cleanly formatted. #189 