### PR TITLE
Remove unused build_chunk function

### DIFF
--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -11,8 +11,6 @@ TOPIC = os.environ.get("KAFKA_TOPIC")
 KAFKA_GROUP = os.environ.get("KAFKA_GROUP", "inventory")
 BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
 
-# payload = payloads.build_chunk()
-
 # Create list of host payloads to add to the message queue
 # payloads.build_payloads takes two optional args: number of hosts, and payload type ("default", "rhsm", "qpc")
 start = time.time()

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -166,15 +166,6 @@ def build_host_chunk():
     return payload
 
 
-def build_chunk():
-    payload = {
-        "id": host_id,
-        # "system_profile": create_system_profile(),
-        "system_profile": {},
-    }
-    return payload
-
-
 def build_data(payload_type):
     if payload_type == "default":
         return build_host_chunk()


### PR DESCRIPTION
The [_build_chunk_](https://github.com/RedHatInsights/insights-host-inventory/blob/performance_input/utils/payloads.py#L169) function is not used anywhere and it doesn’t do anything useful. Removed entirely.