### PR TITLE
Adding requested metric to ingress.py

### DIFF
--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -65,6 +65,7 @@ def add_host(host_data):
         raise
 
 
+@metrics.ingress_message_handler_time.time()
 def handle_message(message, event_producer):
     validated_operation_msg = parse_operation_message(message)
     metadata = validated_operation_msg.get("platform_metadata") or {}

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -19,6 +19,9 @@ ingress_message_handler_success = Counter(
 ingress_message_handler_failure = Counter(
     "inventory_ingress_message_handler_failures", "Total amount of failures handling messages from the ingress queue"
 )
+ingress_message_handler_time = Summary(
+    "inventory_ingress_message_handler_seconds", "Total time spent handling messages from the ingress queue"
+)
 version = Info("inventory_mq_service_version", "Build version for the inventory message queue service")
 version.info({"version": get_build_version()})
 egress_message_handler_success = Counter(


### PR DESCRIPTION
Divide this metric by the count to determine the average time spent handling a message from the ingress queue.