### PR TITLE
Use passed request ID in the test

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1252,7 +1252,7 @@ class DeleteHostsTestCase(PreCreatedHostsBaseTestCase):
             self.assertEqual(self.added_hosts[0].id, event["id"])
             self.assertEqual(self.added_hosts[0].insights_id, event["insights_id"])
             if request_id_header is not None:
-                self.assertEqual(REQUEST_ID, event["request_id"])
+                self.assertEqual(request_id_header["x-rh-insights-request-id"], event["request_id"])
             else:
                 self.assertEqual("-1", event["request_id"])
 


### PR DESCRIPTION
Do not use the [REQUEST_ID](https://github.com/Glutexo/insights-host-inventory/blob/3de5be6363854e88d4b1ec0135f34eeffbc888a4/test_api.py#L39) constant in the [assert](https://github.com/Glutexo/insights-host-inventory/blob/3de5be6363854e88d4b1ec0135f34eeffbc888a4/test_api.py#L1255). Like that we are essentially checking for a different value than is [passed in](https://github.com/Glutexo/insights-host-inventory/blob/3de5be6363854e88d4b1ec0135f34eeffbc888a4/test_api.py#L1269), although in fact it’s the same.

This is a follow-up pull request for #419.