### PR TITLE
Jenkinsfile - PR acceptance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,92 @@
+/*
+ * Requires: https://github.com/RedHatInsights/insights-pipeline-lib
+ */
+
+@Library("github.com/RedHatInsights/insights-pipeline-lib") _
+
+podLabel = UUID.randomUUID().toString()
+
+
+node {
+    cancelPriorBuilds()
+    runIfMasterOrPullReq {
+        runStages()
+    }
+}
+
+
+def runStages() {
+    // Fire up a pod on openshift with containers for the DB and the app
+    podTemplate(label: podLabel, slaveConnectTimeout: 120, cloud: 'openshift', containers: [
+        containerTemplate(
+            name: 'jnlp',
+            image: 'registry.access.redhat.com/openshift3/jenkins-agent-nodejs-8-rhel7',
+            args: '${computer.jnlpmac} ${computer.name}',
+            resourceRequestCpu: '200m',
+            resourceLimitCpu: '500m',
+            resourceRequestMemory: '256Mi',
+            resourceLimitMemory: '650Mi'
+        ),
+        containerTemplate(
+            name: 'python3',
+            image: 'python:3.6.5',
+            ttyEnabled: true,
+            command: 'cat',
+            resourceRequestCpu: '300m',
+            resourceLimitCpu: '1000m',
+            resourceRequestMemory: '512Mi',
+            resourceLimitMemory: '1Gi'
+        ),
+        containerTemplate(
+            name: 'postgres',
+            image: 'postgres:9.6',
+            ttyEnabled: true,
+            envVars: [
+                containerEnvVar(key: 'POSTGRES_USER', value: 'insights'),
+                containerEnvVar(key: 'POSTGRES_PASSWORD', value: 'insights'),
+                containerEnvVar(key: 'POSTGRES_DB', value: 'insights'),
+                containerEnvVar(key: 'PGDATA', value: '/var/lib/postgresql/data/pgdata')
+            ],
+            volumes: [emptyDirVolume(mountPath: '/var/lib/postgresql/data/pgdata')],
+            resourceRequestCpu: '200m',
+            resourceLimitCpu: '200m',
+            resourceRequestMemory: '100Mi',
+            resourceLimitMemory: '100Mi'
+        )
+    ]) {
+        node(podLabel) {
+            container("python3") {
+                stage('Setting up environment') {
+                    withStatusContext.custom('setup') {
+                        scmVars = checkout scm
+                        runPipenvInstall(scmVars: scmVars)
+                        sh "${pipelineVars.userPath}/pipenv run python manage.py db upgrade"
+                    }
+                }
+
+                stage('Pre-commit checks') {
+                    withStatusContext.custom('pre-commit') {
+                        sh "${pipelineVars.userPath}/pipenv run pre-commit run --all-files"
+                    }
+                }
+
+                stage('Unit Test') {
+                    jUnitFile = 'junit.xml'
+
+                    withStatusContext.unitTest {
+                        sh "${pipelineVars.userPath}/pipenv run python -m pytest --cov=. --junitxml=${jUnitFile} --cov-report html -sv"
+                    }
+
+                    junit jUnitFile
+                    archiveArtifacts jUnitFile
+                    archiveArtifacts "htmlcov/*"
+                }
+
+                stage('Code coverage') {
+                    checkCoverage(threshold: 80)
+                }
+
+            }
+        }
+    }
+}

--- a/app/models.py
+++ b/app/models.py
@@ -73,7 +73,7 @@ class Host(db.Model):
             )
 
         self.canonical_facts = canonical_facts
-        
+
         if display_name:
             # Only set the display_name field if input the display_name has
             # been set...this will make it so that the "default" logic will


### PR DESCRIPTION
The Jenkinsfile within this PR fires up this job https://jenkins-jenkins.5a9f.insights-dev.openshiftapps.com/job/insights-host-inventory/view/change-requests/ for us and updates back the PR with the status of each stage:
- Env configuration
- Lint (pre-commit checks)
- Unit tests
- Coverage
- Artifacts collecting

This is an effort to keep the code clear and service up and running smoothly and to avoid to send a eventually broken code to the master. If any step fails, the PR get blocked till the issue gets resolved.
It is worth mention that this also follows what other teams are doing, like the Advisor API team, Vmaas, among others.