### PR TITLE
release culling

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -43,6 +43,9 @@ class Config:
         payload_tracker_enabled = os.environ.get("PAYLOAD_TRACKER_ENABLED", "true")
         self.payload_tracker_enabled = payload_tracker_enabled.lower() == "true"
 
+        self.culling_stale_warning_offset_days = int(os.environ.get("CULLING_STALE_WARNING_OFFSET_DAYS", "7"))
+        self.culling_culled_offset_days = int(os.environ.get("CULLING_CULLED_OFFSET_DAYS", "14"))
+
     def _build_base_url_path(self):
         app_name = os.getenv("APP_NAME", "inventory")
         path_prefix = os.getenv("PATH_PREFIX", "api")

--- a/app/culling.py
+++ b/app/culling.py
@@ -1,0 +1,24 @@
+from collections import namedtuple
+from datetime import timedelta
+
+
+__all__ = ("StalenessOffset",)
+
+
+class StalenessOffset(namedtuple("StalenessOffset", ("stale_warning_offset_days", "culled_offset_days"))):
+    @classmethod
+    def from_config(cls, config):
+        return cls(config.culling_stale_warning_offset_days, config.culling_culled_offset_days)
+
+    @staticmethod
+    def _add_days(timestamp, days):
+        return timestamp + timedelta(days=days)
+
+    def stale_timestamp(self, stale_timestamp):
+        return self._add_days(stale_timestamp, 0)
+
+    def stale_warning_timestamp(self, stale_timestamp):
+        return self._add_days(stale_timestamp, self.stale_warning_offset_days)
+
+    def culled_timestamp(self, stale_timestamp):
+        return self._add_days(stale_timestamp, self.culled_offset_days)

--- a/app/queue/egress.py
+++ b/app/queue/egress.py
@@ -75,6 +75,10 @@ class HostSchema(Schema):
     # FIXME:
     created = fields.Str()
     updated = fields.Str()
+    stale_timestamp = fields.Str()
+    stale_warning_timestamp = fields.Str()
+    culled_timestamp = fields.Str()
+    reporter = fields.Str()
 
 
 class HostEvent(Schema):

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -11,9 +11,11 @@ ingress_message_parsing_failure = Counter(
     "inventory_ingress_message_parsing_failures", "Total amount of failures parsing ingress messages"
 )
 add_host_success = Counter(
-    "inventory_ingress_add_host_successes", "Total amount of successfully added hosts", ["result"]
+    "inventory_ingress_add_host_successes", "Total amount of successfully added hosts", ["result", "reporter"]
 )
-add_host_failure = Counter("inventory_ingress_add_host_failures", "Total amount of failures adding hosts", ["cause"])
+add_host_failure = Counter(
+    "inventory_ingress_add_host_failures", "Total amount of failures adding hosts", ["cause", "reporter"]
+)
 ingress_message_handler_success = Counter(
     "inventory_ingress_message_handler_successes",
     "Total amount of successfully handled messages from the ingress queue",

--- a/app/utils.py
+++ b/app/utils.py
@@ -140,6 +140,22 @@ class HostWrapper:
     def ansible_host(self, ansible_host):
         self.__data["ansible_host"] = ansible_host
 
+    @property
+    def stale_timestamp(self):
+        return self.__data.get("stale_timestamp", None)
+
+    @stale_timestamp.setter
+    def stale_timestamp(self, stale_timestamp):
+        self.__data["stale_timestamp"] = stale_timestamp
+
+    @property
+    def reporter(self):
+        return self.__data.get("reporter", None)
+
+    @reporter.setter
+    def reporter(self, reporter):
+        self.__data["reporter"] = reporter
+
     def to_json(self):
         return json.dumps(self.__data)
 

--- a/host_dumper.py
+++ b/host_dumper.py
@@ -3,6 +3,7 @@ import argparse
 import pprint
 
 from app import create_app
+from app import staleness_offset
 from app.models import Host
 from app.serialization import serialize_host
 
@@ -41,7 +42,7 @@ with application.app_context():
     elif args.account_number:
         query_results = Host.query.filter(Host.account == args.account_number).all()
 
-    json_host_list = [serialize_host(host) for host in query_results]
+    json_host_list = [serialize_host(host, staleness_offset()) for host in query_results]
 
     if args.no_pp:
         print(json_host_list)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -20,7 +20,7 @@ ELEVATED_CANONICAL_FACT_FIELDS = ("insights_id", "subscription_manager_id")
 logger = get_logger(__name__)
 
 
-def add_host(input_host, update_system_profile=True):
+def add_host(input_host, staleness_offset, update_system_profile=True):
     """
     Add or update a host
 
@@ -31,11 +31,10 @@ def add_host(input_host, update_system_profile=True):
 
     with db_session_guard():
         existing_host = find_existing_host(input_host.account, input_host.canonical_facts)
-
         if existing_host:
-            return update_existing_host(existing_host, input_host, update_system_profile)
+            return update_existing_host(existing_host, input_host, staleness_offset, update_system_profile)
         else:
-            return create_new_host(input_host)
+            return create_new_host(input_host, staleness_offset)
 
 
 @metrics.host_dedup_processing_time.time()
@@ -85,20 +84,21 @@ def find_host_by_canonical_facts(account_number, canonical_facts):
 
 
 @metrics.new_host_commit_processing_time.time()
-def create_new_host(input_host):
+def create_new_host(input_host, staleness_offset):
     logger.debug("Creating a new host")
     input_host.save()
     db.session.commit()
     metrics.create_host_count.inc()
     logger.debug("Created host:%s", input_host)
-    return serialize_host(input_host), AddHostResults.created
+    return serialize_host(input_host, staleness_offset), AddHostResults.created
 
 
 @metrics.update_host_commit_processing_time.time()
-def update_existing_host(existing_host, input_host, update_system_profile):
+def update_existing_host(existing_host, input_host, staleness_offset, update_system_profile):
     logger.debug("Updating an existing host")
+    logger.debug(f"existing host = {existing_host}")
     existing_host.update(input_host, update_system_profile)
     db.session.commit()
     metrics.update_host_count.inc()
     logger.debug("Updated host:%s", existing_host)
-    return serialize_host(existing_host), AddHostResults.updated
+    return serialize_host(existing_host, staleness_offset), AddHostResults.updated

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -53,6 +53,7 @@ paths:
         - $ref: '#/components/parameters/pageParam'
         - $ref: '#/components/parameters/orderByParam'
         - $ref: '#/components/parameters/orderHowParam'
+        - $ref: '#/components/parameters/stalenessParam'
       responses:
         '200':
           description: Successfully read the hosts list.
@@ -122,6 +123,7 @@ paths:
         - $ref: '#/components/parameters/pageParam'
         - $ref: '#/components/parameters/orderByParam'
         - $ref: '#/components/parameters/orderHowParam'
+        - $ref: '#/components/parameters/stalenessParam'
       responses:
         '200':
           description: Successfully searched for hosts.
@@ -388,6 +390,24 @@ components:
       description: >-
         Direction of the ordering, defaults to ASC for display_name and to DESC for
         updated
+    stalenessParam:
+      name: staleness
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+            - fresh
+            - stale
+            - stale_warning
+            - unknown
+        default:
+          - fresh
+          - stale
+          - unknown
+      description: "Culling states of the hosts. Default: fresh,stale,unknown"
   schemas:
     TagsOut:
       type: object
@@ -585,6 +605,13 @@ components:
             $ref: '#/components/schemas/FactSet'
         system_profile:
           $ref: '#/components/schemas/SystemProfileIn'
+        stale_timestamp:
+          description: Timestamp from which the host is considered stale.
+          type: string
+          format: date-time
+        reporter:
+          description: Reporting source of the host. Used when updating the stale_timestamp.
+          type: string
     CreateHostOut:
       title: Create Host Out
       description: >-
@@ -704,6 +731,27 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StructuredTag'
+        stale_timestamp:
+          description: Timestamp from which the host is considered stale.
+          type: string
+          format: date-time
+          nullable: true
+        stale_warning_timestamp:
+          description: >-
+            Timestamp from which the host is considered too stale to be listed without an explicit
+            toggle.
+          type: string
+          format: date-time
+          nullable: true
+        culled_timestamp:
+          description: Timestamp from which the host is considered deleted.
+          type: string
+          format: date-time
+          nullable: true
+        reporter:
+          description: Reporting source of the host. Used when updating the stale_timestamp.
+          type: string
+          nullable: true
     HostOut:
       title: A Host Inventory entry
       description: A database entry representing a single host with its Inventory metadata.

--- a/test_api.py
+++ b/test_api.py
@@ -23,6 +23,7 @@ from api.host import _get_host_list_by_id_list
 from app import create_app
 from app import db
 from app.auth.identity import Identity
+from app.culling import StalenessOffset
 from app.models import Host
 from app.serialization import serialize_host
 from app.utils import HostWrapper
@@ -64,6 +65,8 @@ def test_data(**values):
     }
     if not data["facts"]:
         data["facts"] = FACTS
+    if "stale_timestamp" in data:
+        data["stale_timestamp"] = data["stale_timestamp"].isoformat()
     return data
 
 
@@ -707,6 +710,154 @@ class CreateHostsTestCase(DBAPITestCase):
                 self.assertEqual(error_host["status"], 400)
 
                 self.verify_error_response(error_host, expected_title="Bad Request")
+
+
+class CreateHostsWithStaleTimestampTestCase(DBAPITestCase):
+    def _add_host(self, expected_status, **values):
+        host_data = HostWrapper(test_data(fqdn="match this host", **values))
+        response = self.post(HOST_URL, [host_data.data()], 207)
+        self._verify_host_status(response, 0, expected_status)
+        created_host = self._pluck_host_from_response(response, 0)
+        return created_host["id"]
+
+    def _retrieve_host(self, host_id):
+        with self.app.app_context():
+            return Host.query.filter(Host.id == host_id).first()
+
+    def test_create_host_with_stale_timestamp_and_reporter(self):
+        stale_timestamp = datetime.now(timezone.utc)
+        reporter = "some reporter"
+        created_host_id = self._add_host(201, stale_timestamp=stale_timestamp, reporter=reporter)
+
+        retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(stale_timestamp, retrieved_host.stale_timestamp)
+        self.assertEqual(reporter, retrieved_host.reporter)
+
+    def test_update_host_with_stale_timestamp_and_reporter(self):
+        created_host_id = self._add_host(201)
+        old_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertIsNone(old_retrieved_host.stale_timestamp)
+        self.assertIsNone(old_retrieved_host.reporter)
+
+        stale_timestamp = datetime.now(timezone.utc)
+        reporter = "some reporter"
+
+        self._add_host(200, stale_timestamp=stale_timestamp, reporter=reporter)
+
+        new_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(stale_timestamp, new_retrieved_host.stale_timestamp)
+        self.assertEqual(reporter, new_retrieved_host.reporter)
+
+    def test_dont_update_host_with_stale_timestamp_and_reporter(self):
+        stale_timestamp = datetime.now(timezone.utc)
+        reporter = "some reporter"
+
+        created_host_id = self._add_host(201, stale_timestamp=stale_timestamp, reporter=reporter)
+        old_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(stale_timestamp, old_retrieved_host.stale_timestamp)
+        self.assertEqual(reporter, old_retrieved_host.reporter)
+
+        self._add_host(200)
+
+        new_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(stale_timestamp, new_retrieved_host.stale_timestamp)
+        self.assertEqual(reporter, new_retrieved_host.reporter)
+
+    def test_update_stale_timestamp_from_same_reporter(self):
+        now = datetime.now(timezone.utc)
+
+        old_stale_timestamp = now + timedelta(days=1)
+        reporter = "some reporter"
+
+        created_host_id = self._add_host(201, stale_timestamp=old_stale_timestamp, reporter=reporter)
+        old_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(old_stale_timestamp, old_retrieved_host.stale_timestamp)
+        self.assertEqual(reporter, old_retrieved_host.reporter)
+
+        new_stale_timestamp = now + timedelta(days=2)
+        self._add_host(200, stale_timestamp=new_stale_timestamp, reporter=reporter)
+
+        new_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(new_stale_timestamp, new_retrieved_host.stale_timestamp)
+        self.assertEqual(reporter, new_retrieved_host.reporter)
+
+    def test_dont_update_stale_timestamp_from_same_reporter(self):
+        now = datetime.now(timezone.utc)
+
+        old_stale_timestamp = now + timedelta(days=2)
+        reporter = "some reporter"
+
+        created_host_id = self._add_host(201, stale_timestamp=old_stale_timestamp, reporter=reporter)
+        old_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(old_stale_timestamp, old_retrieved_host.stale_timestamp)
+
+        new_stale_timestamp = now + timedelta(days=1)
+        self._add_host(200, stale_timestamp=new_stale_timestamp, reporter=reporter)
+
+        new_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(old_stale_timestamp, new_retrieved_host.stale_timestamp)
+
+    def test_update_stale_timestamp_from_different_reporter(self):
+        now = datetime.now(timezone.utc)
+
+        old_stale_timestamp = now + timedelta(days=2)
+        old_reporter = "old reporter"
+
+        created_host_id = self._add_host(201, stale_timestamp=old_stale_timestamp, reporter=old_reporter)
+        old_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(old_stale_timestamp, old_retrieved_host.stale_timestamp)
+        self.assertEqual(old_reporter, old_retrieved_host.reporter)
+
+        new_stale_timestamp = now + timedelta(days=1)
+        new_reporter = "new reporter"
+        self._add_host(200, stale_timestamp=new_stale_timestamp, reporter=new_reporter)
+
+        new_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(new_stale_timestamp, new_retrieved_host.stale_timestamp)
+        self.assertEqual(new_reporter, new_retrieved_host.reporter)
+
+    def test_dont_update_stale_timestamp_from_different_reporter(self):
+        now = datetime.now(timezone.utc)
+
+        old_stale_timestamp = now + timedelta(days=1)
+        old_reporter = "old reporter"
+
+        created_host_id = self._add_host(201, stale_timestamp=old_stale_timestamp, reporter=old_reporter)
+
+        old_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(old_stale_timestamp, old_retrieved_host.stale_timestamp)
+        self.assertEqual(old_reporter, old_retrieved_host.reporter)
+
+        new_stale_timestamp = now + timedelta(days=2)
+        self._add_host(200, stale_timestamp=new_stale_timestamp, reporter="new_reporter")
+
+        new_retrieved_host = self._retrieve_host(created_host_id)
+
+        self.assertEqual(old_stale_timestamp, new_retrieved_host.stale_timestamp)
+        self.assertEqual(old_reporter, new_retrieved_host.reporter)
+
+    def test_create_host_with_only_one_culling_field(self):
+        valueses = ({"stale_timestamp": datetime.now(timezone.utc)}, {"reporter": "some reporter"})
+        for values in valueses:
+            host_data = HostWrapper(test_data(**values))
+            response = self.post(HOST_URL, [host_data.data()], 207)
+
+            error_host = response["data"][0]
+
+            self.assertEqual(error_host["status"], 400)
+            self.verify_error_response(error_host, expected_title="Invalid request")
 
 
 class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):
@@ -1997,7 +2148,9 @@ class QueryOrderWithSameModifiedOnTestsCase(QueryOrderWithAdditionalHostsBaseTes
         old_host.modified_on = new_modified_on
         db.session.add(old_host)
 
-        self.added_hosts[added_host_index] = HostWrapper(serialize_host(old_host))
+        staleness_offset = StalenessOffset.from_config(self.app.config["INVENTORY_CONFIG"])
+        serialized_old_host = serialize_host(old_host, staleness_offset)
+        self.added_hosts[added_host_index] = HostWrapper(serialized_old_host)
 
     def _update_hosts(self, id_updates):
         # New modified_on value must be set explicitly so it’s saved the same to all
@@ -2073,6 +2226,239 @@ class QueryOrderBadRequestsTestCase(QueryOrderBaseTestCase):
         for url in self._queries_subtests_with_added_hosts():
             with self.subTest(url=url):
                 self._get(url, None, "ASC", 400)
+
+
+class QueryStaleTimestampTestCase(DBAPITestCase):
+    def setUp(self):
+        super().setUp()
+
+    def _host_data(self, **values):
+        return {"account": ACCOUNT, "fqdn": "matching fqdn", **values}
+
+    def _create_host(self, host):
+        response = self.post(HOST_URL, [host.data()], 207)
+        self._verify_host_status(response, 0, 201)
+        return self._pluck_host_from_response(response, 0)
+
+    def _update_host(self, host):
+        response = self.post(HOST_URL, [host.data()], 207)
+        self._verify_host_status(response, 0, 200)
+        return self._pluck_host_from_response(response, 0)
+
+    def _get_all_hosts(self):
+        response = self.get(HOST_URL, 200)
+        return response["results"][0]
+
+    def _get_host_by_id(self, host_id):
+        response = self.get(f"{HOST_URL}/{host_id}", 200)
+        return response["results"][0]
+
+    def test_without_stale_timestamp(self):
+        def _assert_values(response_host):
+            self.assertIn("stale_timestamp", response_host)
+            self.assertIn("stale_warning_timestamp", response_host)
+            self.assertIn("culled_timestamp", response_host)
+            self.assertIn("reporter", response_host)
+            self.assertIsNone(response_host["stale_timestamp"])
+            self.assertIsNone(response_host["stale_warning_timestamp"])
+            self.assertIsNone(response_host["culled_timestamp"])
+            self.assertIsNone(response_host["reporter"])
+
+        host_to_create = HostWrapper(self._host_data())
+
+        created_host = self._create_host(host_to_create)
+        _assert_values(created_host)
+
+        updated_host = self._update_host(host_to_create)
+        _assert_values(updated_host)
+
+        retrieved_host_from_all = self._get_all_hosts()
+        _assert_values(retrieved_host_from_all)
+
+        retrieved_host_from_by_id = self._get_host_by_id(created_host["id"])
+        _assert_values(retrieved_host_from_by_id)
+
+    def test_with_stale_timestamp(self):
+        def _assert_values(response_host):
+            self.assertIn("stale_timestamp", response_host)
+            self.assertIn("stale_warning_timestamp", response_host)
+            self.assertIn("culled_timestamp", response_host)
+            self.assertIn("reporter", response_host)
+            self.assertEqual(stale_timestamp_str, response_host["stale_timestamp"])
+            self.assertEqual(stale_warning_timestamp_str, response_host["stale_warning_timestamp"])
+            self.assertEqual(culled_timestamp_str, response_host["culled_timestamp"])
+            self.assertEqual(reporter, response_host["reporter"])
+
+        stale_timestamp = datetime.now(timezone.utc)
+        stale_timestamp_str = stale_timestamp.isoformat()
+        stale_warning_timestamp = stale_timestamp + timedelta(weeks=1)
+        stale_warning_timestamp_str = stale_warning_timestamp.isoformat()
+        culled_timestamp = stale_timestamp + timedelta(weeks=2)
+        culled_timestamp_str = culled_timestamp.isoformat()
+        reporter = "some reporter"
+
+        host_to_create = HostWrapper(self._host_data(stale_timestamp=stale_timestamp_str, reporter=reporter))
+
+        created_host = self._create_host(host_to_create)
+        _assert_values(created_host)
+
+        updated_host = self._update_host(host_to_create)
+        _assert_values(updated_host)
+
+        retrieved_host_from_all = self._get_all_hosts()
+        _assert_values(retrieved_host_from_all)
+
+        retrieved_host_from_by_id = self._get_host_by_id(created_host["id"])
+        _assert_values(retrieved_host_from_by_id)
+
+
+class QueryStalenessBaseTestCase(DBAPITestCase):
+    def _create_host(self, stale_timestamp):
+        data = {"account": ACCOUNT, "insights_id": str(generate_uuid())}
+        if stale_timestamp:
+            data["reporter"] = "some reporter"
+            data["stale_timestamp"] = stale_timestamp.isoformat()
+
+        host = HostWrapper(data)
+        response = self.post(HOST_URL, [host.data()], 207)
+        self._verify_host_status(response, 0, 201)
+        return self._pluck_host_from_response(response, 0)
+
+    def _get_hosts_by_id_url(self, query, host_id_list):
+        host_id_query = ",".join(host_id_list)
+        return f"{HOST_URL}/{host_id_query}{query}"
+
+    def _get_hosts_by_id(self, query, host_id_list):
+        url = self._get_hosts_by_id_url(query, host_id_list)
+        response = self.get(url, 200)
+        return response["results"]
+
+
+class QueryStalenessGetHostsTestCase(QueryStalenessBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.fresh_host = self._create_host(datetime.now(timezone.utc) + timedelta(hours=1))
+        self.stale_host = self._create_host(datetime.now(timezone.utc) - timedelta(hours=1))
+        self.stale_warning_host = self._create_host(datetime.now(timezone.utc) - timedelta(weeks=1, hours=1))
+        self.culled_host = self._create_host(datetime.now(timezone.utc) - timedelta(weeks=2, hours=1))
+        self.unknown_host = self._create_host(None)
+
+    def _created_hosts(self):
+        return (self.fresh_host["id"], self.stale_host["id"], self.stale_warning_host["id"], self.culled_host["id"])
+
+    def _get_all_hosts_url(self, query):
+        return f"{HOST_URL}{query}"
+
+    def _get_all_hosts(self, query):
+        url = self._get_all_hosts_url(query)
+        response = self.get(url, 200)
+        return tuple(host["id"] for host in response["results"])
+
+    def _get_created_hosts_by_id_url(self, query):
+        return self._get_hosts_by_id_url(query, self._created_hosts())
+
+    def _get_created_hosts_by_id(self, query):
+        hosts = self._get_hosts_by_id(query, self._created_hosts())
+        return tuple(host["id"] for host in hosts)
+
+    def _sub_tests_for_get_operations(self):
+        for method in (self._get_all_hosts, self._get_created_hosts_by_id):
+            with self.subTest(method=method):
+                yield method
+
+    def test_get_only_fresh(self):
+        for get_method in self._sub_tests_for_get_operations():
+            retrieved_host_ids = get_method("?staleness=fresh")
+            self.assertEqual((self.fresh_host["id"],), retrieved_host_ids)
+
+    def test_get_only_stale(self):
+        retrieved_host_ids = self._get_all_hosts("?staleness=stale")
+        self.assertEqual((self.stale_host["id"],), retrieved_host_ids)
+
+    def test_get_only_stale_warning(self):
+        retrieved_host_ids = self._get_all_hosts("?staleness=stale_warning")
+        self.assertEqual((self.stale_warning_host["id"],), retrieved_host_ids)
+
+    def test_dont_get_only_culled(self):
+        for get_hosts_url_method in (self._get_all_hosts_url, self._get_created_hosts_by_id_url):
+            with self.subTest(get_hosts_url_method=get_hosts_url_method):
+                url = get_hosts_url_method("?staleness=culled")
+                from logging import DEBUG, getLogger
+
+                logger = getLogger(__name__)
+                logger.setLevel(DEBUG)
+                logger.debug(url)
+                self.get(url, 400)
+
+
+class QueryStalenessConfigTimestampsTestCase(QueryStalenessBaseTestCase):
+    def _create_and_get_host(self, stale_timestamp):
+        host_to_create = self._create_host(stale_timestamp)
+        query = "?staleness=fresh,stale,stale_warning,unknown"
+        retrieved_host = self._get_hosts_by_id(query, (host_to_create["id"],))[0]
+        self.assertEqual(stale_timestamp.isoformat(), retrieved_host["stale_timestamp"])
+        return retrieved_host
+
+    def test_stale_warning_timestamp(self):
+        for culling_stale_warning_offset_days in (1, 7, 12):
+            with self.subTest(culling_stale_warning_offset_days=culling_stale_warning_offset_days):
+                config = self.app.config["INVENTORY_CONFIG"]
+                config.culling_stale_warning_offset_days = culling_stale_warning_offset_days
+
+                stale_timestamp = datetime.now(timezone.utc) + timedelta(hours=1)
+                host = self._create_and_get_host(stale_timestamp)
+
+                stale_warning_timestamp = stale_timestamp + timedelta(days=culling_stale_warning_offset_days)
+                self.assertEqual(stale_warning_timestamp.isoformat(), host["stale_warning_timestamp"])
+
+    def test_culled_timestamp(self):
+        for culling_culled_offset_days in (8, 14, 20):
+            with self.subTest(culling_culled_offset_days=culling_culled_offset_days):
+                config = self.app.config["INVENTORY_CONFIG"]
+                config.culling_culled_offset_days = culling_culled_offset_days
+
+                stale_timestamp = datetime.now(timezone.utc) + timedelta(hours=1)
+                host = self._create_and_get_host(stale_timestamp)
+
+                culled_timestamp = stale_timestamp + timedelta(days=culling_culled_offset_days)
+                self.assertEqual(culled_timestamp.isoformat(), host["culled_timestamp"])
+
+
+class QueryStalenessConfigFilterTestCase(QueryStalenessBaseTestCase):
+    def _assert_host_state(self, host, state, assert_method):
+        hosts = self._get_hosts_by_id(f"?staleness={state}", (host["id"],))
+        assert_method(host["id"], tuple(host["id"] for host in hosts))
+
+    def _assert_host_in_state(self, host, state):
+        self._assert_host_state(host, state, self.assertIn)
+
+    def _assert_host_not_in_state(self, host, state):
+        self._assert_host_state(host, state, self.assertNotIn)
+
+    def test_stale_warning_config_timestamp(self):
+        for culling_stale_warning_offset_days in (1, 6, 7, 8, 12):
+            with self.subTest(culling_stale_warning_offset_days=culling_stale_warning_offset_days):
+                host = self._create_host(
+                    datetime.now(timezone.utc) - timedelta(days=culling_stale_warning_offset_days, hours=1)
+                )
+
+                config = self.app.config["INVENTORY_CONFIG"]
+                config.culling_stale_warning_offset_days = culling_stale_warning_offset_days
+
+                self._assert_host_in_state(host, "stale_warning")
+                self._assert_host_not_in_state(host, "fresh,stale,unknown")
+
+    def test_culled_config_timestamp(self):
+        for culling_culled_offset_days in (8, 13, 14, 15, 20):
+            with self.subTest(culling_culled_offset_days=culling_culled_offset_days):
+                host = self._create_host(
+                    datetime.now(timezone.utc) - timedelta(days=culling_culled_offset_days, hours=1)
+                )
+
+                config = self.app.config["INVENTORY_CONFIG"]
+                config.culling_culled_offset_days = culling_culled_offset_days
+
+                self._assert_host_not_in_state(host, "fresh,stale,stale_warning,unknown")
 
 
 class FactsTestCase(PreCreatedHostsBaseTestCase):

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -1,0 +1,299 @@
+import json
+import unittest
+import uuid
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest import main
+from unittest import TestCase
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import marshmallow
+
+from app import create_app
+from app import db
+from app.exceptions import InventoryException
+from app.queue.ingress import event_loop
+from app.queue.ingress import handle_message
+from lib.host_repository import AddHostResults
+from test_utils import rename_host_table_and_indexes
+
+
+class FakeKafkaMessage:
+    value = None
+
+    def __init__(self, message):
+        self.value = message
+
+
+class mockEventProducer:
+    def __init__(self):
+        self.__data = {}
+
+    def write_event(self, val):
+        self.__data["write_event"] = val
+
+    def get_write_event(self):
+        return self.__data["write_event"]
+
+
+class MQServiceTestCase(TestCase):
+    def setUp(self):
+        """
+        Creates the application and a test client to make requests.
+        """
+        self.app = create_app(config_name="testing")
+
+    def test_event_loop_exception_handling(self):
+        """
+        Test to ensure that an exception in message handler method does not cause the
+        event loop to stop processing messages
+        """
+        # fake_consumer = [FakeKafkaMessage("blah"), FakeKafkaMessage("fred"), FakeKafkaMessage("ugh")]
+        fake_consumer = [Mock(), Mock(), Mock()]
+        fake_event_producer = None
+
+        handle_message_mock = Mock(side_effect=[None, KeyError("blah"), None])
+        event_loop(fake_consumer, self.app, fake_event_producer, handler=handle_message_mock)
+
+        self.assertEqual(handle_message_mock.call_count, 3)
+
+    def test_handle_message_failure_invalid_json_message(self):
+
+        invalid_message = "failure {} "
+        mock_event_producer = Mock()
+
+        with self.assertRaises(json.decoder.JSONDecodeError):
+            handle_message(invalid_message, mock_event_producer)
+
+        mock_event_producer.assert_not_called()
+
+    def test_handle_message_failure_invalid_message_format(self):
+
+        invalid_message = json.dumps({"operation": "add_host", "NOTdata": {}})  # Missing data field
+
+        mock_event_producer = Mock()
+
+        with self.assertRaises(marshmallow.exceptions.ValidationError):
+            handle_message(invalid_message, mock_event_producer)
+
+        mock_event_producer.assert_not_called()
+
+    @patch("app.queue.egress.datetime", **{"utcnow.return_value": datetime.utcnow()})
+    def test_handle_message_happy_path(self, datetime_mock):
+        expected_insights_id = str(uuid.uuid4())
+        host_id = uuid.uuid4()
+        timestamp_iso = datetime_mock.utcnow.return_value.isoformat() + "+00:00"
+        message = {"operation": "add_host", "data": {"insights_id": expected_insights_id, "account": "0000001"}}
+        with self.app.app_context():
+            with unittest.mock.patch("app.queue.ingress.host_repository.add_host") as m:
+                m.return_value = ({"id": host_id, "insights_id": None}, AddHostResults.created)
+                mock_event_producer = Mock()
+                handle_message(json.dumps(message), mock_event_producer)
+
+                mock_event_producer.write_event.assert_called_once()
+
+                self.assertEquals(
+                    json.loads(mock_event_producer.write_event.call_args[0][0]),
+                    {
+                        "host": {"id": str(host_id), "insights_id": None},
+                        "platform_metadata": {},
+                        "timestamp": timestamp_iso,
+                        "type": "created",
+                    },
+                )
+
+    # Leaving this in as a reminder that we need to impliment this test eventually
+    # when the problem that it is supposed to test is fixed
+    # https://projects.engineering.redhat.com/browse/RHCLOUD-3503
+    # def test_handle_message_verify_threadctx_request_id_set_and_cleared(self):
+    #     # set the threadctx.request_id
+    #     # and clear it
+    #     pass
+
+
+class MQAddHostBaseClass(MQServiceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        """
+        Temporarily rename the host table while the tests run.  This is done
+        to make dropping the table at the end of the tests a bit safer.
+        """
+        rename_host_table_and_indexes()
+
+    def setUp(self):
+        """
+        Initializes the database by creating all tables.
+        """
+        super().setUp()
+
+        # binds the app to the current context
+        with self.app.app_context():
+            # create all tables
+            db.create_all()
+
+    def tearDown(self):
+        """
+        Cleans up the database by dropping all tables.
+        """
+        with self.app.app_context():
+            # drop all tables
+            db.session.remove()
+            db.drop_all()
+
+    def _base_add_host_test(self, host_data, expected_results, host_keys_to_check):
+        message = {"operation": "add_host", "data": host_data}
+
+        mock_event_producer = mockEventProducer()
+        with self.app.app_context():
+            handle_message(json.dumps(message), mock_event_producer)
+
+        for key in host_keys_to_check:
+            self.assertEqual(
+                json.loads(mock_event_producer.get_write_event())["host"][key], expected_results["host"][key]
+            )
+
+
+class MQhandleMessageTestCase(MQAddHostBaseClass):
+    def test_handle_message_verify_metadata_pass_through(self):
+        request_id = str(uuid.uuid4())
+        expected_insights_id = str(uuid.uuid4())
+
+        metadata = {"request_id": request_id, "archive_url": "https://some.url"}
+
+        host_data = {"display_name": "test_host", "insights_id": expected_insights_id, "account": "0000001"}
+
+        message = {"operation": "add_host", "platform_metadata": metadata, "data": host_data}
+
+        expected_results = {"platform_metadata": {**metadata}}
+
+        mock_event_producer = mockEventProducer()
+        with self.app.app_context():
+            handle_message(json.dumps(message), mock_event_producer)
+
+        self.assertEqual(
+            json.loads(mock_event_producer.get_write_event())["platform_metadata"],
+            expected_results["platform_metadata"],
+        )
+
+    def test_handle_message_verify_metadata_is_not_required(self):
+        expected_insights_id = str(uuid.uuid4())
+
+        host_data = {"display_name": "test_host", "insights_id": expected_insights_id, "account": "0000001"}
+
+        message = {"operation": "add_host", "data": host_data}
+
+        expected_results = {"host": {**host_data}}
+
+        mock_event_producer = mockEventProducer()
+        with self.app.app_context():
+            handle_message(json.dumps(message), mock_event_producer)
+
+        host_keys_to_check = ["display_name", "insights_id", "account"]
+
+        for key in host_keys_to_check:
+            self.assertEqual(
+                json.loads(mock_event_producer.get_write_event())["host"][key], expected_results["host"][key]
+            )
+
+
+class MQAddHostTestCase(MQAddHostBaseClass):
+    @patch("app.queue.egress.datetime", **{"utcnow.return_value": datetime.utcnow()})
+    def test_add_host_simple(self, datetime_mock):
+        """
+        Tests adding a host with some simple data
+        """
+        expected_insights_id = str(uuid.uuid4())
+        timestamp_iso = datetime_mock.utcnow.return_value.isoformat() + "+00:00"
+
+        host_data = {"display_name": "test_host", "insights_id": expected_insights_id, "account": "0000001"}
+
+        expected_results = {
+            "host": {**host_data},
+            "platform_metadata": {},
+            "timestamp": timestamp_iso,
+            "type": "created",
+        }
+
+        host_keys_to_check = ["display_name", "insights_id", "account"]
+
+        self._base_add_host_test(host_data, expected_results, host_keys_to_check)
+
+
+class MQCullingTests(MQAddHostBaseClass):
+    @patch("app.queue.egress.datetime", **{"utcnow.return_value": datetime.utcnow()})
+    def test_add_host_stale_timestamp(self, datetime_mock):
+        """
+        Tests to see if the host is succesfully created with both reporter
+        and stale_timestamp set.
+        """
+        expected_insights_id = str(uuid.uuid4())
+        timestamp_iso = datetime_mock.utcnow.return_value.isoformat() + "+00:00"
+        stale_timestamp = datetime.now(timezone.utc)
+
+        host_data = {
+            "display_name": "test_host",
+            "insights_id": expected_insights_id,
+            "account": "0000001",
+            "stale_timestamp": stale_timestamp.isoformat(),
+            "reporter": "puptoo",
+        }
+
+        expected_results = {
+            "host": {
+                **host_data,
+                "stale_warning_timestamp": (stale_timestamp + timedelta(weeks=1)).isoformat(),
+                "culled_timestamp": (stale_timestamp + timedelta(weeks=2)).isoformat(),
+            },
+            "platform_metadata": {},
+            "timestamp": timestamp_iso,
+            "type": "created",
+        }
+
+        host_keys_to_check = ["reporter", "stale_timestamp", "culled_timestamp"]
+
+        self._base_add_host_test(host_data, expected_results, host_keys_to_check)
+
+    def _base_incomplete_staleness_data_test(self, additional_host_data):
+        expected_insights_id = str(uuid.uuid4())
+
+        host_data = {
+            "display_name": "test_host",
+            "insights_id": expected_insights_id,
+            "account": "0000001",
+            **additional_host_data,
+        }
+
+        message = {"operation": "add_host", "data": host_data}
+        mock_event_producer = mockEventProducer()
+
+        with self.app.app_context():
+            with self.assertRaises(InventoryException):
+                handle_message(json.dumps(message), mock_event_producer)
+
+    def test_add_host_stale_timestamp_no_reporter(self):
+        """
+        tests to check the API will reject a host if it has a stale_timestamp
+        without a reporter. This shoul raise an inventory exception
+        """
+
+        stale_timestamp = datetime.now(timezone.utc)
+
+        additional_host_data = {"stale_timestamp": stale_timestamp.isoformat()}
+
+        self._base_incomplete_staleness_data_test(additional_host_data)
+
+    def test_add_host_reporter_no_stale_timestamp(self):
+        """
+        tests to check the API will reject a host if it has a stale_timestamp
+        without a reporter. This shoul raise an inventory exception
+        """
+
+        additional_host_data = {"reporter": "puptoo"}
+
+        self._base_incomplete_staleness_data_test(additional_host_data)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from base64 import b64encode
 from datetime import datetime
+from datetime import timedelta
 from datetime import timezone
 from json import dumps
 from random import choice
@@ -14,12 +15,14 @@ from uuid import uuid4
 from api import api_operation
 from api.host import _order_how
 from api.host import _params_to_order_by
+from app import create_app
 from app.auth.identity import from_auth_header
 from app.auth.identity import from_bearer_token
 from app.auth.identity import Identity
 from app.auth.identity import SHARED_SECRET_ENV_VAR
 from app.auth.identity import validate
 from app.config import Config
+from app.culling import StalenessOffset
 from app.exceptions import InputFormatException
 from app.exceptions import ValidationException
 from app.models import Host
@@ -214,6 +217,8 @@ class ConfigTestCase(TestCase):
         expected_base_url = f"/{path_prefix}/{app_name}"
         expected_api_path = f"{expected_base_url}/v1"
         expected_mgmt_url_path_prefix = "/mgmt_testing"
+        culling_stale_warning_offset_days = 10
+        culling_culled_offset_days = 20
 
         new_env = {
             "INVENTORY_DB_USER": "fredflintstone",
@@ -225,6 +230,8 @@ class ConfigTestCase(TestCase):
             "APP_NAME": app_name,
             "PATH_PREFIX": path_prefix,
             "INVENTORY_MANAGEMENT_URL_PATH_PREFIX": expected_mgmt_url_path_prefix,
+            "CULLING_STALE_WARNING_OFFSET_DAYS": str(culling_stale_warning_offset_days),
+            "CULLING_CULLED_OFFSET_DAYS": str(culling_culled_offset_days),
         }
 
         with set_environment(new_env):
@@ -236,6 +243,8 @@ class ConfigTestCase(TestCase):
             self.assertEqual(conf.db_pool_size, 8)
             self.assertEqual(conf.api_url_path_prefix, expected_api_path)
             self.assertEqual(conf.mgmt_url_path_prefix, expected_mgmt_url_path_prefix)
+            self.assertEqual(conf.culling_stale_warning_offset_days, culling_stale_warning_offset_days)
+            self.assertEqual(conf.culling_culled_offset_days, culling_culled_offset_days)
 
     def test_config_default_settings(self):
         expected_api_path = "/api/inventory/v1"
@@ -251,6 +260,8 @@ class ConfigTestCase(TestCase):
             self.assertEqual(conf.mgmt_url_path_prefix, expected_mgmt_url_path_prefix)
             self.assertEqual(conf.db_pool_timeout, 5)
             self.assertEqual(conf.db_pool_size, 5)
+            self.assertEqual(conf.culling_stale_warning_offset_days, 7)
+            self.assertEqual(conf.culling_culled_offset_days, 14)
 
     def test_config_development_settings(self):
         with set_environment({"INVENTORY_DB_POOL_TIMEOUT": "3"}):
@@ -258,6 +269,14 @@ class ConfigTestCase(TestCase):
             conf = Config()
 
             self.assertEqual(conf.db_pool_timeout, 3)
+
+
+@patch("app.Config", **{"return_value.mgmt_url_path_prefix": "/"})
+class CreateAppConfigTestCase(TestCase):
+    def test_config_is_assigned(self, config):
+        app = create_app("testing")
+        self.assertIn("INVENTORY_CONFIG", app.config)
+        self.assertEqual(config.return_value, app.config["INVENTORY_CONFIG"])
 
 
 class HostOrderHowTestCase(TestCase):
@@ -638,6 +657,8 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "cores_per_socket": 3,
                 "system_memory_bytes": 4,
             },
+            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "reporter": "some reporter",
         }
         host_schema.return_value.load.return_value.data = input
 
@@ -655,6 +676,8 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             deserialize_facts.return_value,
             deserialize_tags.return_value,
             input["system_profile"],
+            input["stale_timestamp"],
+            input["reporter"],
         )
 
     def test_without_facts(self, host_schema, deserialize_canonical_facts, deserialize_facts, deserialize_tags, host):
@@ -672,6 +695,8 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "cores_per_socket": 3,
                 "system_memory_bytes": 4,
             },
+            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "reporter": "some reporter",
         }
         host_schema.return_value.load.return_value.data = input
 
@@ -689,6 +714,8 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             deserialize_facts.return_value,
             deserialize_tags.return_value,
             input["system_profile"],
+            input["stale_timestamp"],
+            input["reporter"],
         )
 
     def test_without_display_name(
@@ -711,6 +738,8 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "cores_per_socket": 3,
                 "system_memory_bytes": 4,
             },
+            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "reporter": "some reporter",
         }
         host_schema.return_value.load.return_value.data = input
 
@@ -728,6 +757,8 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             deserialize_facts.return_value,
             deserialize_tags.return_value,
             input["system_profile"],
+            input["stale_timestamp"],
+            input["reporter"],
         )
 
     def test_without_system_profile(
@@ -745,6 +776,8 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "some namespace": {"some key": "some value"},
                 "another namespace": {"another key": "another value"},
             },
+            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "reporter": "some reporter",
         }
         host_schema.return_value.load.return_value.data = input
 
@@ -762,6 +795,50 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             deserialize_facts.return_value,
             deserialize_tags.return_value,
             {},
+            input["stale_timestamp"],
+            input["reporter"],
+        )
+
+    def test_without_stale_timestamp(
+        self, host_schema, deserialize_canonical_facts, deserialize_facts, deserialize_tags, host
+    ):
+        input = {
+            "display_name": "some display name",
+            "ansible_host": "some ansible host",
+            "account": "some account",
+            "tags": [
+                {"namespace": "NS1", "key": "key1", "value": "value1"},
+                {"namespace": "NS2", "key": "key2", "value": "value2"},
+            ],
+            "facts": {
+                "some namespace": {"some key": "some value"},
+                "another namespace": {"another key": "another value"},
+            },
+            "system_profile": {
+                "number_of_cpus": 1,
+                "number_of_sockets": 2,
+                "cores_per_socket": 3,
+                "system_memory_bytes": 4,
+            },
+        }
+        host_schema.return_value.load.return_value.data = input
+
+        result = deserialize_host({})
+        self.assertEqual(host.return_value, result)
+
+        deserialize_canonical_facts.assert_called_once_with(input)
+        deserialize_facts.assert_called_once_with(input["facts"])
+        deserialize_tags.assert_called_once_with(input["tags"])
+        host.assert_called_once_with(
+            deserialize_canonical_facts.return_value,
+            input["display_name"],
+            input["ansible_host"],
+            input["account"],
+            deserialize_facts.return_value,
+            deserialize_tags.return_value,
+            input["system_profile"],
+            None,
+            None,
         )
 
     def test_host_validation(
@@ -803,6 +880,10 @@ class SerializationSerializeHostBaseTestCase(TestCase):
 
 
 class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseTestCase):
+    @staticmethod
+    def _add_days(stale_timestamp, days):
+        return stale_timestamp + timedelta(days=days)
+
     def test_with_all_fields(self):
         canonical_facts = {
             "insights_id": str(uuid4()),
@@ -819,6 +900,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
             "display_name": "some display name",
             "ansible_host": "some ansible host",
             "account": "some acct",
+            "reporter": "insights",
         }
         host_init_data = {
             "canonical_facts": canonical_facts,
@@ -827,6 +909,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
                 "some namespace": {"some key": "some value"},
                 "another namespace": {"another key": "another value"},
             },
+            "stale_timestamp": datetime.now(timezone.utc),
         }
         host = Host(**host_init_data)
 
@@ -834,7 +917,10 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
         for k, v in host_attr_data.items():
             setattr(host, k, v)
 
-        actual = serialize_host(host)
+        stale_warning_offset_days = 7
+        culled_offset_days = 14
+        staleness_offset = StalenessOffset(stale_warning_offset_days, culled_offset_days)
+        actual = serialize_host(host, staleness_offset)
         expected = {
             **canonical_facts,
             **unchanged_data,
@@ -844,6 +930,13 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
             "id": str(host_attr_data["id"]),
             "created": self._timestamp_to_str(host_attr_data["created_on"]),
             "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
+            "stale_timestamp": self._timestamp_to_str(host_init_data["stale_timestamp"]),
+            "stale_warning_timestamp": self._timestamp_to_str(
+                self._add_days(host_init_data["stale_timestamp"], stale_warning_offset_days)
+            ),
+            "culled_timestamp": self._timestamp_to_str(
+                self._add_days(host_init_data["stale_timestamp"], culled_offset_days)
+            ),
         }
         self.assertEqual(expected, actual)
 
@@ -856,7 +949,8 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
         for k, v in host_attr_data.items():
             setattr(host, k, v)
 
-        actual = serialize_host(host)
+        staleness_offset = StalenessOffset(7, 14)
+        actual = serialize_host(host, staleness_offset)
         expected = {
             **host_init_data["canonical_facts"],
             "insights_id": None,
@@ -873,8 +967,34 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
             "id": str(host_attr_data["id"]),
             "created": self._timestamp_to_str(host_attr_data["created_on"]),
             "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
+            "stale_timestamp": None,
+            "stale_warning_timestamp": None,
+            "culled_timestamp": None,
+            "reporter": None,
         }
         self.assertEqual(expected, actual)
+
+    def test_stale_timestamp_config(self):
+        for stale_warning_offset_days, culled_offset_days in ((1, 2), (7, 14), (100, 1000)):
+            with self.subTest(
+                stale_warning_offset_days=stale_warning_offset_days, culled_offset_days=culled_offset_days
+            ):
+                stale_timestamp = datetime.now(timezone.utc) + timedelta(days=1)
+                host = Host({"fqdn": "some fqdn"}, facts={}, stale_timestamp=stale_timestamp, reporter="some reporter")
+
+                for k, v in (("id", uuid4()), ("created_on", datetime.utcnow()), ("modified_on", datetime.utcnow())):
+                    setattr(host, k, v)
+
+                staleness_offset = StalenessOffset(stale_warning_offset_days, culled_offset_days)
+                serialized = serialize_host(host, staleness_offset)
+                self.assertEqual(
+                    self._timestamp_to_str(self._add_days(stale_timestamp, stale_warning_offset_days)),
+                    serialized["stale_warning_timestamp"],
+                )
+                self.assertEqual(
+                    self._timestamp_to_str(self._add_days(stale_timestamp, culled_offset_days)),
+                    serialized["culled_timestamp"],
+                )
 
 
 @patch("app.serialization._serialize_facts")
@@ -888,20 +1008,34 @@ class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTes
             {"namespace": "another namespace", "facts": {"another key": "another value"}},
         ]
         serialize_facts.return_value = facts
+        stale_timestamp = datetime.now(timezone.utc)
 
         unchanged_data = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
             "account": "some acct",
+            "reporter": "some reporter",
         }
-        host_init_data = {"canonical_facts": canonical_facts, **unchanged_data, "facts": facts}
+        host_init_data = {
+            "canonical_facts": canonical_facts,
+            **unchanged_data,
+            "facts": facts,
+            "stale_timestamp": stale_timestamp,
+        }
         host = Host(**host_init_data)
 
         host_attr_data = {"id": uuid4(), "created_on": datetime.utcnow(), "modified_on": datetime.utcnow()}
         for k, v in host_attr_data.items():
             setattr(host, k, v)
 
-        actual = serialize_host(host)
+        staleness_offset = Mock(
+            **{
+                "stale_timestamp.return_value": datetime.now(timezone.utc),
+                "stale_timestamp.stale_warning_timestamp": datetime.now(timezone.utc) + timedelta(hours=1),
+                "stale_timestamp.culled_timestamp": datetime.now(timezone.utc) + timedelta(hours=2),
+            }
+        )
+        actual = serialize_host(host, staleness_offset)
         expected = {
             **canonical_facts,
             **unchanged_data,
@@ -909,6 +1043,9 @@ class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTes
             "id": str(host_attr_data["id"]),
             "created": self._timestamp_to_str(host_attr_data["created_on"]),
             "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
+            "stale_timestamp": self._timestamp_to_str(staleness_offset.stale_timestamp.return_value),
+            "stale_warning_timestamp": self._timestamp_to_str(staleness_offset.stale_warning_timestamp.return_value),
+            "culled_timestamp": self._timestamp_to_str(staleness_offset.culled_timestamp.return_value),
         }
         self.assertEqual(expected, actual)
 
@@ -1122,6 +1259,67 @@ class SerializationSerializeUuid(TestCase):
     def test_uuid_has_hyphens_literal(self):
         u = "4950e534-bbef-4432-bde2-aa3dd2bd0a52"
         self.assertEqual(u, _serialize_uuid(UUID(u)))
+
+
+class HostUpdateStaleTimestamp(TestCase):
+    def _make_host(self, **values):
+        return Host(**{"canonical_facts": {"fqdn": "some fqdn"}, **values})
+
+    def test_updated_when_empty(self):
+        host = self._make_host()
+
+        stale_timestamp = datetime.now(timezone.utc)
+        reporter = "some reporter"
+        host._update_stale_timestamp(stale_timestamp, reporter)
+
+        self.assertEqual(stale_timestamp, host.stale_timestamp)
+        self.assertEqual(reporter, host.reporter)
+
+    def test_updated_with_same_reporter(self):
+        old_stale_timestamp = datetime.now(timezone.utc) + timedelta(days=1)
+        reporter = "some reporter"
+        host = self._make_host(stale_timestamp=old_stale_timestamp, reporter=reporter)
+
+        new_stale_timestamp = datetime.now(timezone.utc) + timedelta(days=2)
+        host._update_stale_timestamp(new_stale_timestamp, reporter)
+
+        self.assertEqual(new_stale_timestamp, host.stale_timestamp)
+        self.assertEqual(reporter, host.reporter)
+
+    def test_updated_with_different_reporter(self):
+        old_stale_timestamp = datetime.now(timezone.utc) + timedelta(days=2)
+        old_reporter = "some old reporter"
+        host = self._make_host(stale_timestamp=old_stale_timestamp, reporter=old_reporter)
+
+        new_stale_timestamp = datetime.now(timezone.utc) + timedelta(days=1)
+        new_reporter = "some new reporter"
+        host._update_stale_timestamp(new_stale_timestamp, new_reporter)
+
+        self.assertEqual(new_stale_timestamp, host.stale_timestamp)
+        self.assertEqual(new_reporter, host.reporter)
+
+    def test_not_updated_with_same_reporter(self):
+        old_stale_timestamp = datetime.now(timezone.utc) + timedelta(days=2)
+        reporter = "some reporter"
+        host = self._make_host(stale_timestamp=old_stale_timestamp, reporter=reporter)
+
+        new_stale_timestamp = datetime.now(timezone.utc) + timedelta(days=1)
+        host._update_stale_timestamp(new_stale_timestamp, reporter)
+
+        self.assertEqual(old_stale_timestamp, host.stale_timestamp)
+        self.assertEqual(reporter, host.reporter)
+
+    def test_not_updated_with_different_reporter(self):
+        old_stale_timestamp = datetime.now(timezone.utc) + timedelta(days=1)
+        old_reporter = "some old reporter"
+        host = self._make_host(stale_timestamp=old_stale_timestamp, reporter=old_reporter)
+
+        new_stale_timestamp = datetime.now(timezone.utc) + timedelta(days=2)
+        new_reporter = "some new reporter"
+        host._update_stale_timestamp(new_stale_timestamp, new_reporter)
+
+        self.assertEqual(old_stale_timestamp, host.stale_timestamp)
+        self.assertEqual(old_reporter, host.reporter)
 
 
 if __name__ == "__main__":

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -1,5 +1,8 @@
 import json
 import uuid
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 
 
 def rpm_list():
@@ -520,6 +523,8 @@ def build_host_chunk():
         # "mac_addresses": None,
         "subscription_manager_id": random_uuid(),
         "system_profile": create_system_profile(),
+        "stale_timestamp": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+        "reporter": "me",
     }
     return payload
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/RHCLOUD-2575

* Save stale_timestamp and reporter

Added stale_timestamp and reporter fields to the add_hosts operation.
If one of the fields is present, the other one must be filled in too.
The stale_timestamp gets updated if

* it’s either not set at all
* or if the reporter is the same and the new timestamp is longer
* or if the reporter is different and the new timestamp is shorter

* Save stale_timestamp and reporter

Added stale_timestamp and reporter fields to the add_hosts operation.
If one of the fields is present, the other one must be filled in too.
The stale_timestamp gets updated if

* it’s either not set at all
* or if the reporter is the same and the new timestamp is longer
* or if the reporter is different and the new timestamp is shorter

* Unit test stale timestamp update

Added unit tests for the Host._update_stale_timestamp method. It
contains some rather complex logic, which is now covered by tests.

* Fix unit test

Fixed failing host deserialization unit tests. The tests didn’t consider
new Host constructor field. Added a new test for their default values.

* Add basic culling fields to response

Added the stale_timestamp and reporter fields to the serialized Host –
to the create and get host output.

* Test new fields in response

Added test checking that the new stale_timestamp and reporter fields are
present in all responses: create, update, get all and get by ID.

* Add computed timestamps to responses.

Add stale_warning_timestamp and culled_timestamp to the API responses.
These are computed from the stale_warning timestamp. Added explicit
tests for the timestamps.

* added stale_timestamp input, and stale_warning_timestamp, culled_timestamp output to MQ

* Support filtering by staleness

Added a new staleness parameter to get_host_list and get_host_by_id. It
supports fresh, stale, stale_warning, culled and unknown states.

* add reporter label to ingress metrics

so that we can easily categorize the success/failure/error metrics by reporter

* Added some tests for MQ and the new stale functionality

* actually commiting the new test file this time

* fixed failing test

* master merge in

* made comment match function

* Make culling timestamps configurable

Added application configuration values for the stale_warning and culled
timestamps offsets. They are in days and are loaded from the
environment. This required to add the application configuration to the
application config contextual object and to pass it around for the
serialization.

* Test culling timestamps configuration

Added tests for the new configuration values. They verifies that the
stale warning and culled timestamps are computed correctly using the
values in the configuration object.

* Test culling configuration

* Added default values and enviroment variables to the Config class test
  case.
* Added a new test case verifying that our configuration object is
  stored in the Flask App configuration dictionary.

* fixed the failing test for real this time. Promise

* fixed issue where mq test fail when run alone

* Don’t expose the culled state

The culled state is now only internal. It is no longer possible to get
the culled hosts by any means. Added a regression test verifying that
this state is not supported.

* Use OpenAPI default for staleness

Use OpenAPI standard schema definition of default values for the new
staleness fields. Removed the Python constant and default values.

* finished the empty tests (the ones that can be)

* add reference to a jira issue

* Fix merge conflicts

* Decouple config from serialization

Extracted the culling timestamp computation logic to a separate module.
As a result, the serialization code no longer depends on the whole
Config object.

* use generated stale_timestamp in sample payloads