### PR TITLE
Add an explanatory comment for ObjectDeletedError

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -323,6 +323,7 @@ def delete_by_id(host_id_list):
         for deleted_host in hosts_to_delete:
             # Prevents ObjectDeletedError from being raised.
             if instance_state(deleted_host).expired:
+                # Can’t log the Host ID. Accessing an attribute raises ObjectDeletedError.
                 logger.info("Host already deleted. Delete event not emitted.")
                 pass
             else:


### PR DESCRIPTION
If a race condition occurs during host delete, we [log](https://github.com/RedHatInsights/insights-host-inventory/blob/18e3af13fe3477784682887d586ffdd914654c31/api/host.py#L326) it, but we can’t log the ID of the host that was not deleted. [Added](https://github.com/RedHatInsights/insights-host-inventory/compare/master...Glutexo:host_delete_comment?expand=1#diff-a5c55b46cc9c536070cb56798c97adfaR326) a comment explaining why.