### PR TITLE
Replace sleep with flush

### DIFF
--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -27,7 +27,6 @@ print("TOPIC:", TOPIC)
 start = time.time()
 for payload in all_payloads:
     producer.send(TOPIC, value=payload)
+producer.flush()
 end = time.time()
 print("Time to send all hosts to queue: ", end - start)
-
-time.sleep(2)


### PR DESCRIPTION
The correct way to wait for all pending Kafka messages to be produced is to use the blocking method [_KafkaProducer.flush_](https://kafka-python.readthedocs.io/en/1.4.6/apidoc/KafkaProducer.html#kafka.KafkaProducer.flush). Used this method instead of current [_time.sleep_](https://github.com/RedHatInsights/insights-host-inventory/blob/ba8fe915d8c9131c687b0e9b35a3be24d1b2dcdf/utils/kafka_producer.py#L33), which is unreliable and may result in message loss.

Furthermore, the time measurement doesn’t produce a right value. Without the flush, it only measures how long does it take to add the messages to buffer.