### PR TITLE
Formatting: Simplify super calls

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -150,7 +150,7 @@ class DBAPITestCase(APIBaseTestCase):
         """
         Initializes the database by creating all tables.
         """
-        super(DBAPITestCase, self).setUp()
+        super().setUp()
 
         # binds the app to the current context
         with self.app.app_context():
@@ -1090,7 +1090,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
 
 class PreCreatedHostsBaseTestCase(DBAPITestCase, PaginationBaseTestCase):
     def setUp(self):
-        super(PreCreatedHostsBaseTestCase, self).setUp()
+        super().setUp()
         self.added_hosts = self.create_hosts()
 
     def create_hosts(self):


### PR DESCRIPTION
In newer versions of Python, it’s possible to call just super() instead of super(ParentClass, self). Replaced these obsolete calls with their more concise variant. This is what `pyupgrade --py36-plus` would do.

See the [documentation](https://docs.python.org/3.6/library/functions.html?highlight=super#super) for more info.

This is a part of ultimately fixing the code so it can be checked and fixed automatically on commit.