### PR TITLE
Remove unnecessary pass

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -324,7 +324,6 @@ def delete_by_id(host_id_list):
             # Prevents ObjectDeletedError from being raised.
             if instance_state(deleted_host).expired:
                 logger.info("Host already deleted. Delete event not emitted.")
-                pass
             else:
                 with PayloadTrackerProcessingContext(
                     payload_tracker, processing_status_message="deleted host"


### PR DESCRIPTION
There was a forgotten [_pass_](https://github.com/RedHatInsights/insights-host-inventory/blob/18e3af13fe3477784682887d586ffdd914654c31/api/host.py#L327) clause, not removed after refactoring. Removed to reduce clutter.