### PR TITLE
Explicitly manage the db.session / transaction for the system profile consumer thread.

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,5 @@
 import uuid
+from contextlib import contextmanager
 from datetime import datetime
 
 from flask_sqlalchemy import SQLAlchemy
@@ -22,6 +23,19 @@ from app.validators import verify_uuid_format
 logger = get_logger(__name__)
 
 db = SQLAlchemy()
+
+
+@contextmanager
+def db_session_guard():
+    session = db.session
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.remove()
 
 
 def _set_display_name_on_save(context):


### PR DESCRIPTION
This fixes an issue where the db.session/transaction for the system profile consumer thread does not get cleaned up if the database goes down during processing.  When this happens, the sql operations for that thread always fail.

I'm not overly happy with where the context manager code lives currently.  Perhaps we need a app/db_utils.py for util methods like this.