### PR TITLE
Serialization: Make serialization methods more concise

### DIFF
--- a/app/serialization.py
+++ b/app/serialization.py
@@ -19,71 +19,64 @@ _CANONICAL_FACTS_FIELDS = (
 
 
 def deserialize_host(data):
-    canonical_facts = _deserialize_canonical_facts(data)
-    facts = _deserialize_facts(data.get("facts"))
     return Host(
-        canonical_facts,
-        data.get("display_name", None),
+        _deserialize_canonical_facts(data),
+        data.get("display_name"),
         data.get("ansible_host"),
         data.get("account"),
-        facts,
+        _deserialize_facts(data.get("facts")),
         data.get("system_profile", {}),
     )
 
 
 def serialize_host(host):
-    json_dict = _serialize_canonical_facts(host.canonical_facts)
-    json_dict["id"] = str(host.id)
-    json_dict["account"] = host.account
-    json_dict["display_name"] = host.display_name
-    json_dict["ansible_host"] = host.ansible_host
-    json_dict["facts"] = _serialize_facts(host.facts)
-    json_dict["created"] = host.created_on.isoformat() + "Z"
-    json_dict["updated"] = host.modified_on.isoformat() + "Z"
-    return json_dict
+    return {
+        **_serialize_canonical_facts(host.canonical_facts),
+        "id": _serialize_uuid(host.id),
+        "account": host.account,
+        "display_name": host.display_name,
+        "ansible_host": host.ansible_host,
+        "facts": _serialize_facts(host.facts),
+        "created": _serialize_datetime(host.created_on),
+        "updated": _serialize_datetime(host.modified_on),
+    }
 
 
 def serialize_host_system_profile(host):
-    json_dict = {"id": str(host.id), "system_profile": host.system_profile_facts or {}}
-    return json_dict
+    return {"id": _serialize_uuid(host.id), "system_profile": host.system_profile_facts or {}}
 
 
 def _deserialize_canonical_facts(data):
-    canonical_fact_list = {}
-    for cf in _CANONICAL_FACTS_FIELDS:
-        # Do not allow the incoming canonical facts to be None or ''
-        if cf in data and data[cf]:
-            canonical_fact_list[cf] = data[cf]
-    return canonical_fact_list
+    return {field: data[field] for field in _CANONICAL_FACTS_FIELDS if data.get(field)}
 
 
 def _serialize_canonical_facts(canonical_facts):
-    canonical_fact_dict = dict.fromkeys(_CANONICAL_FACTS_FIELDS, None)
-    for cf in _CANONICAL_FACTS_FIELDS:
-        if cf in canonical_facts:
-            canonical_fact_dict[cf] = canonical_facts[cf]
-    return canonical_fact_dict
+    return {field: canonical_facts.get(field) for field in _CANONICAL_FACTS_FIELDS}
 
 
 def _deserialize_facts(data):
-    if data is None:
-        data = []
-
-    fact_dict = {}
-    for fact in data:
-        if "namespace" in fact and "facts" in fact:
-            if fact["namespace"] in fact_dict:
-                fact_dict[fact["namespace"]].update(fact["facts"])
+    facts = {}
+    for fact in [] if data is None else data:
+        try:
+            if fact["namespace"] in facts:
+                facts[fact["namespace"]].update(fact["facts"])
             else:
-                fact_dict[fact["namespace"]] = fact["facts"]
-        else:
+                facts[fact["namespace"]] = fact["facts"]
+        except KeyError:
             # The facts from the request are formatted incorrectly
             raise InputFormatException(
                 "Invalid format of Fact object.  Fact must contain 'namespace' and 'facts' keys."
             )
-    return fact_dict
+    return facts
 
 
 def _serialize_facts(facts):
-    fact_list = [{"namespace": namespace, "facts": facts if facts else {}} for namespace, facts in facts.items()]
-    return fact_list
+    return [{"namespace": namespace, "facts": facts or {}} for namespace, facts in facts.items()]
+
+
+def _serialize_datetime(dt):
+    return dt.isoformat() + "Z"
+
+
+def _serialize_uuid(u):
+    return str(u)

--- a/test_unit.py
+++ b/test_unit.py
@@ -7,6 +7,7 @@ from unittest import main
 from unittest import TestCase
 from unittest.mock import Mock
 from unittest.mock import patch
+from uuid import UUID
 from uuid import uuid4
 
 from api import api_operation
@@ -23,7 +24,9 @@ from app.models import Host
 from app.serialization import _deserialize_canonical_facts
 from app.serialization import _deserialize_facts
 from app.serialization import _serialize_canonical_facts
+from app.serialization import _serialize_datetime
 from app.serialization import _serialize_facts
+from app.serialization import _serialize_uuid
 from app.serialization import deserialize_host
 from app.serialization import serialize_host
 from app.serialization import serialize_host_system_profile
@@ -822,6 +825,26 @@ class SerializationSerializeFactsTestCase(TestCase):
                     [{"namespace": namespace, "facts": facts or {}} for namespace, facts in facts.items()],
                     _serialize_facts(facts),
                 )
+
+
+class SerializationSerializeDatetime(TestCase):
+    def test_short_utc_timezone_is_included(self):
+        now = datetime.utcnow()
+        self.assertEqual(f"{now.isoformat()}Z", _serialize_datetime(now))
+
+    def test_iso_format_is_used(self):
+        dt = datetime(2019, 7, 3, 1, 1, 4, 20647)
+        self.assertEqual("2019-07-03T01:01:04.020647Z", _serialize_datetime(dt))
+
+
+class SerializationSerializeUuid(TestCase):
+    def test_uuid_has_hyphens_computed(self):
+        u = uuid4()
+        self.assertEqual(str(u), _serialize_uuid(u))
+
+    def test_uuid_has_hyphens_literal(self):
+        u = "4950e534-bbef-4432-bde2-aa3dd2bd0a52"
+        self.assertEqual(u, _serialize_uuid(UUID(u)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extracted a part of #328, so the changes are more atomic and easier to review. This is a small refactoring of (de)serialization methods, so they are more concise, expressive and DRY. Logic is not affected – methods input/output is not affected at all.

- [Extracted](https://github.com/RedHatInsights/insights-host-inventory/pull/390/files#diff-e185216c8cfde59cb503b3a749a0c51fR77) [DateTime](https://github.com/Glutexo/insights-host-inventory/blob/3d5e1adfa20bb4a8595a1f95ae258fd1d27aecef/app/serialization.py#L77) and [UUID](https://github.com/Glutexo/insights-host-inventory/blob/3d5e1adfa20bb4a8595a1f95ae258fd1d27aecef/app/serialization.py#L81) serialization. Like this it is more DRY and [testable](https://github.com/Glutexo/insights-host-inventory/blob/660501ab95bba2fdd5ec0f2c1e61972aed9b9b2f/test_unit.py#L830).
- Shortened some multi-lines to be more expressive: removed unnecessary intermittent variables, converted dict item assignments to a singe-expression dict instantiation, turned for loops into dict/list comprehensions.
- Renamed the input/output variables to they are consistent.

[Added](https://github.com/RedHatInsights/insights-host-inventory/pull/390/files#diff-13729a38e16bcaf94b928e33e5dd468aR830) [tests](https://github.com/Glutexo/insights-host-inventory/blob/660501ab95bba2fdd5ec0f2c1e61972aed9b9b2f/test_unit.py#L830) for the new [helper](https://github.com/Glutexo/insights-host-inventory/blob/660501ab95bba2fdd5ec0f2c1e61972aed9b9b2f/app/serialization.py#L77) methods.