### PR TITLE
Formatting: fix whitespace by Black’s standards

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -259,7 +259,7 @@ def find_hosts_by_canonical_facts(account_number, canonical_facts):
 def find_hosts_by_hostname_or_id(account_number, hostname):
     logger.debug("find_hosts_by_hostname_or_id(%s)", hostname)
     filter_list = [Host.display_name.comparator.contains(hostname),
-                   Host.canonical_facts["fqdn"].astext.contains(hostname) ]
+                   Host.canonical_facts["fqdn"].astext.contains(hostname)]
 
     try:
         uuid.UUID(hostname)

--- a/app/models.py
+++ b/app/models.py
@@ -104,8 +104,8 @@ class Host(db.Model):
         json_dict["display_name"] = self.display_name
         json_dict["ansible_host"] = self.ansible_host
         json_dict["facts"] = Facts.to_json(self.facts)
-        json_dict["created"] = self.created_on.isoformat()+"Z"
-        json_dict["updated"] = self.modified_on.isoformat()+"Z"
+        json_dict["created"] = self.created_on.isoformat() + "Z"
+        json_dict["updated"] = self.modified_on.isoformat() + "Z"
         return json_dict
 
     def to_system_profile_json(self):

--- a/test_api.py
+++ b/test_api.py
@@ -588,7 +588,7 @@ class CreateHostsTestCase(DBAPITestCase):
     def test_create_host_with_ansible_host(self):
         # Create a host with ansible_host field
         host_data = HostWrapper(test_data(facts=None))
-        host_data.ansible_host = "ansible_host_"+generate_uuid()
+        host_data.ansible_host = "ansible_host_" + generate_uuid()
 
         # Create the host
         response = self.post(HOST_URL, [host_data.data()], 207)
@@ -802,7 +802,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
                                         "mtu": 1500,
                                         "mac_address": "aa:bb:cc:dd:ee:ff",
                                         "type": "loopback",
-                                        "name": "eth0" }],
+                                        "name": "eth0"}],
                 "disk_devices": [{"device": "/dev/sdb1",
                                   "label": "home drive",
                                   "options": {"uid": "0",
@@ -832,7 +832,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
                                         "status": "UP"},
                                        {"name": "jbws",
                                         "id": "321",
-                                        "status": "DOWN"} ],
+                                        "status": "DOWN"}],
                 "insights_client_version": "12.0.12",
                 "insights_egg_version": "120.0.1",
                 "installed_packages": ["rpm1", "rpm2"],
@@ -937,9 +937,9 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
         host["rhel_machine_id"] = generate_uuid()
 
         # List of tuples (system profile change, expected system profile)
-        system_profiles = [{"infrastructure_type": "i"*101,
-                            "infrastructure_vendor": "i"*101,
-                            "cloud_provider": "i"*101 }]
+        system_profiles = [{"infrastructure_type": "i" * 101,
+                            "infrastructure_vendor": "i" * 101,
+                            "cloud_provider": "i" * 101}]
 
         for system_profile in system_profiles:
             with self.subTest(system_profile=system_profile):
@@ -994,7 +994,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
 
         host = test_data(display_name="host1", facts=facts)
 
-        cloud_providers = ["cumulonimbus", "cumulus", "c"*100]
+        cloud_providers = ["cumulonimbus", "cumulus", "c" * 100]
 
         for cloud_provider in cloud_providers:
             with self.subTest(cloud_provider=cloud_provider):

--- a/test_unit.py
+++ b/test_unit.py
@@ -78,7 +78,7 @@ class AuthIdentityFromAuthHeaderTestCase(AuthIdentityConstructorTestCase):
 
         identity_data_dicts = [identity_data,
                                # Test with extra data in the identity dict
-                               {**identity_data, **{"extra_data": "value"}} ]
+                               {**identity_data, **{"extra_data": "value"}}]
 
         for identity_data in identity_data_dicts:
             with self.subTest(identity_data=identity_data):


### PR DESCRIPTION
Added/removed whitespace around brackets and operators to follow [Black](https://github.com/python/black)’s strict standards. Didn’t touch [trailing commas](#362).

This is a part of the way towards a completely [Black](https://github.com/python/black)-compliant formatting. It will allow to use the tool automatically for any new code. #335