### PR TITLE
Rename serialization tests

### DIFF
--- a/test_unit.py
+++ b/test_unit.py
@@ -321,7 +321,7 @@ class HostParamsToOrderByErrorsTestCase(TestCase):
             _params_to_order_by(Mock(), order_how="ASC")
 
 
-class ModelsHostFromJsonCompoundTestCase(TestCase):
+class SerializationHostFromJsonCompoundTestCase(TestCase):
 
     def test_with_all_fields(self):
         canonical_facts = {
@@ -671,7 +671,7 @@ class SerializationHostToJsonMockedTestCase(SerializationHostToJsonBaseTestCase)
         facts_to_json.assert_called_once_with(host_init_data["facts"])
 
 
-class ModelsHostToSystemProfileJsonTestCase(TestCase):
+class SerializationHostToSystemProfileJsonTestCase(TestCase):
 
     def test_non_empty_profile_is_not_changed(self):
         system_profile_facts = {


### PR DESCRIPTION
Renamed the remaining tests that still had the models module name in its name. These tests describe functions in the serialization module and other tests follow this naming too. Unified.

A bit related to #374, but not much.