### PR TITLE
Formatting: string interpolation

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -153,7 +153,7 @@ def create_new_host(input_host):
     input_host.save()
     db.session.commit()
     metrics.create_host_count.inc()
-    logger.debug("Created host:%s" % input_host)
+    logger.debug(f"Created host:{input_host}")
     return input_host.to_json(), 201
 
 
@@ -163,7 +163,7 @@ def update_existing_host(existing_host, input_host):
     existing_host.update(input_host)
     db.session.commit()
     metrics.update_host_count.inc()
-    logger.debug("Updated host:%s" % existing_host)
+    logger.debug(f"Updated host:{existing_host}")
     return existing_host.to_json(), 200
 
 
@@ -265,7 +265,7 @@ def _build_json_response(json_data, status=200):
 
 
 def find_hosts_by_display_name(account, display_name):
-    logger.debug("find_hosts_by_display_name(%s)" % display_name)
+    logger.debug(f"find_hosts_by_display_name({display_name})")
     return Host.query.filter(
         (Host.account == account)
         & Host.display_name.comparator.contains(display_name)
@@ -323,7 +323,7 @@ def delete_by_id(host_id_list):
 
     metrics.delete_host_count.inc(len(host_ids_to_delete))
 
-    logger.debug(f"Deleted hosts: %s", host_ids_to_delete)
+    logger.debug("Deleted hosts: %s", host_ids_to_delete)
 
     for deleted_host_id in host_ids_to_delete:
         emit_event(events.delete(deleted_host_id))
@@ -392,8 +392,7 @@ def patch_by_id(host_id_list, host_data):
     try:
         validated_patch_host_data = PatchHostSchema(strict=True).load(host_data).data
     except ValidationError as e:
-        logger.exception("Input validation error while patching host: %s - %s"
-                         % (host_id_list, host_data))
+        logger.exception(f"Input validation error while patching host: {host_id_list} - {host_data}")
         return ({"status": 400,
                  "title": "Bad Request",
                  "detail": str(e.messages),
@@ -407,7 +406,7 @@ def patch_by_id(host_id_list, host_data):
     hosts_to_update = query.all()
 
     if not hosts_to_update:
-        logger.debug("Failed to find hosts during patch operation - hosts: %s" % host_id_list)
+        logger.debug(f"Failed to find hosts during patch operation - hosts: {host_id_list}")
         return flask.abort(status.HTTP_404_NOT_FOUND)
 
     for host in hosts_to_update:
@@ -444,7 +443,7 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
         & Host.facts.has_key(namespace)  # noqa: W601 JSONB query filter, not a dict
     ).all()
 
-    logger.debug("hosts_to_update:%s" % hosts_to_update)
+    logger.debug(f"hosts_to_update:{hosts_to_update}")
 
     if len(hosts_to_update) != len(host_id_list):
         error_msg = (
@@ -464,6 +463,6 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
 
     db.session.commit()
 
-    logger.debug("hosts_to_update:%s" % hosts_to_update)
+    logger.debug(f"hosts_to_update:{hosts_to_update}")
 
     return 200

--- a/api/host.py
+++ b/api/host.py
@@ -153,7 +153,7 @@ def create_new_host(input_host):
     input_host.save()
     db.session.commit()
     metrics.create_host_count.inc()
-    logger.debug(f"Created host:{input_host}")
+    logger.debug("Created host:%s", input_host)
     return input_host.to_json(), 201
 
 
@@ -163,7 +163,7 @@ def update_existing_host(existing_host, input_host):
     existing_host.update(input_host)
     db.session.commit()
     metrics.update_host_count.inc()
-    logger.debug(f"Updated host:{existing_host}")
+    logger.debug("Updated host:%s", existing_host)
     return existing_host.to_json(), 200
 
 
@@ -206,7 +206,7 @@ def get_host_list(
         query = query.order_by(*order_by)
 
     query_results = query.paginate(page, per_page, True)
-    logger.debug(f"Found hosts: {query_results.items}")
+    logger.debug("Found hosts: %s", query_results.items)
 
     return _build_paginated_host_list_response(
         query_results.total, page, per_page, query_results.items
@@ -265,7 +265,7 @@ def _build_json_response(json_data, status=200):
 
 
 def find_hosts_by_display_name(account, display_name):
-    logger.debug(f"find_hosts_by_display_name({display_name})")
+    logger.debug("find_hosts_by_display_name(%s)", display_name)
     return Host.query.filter(
         (Host.account == account)
         & Host.display_name.comparator.contains(display_name)
@@ -343,7 +343,7 @@ def get_host_by_id(host_id_list, page=1, per_page=100, order_by=None, order_how=
         query = query.order_by(*order_by)
     query_results = query.paginate(page, per_page, True)
 
-    logger.debug(f"Found hosts: {query_results.items}")
+    logger.debug("Found hosts: %s", query_results.items)
 
     return _build_paginated_host_list_response(
         query_results.total, page, per_page, query_results.items
@@ -406,7 +406,7 @@ def patch_by_id(host_id_list, host_data):
     hosts_to_update = query.all()
 
     if not hosts_to_update:
-        logger.debug(f"Failed to find hosts during patch operation - hosts: {host_id_list}")
+        logger.debug("Failed to find hosts during patch operation - hosts: %s", host_id_list)
         return flask.abort(status.HTTP_404_NOT_FOUND)
 
     for host in hosts_to_update:
@@ -443,7 +443,7 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
         & Host.facts.has_key(namespace)  # noqa: W601 JSONB query filter, not a dict
     ).all()
 
-    logger.debug(f"hosts_to_update:{hosts_to_update}")
+    logger.debug("hosts_to_update:%s", hosts_to_update)
 
     if len(hosts_to_update) != len(host_id_list):
         error_msg = (
@@ -463,6 +463,6 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
 
     db.session.commit()
 
-    logger.debug(f"hosts_to_update:{hosts_to_update}")
+    logger.debug("hosts_to_update:%s", hosts_to_update)
 
     return 200

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -50,7 +50,7 @@ def create_app(config_name):
                 strict_validation=True,
                 base_path=api_url,
             )
-            app_config.logger.info("Listening on API: %s" % api_url)
+            app_config.logger.info(f"Listening on API: {api_url}")
 
     # Add an error handler that will convert our top level exceptions
     # into error responses

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -50,7 +50,7 @@ def create_app(config_name):
                 strict_validation=True,
                 base_path=api_url,
             )
-            app_config.logger.info(f"Listening on API: {api_url}")
+            app_config.logger.info("Listening on API: %s", api_url)
 
     # Add an error handler that will convert our top level exceptions
     # into error responses

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -55,7 +55,7 @@ def validate(identity):
         # a warning should go into the Config class
         shared_secret = os.getenv(SHARED_SECRET_ENV_VAR)
         if not shared_secret:
-            logger.warning(f"{SHARED_SECRET_ENV_VAR} environment variable is not set")
+            logger.warning(f"%s environment variable is not set", SHARED_SECRET_ENV_VAR)
         if identity.token != shared_secret:
             raise ValueError("Invalid credentials")
     else:

--- a/app/config.py
+++ b/app/config.py
@@ -63,13 +63,13 @@ class Config:
     def log_configuration(self, config_name):
         if config_name != "testing":
             self.logger.info("Insights Host Inventory Configuration:")
-            self.logger.info(f"Build Version: {get_build_version()}")
-            self.logger.info(f"API URL Path: {self.api_url_path_prefix}")
-            self.logger.info(f"Management URL Path Prefix: {self.mgmt_url_path_prefix}")
-            self.logger.info(f"DB Host: {self._db_host}")
-            self.logger.info(f"DB Name: {self._db_name}")
-            self.logger.info(f"DB Connection URI: {self._build_db_uri(self._db_ssl_mode, hide_password=True)}")
+            self.logger.info("Build Version: %s", get_build_version())
+            self.logger.info("API URL Path: %s", self.api_url_path_prefix)
+            self.logger.info("Management URL Path Prefix: %s", self.mgmt_url_path_prefix)
+            self.logger.info("DB Host: %s", self._db_host)
+            self.logger.info("DB Name: %s", self._db_name)
+            self.logger.info("DB Connection URI: %s", self._build_db_uri(self._db_ssl_mode, hide_password=True))
             if self._db_ssl_mode == self.SSL_VERIFY_FULL:
                 self.logger.info("Using SSL for DB connection:")
-                self.logger.info(f"Postgresql SSL verification type: {self._db_ssl_mode}")
-                self.logger.info(f"Path to certificate: {self._db_ssl_cert}")
+                self.logger.info("Postgresql SSL verification type: %s", self._db_ssl_mode)
+                self.logger.info("Path to certificate: %s", self._db_ssl_cert)

--- a/app/config.py
+++ b/app/config.py
@@ -63,13 +63,13 @@ class Config:
     def log_configuration(self, config_name):
         if config_name != "testing":
             self.logger.info("Insights Host Inventory Configuration:")
-            self.logger.info("Build Version: %s" % get_build_version())
-            self.logger.info("API URL Path: %s" % self.api_url_path_prefix)
-            self.logger.info("Management URL Path Prefix: %s" % self.mgmt_url_path_prefix)
-            self.logger.info("DB Host: %s" % self._db_host)
-            self.logger.info("DB Name: %s" % self._db_name)
-            self.logger.info("DB Connection URI: %s" % self._build_db_uri(self._db_ssl_mode, hide_password=True))
+            self.logger.info(f"Build Version: {get_build_version()}")
+            self.logger.info(f"API URL Path: {self.api_url_path_prefix}")
+            self.logger.info(f"Management URL Path Prefix: {self.mgmt_url_path_prefix}")
+            self.logger.info(f"DB Host: {self._db_host}")
+            self.logger.info(f"DB Name: {self._db_name}")
+            self.logger.info(f"DB Connection URI: {self._build_db_uri(self._db_ssl_mode, hide_password=True)}")
             if self._db_ssl_mode == self.SSL_VERIFY_FULL:
                 self.logger.info("Using SSL for DB connection:")
-                self.logger.info("Postgresql SSL verification type: %s" % self._db_ssl_mode)
-                self.logger.info("Path to certificate: %s" % self._db_ssl_cert)
+                self.logger.info(f"Postgresql SSL verification type: {self._db_ssl_mode}")
+                self.logger.info(f"Path to certificate: {self._db_ssl_cert}")

--- a/app/logging.py
+++ b/app/logging.py
@@ -26,8 +26,8 @@ def configure_logging(config_name):
             fh.close()
         except FileNotFoundError:
             print("Error reading the logging configuration file.  "
-                  "Verify the %s environment variable is set "
-                  "correctly. Aborting..." % env_var_name)
+                  f"Verify the {env_var_name} environment variable is set "
+                  "correctly. Aborting...")
             raise
 
         logging.config.fileConfig(fname=log_config_file)

--- a/app/models.py
+++ b/app/models.py
@@ -121,8 +121,7 @@ class Host(db.Model):
         self.update_facts(input_host.facts)
 
     def patch(self, patch_data):
-        logger.debug("patching host (id=%s) with data: %s" %
-                     (self.id, patch_data))
+        logger.debug(f"patching host (id={self.id}) with data: {patch_data}")
 
         if not patch_data:
             raise InventoryException(title="Bad Request",
@@ -149,12 +148,12 @@ class Host(db.Model):
                 self.display_name = self.id
 
     def update_canonical_facts(self, canonical_facts):
-        logger.debug(("Updating host's (id=%s) canonical_facts (%s)"
-                      " with input canonical_facts=%s")
-                     % (self.id, self.canonical_facts, canonical_facts))
+        logger.debug(
+            f"Updating host's (id={self.id}) canonical_facts ({self.canonical_facts}) with input "
+            f"canonical_facts={canonical_facts}"
+        )
         self.canonical_facts.update(canonical_facts)
-        logger.debug("Host (id=%s) has updated canonical_facts (%s)"
-                     % (self.id, self.canonical_facts))
+        logger.debug(f"Host (id={self.id}) has updated canonical_facts ({self.canonical_facts})")
         orm.attributes.flag_modified(self, "canonical_facts")
 
     def update_facts(self, facts_dict):
@@ -182,7 +181,7 @@ class Host(db.Model):
         orm.attributes.flag_modified(self, "facts")
 
     def _update_system_profile(self, input_system_profile):
-        logger.debug("Updating host's (id=%s) system profile" % (self.id))
+        logger.debug(f"Updating host's (id={self.id}) system profile")
         if not self.system_profile_facts:
             self.system_profile_facts = input_system_profile
         else:
@@ -192,12 +191,9 @@ class Host(db.Model):
         orm.attributes.flag_modified(self, "system_profile_facts")
 
     def __repr__(self):
-        tmpl = "<Host id='%s' account='%s' display_name='%s' canonical_facts=%s>"
-        return tmpl % (
-            self.id,
-            self.account,
-            self.display_name,
-            self.canonical_facts,
+        return (
+            f"<Host id='{self.id}' account='{self.account}' display_name='{self.display_name}' "
+            f"canonical_facts={self.canonical_facts}>"
         )
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -121,7 +121,7 @@ class Host(db.Model):
         self.update_facts(input_host.facts)
 
     def patch(self, patch_data):
-        logger.debug(f"patching host (id={self.id}) with data: {patch_data}")
+        logger.debug("patching host (id=%s) with data: %s", self.id, patch_data)
 
         if not patch_data:
             raise InventoryException(title="Bad Request",
@@ -149,11 +149,13 @@ class Host(db.Model):
 
     def update_canonical_facts(self, canonical_facts):
         logger.debug(
-            f"Updating host's (id={self.id}) canonical_facts ({self.canonical_facts}) with input "
-            f"canonical_facts={canonical_facts}"
+            "Updating host's (id=%s) canonical_facts (%s) with input canonical_facts=%s",
+            self.id,
+            self.canonical_facts,
+            canonical_facts
         )
         self.canonical_facts.update(canonical_facts)
-        logger.debug(f"Host (id={self.id}) has updated canonical_facts ({self.canonical_facts})")
+        logger.debug("Host (id=%s) has updated canonical_facts (%s)", self.id, self.canonical_facts)
         orm.attributes.flag_modified(self, "canonical_facts")
 
     def update_facts(self, facts_dict):
@@ -181,7 +183,7 @@ class Host(db.Model):
         orm.attributes.flag_modified(self, "facts")
 
     def _update_system_profile(self, input_system_profile):
-        logger.debug(f"Updating host's (id={self.id}) system profile")
+        logger.debug("Updating host's (id=%s) system profile", self.id)
         if not self.system_profile_facts:
             self.system_profile_facts = input_system_profile
         else:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -14,8 +14,7 @@ logger = get_logger(__name__)
 class NullProducer:
 
     def send(self, topic, value=None):
-        logger.debug("NullProducer - logging message:  topic (%s) - message: %s" %
-                     (topic, value))
+        logger.debug(f"NullProducer - logging message:  topic ({topic}) - message: {value}")
 
 
 producer = None

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -14,7 +14,7 @@ logger = get_logger(__name__)
 class NullProducer:
 
     def send(self, topic, value=None):
-        logger.debug(f"NullProducer - logging message:  topic ({topic}) - message: {value}")
+        logger.debug("NullProducer - logging message:  topic (%s) - message: %s", topic, value)
 
 
 producer = None

--- a/test_api.py
+++ b/test_api.py
@@ -1175,7 +1175,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
         self.assertEqual(results["total"], expected_total)
 
     def test_get_system_profile_with_invalid_host_id(self):
-        invalid_host_ids = ["notauuid", "%s,notuuid" % generate_uuid()]
+        invalid_host_ids = ["notauuid", f"{generate_uuid()},notuuid"]
         for host_id in invalid_host_ids:
             with self.subTest(invalid_host_id=host_id):
                 response = self.get("{}/{}/system_profile".format(HOST_URL, host_id), 400)

--- a/test_api.py
+++ b/test_api.py
@@ -267,7 +267,7 @@ class CreateHostsTestCase(DBAPITestCase):
         modified_time = dateutil.parser.parse(updated_host["updated"])
         self.assertGreater(modified_time, created_time)
 
-        host_lookup_results = self.get("{}/{}".format(HOST_URL, original_id), 200)
+        host_lookup_results = self.get(f"{HOST_URL}/{original_id}", 200)
 
         # sanity check
         # host_lookup_results["results"][0]["facts"][0]["facts"]["key2"] = "blah"
@@ -323,7 +323,7 @@ class CreateHostsTestCase(DBAPITestCase):
         self.assertEqual(updated_host["id"], original_id)
 
         # Retrieve the host using the id that we first received
-        data = self.get("{}/{}".format(HOST_URL, original_id), 200)
+        data = self.get(f"{HOST_URL}/{original_id}", 200)
 
         self._validate_host(data["results"][0],
                             host_data,
@@ -354,7 +354,7 @@ class CreateHostsTestCase(DBAPITestCase):
         # Update the hosts
         self.post(HOST_URL, [host_data.data()], 207)
 
-        host_lookup_results = self.get("{}/{}".format(HOST_URL, original_id), 200)
+        host_lookup_results = self.get(f"{HOST_URL}/{original_id}", 200)
 
         self._validate_host(host_lookup_results["results"][0],
                             host_data,
@@ -657,7 +657,7 @@ class CreateHostsTestCase(DBAPITestCase):
 
         original_id = created_host["id"]
 
-        host_lookup_results = self.get("{}/{}".format(HOST_URL, original_id), 200)
+        host_lookup_results = self.get(f"{HOST_URL}/{original_id}", 200)
 
         self._validate_host(host_lookup_results["results"][0],
                             host_data,
@@ -736,7 +736,7 @@ class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):
 
         original_id = created_host["id"]
 
-        host_lookup_results = self.get("{}/{}".format(HOST_URL, original_id), 200)
+        host_lookup_results = self.get(f"{HOST_URL}/{original_id}", 200)
 
         # Explicitly set the display_name to the be id...this is expected here
         host_data.display_name = created_host["id"]
@@ -765,7 +765,7 @@ class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):
 
         original_id = created_host["id"]
 
-        host_lookup_results = self.get("{}/{}".format(HOST_URL, original_id), 200)
+        host_lookup_results = self.get(f"{HOST_URL}/{original_id}", 200)
 
         # Explicitly set the display_name ...this is expected here
         host_data.display_name = expected_display_name
@@ -935,7 +935,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
         # verify system_profile is not included
         self.assertNotIn("system_profile", created_host)
 
-        host_lookup_results = self.get("{}/{}/system_profile".format(HOST_URL, original_id), 200)
+        host_lookup_results = self.get(f"{HOST_URL}/{original_id}/system_profile", 200)
         actual_host = host_lookup_results["results"][0]
 
         self.assertEqual(original_id, actual_host["id"])
@@ -992,7 +992,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
                 with self.app.app_context():
                     msg_handler(mq_message)
 
-                host_lookup_results = self.get("{}/{}/system_profile".format(HOST_URL, original_id), 200)
+                host_lookup_results = self.get(f"{HOST_URL}/{original_id}/system_profile", 200)
                 actual_host = host_lookup_results["results"][0]
 
                 self.assertEqual(original_id, actual_host["id"])
@@ -1068,7 +1068,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
                 original_id = created_host["id"]
 
                 # Verify that the system profile data is saved
-                host_lookup_results = self.get("{}/{}/system_profile".format(HOST_URL, original_id), 200)
+                host_lookup_results = self.get(f"{HOST_URL}/{original_id}/system_profile", 200)
                 actual_host = host_lookup_results["results"][0]
 
                 self.assertEqual(original_id, actual_host["id"])
@@ -1097,7 +1097,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
                 original_id = created_host["id"]
 
                 # Verify that the system profile data is saved
-                host_lookup_results = self.get("{}/{}/system_profile".format(HOST_URL, original_id), 200)
+                host_lookup_results = self.get(f"{HOST_URL}/{original_id}/system_profile", 200)
                 actual_host = host_lookup_results["results"][0]
 
                 self.assertEqual(original_id, actual_host["id"])
@@ -1122,7 +1122,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
 
         original_id = created_host["id"]
 
-        host_lookup_results = self.get("{}/{}/system_profile".format(HOST_URL, original_id), 200)
+        host_lookup_results = self.get(f"{HOST_URL}/{original_id}/system_profile", 200)
         actual_host = host_lookup_results["results"][0]
 
         self.assertEqual(original_id, actual_host["id"])
@@ -1155,7 +1155,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
             })
 
         url_host_id_list = ",".join(host_id_list)
-        test_url = "{}/{}/system_profile".format(HOST_URL, url_host_id_list)
+        test_url = f"{HOST_URL}/{url_host_id_list}/system_profile"
         host_lookup_results = self.get(test_url, 200)
 
         self.assertEqual(
@@ -1170,7 +1170,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
         expected_count = 0
         expected_total = 0
         host_id = generate_uuid()
-        results = self.get("{}/{}/system_profile".format(HOST_URL, host_id), 200)
+        results = self.get(f"{HOST_URL}/{host_id}/system_profile", 200)
         self.assertEqual(results["count"], expected_count)
         self.assertEqual(results["total"], expected_total)
 
@@ -1178,7 +1178,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationTestCase):
         invalid_host_ids = ["notauuid", f"{generate_uuid()},notuuid"]
         for host_id in invalid_host_ids:
             with self.subTest(invalid_host_id=host_id):
-                response = self.get("{}/{}/system_profile".format(HOST_URL, host_id), 400)
+                response = self.get(f"{HOST_URL}/{host_id}/system_profile", 400)
                 self.verify_error_response(response,
                                            expected_title="Bad Request",
                                            expected_status=400)


### PR DESCRIPTION
Unified all string interpolations.

- Log messages use the logging module’s native % interpolation, receiving the values as position arguments.
- String literals use f-strings instead of the % operator and the _str.format_ method.

This is a part of making the code clean and nicely formatted. #335