### PR TITLE
Unify producer tool env with config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ run_inv_mq_service:
 	INVENTORY_LOGGING_CONFIG_FILE=logconfig.ini INVENTORY_LOG_LEVEL=DEBUG python inv_mq_service.py
 
 run_inv_mq_service_test_producer:
-	KAFKA_GROUP="inventory-mq" KAFKA_TOPIC="platform.inventory.host-ingress" python utils/kafka_producer.py
+	python utils/kafka_producer.py
 
 run_inv_mq_service_test_consumer:
-	KAFKA_GROUP="inventory-mq" KAFKA_TOPIC="platform.inventory.host-egress" python utils/kafka_consumer.py
+	python utils/kafka_consumer.py

--- a/utils/kafka_consumer.py
+++ b/utils/kafka_consumer.py
@@ -7,8 +7,8 @@ from kafka import KafkaConsumer
 # from app.models import Host, SystemProfileSchema
 
 
-TOPIC = os.environ.get("KAFKA_TOPIC", "platform.inventory.host-egress")
-KAFKA_GROUP = os.environ.get("KAFKA_GROUP", "inventory-mq")
+HOST_EGRESS_TOPIC = os.environ.get("KAFKA_HOST_EGRESS_TOPIC", "platform.inventory.host-egress")
+HOST_INGRESS_GROUP = os.environ.get("KAFKA_HOST_INGRESS_GROUP", "inventory-mq")
 BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
 
 
@@ -23,12 +23,12 @@ def msg_handler(parsed):
     # host.save()
 
 
-consumer = KafkaConsumer(TOPIC, group_id=KAFKA_GROUP, bootstrap_servers=BOOTSTRAP_SERVERS)
+consumer = KafkaConsumer(HOST_EGRESS_TOPIC, group_id=HOST_INGRESS_GROUP, bootstrap_servers=BOOTSTRAP_SERVERS)
 
 logging.basicConfig(level=logging.INFO)
 
-print("TOPIC:", TOPIC)
-print("KAFKA_GROUP:", KAFKA_GROUP)
+print("HOST_EGRESS_TOPIC:", HOST_EGRESS_TOPIC)
+print("KAFKA_HOST_INGRESS_GROUP:", HOST_INGRESS_GROUP)
 print("BOOTSTRAP_SERVERS:", BOOTSTRAP_SERVERS)
 
 for msg in consumer:

--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -7,8 +7,7 @@ from kafka import KafkaProducer
 
 logging.basicConfig(level=logging.INFO)
 
-TOPIC = os.environ.get("KAFKA_TOPIC")
-KAFKA_GROUP = os.environ.get("KAFKA_GROUP", "inventory")
+HOST_INGRESS_TOPIC = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
 BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
 
 # payload = payloads.build_chunk()
@@ -22,11 +21,11 @@ print("time elapsed to build payloads: ", end - start)
 print("Number of hosts (payloads): ", len(all_payloads))
 
 producer = KafkaProducer(bootstrap_servers=BOOTSTRAP_SERVERS, api_version=(0, 10))
-print("TOPIC:", TOPIC)
+print("HOST_INGRESS_TOPIC:", HOST_INGRESS_TOPIC)
 
 start = time.time()
 for payload in all_payloads:
-    producer.send(TOPIC, value=payload)
+    producer.send(HOST_INGRESS_TOPIC, value=payload)
 producer.flush()
 end = time.time()
 print("Time to send all hosts to queue: ", end - start)


### PR DESCRIPTION
Made environment variable names and default values in the producer tool with those in the [_Config_](https://github.com/Glutexo/insights-host-inventory/blob/717cd6e88a5549dc6dcd802c5a149030cb49202f/app/config.py#L7) class. This makes it possible to run the tool with the same environment configuration.