### PR TITLE
Formatting: fix trailing commas

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -170,7 +170,7 @@ def get_host_list(
     page=1,
     per_page=100,
     order_by=None,
-    order_how=None
+    order_how=None,
 ):
     if fqdn:
         query = find_hosts_by_canonical_facts(current_identity.account_number, {"fqdn": fqdn})
@@ -259,7 +259,7 @@ def find_hosts_by_canonical_facts(account_number, canonical_facts):
 def find_hosts_by_hostname_or_id(account_number, hostname):
     logger.debug("find_hosts_by_hostname_or_id(%s)", hostname)
     filter_list = [Host.display_name.comparator.contains(hostname),
-                   Host.canonical_facts["fqdn"].astext.contains(hostname), ]
+                   Host.canonical_facts["fqdn"].astext.contains(hostname) ]
 
     try:
         uuid.UUID(hostname)

--- a/test_api.py
+++ b/test_api.py
@@ -802,7 +802,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
                                         "mtu": 1500,
                                         "mac_address": "aa:bb:cc:dd:ee:ff",
                                         "type": "loopback",
-                                        "name": "eth0", }],
+                                        "name": "eth0" }],
                 "disk_devices": [{"device": "/dev/sdb1",
                                   "label": "home drive",
                                   "options": {"uid": "0",
@@ -832,7 +832,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
                                         "status": "UP"},
                                        {"name": "jbws",
                                         "id": "321",
-                                        "status": "DOWN"}, ],
+                                        "status": "DOWN"} ],
                 "insights_client_version": "12.0.12",
                 "insights_egg_version": "120.0.1",
                 "installed_packages": ["rpm1", "rpm2"],
@@ -939,7 +939,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
         # List of tuples (system profile change, expected system profile)
         system_profiles = [{"infrastructure_type": "i"*101,
                             "infrastructure_vendor": "i"*101,
-                            "cloud_provider": "i"*101, }]
+                            "cloud_provider": "i"*101 }]
 
         for system_profile in system_profiles:
             with self.subTest(system_profile=system_profile):
@@ -1501,7 +1501,7 @@ class QueryOrderWithAdditionalHostTestCase(QueryOrderBaseTestCase):
             self.added_hosts[3],
             self.added_hosts[0],
             self.added_hosts[1],
-            self.added_hosts[2]
+            self.added_hosts[2],
         )
 
     def _added_hosts_by_display_name_desc(self):
@@ -1510,7 +1510,7 @@ class QueryOrderWithAdditionalHostTestCase(QueryOrderBaseTestCase):
             self.added_hosts[1],
             # Hosts with same display_name are ordered by updated descending
             self.added_hosts[3],
-            self.added_hosts[0]
+            self.added_hosts[0],
         )
 
     def _assert_host_ids_in_response(self, response, expected_hosts):

--- a/test_unit.py
+++ b/test_unit.py
@@ -78,7 +78,7 @@ class AuthIdentityFromAuthHeaderTestCase(AuthIdentityConstructorTestCase):
 
         identity_data_dicts = [identity_data,
                                # Test with extra data in the identity dict
-                               {**identity_data, **{"extra_data": "value"}}, ]
+                               {**identity_data, **{"extra_data": "value"}} ]
 
         for identity_data in identity_data_dicts:
             with self.subTest(identity_data=identity_data):
@@ -287,7 +287,7 @@ class HostParamsToOrderByTestCase(TestCase):
 
     @patch("api.host.Host.display_name")
     def test_default_for_display_name_is_asc(self, display_name, modified_on, order_how):
-        actual = _params_to_order_by("display_name",)
+        actual = _params_to_order_by("display_name")
         expected = (display_name.asc.return_value, modified_on.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_not_called()


### PR DESCRIPTION
Added trailing commas to the last item of multiline collections, if the ending parenthesis is not of the same line. Removed the comma if the parenthesis is there. This follows Black’s standard on where to put it. Neither moved the parentheses/brackets in any way, nor changed the line count of the expressions.

This is a part of the way towards a completely fixed formatting. Fixing the code according to [Black](https://github.com/python/black)’s standards will allow to use this tool automatically. #335