### PR TITLE
Fix host constructor default values 🐛

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -62,9 +62,9 @@ class Host(db.Model):
     def __init__(
         self,
         canonical_facts,
-        display_name=display_name,
+        display_name=None,
         ansible_host=None,
-        account=account,
+        account=None,
         facts=None,
         system_profile_facts=None,
     ):
@@ -75,7 +75,7 @@ class Host(db.Model):
                                      "fact fields must be present.")
 
         self.canonical_facts = canonical_facts
-
+        
         if display_name:
             # Only set the display_name field if input the display_name has
             # been set...this will make it so that the "default" logic will


### PR DESCRIPTION
The default values for the [app.models.Host](https://github.com/RedHatInsights/insights-host-inventory/blob/009dbbba4f001ae1c7ea398b15aec110bc48ca49/app/models.py#L38) class arguments [_display_name_](https://github.com/RedHatInsights/insights-host-inventory/blob/009dbbba4f001ae1c7ea398b15aec110bc48ca49/app/models.py#L65)
and [_account_](https://github.com/RedHatInsights/insights-host-inventory/blob/009dbbba4f001ae1c7ea398b15aec110bc48ca49/app/models.py#L67) are bugs. The values are actually _sqlalchemy.sql.schema.Column_ instances. The only reasonable defaults here are _None_. Fixed.

I am going to get completely rid of the constructor nevertheless. Until that happens, I’d rather like to see it not buggy.

Steps to reproduce:

1. Create a [_Host_](https://github.com/RedHatInsights/insights-host-inventory/blob/009dbbba4f001ae1c7ea398b15aec110bc48ca49/app/models.py#L38) instance without a display name.

```python
Host({"fqdn": "some fqdn"})
```

2. 💥

```
TypeError: Boolean value of this clause is not defined
```