### PR TITLE
Serialization: Make serialization methods more concise

### DIFF
--- a/test_unit.py
+++ b/test_unit.py
@@ -8,6 +8,7 @@ from unittest import main
 from unittest import TestCase
 from unittest.mock import Mock
 from unittest.mock import patch
+from uuid import UUID
 from uuid import uuid4
 
 from api import api_operation
@@ -25,7 +26,9 @@ from app.models import Host
 from app.models import HostSchema
 from app.serialization import _deserialize_canonical_facts
 from app.serialization import _deserialize_facts
+from app.serialization import _serialize_datetime
 from app.serialization import _serialize_facts
+from app.serialization import _serialize_uuid
 from app.serialization import deserialize_host
 from app.serialization import serialize_canonical_facts
 from app.serialization import serialize_host
@@ -1099,6 +1102,26 @@ class SerializationSerializeFactsTestCase(TestCase):
                     [{"namespace": namespace, "facts": facts or {}} for namespace, facts in facts.items()],
                     _serialize_facts(facts),
                 )
+
+
+class SerializationSerializeDatetime(TestCase):
+    def test_utc_timezone_is_used(self):
+        now = datetime.now(timezone.utc)
+        self.assertEqual(now.isoformat(), _serialize_datetime(now))
+
+    def test_iso_format_is_used(self):
+        dt = datetime(2019, 7, 3, 1, 1, 4, 20647, timezone.utc)
+        self.assertEqual("2019-07-03T01:01:04.020647+00:00", _serialize_datetime(dt))
+
+
+class SerializationSerializeUuid(TestCase):
+    def test_uuid_has_hyphens_computed(self):
+        u = uuid4()
+        self.assertEqual(str(u), _serialize_uuid(u))
+
+    def test_uuid_has_hyphens_literal(self):
+        u = "4950e534-bbef-4432-bde2-aa3dd2bd0a52"
+        self.assertEqual(u, _serialize_uuid(UUID(u)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reviewed the style of the (de)serialization methods. Removed redundant or rather cryptic instructions. Leveraged comprehensions, dried a few bits of code. Made the code more concise and expressive. Unified names a bit.

This is a #390 variant rebased to [current](https://github.com/RedHatInsights/insights-host-inventory/tree/fe49fda9e279f4ef971498fdb486812259d2902b) [_master_](https://github.com/RedHatInsights/insights-host-inventory/tree/master).

Added a [TODO](https://github.com/Glutexo/insights-host-inventory/blob/eea172782596b55427330221e2b088323802ff0b/app/serialization.py#L104) for the new [tag transformation](https://github.com/Glutexo/insights-host-inventory/blob/eea172782596b55427330221e2b088323802ff0b/app/utils.py#L156).