### PR TITLE
Generate random request ID

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -36,7 +36,6 @@ FACTS = [{"namespace": "ns1", "facts": {"key1": "value1"}}]
 TAGS = ["aws/new_tag_1:new_value_1", "aws/k:v"]
 ACCOUNT = "000501"
 SHARED_SECRET = "SuperSecretStuff"
-REQUEST_ID = "BestRequestIdEver"
 
 
 def generate_uuid():
@@ -1266,7 +1265,7 @@ class DeleteHostsTestCase(PreCreatedHostsBaseTestCase):
     @unittest.mock.patch("app.events.datetime", **{"utcnow.return_value": datetime.utcnow()})
     def test_create_then_delete(self, datetime_mock):
         url = HOST_URL + "/" + self.added_hosts[0].id
-        request_id_header = {"x-rh-insights-request-id": REQUEST_ID}
+        request_id_header = {"x-rh-insights-request-id": generate_uuid()}
         timestamp_iso = datetime_mock.utcnow.return_value.isoformat()
 
         # test with request_id_header

--- a/test_api.py
+++ b/test_api.py
@@ -1252,7 +1252,7 @@ class DeleteHostsTestCase(PreCreatedHostsBaseTestCase):
             self.assertEqual(self.added_hosts[0].id, event["id"])
             self.assertEqual(self.added_hosts[0].insights_id, event["insights_id"])
             if request_id_header is not None:
-                self.assertEqual(REQUEST_ID, event["request_id"])
+                self.assertEqual(request_id_header["x-rh-insights-request-id"], event["request_id"])
             else:
                 self.assertEqual("-1", event["request_id"])
 


### PR DESCRIPTION
Used the [_generate_uuid_](https://github.com/Glutexo/insights-host-inventory/blob/5f5028c359b3e1d1f18b5a707223eda7c4afc672/test_api.py#L41) function to create a random request ID for the non-empty ID test. This tests the feature a bit better than a static value.

This is a follow-up pull request for #419.