### PR TITLE
Merge master into split_inventory_service

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
  * Requires: https://github.com/RedHatInsights/insights-pipeline-lib
  */
 
-@Library("github.com/RedHatInsights/insights-pipeline-lib") _
+@Library("github.com/RedHatInsights/insights-pipeline-lib@v1.3") _
 
 podLabel = UUID.randomUUID().toString()
 

--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -2,7 +2,7 @@
  * Requires: https://github.com/RedHatInsights/insights-pipeline-lib
  */
 
-@Library("github.com/RedHatInsights/insights-pipeline-lib") _
+@Library("github.com/RedHatInsights/insights-pipeline-lib@v1.3") _
 
 
 if (env.CHANGE_ID) {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project is the home of the host-based inventory for the Insights Platform.
 ## Getting Started
 
 This project uses pipenv to manage the development and deployment environments.
-To set the project up for development do the following:
+To set the project up for development, we recommend using [pyenv|https://github.com/pyenv/pyenv] to install/manage the appropriate python (currently 3.6.x), pip and pipenv version. Once you have pipenv, do the following:
 
 ```
 pipenv install --dev
@@ -135,9 +135,9 @@ from inside of the deployment cluster.
 ## API Documentation
 
 The API is described by an OpenAPI specification file
-[_swagger/api/api.spec.yaml_](swagger/api.spec.yaml). The application exposes
+[_swagger/api.spec.yaml_](swagger/api.spec.yaml). The application exposes
 a browsable Swagger UI Console at
-[_/r/insights/platform/inventory/api/v1/ui/_](http://localhost:8080/r/insights/platform/inventory/api/v1/ui/).
+[_/api/inventory/v1/ui/_](http://localhost:8080/api/inventory/v1/ui/).
 
 ## Operation
 

--- a/api/host.py
+++ b/api/host.py
@@ -163,7 +163,7 @@ def _params_to_order_by(order_by=None, order_how=None):
             "Provide order_by={updated,display_name}."
         )
 
-    return ordering + modified_on_ordering
+    return ordering + modified_on_ordering + (Host.id.desc(),)
 
 
 def _build_paginated_host_list_response(total, page, per_page, host_list):

--- a/test_api.py
+++ b/test_api.py
@@ -23,6 +23,7 @@ from app import create_app
 from app import db
 from app.auth.identity import Identity
 from app.models import Host
+from app.serialization import serialize_host
 from app.utils import HostWrapper
 from tasks import msg_handler
 from test_utils import rename_host_table_and_indexes
@@ -1762,7 +1763,7 @@ class QueryOrderWithSameModifiedOnTestsCase(QueryOrderWithAdditionalHostsBaseTes
         old_host.modified_on = new_modified_on
         db.session.add(old_host)
 
-        self.added_hosts[added_host_index] = HostWrapper(old_host.to_json())
+        self.added_hosts[added_host_index] = HostWrapper(serialize_host(old_host))
 
     def _update_hosts(self, id_updates):
         # New modified_on value must be set explicitly so it’s saved the same to all

--- a/test_unit.py
+++ b/test_unit.py
@@ -273,50 +273,51 @@ class HostOrderHowTestCase(TestCase):
 
 
 @patch("api.host._order_how")
+@patch("api.host.Host.id")
 @patch("api.host.Host.modified_on")
 class HostParamsToOrderByTestCase(TestCase):
-    def test_default_is_updated_desc(self, modified_on, order_how):
+    def test_default_is_updated_desc(self, modified_on, id_, order_how):
         actual = _params_to_order_by(None, None)
-        expected = (modified_on.desc.return_value,)
+        expected = (modified_on.desc.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_not_called()
 
-    def test_default_for_updated_is_desc(self, modified_on, order_how):
+    def test_default_for_updated_is_desc(self, modified_on, id_, order_how):
         actual = _params_to_order_by("updated", None)
-        expected = (modified_on.desc.return_value,)
+        expected = (modified_on.desc.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_not_called()
 
-    def test_order_by_updated_asc(self, modified_on, order_how):
+    def test_order_by_updated_asc(self, modified_on, id_, order_how):
         actual = _params_to_order_by("updated", "ASC")
-        expected = (order_how.return_value,)
+        expected = (order_how.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_called_once_with(modified_on, "ASC")
 
-    def test_order_by_updated_desc(self, modified_on, order_how):
+    def test_order_by_updated_desc(self, modified_on, id_, order_how):
         actual = _params_to_order_by("updated", "DESC")
-        expected = (order_how.return_value,)
+        expected = (order_how.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_called_once_with(modified_on, "DESC")
 
     @patch("api.host.Host.display_name")
-    def test_default_for_display_name_is_asc(self, display_name, modified_on, order_how):
+    def test_default_for_display_name_is_asc(self, display_name, modified_on, id_, order_how):
         actual = _params_to_order_by("display_name")
-        expected = (display_name.asc.return_value, modified_on.desc.return_value)
+        expected = (display_name.asc.return_value, modified_on.desc.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_not_called()
 
     @patch("api.host.Host.display_name")
-    def test_order_by_display_name_asc(self, display_name, modified_on, order_how):
+    def test_order_by_display_name_asc(self, display_name, modified_on, id_, order_how):
         actual = _params_to_order_by("display_name", "ASC")
-        expected = (order_how.return_value, modified_on.desc.return_value)
+        expected = (order_how.return_value, modified_on.desc.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_called_once_with(display_name, "ASC")
 
     @patch("api.host.Host.display_name")
-    def test_order_by_display_name_desc(self, display_name, modified_on, order_how):
+    def test_order_by_display_name_desc(self, display_name, modified_on, id_, order_how):
         actual = _params_to_order_by("display_name", "DESC")
-        expected = (order_how.return_value, modified_on.desc.return_value)
+        expected = (order_how.return_value, modified_on.desc.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_called_once_with(display_name, "DESC")
 


### PR DESCRIPTION
This merges [current](https://github.com/RedHatInsights/insights-host-inventory/commit/bb076fe4108080aa1e444f7a36f23c875d1bfbfd) [_master_](https://github.com/RedHatInsights/insights-host-inventory/tree/master) to the [_split_inventory_service_](https://github.com/RedHatInsights/insights-host-inventory/tree/split_inventory_service) branch. The [merge](https://github.com/RedHatInsights/insights-host-inventory/commit/b7add607be2f1c6eeca380b12038c8645ffaada4) went through cleanly. The last [commit](https://github.com/RedHatInsights/insights-host-inventory/commit/7dce041722267ebfb9e67264823627716214e791) fixes a semantical merge conflict, fixing the only two failing tests.

This is the first step before auditing the feature branch behavior changes. No fixes are included here. For merging, please confirm that tests are passing and that there are no unnoticed conflicts.