### PR TITLE
Formatting: unify newlines by Black’s standards

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,5 +1,3 @@
-
-
 class InventoryException(Exception):
     def __init__(self, status=400, title=None, detail=None, type="about:blank"):
         self.status = status
@@ -13,6 +11,5 @@ class InventoryException(Exception):
 
 
 class InputFormatException(InventoryException):
-
     def __init__(self, detail):
         InventoryException.__init__(self, title="Bad Request", detail=detail)

--- a/app/logging.py
+++ b/app/logging.py
@@ -86,6 +86,7 @@ class ContextualFilter(logging.Filter):
     to explicitly retrieve/pass around the request id for each
     log message.
     """
+
     def filter(self, log_record):
         try:
             log_record.request_id = threadctx.request_id

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -12,7 +12,6 @@ logger = get_logger(__name__)
 
 
 class NullProducer:
-
     def send(self, topic, value=None):
         logger.debug("NullProducer - logging message:  topic (%s) - message: %s" %
                      (topic, value))

--- a/test_api.py
+++ b/test_api.py
@@ -148,7 +148,6 @@ class BaseAPITestCase(unittest.TestCase):
 
 
 class DBAPITestCase(BaseAPITestCase):
-
     @classmethod
     def setUpClass(cls):
         """
@@ -717,7 +716,6 @@ class CreateHostsTestCase(DBAPITestCase):
 
 
 class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):
-
     def test_create_host_without_display_name_and_without_fqdn(self):
         """
         This test should verify that the display_name is set to the id
@@ -776,7 +774,6 @@ class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):
 
 
 class BulkCreateHostsTestCase(DBAPITestCase):
-
     def _get_valid_auth_header(self):
         return build_valid_auth_header()
 
@@ -862,7 +859,6 @@ class PaginationTestCase(BaseAPITestCase):
 
 
 class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
-
     def _valid_system_profile(self):
         return {"number_of_cpus": 1,
                 "number_of_sockets": 2,
@@ -1212,7 +1208,6 @@ class PreCreatedHostsBaseTestCase(DBAPITestCase, PaginationTestCase):
 
 
 class PatchHostTestCase(PreCreatedHostsBaseTestCase):
-
     def test_update_fields(self):
         original_id = self.added_hosts[0].id
 
@@ -1307,7 +1302,6 @@ class PatchHostTestCase(PreCreatedHostsBaseTestCase):
 
 
 class DeleteHostsTestCase(PreCreatedHostsBaseTestCase):
-
     def test_create_then_delete(self):
         original_id = self.added_hosts[0].id
 
@@ -1317,7 +1311,6 @@ class DeleteHostsTestCase(PreCreatedHostsBaseTestCase):
         self.get(url, 200)
 
         class MockEmitEvent:
-
             def __init__(self):
                 self.events = []
 
@@ -1420,7 +1413,6 @@ class QueryTestCase(PreCreatedHostsBaseTestCase):
 
 
 class QueryByHostIdTestCase(PreCreatedHostsBaseTestCase, PaginationTestCase):
-
     def _base_query_test(self, host_id_list, expected_host_list):
         url = f"{HOST_URL}/{host_id_list}"
         response = self.get(url)
@@ -1505,7 +1497,6 @@ class QueryByHostIdTestCase(PreCreatedHostsBaseTestCase, PaginationTestCase):
 
 
 class QueryByHostnameOrIdTestCase(PreCreatedHostsBaseTestCase):
-
     def _base_query_test(self, query_value, expected_number_of_hosts):
         test_url = HOST_URL + "?hostname_or_id=" + query_value
 
@@ -1538,7 +1529,6 @@ class QueryByHostnameOrIdTestCase(PreCreatedHostsBaseTestCase):
 
 
 class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
-
     def _test_url(self, query_value):
         return HOST_URL + "?insights_id=" + query_value
 
@@ -1573,7 +1563,6 @@ class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
 
 
 class QueryOrderTestCase(PreCreatedHostsBaseTestCase):
-
     def _queries_subtests_with_added_hosts(self):
         host_id_list = [host.id for host in self.added_hosts]
         url_host_id_list = ",".join(host_id_list)
@@ -1598,7 +1587,6 @@ class QueryOrderTestCase(PreCreatedHostsBaseTestCase):
 
 
 class QueryOrderWithAdditionalHostTestCase(QueryOrderTestCase):
-
     def setUp(self):
         super().setUp()
         host_wrapper = HostWrapper()
@@ -1621,7 +1609,6 @@ class QueryOrderWithAdditionalHostTestCase(QueryOrderTestCase):
             # Hosts with same display_name are ordered by updated descending
             self.added_hosts[3],
             self.added_hosts[0],
-
             self.added_hosts[1],
             self.added_hosts[2]
         )
@@ -1630,7 +1617,6 @@ class QueryOrderWithAdditionalHostTestCase(QueryOrderTestCase):
         return (
             self.added_hosts[2],
             self.added_hosts[1],
-
             # Hosts with same display_name are ordered by updated descending
             self.added_hosts[3],
             self.added_hosts[0]
@@ -1692,7 +1678,6 @@ class QueryOrderWithAdditionalHostTestCase(QueryOrderTestCase):
 
 
 class QueryOrderBadRequestsTestCase(QueryOrderTestCase):
-
     def test_invalid_order_by(self):
         for url in self._queries_subtests_with_added_hosts():
             with self.subTest(url=url):

--- a/test_unit.py
+++ b/test_unit.py
@@ -20,6 +20,7 @@ class ApiOperationTestCase(TestCase):
     Test the API operation decorator that increments the request counter with every
     call.
     """
+
     @patch("api.api_request_count.inc")
     def test_counter_is_incremented(self, inc):
         @api_operation
@@ -183,7 +184,6 @@ class TrustedIdentityTestCase(TestCase):
 
 
 class ConfigTestCase(TestCase):
-
     def test_configuration_with_env_vars(self):
         app_name = "brontocrane"
         path_prefix = "r/slaterock/platform"
@@ -237,7 +237,6 @@ class ConfigTestCase(TestCase):
 
 
 class HostOrderHowTestCase(TestCase):
-
     def test_asc(self):
         column = Mock()
         result = _order_how(column, "ASC")
@@ -259,7 +258,6 @@ class HostOrderHowTestCase(TestCase):
 @patch("api.host._order_how")
 @patch("api.host.Host.modified_on")
 class HostParamsToOrderByTestCase(TestCase):
-
     def test_default_is_updated_desc(self, modified_on, order_how):
         actual = _params_to_order_by(None, None)
         expected = (modified_on.desc.return_value,)
@@ -307,7 +305,6 @@ class HostParamsToOrderByTestCase(TestCase):
 
 
 class HostParamsToOrderByErrorsTestCase(TestCase):
-
     def test_order_by_bad_field_raises_error(self):
         with self.assertRaises(ValueError):
             _params_to_order_by(Mock(), "fqdn")


### PR DESCRIPTION
Add newlines between class and function definitions and other pieces of code that need to be visually separated. Also remove excessive newlines. Used [Black](https://github.com/python/black) to fix these cases.

This is a part to fix formatting in the whole codebase to be able to run [Black](https://github.com/python/black), [Flake8](https://gitlab.com/pycqa/flake8) and other tools automatically. #335 