### PR TITLE
Validate hosts when deserializing

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -22,6 +22,7 @@ from app.models import PatchHostSchema
 from app.payload_tracker import get_payload_tracker
 from app.payload_tracker import PayloadTrackerContext
 from app.payload_tracker import PayloadTrackerProcessingContext
+from app.serialization import deserialize_host
 from app.serialization import serialize_host
 from app.serialization import serialize_host_system_profile
 from lib.host_repository import _canonical_facts_host_query
@@ -51,10 +52,11 @@ def add_host_list(host_list):
                 with PayloadTrackerProcessingContext(
                     payload_tracker, processing_status_message="adding/updating host"
                 ) as payload_tracker_processing_ctx:
-                    (host, add_result) = _add_host(host)
+                    input_host = deserialize_host(host)
+                    (output_host, add_result) = _add_host(input_host)
                     status_code = _convert_host_results_to_http_status(add_result)
-                    response_host_list.append({"status": status_code, "host": host})
-                    payload_tracker_processing_ctx.inventory_id = host["id"]
+                    response_host_list.append({"status": status_code, "host": output_host})
+                    payload_tracker_processing_ctx.inventory_id = output_host["id"]
             except ValidationException as e:
                 number_of_errors += 1
                 logger.exception("Input validation error while adding host", extra={"host": host})
@@ -88,7 +90,7 @@ def _convert_host_results_to_http_status(result):
 
 
 def _add_host(input_host):
-    if not current_identity.is_trusted_system and current_identity.account_number != input_host["account"]:
+    if not current_identity.is_trusted_system and current_identity.account_number != input_host.account:
         raise InventoryException(
             title="Invalid request",
             detail="The account number associated with the user does not match the account number associated with the "

--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -12,6 +12,7 @@ from app.payload_tracker import PayloadTrackerContext
 from app.payload_tracker import PayloadTrackerProcessingContext
 from app.queue import metrics
 from app.queue.egress import build_event
+from app.serialization import deserialize_host
 from lib import host_repository
 
 
@@ -60,7 +61,8 @@ def add_host(host_data):
 
         try:
             logger.info("Attempting to add host...")
-            (output_host, add_results) = host_repository.add_host(host_data)
+            input_host = deserialize_host(host_data)
+            (output_host, add_results) = host_repository.add_host(input_host)
             metrics.add_host_success.labels(add_results.name).inc()  # created vs updated
             logger.info("Host added")  # This definitely needs to be more specific (added vs updated?)
             payload_tracker_processing_ctx.inventory_id = output_host["id"]

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -1,14 +1,9 @@
 from enum import Enum
 
-from marshmallow import ValidationError
-
-from app.exceptions import ValidationException
 from app.logging import get_logger
 from app.models import db
 from app.models import db_session_guard
 from app.models import Host
-from app.models import HostSchema
-from app.serialization import deserialize_host
 from app.serialization import serialize_host
 from lib import metrics
 
@@ -25,7 +20,7 @@ ELEVATED_CANONICAL_FACT_FIELDS = ("insights_id", "subscription_manager_id")
 logger = get_logger(__name__)
 
 
-def add_host(host, update_system_profile=True):
+def add_host(input_host, update_system_profile=True):
     """
     Add or update a host
 
@@ -33,12 +28,6 @@ def add_host(host, update_system_profile=True):
      - at least one of the canonical facts fields is required
      - account number
     """
-    try:
-        validated_input_host_dict = HostSchema(strict=True).load(host)
-    except ValidationError as e:
-        raise ValidationException(str(e.messages)) from None
-
-    input_host = deserialize_host(validated_input_host_dict.data)
 
     with db_session_guard():
         existing_host = find_existing_host(input_host.account, input_host.canonical_facts)

--- a/test_api.py
+++ b/test_api.py
@@ -48,18 +48,22 @@ def generate_uuid():
     return str(uuid.uuid4())
 
 
-def test_data(display_name="hi", facts=None):
-    return {
+def test_data(**values):
+    data = {
         "account": ACCOUNT,
-        "display_name": display_name,
+        "display_name": "hi",
         # "insights_id": "1234-56-789",
         # "rhel_machine_id": "1234-56-789",
         # "ip_addresses": ["10.10.0.1", "10.0.0.2"],
         "ip_addresses": ["10.10.0.1"],
         # "mac_addresses": ["c2:00:d0:c8:61:01"],
         # "external_id": "i-05d2313e6b9a42b16"
-        "facts": facts if facts else FACTS,
+        "facts": None,
+        **values,
     }
+    if not data["facts"]:
+        data["facts"] = FACTS
+    return data
 
 
 def build_auth_header(token):
@@ -413,7 +417,27 @@ class CreateHostsTestCase(DBAPITestCase):
 
         response_data = self.post(HOST_URL, [host_data.data()], 400)
 
-        self.verify_error_response(response_data, expected_title="Bad Request")
+        self.verify_error_response(
+            response_data, expected_title="Bad Request", expected_detail="'account' is a required property"
+        )
+
+    def test_create_host_with_invalid_account(self):
+        accounts = ("", "someaccount")
+        for account in accounts:
+            with self.subTest(account=account):
+                host_data = HostWrapper(test_data(account=account, facts=None))
+
+                response_data = self.post(HOST_URL, [host_data.data()], 207)
+
+                self._verify_host_status(response_data, 0, 400)
+
+                response_data = response_data["data"][0]
+
+                self.verify_error_response(
+                    response_data,
+                    expected_title="Bad Request",
+                    expected_detail="{'account': ['Length must be between 1 and 10.']}",
+                )
 
     def test_create_host_with_mismatched_account_numbers(self):
         host_data = HostWrapper(test_data(facts=None))
@@ -425,7 +449,12 @@ class CreateHostsTestCase(DBAPITestCase):
 
         response_data = response_data["data"][0]
 
-        self.verify_error_response(response_data, expected_title="Invalid request")
+        self.verify_error_response(
+            response_data,
+            expected_title="Invalid request",
+            expected_detail="The account number associated with the user does not match the account number associated "
+            "with the host",
+        )
 
     def test_create_host_with_invalid_facts(self):
         facts_with_no_namespace = copy.deepcopy(FACTS)

--- a/test_db_model.py
+++ b/test_db_model.py
@@ -2,7 +2,6 @@ import uuid
 
 from app import db
 from app.models import Host
-from app.serialization import deserialize_host
 
 """
 These tests are for testing the db model classes outside of the api.
@@ -19,19 +18,6 @@ def _create_host(insights_id=None, fqdn=None, display_name=None):
     db.session.add(host)
     db.session.commit()
     return host
-
-
-def test_create_host_with_canonical_facts_as_None(flask_app_fixture):
-    # Test to make sure canonical facts that are None or '' do
-    # not get inserted into the db
-    invalid_canonical_facts = {"fqdn": None, "insights_id": ""}
-    valid_canonical_facts = {"bios_uuid": "1234"}
-
-    host_dict = {**invalid_canonical_facts, **valid_canonical_facts}
-
-    host = deserialize_host(host_dict)
-
-    assert valid_canonical_facts == host.canonical_facts
 
 
 def test_create_host_with_fqdn_and_display_name_as_empty_str(flask_app_fixture):

--- a/test_unit.py
+++ b/test_unit.py
@@ -71,7 +71,7 @@ class AuthIdentityConstructorTestCase(TestCase):
 
     @staticmethod
     def _identity():
-        return Identity(account_number="some number")
+        return Identity(account_number="some acct")
 
 
 class AuthIdentityFromAuthHeaderTestCase(AuthIdentityConstructorTestCase):
@@ -143,7 +143,7 @@ class AuthIdentityFromAuthHeaderTestCase(AuthIdentityConstructorTestCase):
 class AuthIdentityValidateTestCase(TestCase):
     def test_valid(self):
         try:
-            identity = Identity(account_number="some number")
+            identity = Identity(account_number="some acct")
             validate(identity)
             self.assertTrue(True)
         except ValueError:
@@ -349,7 +349,7 @@ class SerializationDeserializeHostCompoundTestCase(TestCase):
         unchanged_input = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
-            "account": "some account",
+            "account": "some acct",
         }
         input = {
             **canonical_facts,
@@ -379,14 +379,15 @@ class SerializationDeserializeHostCompoundTestCase(TestCase):
             self.assertEqual(value, getattr(actual, key))
 
     def test_with_only_required_fields(self):
+        account = "some acct"
         canonical_facts = {"fqdn": "some fqdn"}
-        host = deserialize_host(canonical_facts)
+        host = deserialize_host({"account": account, **canonical_facts})
 
         self.assertIs(Host, type(host))
         self.assertEqual(canonical_facts, host.canonical_facts)
         self.assertIsNone(host.display_name)
         self.assertIsNone(host.ansible_host)
-        self.assertIsNone(host.account)
+        self.assertEqual(account, host.account)
         self.assertEqual({}, host.facts)
         self.assertEqual({}, host.system_profile_facts)
 
@@ -399,7 +400,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
         input = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
-            "account": "some account",
+            "account": "some acct",
             "insights_id": str(uuid4()),
             "rhel_machine_id": str(uuid4()),
             "subscription_manager_id": str(uuid4()),
@@ -409,10 +410,10 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             "fqdn": "some fqdn",
             "mac_addresses": ["c2:00:d0:c8:61:01"],
             "external_id": "i-05d2313e6b9a42b16",
-            "facts": {
-                "some namespace": {"some key": "some value"},
-                "another namespace": {"another key": "another value"},
-            },
+            "facts": [
+                {"namespace": "some namespace", "facts": {"some key": "some value"}},
+                {"namespace": "another namespace", "facts": {"another key": "another value"}},
+            ],
             "system_profile": {
                 "number_of_cpus": 1,
                 "number_of_sockets": 2,
@@ -439,7 +440,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
         input = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
-            "account": "some account",
+            "account": "some acct",
             "system_profile": {
                 "number_of_cpus": 1,
                 "number_of_sockets": 2,
@@ -465,11 +466,11 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
     def test_without_display_name(self, deserialize_canonical_facts, deserialize_facts, host):
         input = {
             "ansible_host": "some ansible host",
-            "account": "some account",
-            "facts": {
-                "some namespace": {"some key": "some value"},
-                "another namespace": {"another key": "another value"},
-            },
+            "account": "some acct",
+            "facts": [
+                {"namespace": "some namespace", "facts": {"some key": "some value"}},
+                {"namespace": "another namespace", "facts": {"another key": "another value"}},
+            ],
             "system_profile": {
                 "number_of_cpus": 1,
                 "number_of_sockets": 2,
@@ -496,11 +497,11 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
         input = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
-            "account": "some account",
-            "facts": {
-                "some namespace": {"some key": "some value"},
-                "another namespace": {"another key": "another value"},
-            },
+            "account": "some acct",
+            "facts": [
+                {"namespace": "some namespace", "facts": {"some key": "some value"}},
+                {"namespace": "another namespace", "facts": {"another key": "another value"}},
+            ],
         }
 
         result = deserialize_host(input)
@@ -539,7 +540,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
         unchanged_data = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
-            "account": "some account",
+            "account": "some acct",
         }
         host_init_data = {
             "canonical_facts": canonical_facts,
@@ -613,7 +614,7 @@ class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTes
         unchanged_data = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
-            "account": "some account",
+            "account": "some acct",
         }
         host_init_data = {"canonical_facts": canonical_facts, **unchanged_data, "facts": facts}
         host = Host(**host_init_data)


### PR DESCRIPTION
Move the schema from the repository host add logic layer to the deserialization one. As a result, every work with an input host dictionary is done after it’s been validated. That includes an account number comparison. Ergo, if the account number is invalid, it’s not being even compared to the one in the identity header.

Fixes [RHCLOUD-3018](https://projects.engineering.redhat.com/browse/RHCLOUD-3018).

Added some tests verifying that the validation actually happens and that it happens in the right place. That required amending all the currently invalid host inputs in tests.

Steps to reproduce:

1. Try to add a host with an invalid account number.

```json
[
    {
        "account": "",
        "fqdn": "test"
    }
]
```

2. See that a Marshmallow validation exception (_Bad Request) is presented instead of our logic one (Invalid request).

```json
{
    "total": 1,
    "errors": 1,
    "data": [
        {
            "detail": "{'account': ['Length must be between 1 and 10.']}",
            "status": 400,
            "title": "Bad Request",
            "type": "about:blank",
            "host": {
                "account": "",
                "fqdn": "test"
            }
        }
    ]
}
```

not

```json
{
    "total": 1,
    "errors": 1,
    "data": [
        {
            "detail": "The account number associated with the user does not match the account number associated with the host",
            "status": 400,
            "title": "Invalid request",
            "type": "about:blank",
            "host": {
                "account": "abc124",
                "fqdn": "test"
            }
        }
    ]
}
```