### PR TITLE
Fix pre-commit checks violations

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -1,10 +1,10 @@
+import re
 import uuid
 from enum import Enum
 
 import flask
 import sqlalchemy
 import ujson
-import re
 from flask_api import status
 from marshmallow import ValidationError
 from sqlalchemy.orm.base import instance_state
@@ -161,7 +161,7 @@ def _tags_host_query(account_number, tags):
     tags_to_find = {}
 
     for tag in tags:
-        split_tag = re.split(r'/|=', tag)
+        split_tag = re.split(r"/|=", tag)
         namespace = split_tag[0]
         key = split_tag[1]
         value = split_tag[2]
@@ -174,9 +174,7 @@ def _tags_host_query(account_number, tags):
         else:
             tags_to_find[namespace] = {key: [value]}
 
-    return Host.query.filter(
-        (Host.account == account_number)
-        & (Host.tags.contains(tags_to_find)))
+    return Host.query.filter((Host.account == account_number) & (Host.tags.contains(tags_to_find)))
 
 
 def find_hosts_by_tag(account_number, tags):

--- a/test_api.py
+++ b/test_api.py
@@ -1143,12 +1143,19 @@ class PreCreatedHostsBaseTestCase(DBAPITestCase, PaginationBaseTestCase):
 
     def create_hosts(self):
         hosts_to_create = [
-            ("host1", generate_uuid(), "host1.domain.test",
-                ["NS1/key1=val1", "NS1/key2=val1", "SPECIAL/tag=ToFind"]),
-            ("host2", generate_uuid(), "host1.domain.test",
-                ["NS1/key1=val1", "NS2/key2=val2", "NS3/key3=val3"]),  # the same fqdn is intentional
-            ("host3", generate_uuid(), "host2.domain.test",
-                ["NS2/key2=val2", "NS3/key3=val3", "NS1/key3=val3"]),  # the same display_name is intentional
+            ("host1", generate_uuid(), "host1.domain.test", ["NS1/key1=val1", "NS1/key2=val1", "SPECIAL/tag=ToFind"]),
+            (
+                "host2",
+                generate_uuid(),
+                "host1.domain.test",
+                ["NS1/key1=val1", "NS2/key2=val2", "NS3/key3=val3"],
+            ),  # the same fqdn is intentional
+            (
+                "host3",
+                generate_uuid(),
+                "host2.domain.test",
+                ["NS2/key2=val2", "NS3/key3=val3", "NS1/key3=val3"],
+            ),  # the same display_name is intentional
         ]
         host_list = []
 
@@ -1605,7 +1612,6 @@ class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
 
 
 class QueryByTagTestCase(PreCreatedHostsBaseTestCase, PaginationBaseTestCase):
-
     def _compare_responses(self, expected_response_list, response_list, test_url):
         self.assertEqual(len(expected_response_list), len(response_list["results"]))
         for host, result in zip(expected_response_list, response_list["results"]):
@@ -1648,7 +1654,7 @@ class QueryByTagTestCase(PreCreatedHostsBaseTestCase, PaginationBaseTestCase):
         expected_response_list = [host_list[1]]
         # host with tags ["NS1/key1=val1", "NS2/key2=val2", "NS3/key3=val3"]
 
-        test_url = (f"{HOST_URL}?tag=NS1/key1=val1,NS2/key2=val2,NS3/key3=val3")
+        test_url = f"{HOST_URL}?tag=NS1/key1=val1,NS2/key2=val2,NS3/key3=val3"
         response_list = self.get(test_url, 200)
 
         self._compare_responses(expected_response_list, response_list, test_url)
@@ -1662,7 +1668,7 @@ class QueryByTagTestCase(PreCreatedHostsBaseTestCase, PaginationBaseTestCase):
         expected_response_list = [host_list[1]]
         # host with tags ["NS1/key1=val1", "NS2/key2=val2", "NS3/key3=val3"]
 
-        test_url = (f"{HOST_URL}?tag=NS1/key1=val1,NS3/key3=val3")
+        test_url = f"{HOST_URL}?tag=NS1/key1=val1,NS3/key3=val3"
         response_list = self.get(test_url, 200)
 
         self._compare_responses(expected_response_list, response_list, test_url)
@@ -1675,7 +1681,7 @@ class QueryByTagTestCase(PreCreatedHostsBaseTestCase, PaginationBaseTestCase):
 
         expected_response_list = [host_list[0]]  # host with tags ["NS1/key1=val1", "NS1/key2=val1"]
 
-        test_url = (f"{HOST_URL}?tag=NS1/key1=val1,NS1/key2=val1")
+        test_url = f"{HOST_URL}?tag=NS1/key1=val1,NS1/key2=val1"
         response_list = self.get(test_url, 200)
 
         self._compare_responses(expected_response_list, response_list, test_url)
@@ -1688,7 +1694,7 @@ class QueryByTagTestCase(PreCreatedHostsBaseTestCase, PaginationBaseTestCase):
 
         expected_response_list = [host_list[2]]  # host with tags ["NS3/key3=val3", "NS1/key3=val3"]
 
-        test_url = (f"{HOST_URL}?tag=NS3/key3=val3,NS1/key3=val3")
+        test_url = f"{HOST_URL}?tag=NS3/key3=val3,NS1/key3=val3"
         response_list = self.get(test_url, 200)
 
         self._compare_responses(expected_response_list, response_list, test_url)


### PR DESCRIPTION
Fixed formatting, syntax and import violations that caused pre-commit checks to fail. These also make the CI pipeline checks to fail. Pull requests that don’t pass those checks should never be merged. This was introduced by accident in #484.