### PR TITLE
Delete tests refactoring: Move MockEmitEvent to class level

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1259,6 +1259,13 @@ class PatchHostTestCase(PreCreatedHostsBaseTestCase):
 
 
 class DeleteHostsTestCase(PreCreatedHostsBaseTestCase):
+    class MockEmitEvent:
+        def __init__(self):
+            self.events = []
+
+        def __call__(self, e):
+            self.events.append(e)
+
     class RaceCondition:
         @classmethod
         def mock(cls, host_ids_to_delete):
@@ -1300,15 +1307,8 @@ class DeleteHostsTestCase(PreCreatedHostsBaseTestCase):
         # Get the host
         self.get(url, 200)
 
-        class MockEmitEvent:
-            def __init__(self):
-                self.events = []
-
-            def __call__(self, e):
-                self.events.append(e)
-
         # Delete the host
-        with unittest.mock.patch("api.host.emit_event", new=MockEmitEvent()) as m:
+        with unittest.mock.patch("api.host.emit_event", new=self.MockEmitEvent()) as m:
             self.delete(url, 200, return_response_as_json=False)
             event = json.loads(m.events[0])
 


### PR DESCRIPTION
Having [a class in a function](https://github.com/RedHatInsights/insights-host-inventory/blob/8d9206814a12418d14922c77e1c0baa6ef763046/test_api.py#L1303) is not necessary here. It just causes Python to redeclare it every time the function is run instead of on the class parse.

This pull request doesn’t change any behavior of the tests. The tests in the [_DeleteHostsTestCase_](https://github.com/Glutexo/insights-host-inventory/blob/e4859bc0aedc1d014510ea042cfea979e867926b/test_api.py#L1261) are still green. 🍏