### PR TITLE
Delete tests refactoring: Check the host presence on the first GET

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1298,7 +1298,8 @@ class DeleteHostsTestCase(PreCreatedHostsBaseTestCase):
 
     def _create_then_delete_host(self, url, timestamp_iso):
         # Get the host
-        self.get(url, 200)
+        before_response = self.get(url, 200)
+        self.assertEqual(before_response["total"], 1)
 
         class MockEmitEvent:
             def __init__(self):
@@ -1323,11 +1324,11 @@ class DeleteHostsTestCase(PreCreatedHostsBaseTestCase):
             self.assertEqual("-1", event["request_id"])
 
         # Try to get the host again
-        response = self.get(url, 200)
+        after_response = self.get(url, 200)
 
-        self.assertEqual(response["count"], 0)
-        self.assertEqual(response["total"], 0)
-        self.assertEqual(response["results"], [])
+        self.assertEqual(after_response["count"], 0)
+        self.assertEqual(after_response["total"], 0)
+        self.assertEqual(after_response["results"], [])
 
     @unittest.mock.patch("app.events.datetime", **{"utcnow.return_value": datetime.utcnow()})
     def test_create_then_delete(self, datetime_mock):


### PR DESCRIPTION
A GET [request](https://github.com/RedHatInsights/insights-host-inventory/blob/8d9206814a12418d14922c77e1c0baa6ef763046/test_api.py#L1301) is currently done before [deleting](https://github.com/RedHatInsights/insights-host-inventory/blob/8d9206814a12418d14922c77e1c0baa6ef763046/test_api.py#L1312) records. This request is rather useless though, because _200 OK_ is [returned](https://github.com/RedHatInsights/insights-host-inventory/blob/8d9206814a12418d14922c77e1c0baa6ef763046/swagger/api.spec.yaml#L48) even if no hosts are found. Added an [assert](https://github.com/Glutexo/insights-host-inventory/blob/0d5f03da0bcdaa2ffea7d349d644be6aa8b34592/test_api.py#L1302) verifying that the host is actually found in the database.