### PR TITLE
Serialization: Refactor Host constructor and tests

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -56,33 +56,6 @@ class Host(db.Model):
     canonical_facts = db.Column(JSONB)
     system_profile_facts = db.Column(JSONB)
 
-    def __init__(
-        self,
-        canonical_facts,
-        display_name=display_name,
-        ansible_host=None,
-        account=account,
-        facts=None,
-        system_profile_facts=None,
-    ):
-
-        if not canonical_facts:
-            raise InventoryException(
-                title="Invalid request", detail="At least one of the canonical fact fields must be present."
-            )
-
-        self.canonical_facts = canonical_facts
-
-        if display_name:
-            # Only set the display_name field if input the display_name has
-            # been set...this will make it so that the "default" logic will
-            # get called during the save to fill in an empty display_name
-            self.display_name = display_name
-        self._update_ansible_host(ansible_host)
-        self.account = account
-        self.facts = facts
-        self.system_profile_facts = system_profile_facts or {}
-
     def save(self):
         db.session.add(self)
 


### PR DESCRIPTION
The logic of creating a [_Host_](https://github.com/RedHatInsights/insights-host-inventory/blob/split_inventory_service/app/models.py#L38) model from JSON dict has been scattered between the [_Host_](https://github.com/RedHatInsights/insights-host-inventory/blob/split_inventory_service/app/models.py#L38) DB model [constructor](https://github.com/RedHatInsights/insights-host-inventory/blob/split_inventory_service/app/models.py#L60) and the [deserialization](https://github.com/RedHatInsights/insights-host-inventory/blob/split_inventory_service/app/serialization.py#L10) method. Moved everything to the [deserializer](https://github.com/RedHatInsights/insights-host-inventory/blob/split_inventory_service/app/serialization.py#L10) without changing any logic.

[Refactored](https://github.com/RedHatInsights/insights-host-inventory/compare/split_inventory_service...Glutexo:host_constructor?expand=1#diff-13729a38e16bcaf94b928e33e5dd468a) the (de)serialization [tests](https://github.com/RedHatInsights/insights-host-inventory/blob/split_inventory_service/test_unit.py#L328) to not work around the bugs and quirks of the [_Host_](https://github.com/RedHatInsights/insights-host-inventory/blob/split_inventory_service/app/models.py#L38) model [constructor](https://github.com/RedHatInsights/insights-host-inventory/blob/split_inventory_service/app/models.py#L60):

* Invalid default values for [_account_](https://github.com/RedHatInsights/insights-host-inventory/blob/split_inventory_service/app/models.py#L65) and [_display_name_](https://github.com/RedHatInsights/insights-host-inventory/blob/2c26d4ce58066f84eecf945c7b6138a8044e2b61/app/models.py#L63)
* Inability to provide all fields as keyword arguments (_id_, _created_on_, _modified_on_)

Added tests for the ability to fill an empty string into _ansible_host_. This is no longer done by a common trusted method [__update_ansible_host_](https://github.com/RedHatInsights/insights-host-inventory/blob/split_inventory_service/app/models.py#L112). It is tested both on serialization and deserialization to verify that the value remains unchanged through the whole process.

Made the (de)serialization tests hopefully more straightforward and readable along the way.

This pull request is a step towards decoupling the logic from the database model. #309 Still some quirks remain like [validation](https://github.com/Glutexo/insights-host-inventory/blob/892ee6be0d620bf27ea8fd2b683f07ebeb78760e/app/serialization.py#L13) in the [deserialization](https://github.com/Glutexo/insights-host-inventory/blob/892ee6be0d620bf27ea8fd2b683f07ebeb78760e/app/serialization.py#L11) method.