### PR TITLE
Adding payload tracker integration to the inventory service

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,39 @@ This is the Base64 encoding of the following JSON document:
 {"identity": {"account_number": "0000001", "internal": {"org_id": "000001"}}}
 ```
 
+#### Payload Tracker Integration
+
+The inventory service has been integrated with the Payload Tracker service.  The payload
+tracker integration can be configured using the following environment variables:
+
+```
+KAFKA_BOOTSTRAP_SERVERS=localhost:29092
+PAYLOAD_TRACKER_KAFKA_TOPIC=platform.payload-status
+PAYLOAD_TRACKER_SERVICE_NAME=inventory
+PAYLOAD_TRACKER_ENABLED=true
+```
+
+The payload tracker can be disabled by setting the PAYLOAD_TRACKER_ENABLED environment
+variable to _false_. The payload tracker will also be disabled for add/delete operations
+that do not include a request_id.  When the payload tracker is disabled, a NullObject
+implementation (NullPayloadTracker) of the PayloadTracker interface is used.
+The NullPayloadTracker implements the PayloadTracker interface but the methods are _no-op_ methods.
+
+The PayloadTracker purposefully eats all exceptions that it generates. The exceptions are logged.
+A failure/exception within the PayloadTracker should not cause a request to fail.
+
+The payload status is a bit "different" due to each "payload" potentially containing
+multiple hosts. For example, the add_host operation will only log an error for the
+payload if the entire payload fails (catastrophic failure during processing...db down, etc).
+One or more of the hosts could fail during the add_host method. These will get logged
+as a "processing_error". If a host is successfully added/updated, then it will be logged
+as a "processing_success". Having one or more hosts get logged as "processing_error"
+will not cause the payload to be flagged as "error" overall.
+
+The payload tracker status logging for the delete operation is similar. The overall status
+of the payload will only be logged as an "error" if the entire delete operation fails
+(a 404 due to the hosts not existing, db down, etc).
+
 ## Contributing
 
 This repository uses [pre-commit](https://pre-commit.com) to check and enforce code style. It uses

--- a/api/host.py
+++ b/api/host.py
@@ -14,10 +14,17 @@ from app import events
 from app.auth import current_identity
 from app.exceptions import InventoryException
 from app.logging import get_logger
+from app.logging import threadctx
 from app.models import Host
 from app.models import HostSchema
 from app.models import PatchHostSchema
+from app.payload_tracker import get_payload_tracker
+from app.payload_tracker import PayloadTrackerContext
+from app.payload_tracker import PayloadTrackerProcessingContext
 from tasks import emit_event
+
+# from app.payload_tracker import payload_status
+# from app.payload_tracker import PayloadStatus
 
 
 TAG_OPERATIONS = ("apply", "remove")
@@ -38,35 +45,44 @@ logger = get_logger(__name__)
 def add_host_list(host_list):
     response_host_list = []
     number_of_errors = 0
-    for host in host_list:
-        try:
-            (host, status_code) = _add_host(host)
-            response_host_list.append({"status": status_code, "host": host})
-        except InventoryException as e:
-            number_of_errors += 1
-            logger.exception("Error adding host", extra={"host": host})
-            response_host_list.append({**e.to_json(), "host": host})
-        except ValidationError as e:
-            number_of_errors += 1
-            logger.exception("Input validation error while adding host", extra={"host": host})
-            response_host_list.append(
-                {"status": 400, "title": "Bad Request", "detail": str(e.messages), "type": "unknown", "host": host}
-            )
-        except Exception:
-            number_of_errors += 1
-            logger.exception("Error adding host", extra={"host": host})
-            response_host_list.append(
-                {
-                    "status": 500,
-                    "title": "Error",
-                    "type": "unknown",
-                    "detail": "Could not complete operation",
-                    "host": host,
-                }
-            )
 
-    response = {"total": len(response_host_list), "errors": number_of_errors, "data": response_host_list}
-    return _build_json_response(response, status=207)
+    payload_tracker = get_payload_tracker(account=current_identity.account_number, payload_id=threadctx.request_id)
+
+    with PayloadTrackerContext(payload_tracker, received_status_message="add host operation"):
+
+        for host in host_list:
+            try:
+                with PayloadTrackerProcessingContext(
+                    payload_tracker, processing_status_message="adding/updating host"
+                ) as payload_tracker_processing_ctx:
+                    (host, status_code) = _add_host(host)
+                    response_host_list.append({"status": status_code, "host": host})
+                    payload_tracker_processing_ctx.inventory_id = host["id"]
+            except InventoryException as e:
+                number_of_errors += 1
+                logger.exception("Error adding host", extra={"host": host})
+                response_host_list.append({**e.to_json(), "host": host})
+            except ValidationError as e:
+                number_of_errors += 1
+                logger.exception("Input validation error while adding host", extra={"host": host})
+                response_host_list.append(
+                    {"status": 400, "title": "Bad Request", "detail": str(e.messages), "type": "unknown", "host": host}
+                )
+            except Exception:
+                number_of_errors += 1
+                logger.exception("Error adding host", extra={"host": host})
+                response_host_list.append(
+                    {
+                        "status": 500,
+                        "title": "Error",
+                        "type": "unknown",
+                        "detail": "Could not complete operation",
+                        "host": host,
+                    }
+                )
+
+        response = {"total": len(response_host_list), "errors": number_of_errors, "data": response_host_list}
+        return _build_json_response(response, status=207)
 
 
 def _add_host(host):
@@ -281,28 +297,36 @@ def find_hosts_by_hostname_or_id(account_number, hostname):
 @api_operation
 @metrics.api_request_time.time()
 def delete_by_id(host_id_list):
-    query = _get_host_list_by_id_list(current_identity.account_number, host_id_list)
+    payload_tracker = get_payload_tracker(account=current_identity.account_number, payload_id=threadctx.request_id)
 
-    hosts_to_delete = query.all()
+    with PayloadTrackerContext(payload_tracker, received_status_message="delete operation"):
 
-    if not hosts_to_delete:
-        return flask.abort(status.HTTP_404_NOT_FOUND)
+        query = _get_host_list_by_id_list(current_identity.account_number, host_id_list)
 
-    with metrics.delete_host_processing_time.time():
-        query.delete(synchronize_session="fetch")
-    db.session.commit()
+        hosts_to_delete = query.all()
 
-    metrics.delete_host_count.inc(len(hosts_to_delete))
+        if not hosts_to_delete:
+            return flask.abort(status.HTTP_404_NOT_FOUND)
 
-    for deleted_host in hosts_to_delete:
-        try:
-            logger.debug("Deleted host: %s", deleted_host)
-            emit_event(events.delete(deleted_host))
-        except sqlalchemy.orm.exc.ObjectDeletedError:
-            logger.exception(
-                "Encountered sqlalchemy.orm.exc.ObjectDeletedError exception during delete_by_id operation.  Host was "
-                "already deleted."
-            )
+        with metrics.delete_host_processing_time.time():
+            query.delete(synchronize_session="fetch")
+        db.session.commit()
+
+        metrics.delete_host_count.inc(len(hosts_to_delete))
+
+        for deleted_host in hosts_to_delete:
+            try:
+                with PayloadTrackerProcessingContext(
+                    payload_tracker, processing_status_message="deleted host"
+                ) as payload_tracker_processing_ctx:
+                    logger.debug("Deleted host: %s", deleted_host)
+                    emit_event(events.delete(deleted_host))
+                    payload_tracker_processing_ctx.inventory_id = deleted_host.id
+            except sqlalchemy.orm.exc.ObjectDeletedError:
+                logger.exception(
+                    "Encountered sqlalchemy.orm.exc.ObjectDeletedError exception during delete_by_id operation.  "
+                    "Host was already deleted."
+                )
 
 
 @api_operation

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,7 @@ from flask import jsonify
 from flask import request
 
 from api.mgmt import monitoring_blueprint
+from app import payload_tracker
 from app.config import Config
 from app.exceptions import InventoryException
 from app.logging import configure_logging
@@ -72,5 +73,11 @@ def create_app(config_name):
         threadctx.request_id = request.headers.get(REQUEST_ID_HEADER, UNKNOWN_REQUEST_ID_VALUE)
 
     init_tasks(app_config, flask_app)
+
+    payload_tracker_producer = None
+    if config_name == "testing":
+        # If we are running in "testing" mode, then inject the NullProducer.
+        payload_tracker_producer = payload_tracker.NullProducer()
+    payload_tracker.init_payload_tracker(app_config, producer=payload_tracker_producer)
 
     return flask_app

--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,11 @@ class Config:
         self.event_topic = os.environ.get("KAFKA_EVENT_TOPIC", "platform.inventory.events")
         self.kafka_enabled = all(map(os.environ.get, ["KAFKA_TOPIC", "KAFKA_GROUP", "KAFKA_BOOTSTRAP_SERVERS"]))
 
+        self.payload_tracker_kafka_topic = os.environ.get("PAYLOAD_TRACKER_KAFKA_TOPIC", "platform.payload-status")
+        self.payload_tracker_service_name = os.environ.get("PAYLOAD_TRACKER_SERVICE_NAME", "inventory")
+        payload_tracker_enabled = os.environ.get("PAYLOAD_TRACKER_ENABLED", "true")
+        self.payload_tracker_enabled = payload_tracker_enabled.lower() == "true"
+
     def _build_base_url_path(self):
         app_name = os.getenv("APP_NAME", "inventory")
         path_prefix = os.getenv("PATH_PREFIX", "api")
@@ -73,3 +78,6 @@ class Config:
                 self.logger.info("Using SSL for DB connection:")
                 self.logger.info("Postgresql SSL verification type: %s", self._db_ssl_mode)
                 self.logger.info("Path to certificate: %s", self._db_ssl_cert)
+            self.logger.info("Payload Tracker Kafka Topic: %s", self.payload_tracker_kafka_topic)
+            self.logger.info("Payload Tracker Service Name: %s", self.payload_tracker_service_name)
+            self.logger.info("Payload Tracker Enabled: %s", self.payload_tracker_enabled)

--- a/app/payload_tracker/__init__.py
+++ b/app/payload_tracker/__init__.py
@@ -1,0 +1,255 @@
+import abc
+import json
+from datetime import datetime
+
+from kafka import KafkaProducer
+
+from app.logging import get_logger
+from app.payload_tracker import metrics
+
+logger = get_logger(__name__)
+
+_CFG = None
+_PRODUCER = None
+_UNKNOWN_PAYLOAD_ID = "-1"
+
+
+def init_payload_tracker(config, producer=None):
+    global _CFG
+    global _PRODUCER
+
+    _CFG = config
+
+    if producer is not None:
+        logger.info("Using injected producer object (%s) for PayloadTracker" % (producer))
+        _PRODUCER = producer
+    else:
+        logger.info("Starting KafkaProducer() for PayloadTracker")
+        _PRODUCER = KafkaProducer(bootstrap_servers=config.bootstrap_servers)
+
+
+def get_payload_tracker(account=None, payload_id=None):
+
+    if _CFG.payload_tracker_enabled is False or payload_id is None or payload_id == _UNKNOWN_PAYLOAD_ID:
+        return NullPayloadTracker()
+
+    payload_tracker = KafkaPayloadTracker(
+        _PRODUCER, _CFG.payload_tracker_kafka_topic, _CFG.payload_tracker_service_name, account, payload_id
+    )
+
+    return payload_tracker
+
+
+class PayloadTracker(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def payload_received(self, status_message=None):
+        pass
+
+    @abc.abstractmethod
+    def payload_success(self, status_message=None):
+        pass
+
+    @abc.abstractmethod
+    def payload_error(self, status_message=None):
+        pass
+
+    @abc.abstractmethod
+    def processing(self, status_message=None):
+        pass
+
+    @abc.abstractmethod
+    def processing_success(self, status_message=None):
+        pass
+
+    @abc.abstractmethod
+    def processing_error(self, status_message=None):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def inventory_id(self):
+        pass
+
+    @inventory_id.setter
+    @abc.abstractmethod
+    def inventory_id(self, inventory_id):
+        pass
+
+
+class NullPayloadTracker(PayloadTracker):
+    def payload_received(self, status_message=None):
+        pass
+
+    def payload_success(self, status_message=None):
+        pass
+
+    def payload_error(self, status_message=None):
+        pass
+
+    def processing(self, status_message=None):
+        pass
+
+    def processing_success(self, status_message=None):
+        pass
+
+    def processing_error(self, status_message=None):
+        pass
+
+    def inventory_id(self):
+        pass
+
+    def inventory_id(self, inventory_id):  # noqa: F811
+        pass
+
+
+class KafkaPayloadTracker(PayloadTracker):
+    def __init__(self, producer, topic, service_name, account, payload_id):
+        self._producer = producer
+        self._topic = topic
+        self._service_name = service_name
+        self._account = account
+        self._payload_id = payload_id
+        self._inventory_id = None
+
+    def payload_received(self, status_message=None):
+        message = self._construct_message("received", status_message=status_message)
+        self._send_message(message)
+
+    def payload_success(self, status_message=None):
+        message = self._construct_message("success", status_message=status_message)
+        self._send_message(message)
+
+    def payload_error(self, status_message=None):
+        message = self._construct_message("error", status_message=status_message)
+        self._send_message(message)
+
+    def processing(self, status_message=None):
+        message = self._construct_message("processing", status_message=status_message)
+        self._send_message(message)
+
+    def processing_success(self, status_message=None):
+        message = self._construct_message("processing_success", status_message=status_message)
+        self._send_message(message)
+
+    def processing_error(self, status_message=None):
+        message = self._construct_message("processing_error", status_message=status_message)
+        self._send_message(message)
+
+    @property
+    def inventory_id(self):
+        return self._inventory_id
+
+    @inventory_id.setter
+    def inventory_id(self, inventory_id):
+        self._inventory_id = inventory_id
+
+    def _construct_message(self, status, status_message=None):
+        try:
+
+            if self._payload_id is None:
+                logger.debug("payload_id is None...ignoring payload_tracker data")
+                return None
+
+            if status not in ["received", "success", "error", "processing", "processing_success", "processing_error"]:
+                logger.debug(f"Invalid payload_tracker status ({status})...ignoring payload_tracker data")
+                return None
+
+            message = {
+                "service": self._service_name,
+                "payload_id": self._payload_id,
+                "status": status,
+                "date": datetime.utcnow().isoformat(),
+            }
+
+            if self._account:
+                message["account"] = self._account
+
+            if self.inventory_id:
+                message["inventory_id"] = self.inventory_id
+
+            if status_message:
+                message["status_msg"] = status_message
+
+            json_message = json.dumps(message, sort_keys=True)
+
+            return json_message
+        except Exception:
+            logger.exception("Error while constructing payload tracker message")
+            metrics.payload_tracker_message_construction_failure.inc()
+            return None
+
+    def _send_message(self, message):
+        if not message:
+            return
+
+        try:
+            self._producer.send(self._topic, message.encode("utf-8"))
+        except Exception:
+            logger.exception("Error sending payload tracker message")
+            metrics.payload_tracker_message_send_failure.inc()
+
+
+class NullProducer:
+    def send(self, topic, msg):
+        print(f"sending message: {topic} - {msg}")
+
+
+class PayloadTrackerContext:
+    def __init__(
+        self,
+        payload_tracker=None,
+        received_status_message=None,
+        success_status_message=None,
+        error_status_message=None,
+    ):
+        self._payload_tracker = payload_tracker
+        self._received_status_msg = received_status_message
+        self._success_status_msg = success_status_message
+        self._error_status_msg = error_status_message
+
+    def __enter__(self):
+        self._payload_tracker.payload_received(status_message=self._received_status_msg)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type:
+            self._payload_tracker.payload_error(status_message=self._error_status_msg)
+        else:
+            self._payload_tracker.payload_success(status_message=self._success_status_msg)
+
+
+class PayloadTrackerProcessingContext:
+    def __init__(
+        self,
+        payload_tracker=None,
+        processing_status_message=None,
+        success_status_message=None,
+        error_status_message=None,
+    ):
+        self._payload_tracker = payload_tracker
+        self._processing_status_msg = processing_status_message
+        self._success_status_msg = success_status_message
+        self._error_status_msg = error_status_message
+        self._inventory_id = None
+
+    def __enter__(self):
+        self._payload_tracker.processing(status_message=self._processing_status_msg)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type:
+            self._payload_tracker.processing_error(status_message=self._error_status_msg)
+        else:
+            self._payload_tracker.processing_success(status_message=self._success_status_msg)
+
+        if self._inventory_id:
+            self._payload_tracker.inventory_id = None
+
+    @property
+    def inventory_id(self):
+        return self._inventory_id
+
+    @inventory_id.setter
+    def inventory_id(self, inventory_id):
+        self._inventory_id = inventory_id
+        self._payload_tracker.inventory_id = inventory_id

--- a/app/payload_tracker/metrics.py
+++ b/app/payload_tracker/metrics.py
@@ -1,0 +1,10 @@
+from prometheus_client import Counter
+
+# from prometheus_client import Summary
+
+payload_tracker_message_send_failure = Counter(
+    "inventory_payload_tracker_message_send_failure_count", "Count of failures to send message to the payload tracker"
+)
+payload_tracker_message_construction_failure = Counter(
+    "inventory_payload_tracker_message_construction_failure_count", "Count of failures to send to the payload tracker"
+)

--- a/test_payload_tracker.py
+++ b/test_payload_tracker.py
@@ -1,0 +1,394 @@
+import json
+from datetime import datetime
+from unittest import main
+from unittest import TestCase
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from app.config import Config
+from app.payload_tracker import _UNKNOWN_PAYLOAD_ID
+from app.payload_tracker import get_payload_tracker
+from app.payload_tracker import init_payload_tracker
+from app.payload_tracker import PayloadTrackerContext
+from app.payload_tracker import PayloadTrackerProcessingContext
+
+
+def method_to_raise_exception():
+    raise ValueError("something bad happened!")
+
+
+@patch("app.payload_tracker.datetime", **{"utcnow.return_value": datetime.utcnow()})
+class PayloadTrackerTestCase(TestCase):
+
+    DEFAULT_TOPIC = "platform.payload-status"
+
+    @patch("app.payload_tracker.NullProducer")
+    @patch("app.payload_tracker.KafkaProducer")
+    def test_payload_tracker_is_disabled_using_env_var(self, kafka_producer, null_producer, datetime_mock):
+        with patch.dict("os.environ", {"PAYLOAD_TRACKER_ENABLED": "False"}):
+
+            tracker = self._get_tracker(payload_id="123456")
+
+            self._verify_payload_tracker_is_disabled(tracker, kafka_producer, null_producer)
+
+    @patch("app.payload_tracker.NullProducer")
+    @patch("app.payload_tracker.KafkaProducer")
+    def test_payload_tracker_is_disabled_by_invalid_payload_id(self, kafka_producer, null_producer, datetime_mock):
+        for invalid_payload_id in [None, _UNKNOWN_PAYLOAD_ID]:
+            with self.subTest(invalid_payload_id=invalid_payload_id):
+                tracker = self._get_tracker(payload_id=invalid_payload_id)
+
+                self._verify_payload_tracker_is_disabled(tracker, kafka_producer, null_producer)
+
+    def test_payload_tracker_configure_topic(self, datetime_mock):
+        expected_topic = "ima.kafka.topic"
+        expected_payload_id = "13579"
+
+        expected_msg = self._build_expected_message(
+            status="received", payload_id=expected_payload_id, datetime_mock=datetime_mock
+        )
+
+        with patch.dict("os.environ", {"PAYLOAD_TRACKER_KAFKA_TOPIC": expected_topic}):
+            producer = Mock()
+            tracker = self._get_tracker(payload_id=expected_payload_id, producer=producer)
+
+            # FIXME: test other methods
+            tracker.payload_received()
+
+            self._verify_mock_send_call(producer, expected_topic, expected_msg)
+
+    def test_payload_tracker_producer_raises_exception(self, datetime_mock):
+        # Test that an exception in the producer does not get propagated
+        producer_mock = Mock()
+        producer_mock.send.side_effect = Exception("Producer send exception!")
+
+        tracker = self._get_tracker(payload_id="expected_payload_id", producer=producer_mock)
+
+        methods_to_test = self._get_payload_tracker_methods_to_test(tracker)
+
+        for (method_to_test, _) in methods_to_test:
+            with self.subTest(method_to_test=method_to_test):
+                # This method should NOT raise an exception...even though
+                # the producer is causing an exception
+                method_to_test(status_message="expected_status_msg")
+
+    @patch("app.payload_tracker.json.dumps")
+    def test_payload_tracker_json_raises_exception(self, json_dumps_mock, datetime_mock):
+        # Test that an exception in the creation of the message does not get propagated
+        json_dumps_mock.side_effect = Exception("json.dumps exception!")
+
+        tracker = self._get_tracker(payload_id="expected_payload_id", producer=Mock())
+
+        methods_to_test = self._get_payload_tracker_methods_to_test(tracker)
+
+        for (method_to_test, _) in methods_to_test:
+            with self.subTest(method_to_test=method_to_test):
+                # This method should NOT raise an exception...even though
+                # the producer is causing an exception
+                method_to_test()
+
+    def test_payload_tracker_account_is_None(self, datetime_mock):
+        expected_payload_id = "1234567890"
+        producer = Mock()
+
+        tracker = self._get_tracker(payload_id=expected_payload_id, producer=producer)
+
+        methods_to_test = self._get_payload_tracker_methods_to_test(tracker)
+
+        for (method_to_test, expected_status) in methods_to_test:
+            with self.subTest(method_to_test=method_to_test):
+                method_to_test()
+
+                expected_msg = self._build_expected_message(
+                    status=expected_status, payload_id=expected_payload_id, datetime_mock=datetime_mock
+                )
+
+                self._verify_mock_send_call(producer, self.DEFAULT_TOPIC, expected_msg)
+
+                producer.reset_mock()
+
+    def test_payload_tracker_pass_status_message(self, datetime_mock):
+        expected_status_msg = "ima status message!"
+        expected_payload_id = "1234567890"
+        producer = Mock()
+
+        tracker = self._get_tracker(payload_id=expected_payload_id, producer=producer)
+
+        methods_to_test = self._get_payload_tracker_methods_to_test(tracker)
+
+        for method_to_test, expected_status in methods_to_test:
+            with self.subTest(method_to_test=method_to_test):
+                method_to_test(status_message=expected_status_msg)
+
+                expected_msg = self._build_expected_message(
+                    status=expected_status,
+                    status_msg=expected_status_msg,
+                    payload_id=expected_payload_id,
+                    datetime_mock=datetime_mock,
+                )
+
+                self._verify_mock_send_call(producer, self.DEFAULT_TOPIC, expected_msg)
+
+                producer.reset_mock()
+
+    def test_payload_tracker_set_account_and_payload_id(self, datetime_mock):
+        expected_account = "789"
+        expected_payload_id = "1234567890"
+        producer = Mock()
+
+        tracker = self._get_tracker(account=expected_account, payload_id=expected_payload_id, producer=producer)
+
+        methods_to_test = self._get_payload_tracker_methods_to_test(tracker)
+
+        for method_to_test, expected_status in methods_to_test:
+            with self.subTest(method_to_test=method_to_test):
+                method_to_test()
+
+                expected_msg = self._build_expected_message(
+                    account=expected_account,
+                    status=expected_status,
+                    payload_id=expected_payload_id,
+                    datetime_mock=datetime_mock,
+                )
+
+                self._verify_mock_send_call(producer, self.DEFAULT_TOPIC, expected_msg)
+
+                producer.reset_mock()
+
+    def test_payload_tracker_context_error(self, datetime_mock):
+        expected_payload_id = "REQUEST_ID"
+        expected_received_status_msg = "ima received msg"
+
+        producer = Mock()
+
+        tracker = self._get_tracker(payload_id=expected_payload_id, producer=producer)
+
+        error_status_msgs = [None, "ima error status msg"]
+
+        for error_status_msg in error_status_msgs:
+            with self.subTest(error_status_msg=error_status_msg):
+
+                with self.assertRaises(ValueError):
+                    with PayloadTrackerContext(
+                        payload_tracker=tracker,
+                        received_status_message=expected_received_status_msg,
+                        error_status_message=error_status_msg,
+                    ):
+
+                        expected_msg = self._build_expected_message(
+                            status="received",
+                            status_msg=expected_received_status_msg,
+                            payload_id=expected_payload_id,
+                            datetime_mock=datetime_mock,
+                        )
+
+                        self._verify_mock_send_call(producer, self.DEFAULT_TOPIC, expected_msg)
+                        producer.reset_mock()
+                        method_to_raise_exception()
+
+                expected_msg = self._build_expected_message(
+                    status="error",
+                    status_msg=error_status_msg,
+                    payload_id=expected_payload_id,
+                    datetime_mock=datetime_mock,
+                )
+
+                self._verify_mock_send_call(producer, self.DEFAULT_TOPIC, expected_msg)
+
+                producer.reset_mock()
+
+    def test_payload_tracker_context_success(self, datetime_mock):
+        expected_payload_id = "REQUEST_ID"
+        expected_received_status_msg = "ima received msg"
+
+        producer = Mock()
+
+        tracker = self._get_tracker(payload_id=expected_payload_id, producer=producer)
+
+        success_status_msgs = [None, "ima success status msg"]
+
+        for success_status_msg in success_status_msgs:
+            with self.subTest(success_status_msg=success_status_msg):
+
+                with PayloadTrackerContext(
+                    payload_tracker=tracker,
+                    received_status_message=expected_received_status_msg,
+                    success_status_message=success_status_msg,
+                ):
+
+                    expected_msg = self._build_expected_message(
+                        status="received",
+                        status_msg=expected_received_status_msg,
+                        payload_id=expected_payload_id,
+                        datetime_mock=datetime_mock,
+                    )
+
+                    self._verify_mock_send_call(producer, self.DEFAULT_TOPIC, expected_msg)
+
+                    producer.reset_mock()
+
+                expected_msg = self._build_expected_message(
+                    status="success",
+                    status_msg=success_status_msg,
+                    payload_id=expected_payload_id,
+                    datetime_mock=datetime_mock,
+                )
+
+                self._verify_mock_send_call(producer, self.DEFAULT_TOPIC, expected_msg)
+
+                producer.reset_mock()
+
+    def test_payload_tracker_processing_context_error(self, datetime_mock):
+        expected_payload_id = "REQUEST_ID"
+        expected_processing_status = "processing"
+        expected_processing_status_msg = "ima processing msg"
+        expected_inventory_id = "000-111-222"
+
+        producer = Mock()
+
+        tracker = self._get_tracker(payload_id=expected_payload_id, producer=producer)
+
+        error_status_msgs = [None, "ima error status msg"]
+
+        for error_status_msg in error_status_msgs:
+            with self.subTest(error_status_msg=error_status_msg):
+
+                with self.assertRaises(ValueError):
+                    with PayloadTrackerProcessingContext(
+                        payload_tracker=tracker,
+                        processing_status_message=expected_processing_status_msg,
+                        error_status_message=error_status_msg,
+                    ) as processing_context:
+
+                        expected_msg = self._build_expected_message(
+                            status=expected_processing_status,
+                            status_msg=expected_processing_status_msg,
+                            payload_id=expected_payload_id,
+                            datetime_mock=datetime_mock,
+                        )
+
+                        self._verify_mock_send_call(producer, self.DEFAULT_TOPIC, expected_msg)
+                        producer.reset_mock()
+                        processing_context.inventory_id = expected_inventory_id
+                        method_to_raise_exception()
+
+                expected_msg = self._build_expected_message(
+                    status="processing_error",
+                    status_msg=error_status_msg,
+                    payload_id=expected_payload_id,
+                    datetime_mock=datetime_mock,
+                )
+
+                expected_msg["inventory_id"] = expected_inventory_id
+
+                self.assertIsNone(tracker.inventory_id)
+
+                self._verify_mock_send_call(producer, self.DEFAULT_TOPIC, expected_msg)
+
+                producer.reset_mock()
+
+    def test_payload_tracker_processing_context_success(self, datetime_mock):
+        expected_payload_id = "REQUEST_ID"
+        expected_processing_status = "processing"
+        expected_processing_status_msg = "ima processing msg"
+        expected_inventory_id = "000-111-222"
+
+        producer = Mock()
+
+        tracker = self._get_tracker(payload_id=expected_payload_id, producer=producer)
+
+        success_status_msgs = [None, "ima success status msg"]
+
+        for success_status_msg in success_status_msgs:
+            with self.subTest(success_status_msg=success_status_msg):
+
+                with PayloadTrackerProcessingContext(
+                    payload_tracker=tracker,
+                    processing_status_message=expected_processing_status_msg,
+                    success_status_message=success_status_msg,
+                ) as processing_context:
+
+                    expected_msg = self._build_expected_message(
+                        status=expected_processing_status,
+                        status_msg=expected_processing_status_msg,
+                        payload_id=expected_payload_id,
+                        datetime_mock=datetime_mock,
+                    )
+
+                    self._verify_mock_send_call(producer, self.DEFAULT_TOPIC, expected_msg)
+
+                    processing_context.inventory_id = expected_inventory_id
+
+                    producer.reset_mock()
+
+                expected_msg = self._build_expected_message(
+                    status="processing_success",
+                    status_msg=success_status_msg,
+                    payload_id=expected_payload_id,
+                    datetime_mock=datetime_mock,
+                )
+
+                expected_msg["inventory_id"] = expected_inventory_id
+
+                self.assertIsNone(tracker.inventory_id)
+
+                self._verify_mock_send_call(producer, self.DEFAULT_TOPIC, expected_msg)
+
+                producer.reset_mock()
+
+    def _get_tracker(self, account=None, payload_id=None, producer=None):
+        config = Config()
+        init_payload_tracker(config, producer=producer)
+        return get_payload_tracker(account=account, payload_id=payload_id)
+
+    def _verify_mock_send_call(self, mock_producer, expected_topic, expected_msg):
+        mock_producer.send.assert_called()
+        args, kwargs = mock_producer.send.call_args
+        actual_topic, actual_msg = args
+        self.assertEqual(actual_topic, expected_topic)
+        self.assertEqual(json.loads(actual_msg), expected_msg)
+
+    def _get_payload_tracker_methods_to_test(self, tracker):
+        return [
+            (tracker.payload_received, "received"),
+            (tracker.payload_success, "success"),
+            (tracker.payload_error, "error"),
+            (tracker.processing, "processing"),
+            (tracker.processing_success, "processing_success"),
+            (tracker.processing_error, "processing_error"),
+        ]
+
+    def _verify_payload_tracker_is_disabled(self, tracker, kafka_producer, null_producer):
+        methods_to_test = self._get_payload_tracker_methods_to_test(tracker)
+
+        for (method_to_test, _) in methods_to_test:
+            with self.subTest(method_to_test=method_to_test):
+                method_to_test(status_message="expected_status_msg")
+
+                # Verify that the KafkaProducer object is not called and that the NullProducer is called
+                kafka_producer.return_value.send.assert_not_called()
+                null_producer.return_value.send.assert_not_called()
+
+                null_producer.reset_mock()
+
+    def _build_expected_message(
+        self, status="received", status_msg=None, payload_id="1357924680", account=None, datetime_mock=None
+    ):
+        expected_msg = {
+            "service": "inventory",
+            "payload_id": payload_id,
+            "status": status,
+            "date": datetime_mock.utcnow.return_value.isoformat(),
+        }
+
+        if status_msg:
+            expected_msg["status_msg"] = status_msg
+
+        if account:
+            expected_msg["account"] = account
+
+        return expected_msg
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The payload tracker can be disabled by setting the PAYLOAD_TRACKER_ENABLED environment variable to "false".   The payload tracker will also be disabled for add/delete operations that do not include a payload_id.  When the payload tracker is disabled, a NullObject implementation (NullPayloadTracker) of the PayloadTracker interface is used.  The NullPayloadTracker implements the PayloadTracker interface but the methods are "do nothing" methods.

The PayloadTracker purposefully eats all exceptions that it generates.  It does log the exceptions though.  I do not want a failure within the PayloadTracker to cause a request to fail.

The payload status is a bit "different" due to each "payload" potentially containing multiple hosts.  For example, the add_host operation will only log an error for the payload if the entire payload fails (catastrophic failure during processing...db down, etc).  One or more of the hosts could fail during the add_host method.  These will get logged as a "processing_error".  If a host is successfully added/updated, then it will be logged as a "processing_success".  Having one or more hosts get logged as "processing_error" will not cause the payload to be flagged as "error" overall.   

The payload tracker status logging for the delete operation is similar.  The overall status of the payload will only be logged as an "error" if the entire delete operation fails (a 404 due to the hosts not existing, db down, etc).

This PR contains two context managers to log overall payload success/errors and individual processing success/errors.

I have looked at this code too long.  I now have "olfactory fatigue".  I can't smell myself.  I need another set of eyes to take a look.

RHCLOUD-1905