### PR TITLE
Setting insights-pipeline-lib version due breaking changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
  * Requires: https://github.com/RedHatInsights/insights-pipeline-lib
  */
 
-@Library("github.com/RedHatInsights/insights-pipeline-lib") _
+@Library("github.com/RedHatInsights/insights-pipeline-lib@v1.3") _
 
 podLabel = UUID.randomUUID().toString()
 


### PR DESCRIPTION
There is a few breaking changes in the latest version of the insights-pipeline-lib, so we have to pin it to the last stable version (1.3).