### PR TITLE
Formatting: final Flake8 fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,17 +13,4 @@ exclude =
     *.mako,
     *.md,
     *.yml
-extend-ignore =
-    E127,
-    E128,
-    E231,
-    E302,
-    E303,
-    E305,
-    E402,
-    F401,
-    F811,
-    F841,
-    W291,
-    W601
 max-line-length = 119

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -5,7 +5,7 @@ api_request_time = Summary("inventory_request_processing_seconds",
 host_dedup_processing_time = Summary("inventory_dedup_processing_seconds",
                                      "Time spent looking for existing host (dedup logic)")
 find_host_using_elevated_ids = Summary("inventory_find_host_using_elevated_ids_processing_seconds",
-                                     "Time spent looking for existing host using the elevated ids")
+                                       "Time spent looking for existing host using the elevated ids")
 new_host_commit_processing_time = Summary("inventory_new_host_commit_seconds",
                                           "Time spent committing a new host to the database")
 update_host_commit_processing_time = Summary("inventory_update_host_commit_seconds",

--- a/app/models.py
+++ b/app/models.py
@@ -35,7 +35,7 @@ class Host(db.Model):
                       Index("idxgincanonicalfacts", "canonical_facts"),
                       Index("idxaccount", "account"),
                       Index("hosts_subscription_manager_id_index",
-                          text("(canonical_facts ->> 'subscription_manager_id')")),
+                            text("(canonical_facts ->> 'subscription_manager_id')")),
                       )
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -307,6 +307,7 @@ class NetworkInterfaceSchema(Schema):
     mac_address = fields.Str(validate=validate.Length(max=18))
     name = fields.Str(validate=validate.Length(min=1, max=50))
     type = fields.Str(validate=validate.Length(max=18))
+
 
 class SystemProfileSchema(Schema):
     number_of_cpus = fields.Int()

--- a/test_host_dedup_logic.py
+++ b/test_host_dedup_logic.py
@@ -68,6 +68,7 @@ def test_find_host_using_insights_id_match(flask_app_fixture):
 
     basic_host_dedup_test(canonical_facts, search_canonical_facts)
 
+
 def test_find_host_using_subscription_manager_id_match(flask_app_fixture):
     canonical_facts = {"fqdn": "fred",
                        "bios_uuid": generate_uuid(),


### PR DESCRIPTION
[Removed](https://github.com/RedHatInsights/insights-host-inventory/commit/75ce37aa50cf2308669396f23f0d896cbfda08b2) all the ignored rules from the [_.flake8_](https://github.com/Glutexo/insights-host-inventory/blob/flake8_config/.flake8) configuration file. Almost all of there were successfully fixed by previous pull requests and are no longer needed. All rule violations (except those ignored by default) are going to be reported from now on.

Along with that [fixed](https://github.com/RedHatInsights/insights-host-inventory/commit/3fa57de066fe94fa87091dcb434a9f568a05eee9) all the remaining violations. These either slipped through the previous pull requests, or appeared newly as a result of merges. All of them are either newline or indentation related.