### PR TITLE
Request ID tests: compose request ID header in the common test

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1285,9 +1285,8 @@ class DeleteHostsEventTestCase(PreCreatedHostsBaseTestCase):
         def __call__(self, e):
             self.events.append(e)
 
-    def _delete(self, url, request_id):
+    def _delete(self, url, header):
         with unittest.mock.patch("api.host.emit_event", new_callable=self.MockEmitEvent) as m:
-            header = {"x-rh-insights-request-id": request_id} if request_id else None
             self.delete(url, 200, header, return_response_as_json=False)
             return json.loads(m.events[0])
 
@@ -1345,10 +1344,11 @@ class DeleteHostsEventTestCase(PreCreatedHostsBaseTestCase):
         self._check_hosts_are_present(url)
 
         request_id = generate_uuid()
-        event = self._delete(url, request_id)
+        header = {"x-rh-insights-request-id": request_id}
+        event = self._delete(url, header)
 
         timestamp = datetime_mock.utcnow.return_value
-        self._assert_event_is_valid(event, host,request_id, timestamp)
+        self._assert_event_is_valid(event, host, request_id, timestamp)
 
     def test_create_then_delete_without_request_id(self, datetime_mock):
         host = self.added_hosts[0]
@@ -1356,7 +1356,7 @@ class DeleteHostsEventTestCase(PreCreatedHostsBaseTestCase):
         self._check_hosts_are_present(url)
 
         request_id = None
-        event = self._delete(url, request_id)
+        event = self._delete(url, header=None)
         self._assert_event_is_valid(event, host, request_id, datetime_mock.utcnow.return_value)
 
 

--- a/test_api.py
+++ b/test_api.py
@@ -1313,39 +1313,51 @@ class DeleteHostsEventTestCase(PreCreatedHostsBaseTestCase):
         self.assertEqual(after_response["total"], 0)
         self.assertEqual(after_response["results"], [])
 
-    def _create_then_delete_host(self, url, host, request_id, timestamp):
-        self._check_hosts_are_present(url)
-        event = self._delete(url, request_id)
-        self._assert_event_is_valid(event, host, request_id, timestamp)
-        self._check_hosts_are_deleted(url)
-
     def test_create_then_delete(self, datetime_mock):
         host = self.added_hosts[0]
         url = HOST_URL + "/" + host.id
+        self._check_hosts_are_present(url)
+
         request_id = None
+        event = self._delete(url, request_id)
+
         timestamp = datetime_mock.utcnow.return_value
-        self._create_then_delete_host(url, host, request_id, timestamp)
+        self._assert_event_is_valid(event, host, request_id, timestamp)
+
+        self._check_hosts_are_deleted(url)
 
     def test_create_then_delete_with_branch_id(self, datetime_mock):
         host = self.added_hosts[0]
         url = HOST_URL + "/" + host.id + "?" + "branch_id=1234"
+        self._check_hosts_are_present(url)
+
         request_id = None
+        event = self._delete(url, request_id)
+
         timestamp = datetime_mock.utcnow.return_value
-        self._create_then_delete_host(url, host, request_id, timestamp)
+        self._assert_event_is_valid(event, host, request_id, timestamp)
+
+        self._check_hosts_are_deleted(url)
 
     def test_create_then_delete_with_request_id(self, datetime_mock):
         host = self.added_hosts[0]
         url = HOST_URL + "/" + host.id
+        self._check_hosts_are_present(url)
+
         request_id = generate_uuid()
+        event = self._delete(url, request_id)
+
         timestamp = datetime_mock.utcnow.return_value
-        self._create_then_delete_host(url, host, request_id, timestamp)
+        self._assert_event_is_valid(event, host,request_id, timestamp)
 
     def test_create_then_delete_without_request_id(self, datetime_mock):
         host = self.added_hosts[0]
         url = HOST_URL + "/" + host.id
+        self._check_hosts_are_present(url)
+
         request_id = None
-        timestamp = datetime_mock.utcnow.return_value
-        self._create_then_delete_host(url, host, request_id, timestamp)
+        event = self._delete(url, request_id)
+        self._assert_event_is_valid(event, host, request_id, datetime_mock.utcnow.return_value)
 
 
 @patch("api.host.emit_event")


### PR DESCRIPTION
Move the request ID header [composition](https://github.com/RedHatInsights/insights-host-inventory/blob/b0308b020de7c3f5b046a5f971f7aac7280f98cb/test_api.py#L1290) from the DELETE [method](https://github.com/RedHatInsights/insights-host-inventory/blob/b0308b020de7c3f5b046a5f971f7aac7280f98cb/test_api.py#L1288) to the request ID [tests](https://github.com/Glutexo/insights-host-inventory/blob/252af41c0fdd07674b50468cd5b05b8480759151/test_api.py#L1341). Like this, the logic is at a more appropriate [place].

This is a follow-up to #475.