### PR TITLE
Fix host deletion JSON example formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,13 @@ to the _platform.inventory.events_ message queue.  The delete event message
 will look like the following:
 
 ```json
-  {"id": <host id>,
-   "timestamp": <delete timestamp>,
-   "type": "delete",
-   "account": <account number>,
-   "insights_id": <insights id>,
-   "request_id": <request id>
+{
+  "id": "<host id>",
+  "timestamp": "<delete timestamp>",
+  "type": "delete",
+  "account": "<account number>",
+  "insights_id": "<insights id>",
+  "request_id": "<request id>"
 }
 ```
 


### PR DESCRIPTION
Fixed the [host deletion](https://github.com/Glutexo/insights-host-inventory/tree/host_deletetion_json_formatting#host-deletion) JSON example in the [_README_](https://github.com/Glutexo/insights-host-inventory/blob/host_deletetion_json_formatting/README.md), so it’s better rendered by GitHub. Quoting the missing values results in them not being painted red and it also adds the information that they are strings. Also changed whitespace not to use hanging indentation and to start right at the beginning of the line.