### PR TITLE
Extract random UUID function

### DIFF
--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -139,7 +139,7 @@ qpc_payload = {
 system_profile = create_system_profile()
 
 
-# host_id = str(uuid.uuid4())
+# host_id = random_uuid()
 host_id = "1d518fdd-341d-4286-803b-2507ca046a94"
 
 
@@ -147,20 +147,24 @@ account_number = "0000001"
 fqdn = "fred.flintstone.com"
 
 
-metadata_dict = {"request_id": str(uuid.uuid4()), "archive_url": "http://s3.aws.com/redhat/insights/1234567"}
+def random_uuid():
+    return str(uuid.uuid4())
+
+
+metadata_dict = {"request_id": random_uuid(), "archive_url": "http://s3.aws.com/redhat/insights/1234567"}
 
 
 def build_host_chunk():
     payload = {
         "account": account_number,
-        "insights_id": str(uuid.uuid4()),
-        "bios_uuid": str(uuid.uuid4()),
+        "insights_id": random_uuid(),
+        "bios_uuid": random_uuid(),
         "fqdn": fqdn,
         "display_name": fqdn,
         # "ip_addresses": None,
         # "ip_addresses": ["1",],
         # "mac_addresses": None,
-        "subscription_manager_id": str(uuid.uuid4()),
+        "subscription_manager_id": random_uuid(),
         "system_profile": create_system_profile(),
     }
     return payload


### PR DESCRIPTION
Dried repeating `str(uuid.uuid4())` code snippet to a single [_generate_uuid_](https://github.com/Glutexo/insights-host-inventory/blob/72aede4839294dc87106df5d87ab8fc7bc0bef30/utils/payloads.py#L150) function.