### PR TITLE
pin pipeline lib to previous stable version 1.3

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -2,7 +2,7 @@
  * Requires: https://github.com/RedHatInsights/insights-pipeline-lib
  */
 
-@Library("github.com/RedHatInsights/insights-pipeline-lib") _
+@Library("github.com/RedHatInsights/insights-pipeline-lib@v1.3") _
 
 
 if (env.CHANGE_ID) {


### PR DESCRIPTION
Recently there was some change to Jenkins shared pipeline lib a.k.a insights-pipeline that is causing some errors on inventory-smoke job. 

Temporally pinning this to the previous version till they get it stable again.

more info: https://github.com/RedHatInsights/insights-pipeline-lib/pull/40