### PR TITLE
improve MQ service metrics

### DIFF
--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -61,17 +61,17 @@ def add_host(host_data):
         try:
             logger.info("Attempting to add host...")
             (output_host, add_results) = host_repository.add_host(host_data)
-            metrics.add_host_success.inc()
+            metrics.add_host_success.labels(add_results.name).inc()  # created vs updated
             logger.info("Host added")  # This definitely needs to be more specific (added vs updated?)
             payload_tracker_processing_ctx.inventory_id = output_host["id"]
             return (output_host, add_results)
         except InventoryException:
             logger.exception("Error adding host ", extra={"host": host_data})
-            metrics.add_host_failure.inc()
+            metrics.add_host_failure.labels("InventoryException").inc()
             raise
         except Exception:
             logger.exception("Error while adding host", extra={"host": host_data})
-            metrics.add_host_failure.inc()
+            metrics.add_host_failure.labels("Exception").inc()
             raise
 
 

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -10,8 +10,10 @@ ingress_message_parsing_time = Summary(
 ingress_message_parsing_failure = Counter(
     "inventory_ingress_message_parsing_failures", "Total amount of failures parsing ingress messages"
 )
-add_host_success = Counter("inventory_ingress_add_host_successes", "Total amount of successfully added hosts")
-add_host_failure = Counter("inventory_ingress_add_host_failures", "Total amount of failures adding hosts")
+add_host_success = Counter(
+    "inventory_ingress_add_host_successes", "Total amount of successfully added hosts", ["result"]
+)
+add_host_failure = Counter("inventory_ingress_add_host_failures", "Total amount of failures adding hosts", ["cause"])
 ingress_message_handler_success = Counter(
     "inventory_ingress_message_handler_successes",
     "Total amount of successfully handled messages from the ingress queue",


### PR DESCRIPTION
uses labels to distinguish between
* message_handler failures caused by payload failing schema validation vs other errors
* "host added" vs "host updated" events

https://projects.engineering.redhat.com/browse/RHCLOUD-2880