### PR TITLE
updating the event handler to handle db disconnects

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,5 @@
 import uuid
+from contextlib import contextmanager
 from datetime import datetime
 
 from flask_sqlalchemy import SQLAlchemy
@@ -21,6 +22,19 @@ from app.validators import verify_uuid_format
 logger = get_logger(__name__)
 
 db = SQLAlchemy()
+
+
+@contextmanager
+def db_session_guard():
+    session = db.session
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.remove()
 
 
 def _set_display_name_on_save(context):

--- a/app/models.py
+++ b/app/models.py
@@ -72,7 +72,7 @@ class Host(db.Model):
             )
 
         self.canonical_facts = canonical_facts
-        
+
         if display_name:
             # Only set the display_name field if input the display_name has
             # been set...this will make it so that the "default" logic will

--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -1,15 +1,12 @@
 import json
-from time import sleep
 
 from marshmallow import fields
 from marshmallow import Schema
 from marshmallow import ValidationError
-from sqlalchemy import exc
 
 from app.exceptions import InventoryException
 from app.logging import get_logger
 from app.logging import threadctx
-from app.models import db
 from app.queue import metrics
 from app.queue.egress import build_event
 from lib import host_repository
@@ -91,18 +88,12 @@ def event_loop(consumer, flask_app, event_producer, handler=handle_message):
         logger.debug("Waiting for message")
         for msg in consumer:
             logger.debug("Message received")
-            while True:
-                try:
-                    handler(msg.value, event_producer)
-                    metrics.ingress_message_handler_success.inc()
-                    break
-                except exc.OperationalError:
-                    logger.error("Database connection error. Retrying...")
-                    db.session.rollback()
-                    sleep(5)
-                except Exception:
-                    metrics.ingress_message_handler_failure.inc()
-                    logger.exception("Unable to process message")
+            try:
+                handler(msg.value, event_producer)
+                metrics.ingress_message_handler_success.inc()
+            except Exception:
+                metrics.ingress_message_handler_failure.inc()
+                logger.exception("Unable to process message")
 
 
 def initialize_thread_local_storage(metadata):

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -5,6 +5,7 @@ from marshmallow import ValidationError
 from app.exceptions import ValidationException
 from app.logging import get_logger
 from app.models import db
+from app.models import db_session_guard
 from app.models import Host
 from app.models import HostSchema
 from app.serialization import deserialize_host
@@ -39,12 +40,13 @@ def add_host(host, update_system_profile=True):
 
     input_host = deserialize_host(validated_input_host_dict.data)
 
-    existing_host = find_existing_host(input_host.account, input_host.canonical_facts)
+    with db_session_guard():
+        existing_host = find_existing_host(input_host.account, input_host.canonical_facts)
 
-    if existing_host:
-        return update_existing_host(existing_host, input_host, update_system_profile)
-    else:
-        return create_new_host(input_host)
+        if existing_host:
+            return update_existing_host(existing_host, input_host, update_system_profile)
+        else:
+            return create_new_host(input_host)
 
 
 @metrics.host_dedup_processing_time.time()


### PR DESCRIPTION
A very simple way to handle the db restarting while adding hosts. If a db OperationalError is caught the transaction will be rolled back and the message handler will try again in 5 seconds. 

Definitely open to other suggestions.