### PR TITLE
release the BIG MERGE to stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: init test run_inv_mq_service
+
+init:
+	pipenv shell
+
+test:
+	pytest --cov=.
+
+upgrade_db:
+	python manage.py db upgrade
+
+run_inv_web_service:
+	# Set the "KAFKA_TOPIC", "KAFKA_GROUP", "KAFKA_BOOTSTRAP_SERVERS" environment variables
+	# if you want the system_profile message queue consumer and event producer to be started
+	#
+	# KAFKA_TOPIC="platform.system-profile" KAFKA_GROUP="inventory" KAFKA_BOOTSTRAP_SERVERS="localhost:29092"
+	#
+	INVENTORY_LOGGING_CONFIG_FILE=logconfig.ini INVENTORY_LOG_LEVEL=DEBUG gunicorn -b :8080 run
+
+run_inv_mq_service:
+	PAYLOAD_TRACKER_SERVICE_NAME=inventory-mq-service INVENTORY_LOGGING_CONFIG_FILE=logconfig.ini \
+	INVENTORY_LOG_LEVEL=DEBUG python inv_mq_service.py
+
+run_inv_mq_service_test_producer:
+	KAFKA_GROUP="inventory-mq" KAFKA_TOPIC="platform.inventory.host-ingress" python utils/kafka_producer.py
+
+run_inv_mq_service_test_consumer:
+	KAFKA_GROUP="inventory-mq" KAFKA_TOPIC="platform.inventory.host-egress" python utils/kafka_consumer.py
+
+run_inv_http_test_producer:
+	python utils/rest_producer.py

--- a/README.md
+++ b/README.md
@@ -177,6 +177,48 @@ will be added to the existing host entry.
 If the canonical facts based lookup does not locate an existing host, then
 a new host entry is created.
 
+#### Bulk Insertion
+
+The REST api should _not_ be used for bulk insertion.  Instead, a batch of
+hosts should be added to the inventory system by sequentially writing the individual
+hosts to the kafka message queue.
+
+#### Message Queue Based Host Insertion
+
+A single host object (see HostSchema defined in
+[_app/models.py_](app/models.py)) should be wrapped in an _operation_
+json document (see OperationSchema defined in [_app/queue/ingress.py_](app/queue/ingress.py))
+ and sent to the kafka message queue.
+
+```json
+  {"operation": "add_host",
+   "platform_metadata": json_doc,
+   "data": host_json_doc}
+```
+  - operation: name of the operation to perform ("add_host" is only supported currently)
+  - platform_metadata: an optional json doc that can be used to pass data associated with the host
+   from the ingress service to the backend applications (request_id, s3 bucket url, etc)
+  - data: a host json doc as defined by the HostSchema in [_app/models.py_](app/models.py)
+
+The kafka topic for adding hosts is _platform.inventory.host-ingress_.
+
+The _platform_metadata_ field will be passed from the incoming message to the outgoing
+event message.  The data within the _platform_metadata_ will not be persisted to the database.
+If the _platform_metadata_ contains a request_id field, the value of the request_id will be
+associated with all of the log messages produced by the service.
+
+The Inventory service will write an event to the _platform.inventory.host-egress_
+kafka topic as a result of adding a host over the message queue.
+
+```json
+  {"type": "created",
+   "platform_metadata": metadata_json_doc,
+   "data": host_json_doc}
+```
+  - type: result of the add host operation ("created" and "updated" are only supported currently)
+  - platform_metadata: a json doc that contains the metadata associated with the host (s3 url, request_id, etc)
+  - data: a host json doc as defined by the HostSchema in [_app/queue/egress.py_](app/queue/egress.py)
+
 #### Host deletion
 
 Hosts can be deleted by using the DELETE HTTP Method on the _/hosts/id_ endpoint.

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -2,22 +2,7 @@ from prometheus_client import Counter
 from prometheus_client import Summary
 
 api_request_time = Summary("inventory_request_processing_seconds", "Time spent processing request")
-host_dedup_processing_time = Summary(
-    "inventory_dedup_processing_seconds", "Time spent looking for existing host (dedup logic)"
-)
-find_host_using_elevated_ids = Summary(
-    "inventory_find_host_using_elevated_ids_processing_seconds",
-    "Time spent looking for existing host using the elevated ids",
-)
-new_host_commit_processing_time = Summary(
-    "inventory_new_host_commit_seconds", "Time spent committing a new host to the database"
-)
-update_host_commit_processing_time = Summary(
-    "inventory_update_host_commit_seconds", "Time spent committing a update host to the database"
-)
 api_request_count = Counter("inventory_request_count", "The total amount of API requests")
-create_host_count = Counter("inventory_create_host_count", "The total amount of hosts created")
-update_host_count = Counter("inventory_update_host_count", "The total amount of hosts updated")
 delete_host_count = Counter("inventory_delete_host_count", "The total amount of hosts deleted")
 delete_host_processing_time = Summary(
     "inventory_delete_host_commit_seconds", "Time spent deleting hosts from the database"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,7 +17,6 @@ from tasks import init_tasks
 
 logger = get_logger(__name__)
 
-
 REQUEST_ID_HEADER = "x-rh-insights-request-id"
 UNKNOWN_REQUEST_ID_VALUE = "-1"
 

--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,9 @@ class Config:
 
         self.api_urls = [self.api_url_path_prefix, self.legacy_api_url_path_prefix]
 
+        self.host_ingress_topic = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
+        self.host_ingress_consumer_group = os.environ.get("KAFKA_HOST_INGRESS_GROUP", "inventory-mq")
+        self.host_egress_topic = os.environ.get("KAFKA_HOST_EGRESS_TOPIC", "platform.inventory.host-egress")
         self.system_profile_topic = os.environ.get("KAFKA_TOPIC", "platform.system-profile")
         self.consumer_group = os.environ.get("KAFKA_GROUP", "inventory")
         self.bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
@@ -78,6 +81,11 @@ class Config:
                 self.logger.info("Using SSL for DB connection:")
                 self.logger.info("Postgresql SSL verification type: %s", self._db_ssl_mode)
                 self.logger.info("Path to certificate: %s", self._db_ssl_cert)
+            self.logger.info("Kafka Host Ingress Topic: %s" % self.host_ingress_topic)
+            self.logger.info("Kafka Host Ingress Group: %s" % self.host_ingress_consumer_group)
+            self.logger.info("Kafka Host Egress Topic: %s" % self.host_egress_topic)
+            self.logger.info("Kafka Consumer Group: %s" % self.consumer_group)
+            self.logger.info("Kafka Bootstrap Servers: %s" % self.bootstrap_servers)
             self.logger.info("Payload Tracker Kafka Topic: %s", self.payload_tracker_kafka_topic)
             self.logger.info("Payload Tracker Service Name: %s", self.payload_tracker_service_name)
             self.logger.info("Payload Tracker Enabled: %s", self.payload_tracker_enabled)

--- a/app/events.py
+++ b/app/events.py
@@ -5,7 +5,7 @@ from marshmallow import fields
 from marshmallow import Schema
 
 from app.logging import threadctx
-from app.models import CanonicalFacts
+from app.serialization import serialize_canonical_facts
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ def delete(host):
             {
                 "timestamp": datetime.utcnow(),
                 "id": host.id,
-                **CanonicalFacts.to_json(host.canonical_facts),
+                **serialize_canonical_facts(host.canonical_facts),
                 "account": host.account,
                 "request_id": threadctx.request_id,
                 "type": "delete",

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -12,3 +12,8 @@ class InventoryException(Exception):
 class InputFormatException(InventoryException):
     def __init__(self, detail):
         InventoryException.__init__(self, title="Bad Request", detail=detail)
+
+
+class ValidationException(InventoryException):
+    def __init__(self, detail):
+        InventoryException.__init__(self, title="Validation Error", detail=detail)

--- a/app/logging.py
+++ b/app/logging.py
@@ -80,7 +80,7 @@ def _configure_contextual_logging_filter():
 
 class ContextualFilter(logging.Filter):
     """
-    This filter gets the request_id from the flask reqeust
+    This filter gets the request_id from the flask request
     and adds it to each log record.  This way we do not have
     to explicitly retrieve/pass around the request id for each
     log message.

--- a/app/models.py
+++ b/app/models.py
@@ -14,7 +14,6 @@ from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID
 
-from app.exceptions import InputFormatException
 from app.exceptions import InventoryException
 from app.logging import get_logger
 from app.validators import verify_uuid_format
@@ -98,38 +97,10 @@ class Host(db.Model):
         self.facts = facts
         self.system_profile_facts = system_profile_facts or {}
 
-    @classmethod
-    def from_json(cls, d):
-        canonical_facts = CanonicalFacts.from_json(d)
-        facts = Facts.from_json(d.get("facts"))
-        return cls(
-            canonical_facts,
-            d.get("display_name", None),
-            d.get("ansible_host"),
-            d.get("account"),
-            facts,
-            d.get("system_profile", {}),
-        )
-
-    def to_json(self):
-        json_dict = CanonicalFacts.to_json(self.canonical_facts)
-        json_dict["id"] = str(self.id)
-        json_dict["account"] = self.account
-        json_dict["display_name"] = self.display_name
-        json_dict["ansible_host"] = self.ansible_host
-        json_dict["facts"] = Facts.to_json(self.facts)
-        json_dict["created"] = self.created_on.isoformat() + "Z"
-        json_dict["updated"] = self.modified_on.isoformat() + "Z"
-        return json_dict
-
-    def to_system_profile_json(self):
-        json_dict = {"id": str(self.id), "system_profile": self.system_profile_facts or {}}
-        return json_dict
-
     def save(self):
         db.session.add(self)
 
-    def update(self, input_host):
+    def update(self, input_host, update_system_profile=False):
         self.update_canonical_facts(input_host.canonical_facts)
 
         self.update_display_name(input_host.display_name)
@@ -137,6 +108,9 @@ class Host(db.Model):
         self._update_ansible_host(input_host.ansible_host)
 
         self.update_facts(input_host.facts)
+
+        if update_system_profile:
+            self._update_system_profile(input_host.system_profile_facts)
 
     def patch(self, patch_data):
         logger.debug("patching host (id=%s) with data: %s", self.id, patch_data)
@@ -213,83 +187,6 @@ class Host(db.Model):
             f"<Host id='{self.id}' account='{self.account}' display_name='{self.display_name}' "
             f"canonical_facts={self.canonical_facts}>"
         )
-
-
-class CanonicalFacts:
-    """
-    There is a mismatch between how the canonical facts are sent as JSON
-    and how the canonical facts are stored in the DB.  This class contains
-    the logic that is responsible for performing the conversion.
-
-    The canonical facts will be stored as a dict in a single json column
-    in the DB.
-    """
-
-    field_names = (
-        "insights_id",
-        "rhel_machine_id",
-        "subscription_manager_id",
-        "satellite_id",
-        "bios_uuid",
-        "ip_addresses",
-        "fqdn",
-        "mac_addresses",
-        "external_id",
-    )
-
-    @staticmethod
-    def from_json(json_dict):
-        canonical_fact_list = {}
-        for cf in CanonicalFacts.field_names:
-            # Do not allow the incoming canonical facts to be None or ''
-            if cf in json_dict and json_dict[cf]:
-                canonical_fact_list[cf] = json_dict[cf]
-        return canonical_fact_list
-
-    @staticmethod
-    def to_json(internal_dict):
-        canonical_fact_dict = dict.fromkeys(CanonicalFacts.field_names, None)
-        for cf in CanonicalFacts.field_names:
-            if cf in internal_dict:
-                canonical_fact_dict[cf] = internal_dict[cf]
-        return canonical_fact_dict
-
-
-class Facts:
-    """
-    There is a mismatch between how the facts are sent as JSON
-    and how the facts are stored in the DB.  This class contains
-    the logic that is responsible for performing the conversion.
-
-    The facts will be stored as a dict in a single json column
-    in the DB.
-    """
-
-    @staticmethod
-    def from_json(fact_list):
-        if fact_list is None:
-            fact_list = []
-
-        fact_dict = {}
-        for fact in fact_list:
-            if "namespace" in fact and "facts" in fact:
-                if fact["namespace"] in fact_dict:
-                    fact_dict[fact["namespace"]].update(fact["facts"])
-                else:
-                    fact_dict[fact["namespace"]] = fact["facts"]
-            else:
-                # The facts from the request are formatted incorrectly
-                raise InputFormatException(
-                    "Invalid format of Fact object.  Fact must contain 'namespace' and 'facts' keys."
-                )
-        return fact_dict
-
-    @staticmethod
-    def to_json(fact_dict):
-        fact_list = [
-            {"namespace": namespace, "facts": facts if facts else {}} for namespace, facts in fact_dict.items()
-        ]
-        return fact_list
 
 
 class DiskDeviceSchema(Schema):

--- a/app/queue/egress.py
+++ b/app/queue/egress.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+from kafka import KafkaProducer
+from marshmallow import fields
+from marshmallow import Schema
+
+from app.logging import get_logger
+from app.queue import metrics
+
+
+logger = get_logger(__name__)
+
+
+def create_event_producer(config, producer_type):
+    if producer_type == "kafka":
+        return KafkaEventProducer(config)
+    else:
+        return NullEventProducer()
+
+
+class KafkaEventProducer:
+    def __init__(self, config):
+        logger.info("Starting KafkaEventProducer()")
+        self._kafka_producer = KafkaProducer(bootstrap_servers=config.bootstrap_servers)
+        self._topic = config.host_egress_topic
+
+    def write_event(self, event):
+        logger.debug(f"Topic: {self._topic} => {event}")
+
+        try:
+            self._kafka_producer.send(self._topic, value=event.encode("utf-8"))
+            metrics.egress_message_handler_success.inc()
+        except Exception:
+            logger.exception("Failed to send event")
+            metrics.egress_message_handler_failure.inc()
+
+
+class NullEventProducer:
+    def __init__(self):
+        logger.info("Starting NullEventProducer()")
+
+    def write_event(self, event):
+        logger.debug("NullEventProducer - logging event: %s" % event)
+
+
+@metrics.egress_event_serialization_time.time()
+def build_event(event_type, host, metadata):
+    if event_type in ("created", "updated"):
+        return (
+            HostEvent(strict=True)
+            .dumps({"type": event_type, "host": host, "platform_metadata": metadata, "timestamp": datetime.utcnow()})
+            .data
+        )
+    else:
+        raise ValueError(f"Invalid event type ({event_type})")
+
+
+class HostSchema(Schema):
+    id = fields.UUID()
+    display_name = fields.Str()
+    ansible_host = fields.Str()
+    account = fields.Str(required=True)
+    insights_id = fields.Str()
+    rhel_machine_id = fields.Str()
+    subscription_manager_id = fields.Str()
+    satellite_id = fields.Str()
+    fqdn = fields.Str()
+    bios_uuid = fields.Str()
+    ip_addresses = fields.List(fields.Str())
+    mac_addresses = fields.List(fields.Str())
+    external_id = fields.Str()
+    # FIXME:
+    # created = fields.DateTime(format="iso8601")
+    # updated = fields.DateTime(format="iso8601")
+    # FIXME:
+    created = fields.Str()
+    updated = fields.Str()
+
+
+class HostEvent(Schema):
+    type = fields.Str()
+    host = fields.Nested(HostSchema())
+    timestamp = fields.DateTime(format="iso8601")
+    platform_metadata = fields.Dict()

--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -1,0 +1,115 @@
+import json
+
+from marshmallow import fields
+from marshmallow import Schema
+from marshmallow import ValidationError
+
+from app.exceptions import InventoryException
+from app.logging import get_logger
+from app.logging import threadctx
+from app.payload_tracker import get_payload_tracker
+from app.payload_tracker import PayloadTrackerContext
+from app.payload_tracker import PayloadTrackerProcessingContext
+from app.queue import metrics
+from app.queue.egress import build_event
+from lib import host_repository
+
+
+logger = get_logger(__name__)
+
+
+class OperationSchema(Schema):
+    operation = fields.Str(required=True)
+    platform_metadata = fields.Dict()
+    data = fields.Dict(required=True)
+
+
+@metrics.ingress_message_parsing_time.time()
+def parse_operation_message(message):
+    try:
+        parsed_message = json.loads(message)
+    except Exception:
+        # The "extra" dict cannot have a key named "msg" or "message"
+        # otherwise an exception in thrown in the logging code
+        logger.exception("Unable to parse json message from message queue", extra={"incoming_message": message})
+        metrics.ingress_message_parsing_failure.inc()
+        raise
+
+    try:
+        parsed_operation = OperationSchema(strict=True).load(parsed_message).data
+    except ValidationError as e:
+        logger.error(
+            "Input validation error while parsing operation message:%s", e, extra={"operation": parsed_message}
+        )  # logger.error is used to avoid printing out the same traceback twice
+        metrics.ingress_message_parsing_failure.inc()
+        raise
+    except Exception:
+        logger.exception("Error parsing operation message", extra={"operation": parsed_message})
+        metrics.ingress_message_parsing_failure.inc()
+        raise
+
+    return parsed_operation
+
+
+def add_host(host_data):
+    payload_tracker = get_payload_tracker(payload_id=threadctx.request_id)
+
+    with PayloadTrackerProcessingContext(
+        payload_tracker, processing_status_message="adding/updating host"
+    ) as payload_tracker_processing_ctx:
+
+        try:
+            logger.info("Attempting to add host...")
+            (output_host, add_results) = host_repository.add_host(host_data)
+            metrics.add_host_success.inc()
+            logger.info("Host added")  # This definitely needs to be more specific (added vs updated?)
+            payload_tracker_processing_ctx.inventory_id = output_host["id"]
+            return (output_host, add_results)
+        except InventoryException:
+            logger.exception("Error adding host ", extra={"host": host_data})
+            metrics.add_host_failure.inc()
+            raise
+        except Exception:
+            logger.exception("Error while adding host", extra={"host": host_data})
+            metrics.add_host_failure.inc()
+            raise
+
+
+@metrics.ingress_message_handler_time.time()
+def handle_message(message, event_producer):
+    validated_operation_msg = parse_operation_message(message)
+    metadata = validated_operation_msg.get("platform_metadata") or {}
+    initialize_thread_local_storage(metadata)
+
+    payload_tracker = get_payload_tracker(payload_id=threadctx.request_id)
+
+    with PayloadTrackerContext(payload_tracker, received_status_message="message received"):
+
+        # FIXME: verify operation type
+        (output_host, add_results) = add_host(validated_operation_msg["data"])
+
+        if add_results == host_repository.AddHostResults.created:
+            event_type = "created"
+        else:
+            event_type = "updated"
+
+        event = build_event(event_type, output_host, metadata)
+
+        event_producer.write_event(event)
+
+
+def event_loop(consumer, flask_app, event_producer, handler=handle_message):
+    with flask_app.app_context():
+        logger.debug("Waiting for message")
+        for msg in consumer:
+            logger.debug("Message received")
+            try:
+                handler(msg.value, event_producer)
+                metrics.ingress_message_handler_success.inc()
+            except Exception:
+                metrics.ingress_message_handler_failure.inc()
+                logger.exception("Unable to process message")
+
+
+def initialize_thread_local_storage(metadata):
+    threadctx.request_id = metadata.get("request_id", "-1")

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -1,0 +1,35 @@
+from prometheus_client import Counter
+from prometheus_client import Info
+from prometheus_client import Summary
+
+from app.common import get_build_version
+
+ingress_message_parsing_time = Summary(
+    "inventory_ingress_message_parsing_seconds", "Time spent parsing a message from the ingress queue"
+)
+ingress_message_parsing_failure = Counter(
+    "inventory_ingress_message_parsing_failures", "Total amount of failures parsing ingress messages"
+)
+add_host_success = Counter("inventory_ingress_add_host_successes", "Total amount of successfully added hosts")
+add_host_failure = Counter("inventory_ingress_add_host_failures", "Total amount of failures adding hosts")
+ingress_message_handler_success = Counter(
+    "inventory_ingress_message_handler_successes",
+    "Total amount of successfully handled messages from the ingress queue",
+)
+ingress_message_handler_failure = Counter(
+    "inventory_ingress_message_handler_failures", "Total amount of failures handling messages from the ingress queue"
+)
+ingress_message_handler_time = Summary(
+    "inventory_ingress_message_handler_seconds", "Total time spent handling messages from the ingress queue"
+)
+version = Info("inventory_mq_service_version", "Build version for the inventory message queue service")
+version.info({"version": get_build_version()})
+egress_message_handler_success = Counter(
+    "inventory_egress_message_handler_successes", "Total amount of messages successfully written to the egress queue"
+)
+egress_message_handler_failure = Counter(
+    "inventory_egress_message_handler_failures", "Total amount of failures while writing messages to the egress queue"
+)
+egress_event_serialization_time = Summary(
+    "inventory_egress_event_serialization_seconds", "Time spent parsing a message from the egress queue"
+)

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -1,0 +1,89 @@
+from app.exceptions import InputFormatException
+from app.models import Host as Host
+
+
+__all__ = ("deserialize_host", "serialize_host", "serialize_host_system_profile", "serialize_canonical_facts")
+
+
+_CANONICAL_FACTS_FIELDS = (
+    "insights_id",
+    "rhel_machine_id",
+    "subscription_manager_id",
+    "satellite_id",
+    "bios_uuid",
+    "ip_addresses",
+    "fqdn",
+    "mac_addresses",
+    "external_id",
+)
+
+
+def deserialize_host(data):
+    canonical_facts = _deserialize_canonical_facts(data)
+    facts = _deserialize_facts(data.get("facts"))
+    return Host(
+        canonical_facts,
+        data.get("display_name", None),
+        data.get("ansible_host"),
+        data.get("account"),
+        facts,
+        data.get("system_profile", {}),
+    )
+
+
+def serialize_host(host):
+    json_dict = serialize_canonical_facts(host.canonical_facts)
+    json_dict["id"] = str(host.id)
+    json_dict["account"] = host.account
+    json_dict["display_name"] = host.display_name
+    json_dict["ansible_host"] = host.ansible_host
+    json_dict["facts"] = _serialize_facts(host.facts)
+    json_dict["created"] = host.created_on.isoformat() + "Z"
+    json_dict["updated"] = host.modified_on.isoformat() + "Z"
+    return json_dict
+
+
+def serialize_host_system_profile(host):
+    json_dict = {"id": str(host.id), "system_profile": host.system_profile_facts or {}}
+    return json_dict
+
+
+def _deserialize_canonical_facts(data):
+    canonical_fact_list = {}
+    for cf in _CANONICAL_FACTS_FIELDS:
+        # Do not allow the incoming canonical facts to be None or ''
+        if cf in data and data[cf]:
+            canonical_fact_list[cf] = data[cf]
+    return canonical_fact_list
+
+
+def serialize_canonical_facts(canonical_facts):
+    canonical_fact_dict = dict.fromkeys(_CANONICAL_FACTS_FIELDS, None)
+    for cf in _CANONICAL_FACTS_FIELDS:
+        if cf in canonical_facts:
+            canonical_fact_dict[cf] = canonical_facts[cf]
+    return canonical_fact_dict
+
+
+def _deserialize_facts(data):
+    if data is None:
+        data = []
+
+    fact_dict = {}
+    for fact in data:
+        if "namespace" in fact and "facts" in fact:
+            if fact["namespace"] in fact_dict:
+                fact_dict[fact["namespace"]].update(fact["facts"])
+            else:
+                fact_dict[fact["namespace"]] = fact["facts"]
+        else:
+            # The facts from the request are formatted incorrectly
+            raise InputFormatException(
+                "Invalid format of Fact object.  Fact must contain 'namespace' and 'facts' keys."
+            )
+    return fact_dict
+
+
+def _serialize_facts(facts):
+    fact_list = [{"namespace": namespace, "facts": facts if facts else {}} for namespace, facts in facts.items()]
+    return fact_list

--- a/host_dumper.py
+++ b/host_dumper.py
@@ -4,6 +4,7 @@ import pprint
 
 from app import create_app
 from app.models import Host
+from app.serialization import serialize_host
 
 application = create_app("cli")
 
@@ -40,7 +41,7 @@ with application.app_context():
     elif args.account_number:
         query_results = Host.query.filter(Host.account == args.account_number).all()
 
-    json_host_list = [host.to_json() for host in query_results]
+    json_host_list = [serialize_host(host) for host in query_results]
 
     if args.no_pp:
         print(json_host_list)

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -1,0 +1,35 @@
+import os
+
+from kafka import KafkaConsumer
+from prometheus_client import start_http_server
+
+from app import create_app
+from app.config import Config
+from app.logging import get_logger
+from app.queue.egress import create_event_producer
+from app.queue.ingress import event_loop
+
+logger = get_logger("mq_service")
+
+
+def main():
+    config_name = os.getenv("APP_SETTINGS", "development")
+    application = create_app(config_name, start_tasks=False, start_payload_tracker=True)
+    start_http_server(9126)
+
+    config = Config()
+
+    consumer = KafkaConsumer(
+        config.host_ingress_topic,
+        group_id=config.host_ingress_consumer_group,
+        bootstrap_servers=config.bootstrap_servers,
+        api_version=(0, 10),
+    )
+
+    event_producer = create_event_producer(config, "kafka")
+
+    event_loop(consumer, application, event_producer)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -1,0 +1,115 @@
+from enum import Enum
+
+from marshmallow import ValidationError
+
+from app.exceptions import ValidationException
+from app.logging import get_logger
+from app.models import db
+from app.models import db_session_guard
+from app.models import Host
+from app.models import HostSchema
+from app.serialization import deserialize_host
+from app.serialization import serialize_host
+from lib import metrics
+
+# FIXME:  rename this
+AddHostResults = Enum("AddHostResults", ["created", "updated"])
+
+# These are the "elevated" canonical facts that are
+# given priority in the host deduplication process.
+# NOTE: The order of this tuple is important.  The order defines
+# the priority.
+ELEVATED_CANONICAL_FACT_FIELDS = ("insights_id", "subscription_manager_id")
+
+
+logger = get_logger(__name__)
+
+
+def add_host(host, update_system_profile=True):
+    """
+    Add or update a host
+
+    Required parameters:
+     - at least one of the canonical facts fields is required
+     - account number
+    """
+    try:
+        validated_input_host_dict = HostSchema(strict=True).load(host)
+    except ValidationError as e:
+        raise ValidationException(str(e.messages)) from None
+
+    input_host = deserialize_host(validated_input_host_dict.data)
+
+    with db_session_guard():
+        existing_host = find_existing_host(input_host.account, input_host.canonical_facts)
+
+        if existing_host:
+            return update_existing_host(existing_host, input_host, update_system_profile)
+        else:
+            return create_new_host(input_host)
+
+
+@metrics.host_dedup_processing_time.time()
+def find_existing_host(account_number, canonical_facts):
+    existing_host = _find_host_by_elevated_ids(account_number, canonical_facts)
+
+    if not existing_host:
+        existing_host = find_host_by_canonical_facts(account_number, canonical_facts)
+
+    return existing_host
+
+
+@metrics.find_host_using_elevated_ids.time()
+def _find_host_by_elevated_ids(account_number, canonical_facts):
+    for elevated_cf_name in ELEVATED_CANONICAL_FACT_FIELDS:
+        cf_value = canonical_facts.get(elevated_cf_name)
+        if cf_value:
+            existing_host = find_host_by_canonical_facts(account_number, {elevated_cf_name: cf_value})
+            if existing_host:
+                return existing_host
+
+    return None
+
+
+def _canonical_facts_host_query(account_number, canonical_facts):
+    return Host.query.filter(
+        (Host.account == account_number)
+        & (
+            Host.canonical_facts.comparator.contains(canonical_facts)
+            | Host.canonical_facts.comparator.contained_by(canonical_facts)
+        )
+    )
+
+
+def find_host_by_canonical_facts(account_number, canonical_facts):
+    """
+    Returns first match for a host containing given canonical facts
+    """
+    logger.debug("find_host_by_canonical_facts(%s)", canonical_facts)
+
+    host = _canonical_facts_host_query(account_number, canonical_facts).first()
+
+    if host:
+        logger.debug("Found existing host using canonical_fact match: %s", host)
+
+    return host
+
+
+@metrics.new_host_commit_processing_time.time()
+def create_new_host(input_host):
+    logger.debug("Creating a new host")
+    input_host.save()
+    db.session.commit()
+    metrics.create_host_count.inc()
+    logger.debug("Created host:%s", input_host)
+    return serialize_host(input_host), AddHostResults.created
+
+
+@metrics.update_host_commit_processing_time.time()
+def update_existing_host(existing_host, input_host, update_system_profile):
+    logger.debug("Updating an existing host")
+    existing_host.update(input_host, update_system_profile)
+    db.session.commit()
+    metrics.update_host_count.inc()
+    logger.debug("Updated host:%s", existing_host)
+    return serialize_host(existing_host), AddHostResults.updated

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -1,0 +1,18 @@
+from prometheus_client import Counter
+from prometheus_client import Summary
+
+host_dedup_processing_time = Summary(
+    "inventory_dedup_processing_seconds", "Time spent looking for existing host (dedup logic)"
+)
+find_host_using_elevated_ids = Summary(
+    "inventory_find_host_using_elevated_ids_processing_seconds",
+    "Time spent looking for existing host using the elevated ids",
+)
+new_host_commit_processing_time = Summary(
+    "inventory_new_host_commit_seconds", "Time spent committing a new host to the database"
+)
+update_host_commit_processing_time = Summary(
+    "inventory_update_host_commit_seconds", "Time spent committing a update host to the database"
+)
+create_host_count = Counter("inventory_create_host_count", "The total amount of hosts created")
+update_host_count = Counter("inventory_update_host_count", "The total amount of hosts updated")

--- a/logconfig.ini
+++ b/logconfig.ini
@@ -1,5 +1,5 @@
 [loggers]
-keys=root, gunicorn.error, gunicorn.access, sqlalchemy.engine, app, api, tasks
+keys=root, gunicorn.error, gunicorn.access, sqlalchemy.engine, app, api, tasks, mq_service, lib
 
 [handlers]
 keys=logstash
@@ -46,6 +46,18 @@ level=DEBUG
 handlers=logstash
 propagate=0
 qualname=inventory.tasks
+
+[logger_mq_service]
+level=DEBUG
+handlers=logstash
+propagate=0
+qualname=inventory.mq_service
+
+[logger_lib]
+level=DEBUG
+handlers=logstash
+propagate=0
+qualname=inventory.lib
 
 [handler_logstash]
 class=StreamHandler

--- a/test_api.py
+++ b/test_api.py
@@ -23,6 +23,7 @@ from app import create_app
 from app import db
 from app.auth.identity import Identity
 from app.models import Host
+from app.serialization import serialize_host
 from app.utils import HostWrapper
 from tasks import msg_handler
 from test_utils import rename_host_table_and_indexes
@@ -1762,7 +1763,7 @@ class QueryOrderWithSameModifiedOnTestsCase(QueryOrderWithAdditionalHostsBaseTes
         old_host.modified_on = new_modified_on
         db.session.add(old_host)
 
-        self.added_hosts[added_host_index] = HostWrapper(old_host.to_json())
+        self.added_hosts[added_host_index] = HostWrapper(serialize_host(old_host))
 
     def _update_hosts(self, id_updates):
         # New modified_on value must be set explicitly so it’s saved the same to all

--- a/test_db_model.py
+++ b/test_db_model.py
@@ -2,6 +2,7 @@ import uuid
 
 from app import db
 from app.models import Host
+from app.serialization import deserialize_host
 
 """
 These tests are for testing the db model classes outside of the api.
@@ -28,7 +29,7 @@ def test_create_host_with_canonical_facts_as_None(flask_app_fixture):
 
     host_dict = {**invalid_canonical_facts, **valid_canonical_facts}
 
-    host = Host.from_json(host_dict)
+    host = deserialize_host(host_dict)
 
     assert valid_canonical_facts == host.canonical_facts
 

--- a/test_host_dedup_logic.py
+++ b/test_host_dedup_logic.py
@@ -2,9 +2,9 @@ import uuid
 
 from pytest import mark
 
-from api.host import find_existing_host
 from app import db
 from app.models import Host
+from lib.host_repository import find_existing_host
 
 
 ACCOUNT_NUMBER = "000102"

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 from base64 import b64encode
+from datetime import datetime
 from json import dumps
+from random import choice
 from unittest import main
 from unittest import TestCase
 from unittest.mock import Mock
 from unittest.mock import patch
+from uuid import uuid4
 
 from api import api_operation
 from api.host import _order_how
@@ -15,6 +18,15 @@ from app.auth.identity import Identity
 from app.auth.identity import SHARED_SECRET_ENV_VAR
 from app.auth.identity import validate
 from app.config import Config
+from app.exceptions import InputFormatException
+from app.models import Host
+from app.serialization import _deserialize_canonical_facts
+from app.serialization import _deserialize_facts
+from app.serialization import _serialize_facts
+from app.serialization import deserialize_host
+from app.serialization import serialize_canonical_facts
+from app.serialization import serialize_host
+from app.serialization import serialize_host_system_profile
 from test_utils import set_environment
 
 
@@ -318,6 +330,499 @@ class HostParamsToOrderByErrorsTestCase(TestCase):
     def test_order_by_only_how_raises_error(self):
         with self.assertRaises(ValueError):
             _params_to_order_by(Mock(), order_how="ASC")
+
+
+class SerializationDeserializeHostCompoundTestCase(TestCase):
+    def test_with_all_fields(self):
+        canonical_facts = {
+            "insights_id": str(uuid4()),
+            "rhel_machine_id": str(uuid4()),
+            "subscription_manager_id": str(uuid4()),
+            "satellite_id": str(uuid4()),
+            "bios_uuid": str(uuid4()),
+            "ip_addresses": ["10.10.0.1", "10.0.0.2"],
+            "fqdn": "some fqdn",
+            "mac_addresses": ["c2:00:d0:c8:61:01"],
+            "external_id": "i-05d2313e6b9a42b16",
+        }
+        unchanged_input = {
+            "display_name": "some display name",
+            "ansible_host": "some ansible host",
+            "account": "some account",
+        }
+        input = {
+            **canonical_facts,
+            **unchanged_input,
+            "facts": [
+                {"namespace": "some namespace", "facts": {"some key": "some value"}},
+                {"namespace": "another namespace", "facts": {"another key": "another value"}},
+            ],
+            "system_profile": {
+                "number_of_cpus": 1,
+                "number_of_sockets": 2,
+                "cores_per_socket": 3,
+                "system_memory_bytes": 4,
+            },
+        }
+
+        actual = deserialize_host(input)
+        expected = {
+            "canonical_facts": canonical_facts,
+            **unchanged_input,
+            "facts": {item["namespace"]: item["facts"] for item in input["facts"]},
+            "system_profile_facts": input["system_profile"],
+        }
+
+        self.assertIs(Host, type(actual))
+        for key, value in expected.items():
+            self.assertEqual(value, getattr(actual, key))
+
+    def test_with_only_required_fields(self):
+        canonical_facts = {"fqdn": "some fqdn"}
+        host = deserialize_host(canonical_facts)
+
+        self.assertIs(Host, type(host))
+        self.assertEqual(canonical_facts, host.canonical_facts)
+        self.assertIsNone(host.display_name)
+        self.assertIsNone(host.ansible_host)
+        self.assertIsNone(host.account)
+        self.assertEqual({}, host.facts)
+        self.assertEqual({}, host.system_profile_facts)
+
+
+@patch("app.serialization.Host")
+@patch("app.serialization._deserialize_facts")
+@patch("app.serialization._deserialize_canonical_facts")
+class SerializationDeserializeHostMockedTestCase(TestCase):
+    def test_with_all_fields(self, deserialize_canonical_facts, deserialize_facts, host):
+        input = {
+            "display_name": "some display name",
+            "ansible_host": "some ansible host",
+            "account": "some account",
+            "insights_id": str(uuid4()),
+            "rhel_machine_id": str(uuid4()),
+            "subscription_manager_id": str(uuid4()),
+            "satellite_id": str(uuid4()),
+            "bios_uuid": str(uuid4()),
+            "ip_addresses": ["10.10.0.1", "10.0.0.2"],
+            "fqdn": "some fqdn",
+            "mac_addresses": ["c2:00:d0:c8:61:01"],
+            "external_id": "i-05d2313e6b9a42b16",
+            "facts": {
+                "some namespace": {"some key": "some value"},
+                "another namespace": {"another key": "another value"},
+            },
+            "system_profile": {
+                "number_of_cpus": 1,
+                "number_of_sockets": 2,
+                "cores_per_socket": 3,
+                "system_memory_bytes": 4,
+            },
+        }
+
+        result = deserialize_host(input)
+        self.assertEqual(host.return_value, result)
+
+        deserialize_canonical_facts.assert_called_once_with(input)
+        deserialize_facts.assert_called_once_with(input["facts"])
+        host.assert_called_once_with(
+            deserialize_canonical_facts.return_value,
+            input["display_name"],
+            input["ansible_host"],
+            input["account"],
+            deserialize_facts.return_value,
+            input["system_profile"],
+        )
+
+    def test_without_facts(self, deserialize_canonical_facts, deserialize_facts, host):
+        input = {
+            "display_name": "some display name",
+            "ansible_host": "some ansible host",
+            "account": "some account",
+            "system_profile": {
+                "number_of_cpus": 1,
+                "number_of_sockets": 2,
+                "cores_per_socket": 3,
+                "system_memory_bytes": 4,
+            },
+        }
+
+        result = deserialize_host(input)
+        self.assertEqual(host.return_value, result)
+
+        deserialize_canonical_facts.assert_called_once_with(input)
+        deserialize_facts.assert_called_once_with(None)
+        host.assert_called_once_with(
+            deserialize_canonical_facts.return_value,
+            input["display_name"],
+            input["ansible_host"],
+            input["account"],
+            deserialize_facts.return_value,
+            input["system_profile"],
+        )
+
+    def test_without_display_name(self, deserialize_canonical_facts, deserialize_facts, host):
+        input = {
+            "ansible_host": "some ansible host",
+            "account": "some account",
+            "facts": {
+                "some namespace": {"some key": "some value"},
+                "another namespace": {"another key": "another value"},
+            },
+            "system_profile": {
+                "number_of_cpus": 1,
+                "number_of_sockets": 2,
+                "cores_per_socket": 3,
+                "system_memory_bytes": 4,
+            },
+        }
+
+        result = deserialize_host(input)
+        self.assertEqual(host.return_value, result)
+
+        deserialize_canonical_facts.assert_called_once_with(input)
+        deserialize_facts.assert_called_once_with(input["facts"])
+        host.assert_called_once_with(
+            deserialize_canonical_facts.return_value,
+            None,
+            input["ansible_host"],
+            input["account"],
+            deserialize_facts.return_value,
+            input["system_profile"],
+        )
+
+    def test_without_system_profile(self, deserialize_canonical_facts, deserialize_facts, host):
+        input = {
+            "display_name": "some display name",
+            "ansible_host": "some ansible host",
+            "account": "some account",
+            "facts": {
+                "some namespace": {"some key": "some value"},
+                "another namespace": {"another key": "another value"},
+            },
+        }
+
+        result = deserialize_host(input)
+        self.assertEqual(host.return_value, result)
+
+        deserialize_canonical_facts.assert_called_once_with(input)
+        deserialize_facts.assert_called_once_with(input["facts"])
+        host.assert_called_once_with(
+            deserialize_canonical_facts.return_value,
+            input["display_name"],
+            input["ansible_host"],
+            input["account"],
+            deserialize_facts.return_value,
+            {},
+        )
+
+
+class SerializationSerializeHostBaseTestCase(TestCase):
+    def _timestamp_to_str(self, timestamp):
+        formatted = timestamp.isoformat()
+        return f"{formatted}Z"
+
+
+class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseTestCase):
+    def test_with_all_fields(self):
+        canonical_facts = {
+            "insights_id": str(uuid4()),
+            "rhel_machine_id": str(uuid4()),
+            "subscription_manager_id": str(uuid4()),
+            "satellite_id": str(uuid4()),
+            "bios_uuid": str(uuid4()),
+            "ip_addresses": ["10.10.0.1", "10.0.0.2"],
+            "fqdn": "some fqdn",
+            "mac_addresses": ["c2:00:d0:c8:61:01"],
+            "external_id": "i-05d2313e6b9a42b16",
+        }
+        unchanged_data = {
+            "display_name": "some display name",
+            "ansible_host": "some ansible host",
+            "account": "some account",
+        }
+        host_init_data = {
+            "canonical_facts": canonical_facts,
+            **unchanged_data,
+            "facts": {
+                "some namespace": {"some key": "some value"},
+                "another namespace": {"another key": "another value"},
+            },
+        }
+        host = Host(**host_init_data)
+
+        host_attr_data = {"id": uuid4(), "created_on": datetime.utcnow(), "modified_on": datetime.utcnow()}
+        for k, v in host_attr_data.items():
+            setattr(host, k, v)
+
+        actual = serialize_host(host)
+        expected = {
+            **canonical_facts,
+            **unchanged_data,
+            "facts": [
+                {"namespace": namespace, "facts": facts} for namespace, facts in host_init_data["facts"].items()
+            ],
+            "id": str(host_attr_data["id"]),
+            "created": self._timestamp_to_str(host_attr_data["created_on"]),
+            "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
+        }
+        self.assertEqual(expected, actual)
+
+    def test_with_only_required_fields(self):
+        unchanged_data = {"display_name": None, "account": None}
+        host_init_data = {"canonical_facts": {"fqdn": "some fqdn"}, **unchanged_data, "facts": {}}
+        host = Host(**host_init_data)
+
+        host_attr_data = {"id": uuid4(), "created_on": datetime.utcnow(), "modified_on": datetime.utcnow()}
+        for k, v in host_attr_data.items():
+            setattr(host, k, v)
+
+        actual = serialize_host(host)
+        expected = {
+            **host_init_data["canonical_facts"],
+            "insights_id": None,
+            "rhel_machine_id": None,
+            "subscription_manager_id": None,
+            "satellite_id": None,
+            "bios_uuid": None,
+            "ip_addresses": None,
+            "mac_addresses": None,
+            "external_id": None,
+            "ansible_host": None,
+            **unchanged_data,
+            "facts": [],
+            "id": str(host_attr_data["id"]),
+            "created": self._timestamp_to_str(host_attr_data["created_on"]),
+            "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
+        }
+        self.assertEqual(expected, actual)
+
+
+@patch("app.serialization._serialize_facts")
+@patch("app.serialization.serialize_canonical_facts")
+class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTestCase):
+    def test_with_all_fields(self, serialize_canonical_facts, serialize_facts):
+        canonical_facts = {"insights_id": str(uuid4()), "fqdn": "some fqdn"}
+        serialize_canonical_facts.return_value = canonical_facts
+        facts = [
+            {"namespace": "some namespace", "facts": {"some key": "some value"}},
+            {"namespace": "another namespace", "facts": {"another key": "another value"}},
+        ]
+        serialize_facts.return_value = facts
+
+        unchanged_data = {
+            "display_name": "some display name",
+            "ansible_host": "some ansible host",
+            "account": "some account",
+        }
+        host_init_data = {"canonical_facts": canonical_facts, **unchanged_data, "facts": facts}
+        host = Host(**host_init_data)
+
+        host_attr_data = {"id": uuid4(), "created_on": datetime.utcnow(), "modified_on": datetime.utcnow()}
+        for k, v in host_attr_data.items():
+            setattr(host, k, v)
+
+        actual = serialize_host(host)
+        expected = {
+            **canonical_facts,
+            **unchanged_data,
+            "facts": serialize_facts.return_value,
+            "id": str(host_attr_data["id"]),
+            "created": self._timestamp_to_str(host_attr_data["created_on"]),
+            "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
+        }
+        self.assertEqual(expected, actual)
+
+        serialize_canonical_facts.assert_called_once_with(host_init_data["canonical_facts"])
+        serialize_facts.assert_called_once_with(host_init_data["facts"])
+
+
+class SerializationSerializeHostSystemProfileTestCase(TestCase):
+    def test_non_empty_profile_is_not_changed(self):
+        system_profile_facts = {
+            "number_of_cpus": 1,
+            "number_of_sockets": 2,
+            "cores_per_socket": 3,
+            "system_memory_bytes": 4,
+        }
+        host = Host(
+            canonical_facts={"fqdn": "some fqdn"},
+            display_name="some display name",
+            system_profile_facts=system_profile_facts,
+        )
+        host.id = uuid4()
+
+        actual = serialize_host_system_profile(host)
+        expected = {"id": str(host.id), "system_profile": system_profile_facts}
+        self.assertEqual(expected, actual)
+
+    def test_empty_profile_is_empty_dict(self):
+        host = Host(canonical_facts={"fqdn": "some fqdn"}, display_name="some display name")
+        host.id = uuid4()
+        host.system_profile_facts = None
+
+        actual = serialize_host_system_profile(host)
+        expected = {"id": str(host.id), "system_profile": {}}
+        self.assertEqual(expected, actual)
+
+
+class SerializationDeserializeCanonicalFactsTestCase(TestCase):
+    def _format_uuid_without_hyphens(self, uuid_):
+        return uuid_.hex
+
+    def _format_uuid_with_hyphens(self, uuid_):
+        return str(uuid_)
+
+    def _randomly_formatted_uuid(self, uuid_):
+        transformation = choice((self._format_uuid_without_hyphens, self._format_uuid_with_hyphens))
+        return transformation(uuid_)
+
+    def _randomly_formatted_sequence(self, seq):
+        transformation = choice((list, tuple))
+        return transformation(seq)
+
+    def test_values_are_stored_unchanged(self):
+        input = {
+            "insights_id": self._randomly_formatted_uuid(uuid4()),
+            "rhel_machine_id": self._randomly_formatted_uuid(uuid4()),
+            "subscription_manager_id": self._randomly_formatted_uuid(uuid4()),
+            "satellite_id": self._randomly_formatted_uuid(uuid4()),
+            "bios_uuid": self._randomly_formatted_uuid(uuid4()),
+            "ip_addresses": self._randomly_formatted_sequence(("10.10.0.1", "10.10.0.2")),
+            "fqdn": "some fqdn",
+            "mac_addresses": self._randomly_formatted_sequence(("c2:00:d0:c8:61:01",)),
+            "external_id": "i-05d2313e6b9a42b16",
+        }
+        result = _deserialize_canonical_facts(input)
+        self.assertEqual(result, input)
+
+    def test_unknown_fields_are_rejected(self):
+        canonical_facts = {
+            "insights_id": str(uuid4()),
+            "rhel_machine_id": str(uuid4()),
+            "subscription_manager_id": str(uuid4()),
+            "satellite_id": str(uuid4()),
+            "bios_uuid": str(uuid4()),
+            "ip_addresses": ("10.10.0.1", "10.10.0.2"),
+            "fqdn": "some fqdn",
+            "mac_addresses": ["c2:00:d0:c8:61:01"],
+            "external_id": "i-05d2313e6b9a42b16",
+        }
+        input = {**canonical_facts, "unknown": "something"}
+        result = _deserialize_canonical_facts(input)
+        self.assertEqual(result, canonical_facts)
+
+    def test_empty_fields_are_rejected(self):
+        canonical_facts = {"fqdn": "some fqdn"}
+        input = {
+            **canonical_facts,
+            "insights_id": "",
+            "rhel_machine_id": None,
+            "ip_addresses": [],
+            "mac_addresses": tuple(),
+        }
+        result = _deserialize_canonical_facts(input)
+        self.assertEqual(result, canonical_facts)
+
+
+class SerializationSerializeCanonicalFactsTestCase(TestCase):
+    def test_contains_all_values_unchanged(self):
+        canonical_facts = {
+            "insights_id": str(uuid4()),
+            "rhel_machine_id": str(uuid4()),
+            "subscription_manager_id": str(uuid4()),
+            "satellite_id": str(uuid4()),
+            "bios_uuid": str(uuid4()),
+            "ip_addresses": ("10.10.0.1", "10.10.0.2"),
+            "fqdn": "some fqdn",
+            "mac_addresses": ("c2:00:d0:c8:61:01",),
+            "external_id": "i-05d2313e6b9a42b16",
+        }
+        self.assertEqual(canonical_facts, serialize_canonical_facts(canonical_facts))
+
+    def test_missing_fields_are_filled_with_none(self):
+        canonical_fact_fields = (
+            "insights_id",
+            "rhel_machine_id",
+            "subscription_manager_id",
+            "satellite_id",
+            "bios_uuid",
+            "ip_addresses",
+            "fqdn",
+            "mac_addresses",
+            "external_id",
+        )
+        self.assertEqual({field: None for field in canonical_fact_fields}, serialize_canonical_facts({}))
+
+
+class SerializationDeserializeFactsTestCase(TestCase):
+    def test_non_empty_namespaces_become_dict_items(self):
+        input = [
+            {"namespace": "first namespace", "facts": {"first key": "first value", "second key": "second value"}},
+            {"namespace": "second namespace", "facts": {"third key": "third value"}},
+        ]
+        self.assertEqual({item["namespace"]: item["facts"] for item in input}, _deserialize_facts(input))
+
+    def test_empty_namespaces_remain_unchanged(self):
+        for empty_facts in ({}, None):
+            with self.subTest(empty_facts=empty_facts):
+                input = [
+                    {"namespace": "first namespace", "facts": {"first key": "first value"}},
+                    {"namespace": "second namespace", "facts": empty_facts},
+                ]
+                self.assertEqual({item["namespace"]: item["facts"] for item in input}, _deserialize_facts(input))
+
+    def test_duplicate_namespaces_are_merged(self):
+        input = [
+            {"namespace": "first namespace", "facts": {"first key": "first value", "second key": "second value"}},
+            {"namespace": "second namespace", "facts": {"third key": "third value"}},
+            {"namespace": "first namespace", "facts": {"first key": "fourth value"}},
+        ]
+        actual = _deserialize_facts(input)
+        expected = {
+            "first namespace": {"first key": "fourth value", "second key": "second value"},
+            "second namespace": {"third key": "third value"},
+        }
+        self.assertEqual(expected, actual)
+
+    def test_none_becomes_empty_dict(self):
+        self.assertEqual({}, _deserialize_facts(None))
+
+    def test_missing_key_raises_exception(self):
+        invalid_items = (
+            {"spacename": "second namespace", "facts": {"second key": "second value"}},
+            {"namespace": "second namespace", "fact": {"second key": "second value"}},
+            {"namespace": "second namespace"},
+            {},
+        )
+        for invalid_item in invalid_items:
+            with self.subTest(invalid_item=invalid_item):
+                input = [{"namespace": "first namespace", "facts": {"first key": "first value"}}, invalid_item]
+                with self.assertRaises(InputFormatException):
+                    _deserialize_facts(input)
+
+
+class SerializationSerializeFactsTestCase(TestCase):
+    def test_empty_dict_becomes_empty_list(self):
+        self.assertEqual([], _serialize_facts({}))
+
+    def test_non_empty_namespaces_become_list_of_dicts(self):
+        facts = {
+            "first namespace": {"first key": "first value", "second key": "second value"},
+            "second namespace": {"third key": "third value"},
+        }
+        self.assertEqual(
+            [{"namespace": namespace, "facts": facts} for namespace, facts in facts.items()], _serialize_facts(facts)
+        )
+
+    def test_empty_namespaces_have_facts_as_empty_dicts(self):
+        for empty_value in {}, None:
+            with self.subTest(empty_value=empty_value):
+                facts = {"first namespace": empty_value, "second namespace": {"first key": "first value"}}
+                self.assertEqual(
+                    [{"namespace": namespace, "facts": facts or {}} for namespace, facts in facts.items()],
+                    _serialize_facts(facts),
+                )
 
 
 if __name__ == "__main__":

--- a/utils/kafka_consumer.py
+++ b/utils/kafka_consumer.py
@@ -1,0 +1,36 @@
+import json
+import logging
+import os
+
+from kafka import KafkaConsumer
+
+# from app.models import Host, SystemProfileSchema
+
+
+TOPIC = os.environ.get("KAFKA_TOPIC", "platform.inventory.host-egress")
+KAFKA_GROUP = os.environ.get("KAFKA_GROUP", "inventory-mq")
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
+
+
+def msg_handler(parsed):
+    print("inside msg_handler()")
+    print("type(parsed):", type(parsed))
+    print("parsed:", parsed)
+    # id_ = parsed["id"]
+    # profile = SystemProfileSchema(strict=True).load(parsed["system_profile"])
+    # host = Host.query.get(id_)
+    # host._update_system_profile(profile)
+    # host.save()
+
+
+consumer = KafkaConsumer(TOPIC, group_id=KAFKA_GROUP, bootstrap_servers=BOOTSTRAP_SERVERS)
+
+logging.basicConfig(level=logging.INFO)
+
+print("TOPIC:", TOPIC)
+print("KAFKA_GROUP:", KAFKA_GROUP)
+print("BOOTSTRAP_SERVERS:", BOOTSTRAP_SERVERS)
+
+for msg in consumer:
+    print("calling msg_handler()")
+    msg_handler(json.loads(msg.value))

--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -1,0 +1,33 @@
+import logging
+import os
+import time
+
+import payloads
+from kafka import KafkaProducer
+
+logging.basicConfig(level=logging.INFO)
+
+TOPIC = os.environ.get("KAFKA_TOPIC")
+KAFKA_GROUP = os.environ.get("KAFKA_GROUP", "inventory")
+BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
+
+# payload = payloads.build_chunk()
+
+# Create list of host payloads to add to the message queue
+# payloads.build_payloads takes two optional args: number of hosts, and payload type ("default", "rhsm", "qpc")
+start = time.time()
+all_payloads = payloads.build_mq_payloads()  # pass in the number of hosts you'd like to send (defaults to 1)
+end = time.time()
+print("time elapsed to build payloads: ", end - start)
+print("Number of hosts (payloads): ", len(all_payloads))
+
+producer = KafkaProducer(bootstrap_servers=BOOTSTRAP_SERVERS, api_version=(0, 10))
+print("TOPIC:", TOPIC)
+
+start = time.time()
+for payload in all_payloads:
+    producer.send(TOPIC, value=payload)
+end = time.time()
+print("Time to send all hosts to queue: ", end - start)
+
+time.sleep(2)

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -1,0 +1,207 @@
+import json
+import subprocess
+import uuid
+
+
+rpm_list = subprocess.getoutput("rpm -qa").split("\n")
+print("len(rpm_list):", len(rpm_list))
+# print("rpm_list:", rpm_list)
+
+
+def create_system_profile():
+    return {
+        "number_of_cpus": 1,
+        "number_of_sockets": 2,
+        "cores_per_socket": 4,
+        "system_memory_bytes": 1024,
+        "infrastructure_type": "jingleheimer junction cpu",
+        "infrastructure_vendor": "dell",
+        "network_interfaces": [
+            {
+                "ipv4_addresses": ["10.10.10.1"],
+                "state": "UP",
+                "ipv6_addresses": ["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
+                "mtu": 1500,
+                "mac_address": "aa:bb:cc:dd:ee:ff",
+                "type": "loopback",
+                "name": "eth0",
+            }
+        ],
+        "disk_devices": [
+            {
+                "device": "/dev/sdb1",
+                "label": "home drive",
+                "options": {"uid": "0", "ro": True},
+                "mount_point": "/home",
+                "type": "ext3",
+            }
+        ],
+        "bios_vendor": "Turd Ferguson",
+        "bios_version": "1.0.0uhoh",
+        "bios_release_date": "10/31/2013",
+        "cpu_flags": ["flag1", "flag2"],
+        "os_release": "Red Hat EL 7.0.1",
+        "os_kernel_version": "Linux 2.0.1",
+        "arch": "x86-64",
+        "last_boot_time": "12:25 Mar 19, 2019",
+        "kernel_modules": ["i915", "e1000e"],
+        "running_processes": ["vim", "gcc", "python"],
+        "subscription_status": "valid",
+        "subscription_auto_attach": "yes",
+        "katello_agent_running": False,
+        "satellite_managed": False,
+        "yum_repos": [{"name": "repo1", "gpgcheck": True, "enabled": True, "base_url": "http://rpms.redhat.com"}],
+        "installed_products": [
+            {"name": "eap", "id": "123", "status": "UP"},
+            {"name": "jbws", "id": "321", "status": "DOWN"},
+        ],
+        "insights_client_version": "12.0.12",
+        "insights_egg_version": "120.0.1",
+        # "installed_packages": ["rpm1", "rpm2"],
+        # "installed_packages": subprocess.getoutput("rpm -qa").split("\n"),
+        # "installed_packages": rpm_list,
+        "installed_services": ["ndb", "krb5"],
+        "enabled_services": ["ndb", "krb5"],
+    }
+
+
+rhsm_payload = {
+    "account": "939054",
+    "bios_uuid": "e56890e3-9ce5-4fb2-b677-3d84e3e4d4a9",
+    "facts": [
+        {
+            "facts": {
+                "ARCHITECTURE": "x86_64",
+                "CPU_CORES": 4,
+                "CPU_SOCKETS": 4,
+                "IS_VIRTUAL": True,
+                "MEMORY": 8,
+                "RH_PROD": ["69", "408", "290"],
+                "SYNC_TIMESTAMP": "2019-08-08T16:32:40.355-04:00",
+                "orgId": "5389686",
+            },
+            "namespace": "rhsm",
+        }
+    ],
+    "fqdn": "node01.ose.skunkfu.org",
+    "ip_addresses": [
+        "fe80::46:6bff:fe06:c0f0",
+        "10.129.0.1",
+        "172.16.10.118",
+        "172.17.0.1",
+        "fe80::a443:aa45:96ff:2f00",
+        "127.0.0.1",
+    ],
+    "mac_addresses": [
+        "5A:3D:18:47:EB:44",
+        "02:42:B0:F1:FD:01",
+        "52:54:00:CD:65:84",
+        "BE:FE:93:D1:A8:20",
+        "02:46:6B:06:C0:F0",
+        "D6:58:86:AA:AA:40",
+    ],
+    "subscription_manager_id": "77ecf4c6-ab06-405c-844c-d815973de7f2",
+}
+
+
+qpc_payload = {
+    "display_name": "dhcp-8-29-119.lab.eng.rdu2.redhat.com",
+    "bios_uuid": "7E681E42-FCBE-2831-E9E2-78983C7FA869",
+    "ip_addresses": ["10.8.29.119"],
+    "mac_addresses": ["00:50:56:9e:bb:eb"],
+    "insights_id": "137c9d58-941c-4bb9-9426-7879a367c23b",
+    "subscription_manager_id": "7E681E42-FCBE-2831-E9E2-78983C7FA869",
+    "rhel_machine_id": "e2c9d65ad21c4c7092ffb97a2ca744f3",
+    "fqdn": "dhcp-8-29-119.lab.eng.rdu2.redhat.com",
+    "facts": [
+        {
+            "namespace": "qpc",
+            "facts": {
+                "rh_product_certs": [],
+                "rh_products_installed": ["RHEL", "EAP", "DCSM", "JWS", "FUSE"],
+                "last_reported": "2019-08-08T15:22:38.345587",
+                "source_types": ["network"],
+            },
+        }
+    ],
+    "system_profile": {
+        "infrastructure_type": "virtualized",
+        "arch": "x86_64",
+        "os_release": "Red Hat Enterprise Linux Server release 7.5 (Maipo)",
+        "os_kernel_version": "7.5 (Maipo)",
+        "number_of_cpus": 2,
+        "number_of_sockets": 2,
+        "cores_per_socket": 1,
+    },
+}
+
+
+system_profile = create_system_profile()
+
+
+# host_id = str(uuid.uuid4())
+host_id = "1d518fdd-341d-4286-803b-2507ca046a94"
+
+
+account_number = "0000001"
+fqdn = "fred.flintstone.com"
+domainnames = ["domain1", "domain2", "domain3", "domain4", "domain5"]
+hostnames1 = ["apple", "pear", "orange", "banana", "apricot", "grape"]
+hostnames2 = ["coke", "pepsi", "drpepper", "mrpib", "sprite", "7up", "unsweettea", "sweettea"]
+
+
+metadata_dict = {"request_id": str(uuid.uuid4()), "archive_url": "http://s3.aws.com/redhat/insights/1234567"}
+
+
+def build_host_chunk():
+    payload = {
+        "account": account_number,
+        "insights_id": str(uuid.uuid4()),
+        "bios_uuid": str(uuid.uuid4()),
+        "fqdn": fqdn,
+        "display_name": fqdn,
+        # "ip_addresses": None,
+        # "ip_addresses": ["1",],
+        # "mac_addresses": None,
+        "subscription_manager_id": str(uuid.uuid4()),
+        "system_profile": create_system_profile(),
+    }
+    return payload
+
+
+def build_chunk():
+    payload = {
+        "id": host_id,
+        # "system_profile": create_system_profile(),
+        "system_profile": {},
+    }
+    return payload
+
+
+def build_data(payload_type):
+    if payload_type == "default":
+        return build_host_chunk()
+    elif payload_type == "rhsm":
+        return rhsm_payload
+    elif payload_type == "qpc":
+        return qpc_payload
+
+
+def build_mq_payloads(num_hosts=1, payload_type="default"):
+    all_payloads = []
+    for _ in range(num_hosts):
+        all_payloads.append(
+            str.encode(
+                json.dumps(
+                    {"operation": "add_host", "platform_metadata": metadata_dict, "data": build_data(payload_type)}
+                )
+            )
+        )
+    return all_payloads
+
+
+def build_http_payloads(num_hosts=1, payload_type="default"):  # FIXME: Could combine with the above method?
+    all_payloads = []
+    for _ in range(num_hosts):
+        all_payloads.append(build_data(payload_type))
+    return all_payloads

--- a/utils/rest_producer.py
+++ b/utils/rest_producer.py
@@ -1,0 +1,40 @@
+import base64
+import json
+
+import payloads
+import requests
+
+# URL = "http://localhost:8080/r/insights/platform/inventory/api/v1/hosts" # LEGACY
+URL = "http://localhost:8080/api/inventory/v1/hosts"
+
+account_number = "0000001"
+
+bulk_insert = False
+
+headers = {"Content-type": "application/json", "x-rh-insights-request-id": "654321"}
+
+# headers["Authorization"] = "Bearer secret"
+# headers["Authorization"] = "Bearer 023e4f11185e4c17478bb9c6750d3068eeebe85b"
+
+identity = {"identity": {"account_number": account_number}}
+headers["x-rh-identity"] = base64.b64encode(json.dumps(identity).encode())
+
+
+def main():
+    all_payloads = payloads.build_http_payloads()
+
+    if bulk_insert:
+        r = requests.post(URL, data=json.dumps(all_payloads), headers=headers)
+        # print("response:", r.text)
+        print("status_code", r.status_code)
+        # print("test:", r.headers)
+    else:
+        for payload in all_payloads:
+            r = requests.post(URL, data=json.dumps([payload]), headers=headers)
+            # print("response:", r.text)
+            print("status_code", r.status_code)
+            # print("test:", r.headers)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* POC for splitting up the inventory service

Adding a kafka producer script for testing

Start kafka and db using:  docker-compose -f dev.yml up
Run the service using: make run_inv_mq_service
Run the kafka producer script using: make run_inv_mq_service_test

* Start the web service using make

* Adding a kafka based host producer for testing

* Getting app.logging wired into the new inv_mq_service (#311)

* Getting app.logging wired into the new inv_mq_service
* Moved logging messages to config. Refactored threadctx initialization into method.

* Tweaked the order of the db/kafka configuration log messages

* Renamed the host ingress kafka topic env vars to match the others

* Adding a new entry to logconfig.ini to enable logging for anything in the lib directory.

* Add a mq service_specific kafka consumer group

* Allow the "tasks" (threads, system profile kafka consumers, delete host event kafka producers)
to be disabled.  The tasks stuff should likely be injected in.

* Define the add_host operation message

* Do not start the tasks subsystem unless explicitly asked to

* Document mq service topic and message (#320)

* Start documenting the new message queue data format and topic

* Updating kafka topic name (#321)

* Updated host-ingress kafka topic name in README

* Fix test after merging in changes from master

* Move the metrics around.  Add the metrics back to the add_host logic.

* Removed extra while loop

* Do not process the message if it cannot be parsed

* Log the json message that failed to parse

* Handle errors a bit more robustly

* Add more info to the Makefile

* Extract host (de)serialization

Created a new module app.serialization. Extracted all Host serialization
and deserialization logic into that module. Used the existing paradigm
from CanonicalFacts and Facts classes for the Host itself too. All the
logic and behavior remained unchanged.

* Test host (de)serializaton

Added tests for the from_json and to_json of the Host, CanonicalFacts
and Facts classes. For the Host methods there are two sets of tests: one
that mocks the internal calls and one compound that tests these three
models as a one unit.

* Initial commit to refactor message parsing into separate module.

* Added new logging exception to hide marshmallow implementation.

* Slightly cleaner exception handling for handle_message

* Renamed mq_parser to app/queue/ingress.py. Removed error handling from handle_message()

* Minor tweaks to the exception handling

* Fix some tests that broke due to moving code around

* Fix host deserialization tests

Host deserialization tests didn’t survive merging. After extracting the
(de)serialization methods from app.models.Host, the new
app.serialization.Host methods don’t create instances of the declaring
class. That makes the tests simpler as there is no more need for the
constructor shenanigans. Fixed, simplified.

* Rename serialization tests

The (de)serialization classes and functions have been moved to the
app.serialization module. Renamed the related tests so they reflect this
change.

* Adding prometheus metrics to inv_mq_service

* Moving parsing logic into same function. Adding failure counters.

* Adding new metrics

* Export version (#368)

* Using prometheus to export build version

* newline

* Moving version_info metric call to metrics.py

* Moving more code to ingress. Renaming host.py to host_repository.

* I gotta learn to read

* test error

* Modify the Host.update() method so that updating the system profile is optional. (#378)

Modify the Host.update() method so that updating the system profile is
optional.  This is a hack but its required at the moment.  The MQ
service needs to update the system profile when updating a host.  The
REST web service doesn't need to update the system profile when updating
a host.

* Rename serialization tests

Renamed the remaining tests that still had the models module name in its
name. These tests describe functions in the serialization module and
other tests follow this naming too. Unified.

* Adding metadata field to the ingress data format
The request_id will be pulled from the metadata.

* Modify the MQ based inventory service to write events to the message queue (#379)

* Initial pass at egress implementation

* Print the egress kafka topic during startup

* Fixed a field name mix-up

* Re-raise an exception so the error is handled better

* Removed some unused variables

* Using black to format the code

* Fix pre-commit violations

Fix all pre-commit hooks violations introduced in the
split_inventory_service branch. This will allow to use the pre-commit
hooks when working on this branch.

* Extract (de)serialization methods

Moved all the Host, CanonicalFacts and Facts (de)serialization methods
from the classes to bare functions. The CanonicalFacts and Facts were
mere containers for static methods. The Host is a database model, which
should not be concerned about serialization.

The new bare methods can be easily extracted to a separate module. They
have unified naming including the argument names.

* Minor message processing cleanup

* Rename metadata to platform_metadata

* Update the README

* Modified the operation schema to make the operation and data fields required

* Add more info to the error message that is logged when the operation message fails validation

* Use "localhost" for the kafka hostname instead of "kafka".  This should
work when testing locally using docker-compose.

* Refactoring payload building out of kafka_producer, and making it really easy to send multiple payloads (#401)

* Rename metadata to platform_metadata

* Reformatted using black

* Fixed an issue where the egress message was getting json encoded twice

* Removed the facts and system_profile from the HostEvent schema as they are not used yet.

* Adding a simple script to hit the rest interface

* Left in 180000 hosts as default..

* Adding requested metric to ingress.py

* updating the event handler to handle db disconnects

Adding db_context_manager to handle db disconnects

* Make serialize_canonical_facts a public method

* Payload tracker integration with the MQ service
RHCLOUD-1904

* Merge master into split_inventory_service (#488)

* pin pipeline lib to previous stable version 1.3
recently there was some change to Jenkins shared pipeline lib a.k.a insights-pipeline that is causing some errors on inventory-smoke job. Temporally pinning this to the previous version till they get it stable again.
more info: https://github.com/RedHatInsights/insights-pipeline-lib/pull/40

* Move MockEmitEvent to class level

Having a class in a function is not necessary here. It just causes
Python to redeclare it every time the function is run instead of on the
class parse.

* Pass unformatted timestamp

DRY timestamp formatting. Pass it unformatted and call the isoformat
method right at the place where the other formatting happens.

* Check the host presence on the first GET

A GET request is currently done before deleting records. This request is
rather useless though, because 200 OK is returned even if no hosts are
found. Added an assert verifying that the host is actually found in the
database.

* Setting insights-pipeline-lib version due breaking changes

* Replace Mock.new with new_callable

unittest.Mock can use a callable (including a class constructor) to
create the mock. This is actually better than passing a manually created
class instance as we are sure that the instance is not shared anywhere.
Use as much from the Mock capabilities as possible.

* Pass host to the common test method

The shared _create_then_delete_host test method validates a host ID in
an emitted event, but it gets the delete URL determining the hosts to
delete from outside as an argument. Added a host argument to unify this.

* Split the delete tests class into three

The DeleteHostsTestCase class contains sets of rather unrelated tests.

- The race condition tests with a special interceptor class.
- The event tests with a special mock class.
- The invalid query tests that don’t require pre-created hosts.

Split into three separate classes.

* DOC: update README (#469)

* Dissect the delete event test

Split the common _create_then_delete_host method into smaller chunks.
This makes the tests more readable as the chunks are small and named. It
will also make it easier to completely get rid of the common method
without repeating too much logic.

* Added request_id test (#419)

Added the additional request_id test and query.all() in host.py.

* Extract datetime patching to setUp (#481)

Moved datetime return value patch to the shared _delete method and
timestamp to setUp. That gets us rid of passing around the timestamp and
digging it out of the mock.

* Extract host ID to the setUp method (#479)

Simplify tests by leveraging the setUp method. Extracted the host ID
there.

* Do not check request ID in every test (#474)

Check request ID only in request ID tests. This removes no request ID
test duplication and make the tests a little bit more atomic.

* Extract URL to the setUp method (#480)

Build the URL in the setUp method, so it’s not necessary to build it in
every test case and pass it around.

* Compose request ID header in tests (#476)

Move the request ID header composition from the DELETE method to the
request ID tests. Like this, the logic is at a more appropriate place.

* Remove the common test method (#475)

Remove the universal test method and call the stuff from its body
directly. Like this the tests are more straightforward.

* README - minor fixes (#472)

* Add ORDER BY id DESC to queries

To ensure unambiguous record ordering, oder by modified_on is not
enough. Order by primary key must be there so the same order is really
guaranteed. Added this ORDER BY clause to the host queries.

* Clean up the unittest imports

There were some unittest modules and submodules imports in test_api, but
they were used quite chaotically. Cleaned that up by always importing
and using the specific methods.

* DRY the invalid pagination parameter test

Wherever PaginationTestCase._base_paging_test is used, there is a query
that must accept valid pagination parameters and reject invalid ones.
Extracted the invalid pagination parameter test to PaginationTestCase
and used it in all places alongside _base_paging_test. This makes tests
more consistent.

* Fix two failing tests.

* Split inventory service merge – part two (#491)

* pin pipeline lib to previous stable version 1.3
recently there was some change to Jenkins shared pipeline lib a.k.a insights-pipeline that is causing some errors on inventory-smoke job. Temporally pinning this to the previous version till they get it stable again.
more info: https://github.com/RedHatInsights/insights-pipeline-lib/pull/40

* Move MockEmitEvent to class level

Having a class in a function is not necessary here. It just causes
Python to redeclare it every time the function is run instead of on the
class parse.

* Pass unformatted timestamp

DRY timestamp formatting. Pass it unformatted and call the isoformat
method right at the place where the other formatting happens.

* Check the host presence on the first GET

A GET request is currently done before deleting records. This request is
rather useless though, because 200 OK is returned even if no hosts are
found. Added an assert verifying that the host is actually found in the
database.

* Setting insights-pipeline-lib version due breaking changes

* Replace Mock.new with new_callable

unittest.Mock can use a callable (including a class constructor) to
create the mock. This is actually better than passing a manually created
class instance as we are sure that the instance is not shared anywhere.
Use as much from the Mock capabilities as possible.

* Pass host to the common test method

The shared _create_then_delete_host test method validates a host ID in
an emitted event, but it gets the delete URL determining the hosts to
delete from outside as an argument. Added a host argument to unify this.

* Split the delete tests class into three

The DeleteHostsTestCase class contains sets of rather unrelated tests.

- The race condition tests with a special interceptor class.
- The event tests with a special mock class.
- The invalid query tests that don’t require pre-created hosts.

Split into three separate classes.

* DOC: update README (#469)

* Dissect the delete event test

Split the common _create_then_delete_host method into smaller chunks.
This makes the tests more readable as the chunks are small and named. It
will also make it easier to completely get rid of the common method
without repeating too much logic.

* Added request_id test (#419)

Added the additional request_id test and query.all() in host.py.

* Extract datetime patching to setUp (#481)

Moved datetime return value patch to the shared _delete method and
timestamp to setUp. That gets us rid of passing around the timestamp and
digging it out of the mock.

* Extract host ID to the setUp method (#479)

Simplify tests by leveraging the setUp method. Extracted the host ID
there.

* Do not check request ID in every test (#474)

Check request ID only in request ID tests. This removes no request ID
test duplication and make the tests a little bit more atomic.

* Extract URL to the setUp method (#480)

Build the URL in the setUp method, so it’s not necessary to build it in
every test case and pass it around.

* Compose request ID header in tests (#476)

Move the request ID header composition from the DELETE method to the
request ID tests. Like this, the logic is at a more appropriate place.

* Remove the common test method (#475)

Remove the universal test method and call the stuff from its body
directly. Like this the tests are more straightforward.

* README - minor fixes (#472)

* Add ORDER BY id DESC to queries

To ensure unambiguous record ordering, oder by modified_on is not
enough. Order by primary key must be there so the same order is really
guaranteed. Added this ORDER BY clause to the host queries.

* Clean up the unittest imports

There were some unittest modules and submodules imports in test_api, but
they were used quite chaotically. Cleaned that up by always importing
and using the specific methods.

* DRY the invalid pagination parameter test

Wherever PaginationTestCase._base_paging_test is used, there is a query
that must accept valid pagination parameters and reject invalid ones.
Extracted the invalid pagination parameter test to PaginationTestCase
and used it in all places alongside _base_paging_test. This makes tests
more consistent.