### PR TITLE
Formatting: trim trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ care about the Prometheus temp directory or to set the
 _prometheus_multiproc_dir_ environment variable. This is done automatically.
 
 ```
-python run_gunicorn.py 
+python run_gunicorn.py
 ```
 
 
@@ -129,7 +129,7 @@ from inside of the deployment cluster.
 * _/health_ responds with _200_ to any GET requests, point your liveness
   or readiness probe here.
 * _/metrics_ offers metrics and monitoring intended to be pulled by
-  [Prometheus](https://prometheus.io). 
+  [Prometheus](https://prometheus.io).
 * _/version_ responds with a json doc that contains the build version info
   (the value of the OPENSHIFT_BUILD_COMMIT environment variable)
 

--- a/dev.yml
+++ b/dev.yml
@@ -7,7 +7,7 @@ services:
             POSTGRES_PASSWORD: insights
             POSTGRES_USER: insights
             POSTGRES_DB: insights
-        ports: 
+        ports:
             - "5432:5432"
     zookeeper:
       image: confluentinc/cp-zookeeper

--- a/migrations/versions/2d951983fa89_.py
+++ b/migrations/versions/2d951983fa89_.py
@@ -1,7 +1,7 @@
 """empty message
 
 Revision ID: 2d951983fa89
-Revises: 
+Revises:
 Create Date: 2018-10-31 21:23:07.038176
 
 """


### PR DESCRIPTION
Use the [_pre-commit-hooks_](https://github.com/pre-commit/pre-commit-hooks) [_trailing-whitespace-fixer_](https://github.com/pre-commit/pre-commit-hooks/blob/master/pre_commit_hooks/trailing_whitespace_fixer.py) tool to remove all trailing whitespaces from the textual files in the repository. Another pull request #348 adds the tool as a development dependency.

```bash
for PATTERN in '*.py' '*.ini' 'README' '*.mako' '*.yaml' '.gitignore' '*.yml' '*.groovy' 'Pipfile' 'Pipfile.lock' '*.md'
do
    find . -type f -name "$PATTERN" | xargs -L1 trailing-whitespace-fixer
done
``` 

This is a part of the way towards fixed formatting. See #189 and #331.