### PR TITLE
Fix ORDER BY id tests in <UTC timezones

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1802,7 +1802,7 @@ class QueryOrderWithSameModifiedOnTestsCase(QueryOrderWithAdditionalHostsBaseTes
         # New modified_on value must be set explicitly so it’s saved the same to all
         # records. Otherwise SQLAlchemy would consider it unchanged and update it
         # automatically to its own "now" only for records whose ID changed.
-        new_modified_on = datetime.now()
+        new_modified_on = datetime.now(timezone.utc)
 
         with self.app.app_context():
             for added_host_index, new_id in id_updates:


### PR DESCRIPTION
The created/modified timestamps were [converted](https://github.com/RedHatInsights/insights-host-inventory/commit/b2d37d641a43f180c7b8fd0cb55c833020df6cc3) to be time zone aware. This has broken [tests](https://github.com/RedHatInsights/insights-host-inventory/blob/2b4c4c91ba5bff1e7f6652e4025c4539de8393b0/test_api.py#L1835) tampering with those timestamps in a non-aware way. In negative offset time zones, the _modified_on_ timestamp was set incorrectly resulting in a different order than expected. Fixed by using time zone aware _datetime_ objects.

Steps to reproduce:

1. Use a time zone with a negative offset, e.g. EST.
2. Verify that without this patch, the [_test_hosts_ordered_by_updated_are_also_ordered_by_id_desc_](https://github.com/RedHatInsights/insights-host-inventory/blob/2b4c4c91ba5bff1e7f6652e4025c4539de8393b0/test_api.py#L1835) test fails.
3. Verify that with this patch the test pass.

Please do not approve this pull request without actually reproducing the problem and its fix.

Reported by @ryandillinfelton.