### PR TITLE
Move executive code to main function

### DIFF
--- a/utils/kafka_consumer.py
+++ b/utils/kafka_consumer.py
@@ -23,14 +23,19 @@ def msg_handler(parsed):
     # host.save()
 
 
-consumer = KafkaConsumer(HOST_EGRESS_TOPIC, group_id=HOST_INGRESS_GROUP, bootstrap_servers=BOOTSTRAP_SERVERS)
+def main():
+    consumer = KafkaConsumer(HOST_EGRESS_TOPIC, group_id=HOST_INGRESS_GROUP, bootstrap_servers=BOOTSTRAP_SERVERS)
 
-logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.INFO)
 
-print("HOST_EGRESS_TOPIC:", HOST_EGRESS_TOPIC)
-print("KAFKA_HOST_INGRESS_GROUP:", HOST_INGRESS_GROUP)
-print("BOOTSTRAP_SERVERS:", BOOTSTRAP_SERVERS)
+    print("HOST_EGRESS_TOPIC:", HOST_EGRESS_TOPIC)
+    print("KAFKA_HOST_INGRESS_GROUP:", HOST_INGRESS_GROUP)
+    print("BOOTSTRAP_SERVERS:", BOOTSTRAP_SERVERS)
 
-for msg in consumer:
-    print("calling msg_handler()")
-    msg_handler(json.loads(msg.value))
+    for msg in consumer:
+        print("calling msg_handler()")
+        msg_handler(json.loads(msg.value))
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -5,25 +5,30 @@ import time
 import payloads
 from kafka import KafkaProducer
 
-logging.basicConfig(level=logging.INFO)
-
 HOST_INGRESS_TOPIC = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
 BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
 
-# Create list of host payloads to add to the message queue
-# payloads.build_payloads takes two optional args: number of hosts, and payload type ("default", "rhsm", "qpc")
-start = time.time()
-all_payloads = payloads.build_payloads()  # pass in the number of hosts you'd like to send (defaults to 1)
-end = time.time()
-print("time elapsed to build payloads: ", end - start)
-print("Number of hosts (payloads): ", len(all_payloads))
 
-producer = KafkaProducer(bootstrap_servers=BOOTSTRAP_SERVERS, api_version=(0, 10))
-print("HOST_INGRESS_TOPIC:", HOST_INGRESS_TOPIC)
+def main():
+    #  Create list of host payloads to add to the message queue
+    # payloads.build_payloads takes two optional args: number of hosts, and payload type ("default", "rhsm", "qpc")
+    start = time.time()
+    all_payloads = payloads.build_payloads()  # pass in the number of hosts you'd like to send (defaults to 1)
+    end = time.time()
+    print("time elapsed to build payloads: ", end - start)
+    print("Number of hosts (payloads): ", len(all_payloads))
 
-start = time.time()
-for payload in all_payloads:
-    producer.send(HOST_INGRESS_TOPIC, value=payload)
-producer.flush()
-end = time.time()
-print("Time to send all hosts to queue: ", end - start)
+    producer = KafkaProducer(bootstrap_servers=BOOTSTRAP_SERVERS, api_version=(0, 10))
+    print("HOST_INGRESS_TOPIC:", HOST_INGRESS_TOPIC)
+
+    start = time.time()
+    for payload in all_payloads:
+        producer.send(HOST_INGRESS_TOPIC, value=payload)
+    producer.flush()
+    end = time.time()
+    print("Time to send all hosts to queue: ", end - start)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -3,9 +3,11 @@ import subprocess
 import uuid
 
 
-rpm_list = subprocess.getoutput("rpm -qa").split("\n")
-print("len(rpm_list):", len(rpm_list))
-# print("rpm_list:", rpm_list)
+def rpm_list():
+    rpm_list = subprocess.getoutput("rpm -qa").split("\n")
+    print("len(rpm_list):", len(rpm_list))
+    # print("rpm_list:", rpm_list)
+    return rpm_list
 
 
 def create_system_profile():
@@ -59,7 +61,7 @@ def create_system_profile():
         "insights_egg_version": "120.0.1",
         # "installed_packages": ["rpm1", "rpm2"],
         # "installed_packages": subprocess.getoutput("rpm -qa").split("\n"),
-        # "installed_packages": rpm_list,
+        # "installed_packages": rpm_list(),
         "installed_services": ["ndb", "krb5"],
         "enabled_services": ["ndb", "krb5"],
     }


### PR DESCRIPTION
Modified the [consumer](https://github.com/Glutexo/insights-host-inventory/blob/ffa80636b8db5eb999e5473933de5e75d0987904/utils/kafka_consumer.py)/[producer](https://github.com/Glutexo/insights-host-inventory/blob/ffa80636b8db5eb999e5473933de5e75d0987904/utils/kafka_producer.py) scripts so they are more module-like. The executive (side-effect) code is encapsulated in a main function. The actual execution is under `__name__ == "__main__"` conditional.