### PR TITLE
Delete tests refactoring: Replace Mock.new with new_callable

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1309,7 +1309,7 @@ class DeleteHostsTestCase(PreCreatedHostsBaseTestCase):
         self.assertEqual(before_response["total"], 1)
 
         # Delete the host
-        with unittest.mock.patch("api.host.emit_event", new=self.MockEmitEvent()) as m:
+        with unittest.mock.patch("api.host.emit_event", new_callable=self.MockEmitEvent) as m:
             self.delete(url, 200, return_response_as_json=False)
             event = json.loads(m.events[0])
 


### PR DESCRIPTION
_unittest.Mock_ can use a callable (including a class constructor) to create the mock. This is actually better than passing a manually created class instance as we are sure that the instance is not shared anywhere. Use as much from the _Mock_ capabilities as possible.

This doesn’t change any actual behavior of the tests. [_DeleteHostsTestCase_](https://github.com/Glutexo/insights-host-inventory/blob/b753df49432e7a7e44de59b9e1fe28f86d24764b/test_api.py#L1261) is still passing. 🍏