### PR TITLE
Add tags regression test

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1686,6 +1686,17 @@ class QueryByTagTestCase(PreCreatedHostsBaseTestCase, PaginationBaseTestCase):
 
         self._compare_responses(expected_response_list, response_list, test_url)
 
+    def test_get_no_host_with_different_tags_same_namespace(self):
+        """
+        Don’t get a host with two tags in the same namespace, from which only one match. This is a
+        regression test.
+        """
+        test_url = f"{HOST_URL}?tags=NS1/key1=val2,NS1/key2=val1"
+        response_list = self.get(test_url, 200)
+
+        # self.added_hosts[0] would have been matched by NS1/key2=val1, this must not happen.
+        self.assertEqual(0, len(response_list["results"]))
+
     def test_get_host_with_same_tags_different_namespaces(self):
         """
         get a host with two tags in the same namespace with diffent key and same value


### PR DESCRIPTION
Added a [test](https://github.com/Glutexo/insights-host-inventory/blob/be9ebf4a2c3f81d85e4fa97d874548dc50955d6f/test_api.py#L1689) for a case when hosts are queried by more tags in a single namespace. Like that hosts with only the last tag in the query would be matched even though they wouldn’t possess the other tags in the namespace. This tests verifies that the bug is no longer present.

Example:

A host has tags _NS1/key1=val1_ and _NS1/key2=val1_. We query hosts with tags _NS1/key1=val2_ and _NS1/key2=val1_. Only the last tag in the _NS1_ namespace was actually used and as a result, the hosts was matched by only _NS1/key2=val1_ even though it doesn’t have the _NS1/key1=val2_ tag.

Steps to reproduce:

1. In [_api/host.py:_tags_host_query_](https://github.com/Glutexo/insights-host-inventory/blob/be9ebf4a2c3f81d85e4fa97d874548dc50955d6f/api/host.py#L160), replace the query building snippet from

```python
if namespace in tags_to_find:
    if key in tags_to_find[namespace]:
        tags_to_find[namespace][key].append(value)
    else:
        tags_to_find[namespace][key] = [value]
else:
    tags_to_find[namespace] = {key: [value]}
```

to

```
tags_to_find[namespace] = {key: [value]}
```

which was there before a fix was introduced.

2. Run the [API tests](https://github.com/Glutexo/insights-host-inventory/blob/be9ebf4a2c3f81d85e4fa97d874548dc50955d6f/api/host.py) and see that the new [test](https://github.com/Glutexo/insights-host-inventory/blob/be9ebf4a2c3f81d85e4fa97d874548dc50955d6f/test_api.py#L1689) fails, but other [tests](https://github.com/Glutexo/insights-host-inventory/blob/be9ebf4a2c3f81d85e4fa97d874548dc50955d6f/test_api.py#L1614) don’t. 🍎

3. Revert the code to its current state and see that all tests are green. 🍏