### PR TITLE
Remove pytest from runtime dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,7 +21,6 @@ connexion = {version = "~=2.3.0", extras = ["swagger-ui"]}
 pyyaml = "~=5.1.2"
 prometheus-client = "~=0.7.1"
 logstash-formatter = "~=0.5.17"
-pytest = "~=5.0.1"
 validators = "~=0.13.0"
 marshmallow = "~=2.19.5"
 ujson = "==1.35"  # Not semver


### PR DESCRIPTION
[Pytest](https://pypi.org/project/pytest/) is a development [dependency](https://github.com/Glutexo/insights-host-inventory/blob/remove_pytest/Pipfile#L6) and is not required in runtime. It was listed in the [Pipfile](https://github.com/Glutexo/insights-host-inventory/blob/remove_pytest/Pipfile) twice. [Removed](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:remove_pytest?expand=1#diff-1e61a31bf9b94805f869dc4137ec1885L24) the runtime [line](https://github.com/RedHatInsights/insights-host-inventory/blob/4b377d01559b22e374341c9cb15454a3dff61087/Pipfile#L24).