### PR TITLE
Remove for abstraction from payloads

### DIFF
--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -8,12 +8,14 @@ from ttictoc import TicToc
 HOST_INGRESS_TOPIC = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
 BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
 
+NUM_HOSTS = 1
+
 
 def main():
     # Create list of host payloads to add to the message queue
     # payloads.build_payloads takes two optional args: number of hosts, and payload type ("default", "rhsm", "qpc")
     with TicToc("Build payloads"):
-        all_payloads = payloads.build_payloads()  # pass in the number of hosts you'd like to send (defaults to 1)
+        all_payloads = [payloads.build_payload() for _ in range(NUM_HOSTS)]
     print("Number of hosts (payloads): ", len(all_payloads))
 
     producer = KafkaProducer(bootstrap_servers=BOOTSTRAP_SERVERS, api_version=(0, 10))

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -177,14 +177,11 @@ def build_data(payload_type):
         return qpc_payload
 
 
-def build_payloads(num_hosts=1, payload_type="default"):
-    all_payloads = []
-    for _ in range(num_hosts):
-        all_payloads.append(
-            str.encode(
-                json.dumps(
-                    {"operation": "add_host", "platform_metadata": metadata_dict, "data": build_data(payload_type)}
-                )
+def build_payload(payload_type="default"):
+    return (
+        str.encode(
+            json.dumps(
+                {"operation": "add_host", "platform_metadata": metadata_dict, "data": build_data(payload_type)}
             )
         )
-    return all_payloads
+    )


### PR DESCRIPTION
For-cycle is a notorious pattern and there is no need to abstract it to the payloads module. Moved to the [_kafka_producer_](https://github.com/Glutexo/insights-host-inventory/blob/83bad6a97493fb05a8f800c945a3dddb7eb8af0c/utils/kafka_producer.py) module, where it is symmetric with the further MQ send iteration. It makes the code cleaner.