### PR TITLE
Remove .idea from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ pyvenv.cfg
 tags
 .coverage
 .pytest_cache/
-.idea/


### PR DESCRIPTION
[Removed](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:gitignore_idea?expand=1#diff-a084b794bc0759e7a6b77810e01874f2L11) the [_.idea_](https://github.com/RedHatInsights/insights-host-inventory/blob/257e0de2d6934af8882d4638e711de1b77cbb8e6/.gitignore#L11) entry from project’s [_.gitignore_](https://github.com/RedHatInsights/insights-host-inventory/blob/257e0de2d6934af8882d4638e711de1b77cbb8e6/.gitignore) file. It targets a directory created by an arbitrary IDE, not in any way related to the project.

If you want to ignore _.idea_ folders on your development machine, please do so in your global .gitignore file. That is done by setting a [_core.excludesfile_](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_code_core_excludesfile_code) configuration variable.

```
$ git config --global core.excludesfile ~/.gitignore_global
$ echo ".idea\n" >> ~/.gitignore_global
```