### PR TITLE
Test basic model properties

### DIFF
--- a/test_db_model.py
+++ b/test_db_model.py
@@ -125,6 +125,8 @@ def test_host_model_assigned_values(flask_app_fixture):
         "tags": {"namespace": {"key": ["value"]}},
         "canonical_facts": {"fqdn": "fqdn"},
         "system_profile_facts": {"number_of_cpus": 1},
+        "stale_timestamp": datetime.now(timezone.utc),
+        "reporter": "reporter",
     }
 
     inserted_host = TestHost(**values)
@@ -178,16 +180,18 @@ def test_host_model_updated_timestamp(flask_app_fixture):
 
 
 def test_host_model_timestamp_timezones(flask_app_fixture):
-    host = TestHost(account="00102", canonical_facts={"fqdn": "fqdn"})
+    host = TestHost(account="00102", canonical_facts={"fqdn": "fqdn"}, stale_timestamp=datetime.now(timezone.utc))
     db.session.add(host)
     db.session.commit()
 
     assert host.created_on.tzinfo
     assert host.modified_on.tzinfo
+    assert host.stale_timestamp.tzinfo
 
 
 @mark.parametrize(
-    ("field", "value"), (("account", "00000000102"), ("display_name", "x" * 201), ("ansible_host", "x" * 256))
+    ("field", "value"),
+    (("account", "00000000102"), ("display_name", "x" * 201), ("ansible_host", "x" * 256), ("reporter", "x" * 256)),
 )
 def test_host_model_constraints(flask_app_fixture, field, value):
     values = {"account": "00102", "canonical_facts": {"fqdn": "fqdn"}, **{field: value}}

--- a/test_db_model.py
+++ b/test_db_model.py
@@ -1,4 +1,10 @@
 import uuid
+from datetime import datetime
+from datetime import timezone
+
+from pytest import mark
+from pytest import raises
+from sqlalchemy.exc import DataError
 
 from app import db
 from app.models import Host
@@ -6,6 +12,11 @@ from app.models import Host
 """
 These tests are for testing the db model classes outside of the api.
 """
+
+
+class TestHost(Host):
+    def __init__(self, *args, **kwargs):
+        super(Host, self).__init__(*args, **kwargs)
 
 
 def _create_host(insights_id=None, fqdn=None, display_name=None):
@@ -103,3 +114,85 @@ def test_create_host_with_system_profile(flask_app_fixture):
     db.session.commit()
 
     assert host.system_profile_facts == system_profile_facts
+
+
+def test_host_model_assigned_values(flask_app_fixture):
+    values = {
+        "account": "00102",
+        "display_name": "display_name",
+        "ansible_host": "ansible_host",
+        "facts": [{"namespace": "namespace", "facts": {"key": "value"}}],
+        "tags": {"namespace": {"key": ["value"]}},
+        "canonical_facts": {"fqdn": "fqdn"},
+        "system_profile_facts": {"number_of_cpus": 1},
+    }
+
+    inserted_host = TestHost(**values)
+    db.session.add(inserted_host)
+    db.session.commit()
+
+    selected_host = Host.query.filter(Host.id == inserted_host.id).first()
+    for key, value in values.items():
+        assert getattr(selected_host, key) == value
+
+
+def test_host_model_default_id(flask_app_fixture):
+    host = TestHost(account="00102", canonical_facts={"fqdn": "fqdn"})
+    db.session.add(host)
+    db.session.commit()
+
+    assert isinstance(host.id, uuid.UUID)
+
+
+def test_host_model_default_timestamps(flask_app_fixture):
+    host = TestHost(account="00102", canonical_facts={"fqdn": "fqdn"})
+    db.session.add(host)
+
+    before_commit = datetime.now(timezone.utc)
+    db.session.commit()
+    after_commit = datetime.now(timezone.utc)
+
+    assert isinstance(host.created_on, datetime)
+    assert before_commit < host.created_on < after_commit
+    assert isinstance(host.modified_on, datetime)
+    assert before_commit < host.modified_on < after_commit
+
+
+def test_host_model_updated_timestamp(flask_app_fixture):
+    host = TestHost(account="00102", canonical_facts={"fqdn": "fqdn"})
+    db.session.add(host)
+
+    before_insert_commit = datetime.now(timezone.utc)
+    db.session.commit()
+    after_insert_commit = datetime.now(timezone.utc)
+
+    host.canonical_facts = {"fqdn": "ndqf"}
+    db.session.add(host)
+
+    before_update_commit = datetime.now(timezone.utc)
+    db.session.commit()
+    after_update_commit = datetime.now(timezone.utc)
+
+    assert before_insert_commit < host.created_on < after_insert_commit
+    assert before_update_commit < host.modified_on < after_update_commit
+
+
+def test_host_model_timestamp_timezones(flask_app_fixture):
+    host = TestHost(account="00102", canonical_facts={"fqdn": "fqdn"})
+    db.session.add(host)
+    db.session.commit()
+
+    assert host.created_on.tzinfo
+    assert host.modified_on.tzinfo
+
+
+@mark.parametrize(
+    ("field", "value"), (("account", "00000000102"), ("display_name", "x" * 201), ("ansible_host", "x" * 256))
+)
+def test_host_model_constraints(flask_app_fixture, field, value):
+    values = {"account": "00102", "canonical_facts": {"fqdn": "fqdn"}, **{field: value}}
+    host = TestHost(**values)
+    db.session.add(host)
+
+    with raises(DataError):
+        db.session.commit()


### PR DESCRIPTION
Added a few database model tests that verify column presence, type and default values.

Triggered by #510 a #489. There are no tests checking that there are correct columns in the database and the model is correctly set.