### PR TITLE
Formatting: Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+default_language_version:
+  python: python3.6
+repos:
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v1.6.0
+  hooks:
+  - id: reorder-python-imports
+    args: [--py3-plus]
+- repo: https://github.com/asottile/pyupgrade
+  rev: v1.19.0
+  hooks:
+  - id: pyupgrade
+    args: [--py36-plus]
+- repo: https://github.com/ambv/black
+  rev: 19.3b0
+  hooks:
+  - id: black
+    args: [--line-length, "119"]
+    require_serial: true
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.2.3
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: debug-statements
+  - id: flake8

--- a/README.md
+++ b/README.md
@@ -208,3 +208,18 @@ This is the Base64 encoding of the following JSON document:
 ```json
 {"identity": {"account_number": "0000001", "internal": {"org_id": "000001"}}}
 ```
+
+## Contributing
+
+This repository uses [pre-commit](https://pre-commit.com) to check and enforce code style. It uses
+[Black](https://github.com/psf/black) to reformat the Python code and [Flake8](http://flake8.pycqa.org) to check it
+afterwards. Other formats and text files are linted as well.
+
+Install pre-commit hooks to your local repository by running:
+
+```bash
+$ pre-commit install
+```
+
+After that, all your commited files will be linted. If the checks don’t succeed, the commit will be rejected. Please
+make sure all checks pass before submitting a pull request. Thanks!


### PR DESCRIPTION
Added a pre-commit configuration file based on that in #331. I made some changes to that:

- Removed the _iqe_ exclusion as such folder is not a part of the repository.
- DRIED the language version.
- Bumped up versions to the most recent ones.
- Reodered the hooks – put [asottile’s](https://github.com/asottile)’s tools together and [_pre-commit-hooks_](https://github.com/pre-commit/pre-commit-hooks) to the end.
- Removed [Black](https://github.com/psf/black) [arguments](https://github.com/diegorafrh/insights-host-inventory/blob/3318b3be4765bceb6160bbe7a4113ed347dcf016/.pre-commit-config.yaml#L12): _safe_ is on by default, _quiet_ is not necessary
- Added a [_py3-plus_](https://github.com/Glutexo/insights-host-inventory/blob/31daba8b51dad20af99469cdde659204a9127f93/.pre-commit-config.yaml#L8) argument to [_reorder_python_imports_](https://github.com/asottile/reorder_python_imports) and [_py36-plus_](https://github.com/Glutexo/insights-host-inventory/blob/31daba8b51dad20af99469cdde659204a9127f93/.pre-commit-config.yaml#L13) to [_pyupgrade_](https://github.com/asottile/pyupgrade).

[Black](https://github.com/psf/black) is not quiet in my configuration, because other tools aren’t too. Even [_pre-commit-hooks_](https://github.com/pre-commit/pre-commit-hooks) report which files has been changed.

Kept the [_--line-length_](https://github.com/Glutexo/insights-host-inventory/blob/1fc6db67fe469adfc1f28ff2226bc7e636f48414/.pre-commit-config.yaml#L18) argument until [_pyproject.toml_](https://github.com/Glutexo/insights-host-inventory/blob/4645220087bda7444e975cc762335874153524f8/pyproject.toml) is added (#366).

The _--py36?-plus_ arguments configure the tools not to ensure compatibility with older Python versions. Our application is running on Python 3.6 and is never going to be downgraded.