### PR TITLE
Specify versions in Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,40 +4,40 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-flask = "==1.1.0"
-jsonify = "==0.5"
-flask-restful = "==0.3.7"
-requests = "==2.22.0"
-flask-limiter = "==1.0.1"
-flask-script = "==2.0.6"
-flask-api = "==1.1"
-flask-sqlalchemy = "==2.4.0"
-"psycopg2-binary" = "==2.8.3"
-flask-migrate = "==2.5.2"
-itsdangerous = "==1.1.0"
-request = "==2019.4.13"
-gunicorn = "==19.9.0"
-connexion = {version = "==2.3.0", extras = ["swagger-ui"]}
-pyyaml = "==5.1.1"
-prometheus-client = "==0.7.1"
-logstash-formatter = "==0.5.17"
-pytest = "==5.0.1"
-validators = "==0.13.0"
-marshmallow = "==2.19.5"
-ujson = "==1.35"
-watchtower = "==0.6.0"
-"boto3" = "==1.9.183"
-kafka = "==1.3.5"
+flask = "~=1.1.0"
+jsonify = "==0.5"  # Not semver
+flask-restful = "~=0.3.7"
+requests = "~=2.22.0"
+flask-limiter = "~=1.0.1"
+flask-script = "~=2.0.6"
+flask-api = "==1.1"  # Not semver
+flask-sqlalchemy = "~=2.4.0"
+"psycopg2-binary" = "~=2.8.3"
+flask-migrate = "~=2.5.2"
+itsdangerous = "~=1.1.0"
+request = "==2019.4.13"  # Not semver
+gunicorn = "~=19.9.0"
+connexion = {version = "~=2.3.0", extras = ["swagger-ui"]}
+pyyaml = "~=5.1.2"
+prometheus-client = "~=0.7.1"
+logstash-formatter = "~=0.5.17"
+pytest = "~=5.0.1"
+validators = "~=0.13.0"
+marshmallow = "~=2.19.5"
+ujson = "==1.35"  # Not semver
+watchtower = "~=0.6.0"
+"boto3" = "~=1.9.183"
+kafka = "~=1.3.5"
 
 [dev-packages]
-pytest = "==5.0.1"
-pytest-cov = "==2.7.1"
-coverage = "==4.5.3"
-flake8 = "==3.7.7"
-pyupgrade = "==1.21.0"
-reorder-python-imports = "==1.6.1"
-pre-commit-hooks = "==2.2.3"
-black = "==19.3b0"
+pytest = "~=5.0.1"
+pytest-cov = "~=2.7.1"
+coverage = "~=4.5.3"
+flake8 = "~=3.7.7"
+pyupgrade = "~=1.21.0"
+reorder-python-imports = "~=1.6.1"
+pre-commit-hooks = "~=2.2.3"
+black = "==19.3b0"  # Pre-release, not semver
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fa477b9de4be305cbd640c5ba50ad5793a95fcb104658963505093d6ed7510a6"
+            "sha256": "1b589f25b0f6e4be6f90287f63171871a9ee1fe6a7ec32322bded7157359a053"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -53,10 +53,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:9448deffdb58e852935eeaae90682b7a0b4ef3c45eb6f17fa4444873f45f9ae6",
-                "sha256:d2ead76e77e7d0cd4c6bf9445e0ff54e279aee3c727eb30255b4ec327f956d22"
+                "sha256:56cd1114e0ce35733e890b321160c8c438243f4fa54d3d074dfa6bdce4ee55aa",
+                "sha256:f86504bcc9c44d5b2e7b019f2f279b70f17b1400d2fc4775bc009ec473530cad"
             ],
-            "version": "==1.12.200"
+            "version": "==1.12.204"
         },
         "certifi": {
             "hashes": [
@@ -758,35 +758,32 @@
         },
         "ruamel.yaml": {
             "hashes": [
-                "sha256:4c1dbad22790b5ea8587c2a0cae97ebc7a9d0d88de5d0edb70dea2eab7d8534a",
-                "sha256:eb4b1ffd095785c50f110118cb6f7bb9cd011ecc013b014436d38b7f8fb7afa9"
+                "sha256:547aeab5c51c93bc750ed2a320c1559b605bde3aa569216aa75fd91d8a1c4623"
             ],
-            "version": "==0.16.0"
+            "version": "==0.16.1"
         },
         "ruamel.yaml.clib": {
             "hashes": [
-                "sha256:32c37bdc7ee5fbc5e794b497b98f98ecc12e1f1541cdd3bbd65f8ec32e0270d2",
-                "sha256:385b70734435d2f66f00823d4e224c1a4b53dfeaf9ded3a655a6a2f9c229b1f6",
-                "sha256:4040ddea350698138e341395508b8dd7610b2312177cb41c8db2b6260adee348",
-                "sha256:4dc088e55e0cc3f8c18652e830e3ecff159425f01327de4d94e5ce473fdcd2f8",
-                "sha256:53768934bc28ce07ca82c02d9db6717ae9bad4cdf9511d3a3e6d1b576235d04e",
-                "sha256:53fd2ef53be8301707662f4c353731d97a4cb2b372972b7dcd73ef245dbab9e9",
-                "sha256:5712728e6ba56d3b93f5f99a175760c778420caae714687592548c4f7699782e",
-                "sha256:66df3233e5cca3528be2a700f2a54e26262dde6d5e22b34953e7f44785857c8c",
-                "sha256:750a15f07178d91204ce4baffb16697cef4c8f583495d4f0fec52902dad8e7fc",
-                "sha256:820ec13201ed5c015dc74ea7087b2c5c56b8aeb51af4b7d7c859e0b45c07f035",
-                "sha256:8dcab8a09c17a030d046749eb97ed9a81e02bb642d7816e8757fc5a3016af89d",
-                "sha256:9e1acd628f2bf601fd4df69523476ee4640be8ba7d9aff8f04cd66a1ae07f119",
-                "sha256:b31bc078c9bac3dbb5855e94eb382aeef23076bf3d1a2d02ee8d91c55567cb08",
-                "sha256:b7a681e2d6dbd147ec9808cb1a736c1ef96bc2c693f54e0fc01fe0d10409bd88",
-                "sha256:c1333e8911c29c6e209db117345141d5fcb772464d62cac3e117912a965d9619",
-                "sha256:d583e7b9646418dff5ee0e36875b3cabc3d0fb925dfdeec239697c583388f9b2",
-                "sha256:da610ff9feeb075641128ce40881d2ac3c8e57e7ea04636169b0c3b5e8f711f7",
-                "sha256:e9b6ebb62806817b01e9eea9fc7da57c12557e44e94e79f5fa82eca4bc7fad60",
-                "sha256:f36035f1c0b6a7a20010e98b582d38272514a77f34cd45ec0d2847abaa89ac78"
+                "sha256:0bbe19d3e099f8ba384e1846e6b54f245f58aeec8700edbbf9abb87afa54fd82",
+                "sha256:2f38024592613f3a8772bbc2904be027d9abf463518ba145f2d0c8e6da27009f",
+                "sha256:44449b3764a3f75815eea8ae5930b98e8326be64a90b0f782747318f861abfe0",
+                "sha256:5710be9a357801c31c1eaa37b9bc92d38176d785af5b2f0c9751385c5dc9659a",
+                "sha256:5a089acb6833ed5f412e24cbe3e665683064c1429824d2819137b5ade54435c3",
+                "sha256:6143386ddd61599ea081c012a69a16e5bdd7b3c6c231bd039534365a48940f30",
+                "sha256:6726aaf851f5f9e4cbdd3e1e414bc700bdd39220e8bc386415fd41c87b1b53c2",
+                "sha256:68fbc3b5d94d145a391452f886ae5fca240cb7e3ab6bd66e1a721507cdaac28a",
+                "sha256:75ebddf99ba9e0b48f32b5bdcf9e5a2b84c017da9e0db7bf11995fa414aa09cd",
+                "sha256:79948a6712baa686773a43906728e20932c923f7b2a91be7347993be2d745e55",
+                "sha256:8a2dd8e8b08d369558cade05731172c4b5e2f4c5097762c6b352bd28fd9f9dc4",
+                "sha256:c747acdb5e8c242ab2280df6f0c239e62838af4bee647031d96b3db2f9cefc04",
+                "sha256:cadc8eecd27414dca30366b2535cb5e3f3b47b4e2d6be7a0b13e4e52e459ff9f",
+                "sha256:cee86ecc893a6a8ecaa7c6a9c2d06f75f614176210d78a5f155f8e78d6989509",
+                "sha256:e59af39e895aff28ee5f55515983cab3466d1a029c91c04db29da1c0f09cf333",
+                "sha256:eee7ecd2eee648884fae6c51ae50c814acdcc5d6340dc96c970158aebcd25ac6",
+                "sha256:ef8d4522d231cb9b29f6cdd0edc8faac9d9715c60dc7becbd6eb82c915a98e5b",
+                "sha256:f504d45230cc9abf2810623b924ae048b224a90adb01f97db4e766cfdda8e6eb"
             ],
-            "markers": "platform_python_implementation == 'CPython' and python_version < '3.8'",
-            "version": "==0.1.0"
+            "version": "==0.1.2"
         },
         "six": {
             "hashes": [


### PR DESCRIPTION
Replace broad _*_ version requirements by specific ones. Packages using semantic versioning use _~=_ to enable bugfix upgrades, others are locked to the exact version as we can’t be sure what changes on an upgrade.

The non-semver packages are:

* [_jsonify_](https://github.com/Glutexo/insights-host-inventory/blob/b4f9fdeb5b865250048bfbac374c60bca36d4281/Pipfile#L8) 0.5 – no third place
* [_flask-api_](https://github.com/Glutexo/insights-host-inventory/blob/b4f9fdeb5b865250048bfbac374c60bca36d4281/Pipfile#L13) 1.1 – no third place
* [_request_](https://github.com/Glutexo/insights-host-inventory/blob/b4f9fdeb5b865250048bfbac374c60bca36d4281/Pipfile#L18) 2019.4.13 – uses dates
* [_ujson_](https://github.com/Glutexo/insights-host-inventory/blob/b4f9fdeb5b865250048bfbac374c60bca36d4281/Pipfile#L27) – no third place
* [_black_](https://github.com/Glutexo/insights-host-inventory/blob/b4f9fdeb5b865250048bfbac374c60bca36d4281/Pipfile#L40) – a development dependency, no third place, as a pre-release it must have been locked to a specific version already

This is a better version of #386. Level 2 dependencies still get their upgrades depending on how level 1 ones define them. Bugfix upgrades should be safe, but still must go through the pipeline testing. Major/minor version upgrades should be backed up by a reason and verified for any relevant breaking changes. Hence the freeze.