### PR TITLE
Remove unwanted char from API spec

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -17,7 +17,7 @@ paths:
         - in: query
           name: display_name
           schema:
-            type: string`
+            type: string
           description: A part of a searched host’s display name.
           required: false
         - in: query


### PR DESCRIPTION
There is an unwanted backtick in the OpenAPI specification YAML. Removed, so it’s valid again. This was introduced in #484 and is a bug.