### PR TITLE
Add culling columns

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -74,6 +74,8 @@ class Host(db.Model):
     tags = db.Column(JSONB)
     canonical_facts = db.Column(JSONB)
     system_profile_facts = db.Column(JSONB)
+    stale_timestamp = db.Column(db.DateTime(timezone=True))
+    reporter = db.Column(db.String(255))
 
     def __init__(
         self,

--- a/migrations/versions/c6bfa7ebeaee_add_stale_timestamp_and_reporter_columns.py
+++ b/migrations/versions/c6bfa7ebeaee_add_stale_timestamp_and_reporter_columns.py
@@ -1,0 +1,25 @@
+"""add_stale_timestamp_and_reporter_columns
+
+Revision ID: c6bfa7ebeaee
+Revises: b2102a7db5e8
+Create Date: 2019-11-08 12:58:11.107559
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c6bfa7ebeaee"
+down_revision = "b2102a7db5e8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("hosts", sa.Column("stale_timestamp", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("hosts", sa.Column("reporter", sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    op.drop_column("hosts", "stale_timestamp")
+    op.drop_column("hosts", "reporter")


### PR DESCRIPTION
Added _stale_timestamp_ (timestamp with time zone) and _reporter_ (varchar 255) to the [database](https://github.com/Glutexo/insights-host-inventory/blob/08abebd01fe8a2b15c6081020322644442545637/migrations/versions/c6bfa7ebeaee_add_stale_timestamp_and_reporter_columns.py) and to the SQLAlchemy [model](https://github.com/Glutexo/insights-host-inventory/blob/08abebd01fe8a2b15c6081020322644442545637/app/models.py#L56). Both are nullable, because they are not filled for the existing records.

The _stale_timestamp_ includes time zone information for it to be aligned with other timestamp columns. Although this is not necessary, it makes it somehow easier to pump the data to the cross join database.

The new fields are not in the [HostWrapper](https://github.com/Glutexo/insights-host-inventory/blob/08abebd01fe8a2b15c6081020322644442545637/app/utils.py#L4) class, because it is only used for the [API tests](https://github.com/Glutexo/insights-host-inventory/blob/08abebd01fe8a2b15c6081020322644442545637/test_api.py). The API doesn’t use those columns yet.

No tests as there is nothing to test. There are even no pure model tests, no nothing to add there.