### PR TITLE
Host query GraphQL integration

### DIFF
--- a/api/host_query.py
+++ b/api/host_query.py
@@ -1,0 +1,29 @@
+from collections import namedtuple
+from enum import Enum
+
+from app import inventory_config
+from app.culling import Timestamps
+from app.serialization import serialize_host
+
+
+__all__ = ("build_paginated_host_list_response", "staleness_timestamps")
+
+OrderBy = Enum("OrderBy", ("display_name", "id", "modified_on"))
+OrderHow = Enum("OrderHow", ("ASC", "DESC"))
+Order = namedtuple("Order", ("by", "how"))
+
+
+def build_paginated_host_list_response(total, page, per_page, host_list):
+    timestamps = staleness_timestamps()
+    json_host_list = [serialize_host(host, timestamps) for host in host_list]
+    return {
+        "total": total,
+        "count": len(json_host_list),
+        "page": page,
+        "per_page": per_page,
+        "results": json_host_list,
+    }
+
+
+def staleness_timestamps():
+    return Timestamps.from_config(inventory_config())

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -1,0 +1,147 @@
+from uuid import UUID
+
+from sqlalchemy import and_
+from sqlalchemy import or_
+
+from app import inventory_config
+from app.auth import current_identity
+from app.culling import staleness_to_conditions
+from app.logging import get_logger
+from app.models import Host
+from app.utils import Tag
+from lib.host_repository import canonical_facts_host_query
+
+__all__ = ("get_host_list", "find_hosts_by_staleness", "params_to_order_by")
+
+NULL = None
+
+logger = get_logger(__name__)
+
+
+def get_host_list(
+    display_name, fqdn, hostname_or_id, insights_id, tags, page, per_page, order_by, order_how, staleness
+):
+    if fqdn:
+        query = _find_hosts_by_canonical_facts({"fqdn": fqdn})
+    elif display_name:
+        query = _find_hosts_by_display_name(display_name)
+    elif hostname_or_id:
+        query = _find_hosts_by_hostname_or_id(hostname_or_id)
+    elif insights_id:
+        query = _find_hosts_by_canonical_facts({"insights_id": insights_id})
+    else:
+        query = _find_all_hosts()
+
+    if tags:
+        # add tag filtering to the query
+        query = _find_hosts_by_tag(tags, query)
+
+    if staleness:
+        query = find_hosts_by_staleness(staleness, query)
+
+    order_by = params_to_order_by(order_by, order_how)
+    query = query.order_by(*order_by)
+    query_results = query.paginate(page, per_page, True)
+
+    logger.debug("Found hosts: %s", query_results.items)
+
+    return query_results.items, query_results.total
+
+
+def find_hosts_by_staleness(staleness, query):
+    logger.debug("find_hosts_by_staleness(%s)", staleness)
+    config = inventory_config()
+    staleness_conditions = tuple(staleness_to_conditions(config, staleness, _stale_timestamp_filter))
+    if "unknown" in staleness:
+        staleness_conditions += (Host.stale_timestamp == NULL,)
+
+    return query.filter(or_(*staleness_conditions))
+
+
+def params_to_order_by(order_by=None, order_how=None):
+    modified_on_ordering = (Host.modified_on.desc(),)
+    ordering = ()
+
+    if order_by == "updated":
+        if order_how:
+            modified_on_ordering = (_order_how(Host.modified_on, order_how),)
+    elif order_by == "display_name":
+        if order_how:
+            ordering = (_order_how(Host.display_name, order_how),)
+        else:
+            ordering = (Host.display_name.asc(),)
+    elif order_by:
+        raise ValueError('Unsupported ordering column, use "updated" or "display_name".')
+    elif order_how:
+        raise ValueError(
+            "Providing ordering direction without a column is not supported. "
+            "Provide order_by={updated,display_name}."
+        )
+
+    return ordering + modified_on_ordering + (Host.id.desc(),)
+
+
+def _order_how(column, order_how):
+    if order_how == "ASC":
+        return column.asc()
+    elif order_how == "DESC":
+        return column.desc()
+    else:
+        raise ValueError('Unsupported ordering direction, use "ASC" or "DESC".')
+
+
+def _find_all_hosts():
+    return Host.query.filter(Host.account == current_identity.account_number)
+
+
+def _find_hosts_by_canonical_facts(canonical_facts):
+    return canonical_facts_host_query(current_identity.account_number, canonical_facts)
+
+
+def _find_hosts_by_tag(string_tags, query):
+    logger.debug("_find_hosts_by_tag(%s)", string_tags)
+
+    tags = []
+
+    for string_tag in string_tags:
+        tags.append(Tag().from_string(string_tag))
+
+    tags_to_find = Tag.create_nested_from_tags(tags)
+
+    return query.filter(Host.tags.contains(tags_to_find))
+
+
+def _find_hosts_by_hostname_or_id(hostname):
+    logger.debug("_find_hosts_by_hostname_or_id(%s)", hostname)
+
+    filter_list = [
+        Host.display_name.comparator.contains(hostname),
+        Host.canonical_facts["fqdn"].astext.contains(hostname),
+    ]
+
+    try:
+        UUID(hostname)
+        host_id = hostname
+        filter_list.append(Host.id == host_id)
+        logger.debug("Adding id (uuid) to the filter list")
+    except Exception:
+        # Do not filter using the id
+        logger.debug("The hostname (%s) could not be converted into a UUID", hostname, exc_info=True)
+
+    return Host.query.filter(and_(*[Host.account == current_identity.account_number, or_(*filter_list)]))
+
+
+def _find_hosts_by_display_name(display_name):
+    logger.debug("find_hosts_by_display_name(%s)", display_name)
+    return Host.query.filter(
+        and_(Host.account == current_identity.account_number, Host.display_name.comparator.contains(display_name))
+    )
+
+
+def _stale_timestamp_filter(gte=None, lte=None):
+    filter_ = ()
+    if gte:
+        filter_ += (Host.stale_timestamp >= gte,)
+    if lte:
+        filter_ += (Host.stale_timestamp <= lte,)
+    return and_(*filter_)

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -1,0 +1,115 @@
+from uuid import UUID
+
+from app.logging import get_logger
+from app.serialization import deserialize_host_xjoin as deserialize_host
+from app.utils import Tag
+from app.xjoin import check_pagination
+from app.xjoin import graphql_query
+from app.xjoin import pagination_params
+from app.xjoin import staleness_filter
+from app.xjoin import string_contains
+
+__all__ = ("get_host_list",)
+
+logger = get_logger(__name__)
+
+
+QUERY = """query Query(
+    $limit: Int!,
+    $offset: Int!,
+    $order_by: HOSTS_ORDER_BY,
+    $order_how: ORDER_DIR,
+    $filter: [HostFilter!]
+) {
+    hosts(
+        limit: $limit,
+        offset: $offset,
+        order_by: $order_by,
+        order_how: $order_how,
+        filter: {
+            AND: $filter,
+        }
+    ) {
+        meta {
+            total,
+        }
+        data {
+            id,
+            account,
+            display_name,
+            ansible_host,
+            created_on,
+            modified_on,
+            canonical_facts,
+            facts,
+            stale_timestamp,
+            reporter,
+        }
+    }
+}"""
+ORDER_BY_MAPPING = {None: "modified_on", "updated": "modified_on", "display_name": "display_name"}
+ORDER_HOW_MAPPING = {"modified_on": "DESC", "display_name": "ASC"}
+
+
+def get_host_list(
+    display_name, fqdn, hostname_or_id, insights_id, tags, page, per_page, param_order_by, param_order_how, staleness
+):
+    limit, offset = pagination_params(page, per_page)
+    xjoin_order_by, xjoin_order_how = _params_to_order(param_order_by, param_order_how)
+
+    variables = {
+        "limit": limit,
+        "offset": offset,
+        "order_by": xjoin_order_by,
+        "order_how": xjoin_order_how,
+        "filter": _query_filters(fqdn, display_name, hostname_or_id, insights_id, tags, staleness),
+    }
+    response = graphql_query(QUERY, variables)["hosts"]
+
+    total = response["meta"]["total"]
+    check_pagination(offset, total)
+
+    return map(deserialize_host, response["data"]), total
+
+
+def _params_to_order(param_order_by=None, param_order_how=None):
+    if param_order_how and not param_order_by:
+        raise ValueError(
+            "Providing ordering direction without a column is not supported. "
+            "Provide order_by={updated,display_name}."
+        )
+
+    xjoin_order_by = ORDER_BY_MAPPING[param_order_by]
+    xjoin_order_how = param_order_how or ORDER_HOW_MAPPING[xjoin_order_by]
+    return xjoin_order_by, xjoin_order_how
+
+
+def _query_filters(fqdn, display_name, hostname_or_id, insights_id, tags, staleness):
+    if fqdn:
+        query_filters = ({"fqdn": fqdn},)
+    elif display_name:
+        query_filters = ({"display_name": string_contains(display_name)},)
+    elif hostname_or_id:
+        contains = string_contains(hostname_or_id)
+        hostname_or_id_filters = ({"display_name": contains}, {"fqdn": contains})
+        try:
+            id = UUID(hostname_or_id)
+        except ValueError:
+            # Do not filter using the id
+            logger.debug("The hostname (%s) could not be converted into a UUID", hostname_or_id, exc_info=True)
+        else:
+            logger.debug("Adding id (uuid) to the filter list")
+            hostname_or_id_filters += ({"id": str(id)},)
+        query_filters = ({"OR": hostname_or_id_filters},)
+    elif insights_id:
+        query_filters = ({"insights_id": insights_id},)
+    else:
+        query_filters = ()
+
+    if tags:
+        query_filters += tuple({"tag": Tag().from_string(string_tag).data()} for string_tag in tags)
+    if staleness:
+        staleness_filters = tuple(staleness_filter(staleness))
+        query_filters += ({"OR": staleness_filters},)
+
+    return query_filters

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,6 @@ from prometheus_flask_exporter import PrometheusMetrics
 from api.mgmt import monitoring_blueprint
 from app import payload_tracker
 from app.config import Config
-from app.culling import StalenessOffset
 from app.exceptions import InventoryException
 from app.logging import configure_logging
 from app.logging import get_logger
@@ -31,8 +30,8 @@ def render_exception(exception):
     return response
 
 
-def staleness_offset():
-    return StalenessOffset.from_config(current_app.config["INVENTORY_CONFIG"])
+def inventory_config():
+    return current_app.config["INVENTORY_CONFIG"]
 
 
 def create_app(config_name, start_tasks=False, start_payload_tracker=False):

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,15 +1,13 @@
 import connexion
-from flask import request
 from werkzeug.local import LocalProxy
 
 from api.metrics import login_failure_count
-from app import IDENTITY_HEADER
 from app.auth.identity import from_auth_header
 from app.auth.identity import from_bearer_token
 from app.auth.identity import validate
 from app.logging import get_logger
 
-__all__ = ["current_identity", "bearer_token_handler", "authentication_header_handler"]
+__all__ = ("authentication_header_handler", "bearer_token_handler")
 
 logger = get_logger(__name__)
 
@@ -36,13 +34,6 @@ def bearer_token_handler(token):
         return None
 
     return {"uid": identity}
-
-
-def authenticated_request(method, *args, **kwargs):
-    headers = kwargs.get("headers", {})
-    headers[IDENTITY_HEADER] = request.headers[IDENTITY_HEADER]
-    authenticated_kwargs = {**kwargs, "headers": headers}
-    return method(*args, **authenticated_kwargs)
 
 
 def _get_identity():

--- a/app/culling.py
+++ b/app/culling.py
@@ -3,17 +3,26 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
-from flask import current_app
+__all__ = ("Conditions", "staleness_to_conditions", "Timestamps")
 
 
-__all__ = ("StalenessOffset", "StalenessMap")
-
-
-class StalenessOffset(namedtuple("StalenessOffset", ("stale_warning_offset_days", "culled_offset_days"))):
+class _Config(namedtuple("_Config", ("stale_warning_offset_days", "culled_offset_days"))):
     @classmethod
     def from_config(cls, config):
         return cls(config.culling_stale_warning_offset_days, config.culling_culled_offset_days)
 
+
+class _WithConfig:
+    def __init__(self, config):
+        self.config = config
+
+    @classmethod
+    def from_config(cls, config):
+        config = _Config.from_config(config)
+        return cls(config)
+
+
+class Timestamps(_WithConfig):
     @staticmethod
     def _add_days(timestamp, days):
         return timestamp + timedelta(days=days)
@@ -22,16 +31,20 @@ class StalenessOffset(namedtuple("StalenessOffset", ("stale_warning_offset_days"
         return self._add_days(stale_timestamp, 0)
 
     def stale_warning_timestamp(self, stale_timestamp):
-        return self._add_days(stale_timestamp, self.stale_warning_offset_days)
+        return self._add_days(stale_timestamp, self.config.stale_warning_offset_days)
 
     def culled_timestamp(self, stale_timestamp):
-        return self._add_days(stale_timestamp, self.culled_offset_days)
+        return self._add_days(stale_timestamp, self.config.culled_offset_days)
 
 
-class StalenessMap:
-    def __init__(self):
+class Conditions(_WithConfig):
+    def __init__(self, config):
+        super().__init__(config)
         self.now = datetime.now(timezone.utc)
-        self.config = current_app.config["INVENTORY_CONFIG"]
+
+    @staticmethod
+    def _sub_days(timestamp, days):
+        return timestamp - timedelta(days=days)
 
     def fresh(self):
         return self.now, None
@@ -43,9 +56,15 @@ class StalenessMap:
         return self._culled_timestamp(), self._stale_warning_timestamp()
 
     def _stale_warning_timestamp(self):
-        offset = timedelta(days=self.config.culling_stale_warning_offset_days)
+        offset = timedelta(days=self.config.stale_warning_offset_days)
         return self.now - offset
 
     def _culled_timestamp(self):
-        offset = timedelta(days=self.config.culling_culled_offset_days)
+        offset = timedelta(days=self.config.culled_offset_days)
         return self.now - offset
+
+
+def staleness_to_conditions(config, staleness, timestamp_filter_func):
+    condition = Conditions.from_config(config)
+    filtered_states = (state for state in staleness if state not in ("unknown",))
+    return (timestamp_filter_func(*getattr(condition, state)()) for state in filtered_states)

--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -4,7 +4,8 @@ from marshmallow import fields
 from marshmallow import Schema
 from marshmallow import ValidationError
 
-from app import staleness_offset
+from app import inventory_config
+from app.culling import Timestamps
 from app.exceptions import InventoryException
 from app.logging import get_logger
 from app.logging import threadctx
@@ -91,7 +92,8 @@ def add_host(host_data):
         try:
             logger.info("Attempting to add host...")
             input_host = deserialize_host(host_data)
-            (output_host, add_results) = host_repository.add_host(input_host, staleness_offset())
+            staleness_timestamps = Timestamps.from_config(inventory_config())
+            (output_host, add_results) = host_repository.add_host(input_host, staleness_timestamps)
             metrics.add_host_success.labels(
                 add_results.name, host_data.get("reporter", "null")
             ).inc()  # created vs updated

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -48,11 +48,29 @@ def deserialize_host(raw_data):
     )
 
 
-def serialize_host(host, staleness_offset):
+def deserialize_host_xjoin(data):
+    host = Host(
+        canonical_facts=data["canonical_facts"],
+        display_name=data["display_name"],
+        ansible_host=data["ansible_host"],
+        account=data["account"],
+        facts=data["facts"] or {},
+        tags={},  # Not a part of host list output
+        system_profile_facts={},  # Not a part of host list output
+        stale_timestamp=_deserialize_datetime_xjoin(data["stale_timestamp"]),
+        reporter=data["reporter"],
+    )
+    for field in ("created_on", "modified_on"):
+        setattr(host, field, _deserialize_datetime_xjoin(data[field]))
+    host.id = data["id"]
+    return host
+
+
+def serialize_host(host, staleness_timestamps):
     if host.stale_timestamp:
-        stale_timestamp = staleness_offset.stale_timestamp(host.stale_timestamp)
-        stale_warning_timestamp = staleness_offset.stale_warning_timestamp(host.stale_timestamp)
-        culled_timestamp = staleness_offset.culled_timestamp(host.stale_timestamp)
+        stale_timestamp = staleness_timestamps.stale_timestamp(host.stale_timestamp)
+        stale_warning_timestamp = staleness_timestamps.stale_warning_timestamp(host.stale_timestamp)
+        culled_timestamp = staleness_timestamps.culled_timestamp(host.stale_timestamp)
     else:
         stale_timestamp = None
         stale_warning_timestamp = None

--- a/host_dumper.py
+++ b/host_dumper.py
@@ -3,7 +3,8 @@ import argparse
 import pprint
 
 from app import create_app
-from app import staleness_offset
+from app import inventory_config
+from app.culling import Timestamps
 from app.models import Host
 from app.serialization import serialize_host
 
@@ -42,7 +43,8 @@ with application.app_context():
     elif args.account_number:
         query_results = Host.query.filter(Host.account == args.account_number).all()
 
-    json_host_list = [serialize_host(host, staleness_offset()) for host in query_results]
+    staleness_timestamps = Timestamps.from_config(inventory_config())
+    json_host_list = [serialize_host(host, staleness_timestamps) for host in query_results]
 
     if args.no_pp:
         print(json_host_list)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -59,7 +59,7 @@ def _find_host_by_elevated_ids(account_number, canonical_facts):
     return None
 
 
-def _canonical_facts_host_query(account_number, canonical_facts):
+def canonical_facts_host_query(account_number, canonical_facts):
     return Host.query.filter(
         (Host.account == account_number)
         & (
@@ -75,7 +75,7 @@ def find_host_by_canonical_facts(account_number, canonical_facts):
     """
     logger.debug("find_host_by_canonical_facts(%s)", canonical_facts)
 
-    host = _canonical_facts_host_query(account_number, canonical_facts).first()
+    host = canonical_facts_host_query(account_number, canonical_facts).first()
 
     if host:
         logger.debug("Found existing host using canonical_fact match: %s", host)

--- a/test_api.py
+++ b/test_api.py
@@ -3581,243 +3581,236 @@ class HostsXjoinResponseTestCase(HostsXjoinBaseTestCase):
         self.get(f"{HOST_URL}?per_page=2&page=3", 404)
         graphql_query.assert_called_once()
 
-    @patch("api.tag.is_enabled", return_value=True)
-    class TagsRequestTestCase(XjoinRequestBaseTestCase):
-        patch_with_empty_response = partial(
-            patch, "api.tag.graphql_query", return_value={"hostTags": {"meta": {"count": 0, "total": 0}, "data": []}}
+
+@patch("api.tag.is_enabled", return_value=True)
+class TagsRequestTestCase(XjoinRequestBaseTestCase):
+    patch_with_empty_response = partial(
+        patch, "api.tag.graphql_query", return_value={"hostTags": {"meta": {"count": 0, "total": 0}, "data": []}}
+    )
+
+    def test_headers_forwarded(self, is_enabled):
+        value = {"data": {"hostTags": {"meta": {"count": 0, "total": 0}, "data": []}}}
+        with self._patch_xjoin_post(value) as resp:
+            req_id = "353b230b-5607-4454-90a1-589fbd61fde9"
+            self._get_with_request_id(TAGS_URL, req_id)
+            self._assert_called_with_headers(resp, req_id)
+
+    @patch_with_empty_response()
+    def test_query_variables_default_except_staleness(self, graphql_query, is_enabled):
+        self.get(TAGS_URL, 200)
+
+        graphql_query.assert_called_once_with(
+            TAGS_QUERY, {"order_by": "tag", "order_how": "ASC", "limit": 50, "offset": 0, "hostFilter": {"OR": ANY}}
         )
 
-        def test_headers_forwarded(self, is_enabled):
-            value = {"data": {"hostTags": {"meta": {"count": 0, "total": 0}, "data": []}}}
-            with self._patch_xjoin_post(value) as resp:
-                req_id = "353b230b-5607-4454-90a1-589fbd61fde9"
-                self._get_with_request_id(TAGS_URL, req_id)
-                self._assert_called_with_headers(resp, req_id)
+    @patch_with_empty_response()
+    @patch("app.culling.datetime")
+    def test_query_variables_default_staleness(self, datetime_mock, graphql_query, is_enabled):
+        datetime_mock.now.return_value = datetime(2019, 12, 16, 10, 10, 6, 754201, tzinfo=timezone.utc)
 
-        @patch_with_empty_response()
-        def test_query_variables_default_except_staleness(self, graphql_query, is_enabled):
-            self.get(TAGS_URL, 200)
+        self.get(TAGS_URL, 200)
 
-            graphql_query.assert_called_once_with(
-                TAGS_QUERY,
-                {"order_by": "tag", "order_how": "ASC", "limit": 50, "offset": 0, "hostFilter": {"OR": ANY}},
-            )
-
-        @patch_with_empty_response()
-        @patch("app.culling.datetime")
-        def test_query_variables_default_staleness(self, datetime_mock, graphql_query, is_enabled):
-            datetime_mock.now.return_value = datetime(2019, 12, 16, 10, 10, 6, 754201, tzinfo=timezone.utc)
-
-            self.get(TAGS_URL, 200)
-
-            graphql_query.assert_called_once_with(
-                TAGS_QUERY,
-                {
-                    "order_by": ANY,
-                    "order_how": ANY,
-                    "limit": ANY,
-                    "offset": ANY,
-                    "hostFilter": {
-                        "OR": [
-                            {"stale_timestamp": {"gte": "2019-12-16T10:10:06.754201+00:00"}},
-                            {
-                                "stale_timestamp": {
-                                    "gte": "2019-12-09T10:10:06.754201+00:00",
-                                    "lte": "2019-12-16T10:10:06.754201+00:00",
-                                }
-                            },
-                        ]
-                    },
+        graphql_query.assert_called_once_with(
+            TAGS_QUERY,
+            {
+                "order_by": ANY,
+                "order_how": ANY,
+                "limit": ANY,
+                "offset": ANY,
+                "hostFilter": {
+                    "OR": [
+                        {"stale_timestamp": {"gte": "2019-12-16T10:10:06.754201+00:00"}},
+                        {
+                            "stale_timestamp": {
+                                "gte": "2019-12-09T10:10:06.754201+00:00",
+                                "lte": "2019-12-16T10:10:06.754201+00:00",
+                            }
+                        },
+                    ]
                 },
-            )
+            },
+        )
 
-        @patch("app.culling.datetime")
-        def test_query_variables_staleness(self, datetime_mock, is_enabled):
-            now = datetime(2019, 12, 16, 10, 10, 6, 754201, tzinfo=timezone.utc)
-            datetime_mock.now = mock.Mock(return_value=now)
+    @patch("app.culling.datetime")
+    def test_query_variables_staleness(self, datetime_mock, is_enabled):
+        now = datetime(2019, 12, 16, 10, 10, 6, 754201, tzinfo=timezone.utc)
+        datetime_mock.now = mock.Mock(return_value=now)
 
-            for staleness, expected in (
-                ("fresh", {"gte": "2019-12-16T10:10:06.754201+00:00"}),
-                ("stale", {"gte": "2019-12-09T10:10:06.754201+00:00", "lte": "2019-12-16T10:10:06.754201+00:00"}),
-                (
-                    "stale_warning",
-                    {"gte": "2019-12-02T10:10:06.754201+00:00", "lte": "2019-12-09T10:10:06.754201+00:00"},
-                ),
-            ):
-                with self.subTest(staleness=staleness):
-                    with self.patch_with_empty_response() as graphql_query:
-                        self.get(f"{TAGS_URL}?staleness={staleness}", 200)
-
-                        graphql_query.assert_called_once_with(
-                            TAGS_QUERY,
-                            {
-                                "order_by": "tag",
-                                "order_how": "ASC",
-                                "limit": 50,
-                                "offset": 0,
-                                "hostFilter": {"OR": [{"stale_timestamp": expected}]},
-                            },
-                        )
-
-        @patch_with_empty_response()
-        def test_query_variables_tags_simple(self, graphql_query, is_enabled):
-            self.get(f"{TAGS_URL}?tags=insights-client/os=fedora", 200)
-
-            graphql_query.assert_called_once_with(
-                TAGS_QUERY,
-                {
-                    "order_by": "tag",
-                    "order_how": "ASC",
-                    "limit": 50,
-                    "offset": 0,
-                    "hostFilter": {
-                        "AND": [{"tag": {"namespace": "insights-client", "key": "os", "value": "fedora"}}],
-                        "OR": ANY,
-                    },
-                },
-            )
-
-        @patch_with_empty_response()
-        def test_query_variables_tags_complex(self, graphql_query, is_enabled):
-            tag1 = Tag("Sat", "env", "prod")
-            tag2 = Tag("insights-client", "special/keyΔwithčhars", "special/valueΔwithčhars!")
-
-            self.get(f"{TAGS_URL}?tags={quote(tag1.to_string())}&tags={quote(tag2.to_string())}", 200)
-
-            graphql_query.assert_called_once_with(
-                TAGS_QUERY,
-                {
-                    "order_by": "tag",
-                    "order_how": "ASC",
-                    "limit": 50,
-                    "offset": 0,
-                    "hostFilter": {
-                        "AND": [
-                            {"tag": {"namespace": "Sat", "key": "env", "value": "prod"}},
-                            {
-                                "tag": {
-                                    "namespace": "insights-client",
-                                    "key": "special/keyΔwithčhars",
-                                    "value": "special/valueΔwithčhars!",
-                                }
-                            },
-                        ],
-                        "OR": ANY,
-                    },
-                },
-            )
-
-        @patch_with_empty_response()
-        def test_query_variables_search(self, graphql_query, is_enabled):
-            self.get(f"{TAGS_URL}?search={quote('Δwithčhar!/~|+ ')}", 200)
-
-            graphql_query.assert_called_once_with(
-                TAGS_QUERY,
-                {
-                    "order_by": "tag",
-                    "order_how": "ASC",
-                    "limit": 50,
-                    "offset": 0,
-                    "filter": {"name": ".*\\%CE\\%94with\\%C4\\%8Dhar\\%21\\%2F\\%7E\\%7C\\%2B\\+.*"},
-                    "hostFilter": {"OR": ANY},
-                },
-            )
-
-        def test_query_variables_ordering_dir(self, is_enabled):
-            for direction in ["ASC", "DESC"]:
-                with self.subTest(direction=direction):
-                    with self.patch_with_empty_response() as graphql_query:
-                        self.get(f"{TAGS_URL}?order_how={direction}", 200)
-
-                        graphql_query.assert_called_once_with(
-                            TAGS_QUERY,
-                            {
-                                "order_by": "tag",
-                                "order_how": direction,
-                                "limit": 50,
-                                "offset": 0,
-                                "hostFilter": {"OR": ANY},
-                            },
-                        )
-
-        def test_query_variables_ordering_by(self, is_enabled):
-            for ordering in ["tag", "count"]:
+        for staleness, expected in (
+            ("fresh", {"gte": "2019-12-16T10:10:06.754201+00:00"}),
+            ("stale", {"gte": "2019-12-09T10:10:06.754201+00:00", "lte": "2019-12-16T10:10:06.754201+00:00"}),
+            ("stale_warning", {"gte": "2019-12-02T10:10:06.754201+00:00", "lte": "2019-12-09T10:10:06.754201+00:00"}),
+        ):
+            with self.subTest(staleness=staleness):
                 with self.patch_with_empty_response() as graphql_query:
-                    self.get(f"{TAGS_URL}?order_by={ordering}", 200)
+                    self.get(f"{TAGS_URL}?staleness={staleness}", 200)
 
                     graphql_query.assert_called_once_with(
                         TAGS_QUERY,
                         {
-                            "order_by": ordering,
+                            "order_by": "tag",
                             "order_how": "ASC",
+                            "limit": 50,
+                            "offset": 0,
+                            "hostFilter": {"OR": [{"stale_timestamp": expected}]},
+                        },
+                    )
+
+    @patch_with_empty_response()
+    def test_query_variables_tags_simple(self, graphql_query, is_enabled):
+        self.get(f"{TAGS_URL}?tags=insights-client/os=fedora", 200)
+
+        graphql_query.assert_called_once_with(
+            TAGS_QUERY,
+            {
+                "order_by": "tag",
+                "order_how": "ASC",
+                "limit": 50,
+                "offset": 0,
+                "hostFilter": {
+                    "AND": [{"tag": {"namespace": "insights-client", "key": "os", "value": "fedora"}}],
+                    "OR": ANY,
+                },
+            },
+        )
+
+    @patch_with_empty_response()
+    def test_query_variables_tags_complex(self, graphql_query, is_enabled):
+        tag1 = Tag("Sat", "env", "prod")
+        tag2 = Tag("insights-client", "special/keyΔwithčhars", "special/valueΔwithčhars!")
+
+        self.get(f"{TAGS_URL}?tags={quote(tag1.to_string())}&tags={quote(tag2.to_string())}", 200)
+
+        graphql_query.assert_called_once_with(
+            TAGS_QUERY,
+            {
+                "order_by": "tag",
+                "order_how": "ASC",
+                "limit": 50,
+                "offset": 0,
+                "hostFilter": {
+                    "AND": [
+                        {"tag": {"namespace": "Sat", "key": "env", "value": "prod"}},
+                        {
+                            "tag": {
+                                "namespace": "insights-client",
+                                "key": "special/keyΔwithčhars",
+                                "value": "special/valueΔwithčhars!",
+                            }
+                        },
+                    ],
+                    "OR": ANY,
+                },
+            },
+        )
+
+    @patch_with_empty_response()
+    def test_query_variables_search(self, graphql_query, is_enabled):
+        self.get(f"{TAGS_URL}?search={quote('Δwithčhar!/~|+ ')}", 200)
+
+        graphql_query.assert_called_once_with(
+            TAGS_QUERY,
+            {
+                "order_by": "tag",
+                "order_how": "ASC",
+                "limit": 50,
+                "offset": 0,
+                "filter": {"name": ".*\\%CE\\%94with\\%C4\\%8Dhar\\%21\\%2F\\%7E\\%7C\\%2B\\+.*"},
+                "hostFilter": {"OR": ANY},
+            },
+        )
+
+    def test_query_variables_ordering_dir(self, is_enabled):
+        for direction in ["ASC", "DESC"]:
+            with self.subTest(direction=direction):
+                with self.patch_with_empty_response() as graphql_query:
+                    self.get(f"{TAGS_URL}?order_how={direction}", 200)
+
+                    graphql_query.assert_called_once_with(
+                        TAGS_QUERY,
+                        {
+                            "order_by": "tag",
+                            "order_how": direction,
                             "limit": 50,
                             "offset": 0,
                             "hostFilter": {"OR": ANY},
                         },
                     )
 
-        def test_response_pagination(self, is_enabled):
-            for page, limit, offset in [(1, 2, 0), (2, 2, 2), (4, 50, 150)]:
-                with self.subTest(page=page):
-                    with self.patch_with_empty_response() as graphql_query:
-                        self.get(f"{TAGS_URL}?per_page={limit}&page={page}", 200)
+    def test_query_variables_ordering_by(self, is_enabled):
+        for ordering in ["tag", "count"]:
+            with self.patch_with_empty_response() as graphql_query:
+                self.get(f"{TAGS_URL}?order_by={ordering}", 200)
 
-                        graphql_query.assert_called_once_with(
-                            TAGS_QUERY,
-                            {
-                                "order_by": "tag",
-                                "order_how": "ASC",
-                                "limit": limit,
-                                "offset": offset,
-                                "hostFilter": {"OR": ANY},
-                            },
-                        )
+                graphql_query.assert_called_once_with(
+                    TAGS_QUERY,
+                    {"order_by": ordering, "order_how": "ASC", "limit": 50, "offset": 0, "hostFilter": {"OR": ANY}},
+                )
 
-        def test_response_invalid_pagination(self, is_enabled):
-            for page, per_page in [(0, 10), (-1, 10), (1, 0), (1, -5), (1, 101)]:
-                with self.subTest(page=page):
-                    with self.patch_with_empty_response():
-                        self.get(f"{TAGS_URL}?per_page={per_page}&page={page}", 400)
+    def test_response_pagination(self, is_enabled):
+        for page, limit, offset in [(1, 2, 0), (2, 2, 2), (4, 50, 150)]:
+            with self.subTest(page=page):
+                with self.patch_with_empty_response() as graphql_query:
+                    self.get(f"{TAGS_URL}?per_page={limit}&page={page}", 200)
 
-    @patch("api.tag.is_enabled", return_value=True)
-    class TagsResponseTestCase(APIBaseTestCase):
-        RESPONSE = {
-            "hostTags": {
-                "meta": {"count": 3, "total": 3},
-                "data": [
-                    {"tag": {"namespace": "Sat", "key": "env", "value": "prod"}, "count": 3},
-                    {"tag": {"namespace": "insights-client", "key": "database", "value": None}, "count": 2},
-                    {"tag": {"namespace": "insights-client", "key": "os", "value": "fedora"}, "count": 2},
-                ],
-            }
+                    graphql_query.assert_called_once_with(
+                        TAGS_QUERY,
+                        {
+                            "order_by": "tag",
+                            "order_how": "ASC",
+                            "limit": limit,
+                            "offset": offset,
+                            "hostFilter": {"OR": ANY},
+                        },
+                    )
+
+    def test_response_invalid_pagination(self, is_enabled):
+        for page, per_page in [(0, 10), (-1, 10), (1, 0), (1, -5), (1, 101)]:
+            with self.subTest(page=page):
+                with self.patch_with_empty_response():
+                    self.get(f"{TAGS_URL}?per_page={per_page}&page={page}", 400)
+
+
+@patch("api.tag.is_enabled", return_value=True)
+class TagsResponseTestCase(APIBaseTestCase):
+    RESPONSE = {
+        "hostTags": {
+            "meta": {"count": 3, "total": 3},
+            "data": [
+                {"tag": {"namespace": "Sat", "key": "env", "value": "prod"}, "count": 3},
+                {"tag": {"namespace": "insights-client", "key": "database", "value": None}, "count": 2},
+                {"tag": {"namespace": "insights-client", "key": "os", "value": "fedora"}, "count": 2},
+            ],
         }
+    }
 
-        patch_with_tags = partial(patch, "api.tag.graphql_query", return_value=RESPONSE)
+    patch_with_tags = partial(patch, "api.tag.graphql_query", return_value=RESPONSE)
 
-        @patch_with_tags()
-        def test_response_processed_properly(self, graphql_query, is_enabled):
-            expected = self.RESPONSE["hostTags"]
-            result = self.get(TAGS_URL, 200)
-            graphql_query.assert_called_once()
+    @patch_with_tags()
+    def test_response_processed_properly(self, graphql_query, is_enabled):
+        expected = self.RESPONSE["hostTags"]
+        result = self.get(TAGS_URL, 200)
+        graphql_query.assert_called_once()
 
-            self.assertEqual(
-                result,
-                {
-                    "total": expected["meta"]["total"],
-                    "count": expected["meta"]["count"],
-                    "page": 1,
-                    "per_page": 50,
-                    "results": expected["data"],
-                },
-            )
+        self.assertEqual(
+            result,
+            {
+                "total": expected["meta"]["total"],
+                "count": expected["meta"]["count"],
+                "page": 1,
+                "per_page": 50,
+                "results": expected["data"],
+            },
+        )
 
-        @patch_with_tags()
-        def test_response_pagination_index_error(self, graphql_query, is_enabled):
-            self.get(f"{TAGS_URL}?per_page=2&page=3", 404)
+    @patch_with_tags()
+    def test_response_pagination_index_error(self, graphql_query, is_enabled):
+        self.get(f"{TAGS_URL}?per_page=2&page=3", 404)
 
-            graphql_query.assert_called_once_with(
-                TAGS_QUERY, {"order_by": "tag", "order_how": "ASC", "limit": 2, "offset": 4, "hostFilter": {"OR": ANY}}
-            )
+        graphql_query.assert_called_once_with(
+            TAGS_QUERY, {"order_by": "tag", "order_how": "ASC", "limit": 2, "offset": 4, "hostFilter": {"OR": ANY}}
+        )
 
-    if __name__ == "__main__":
-        main()
+
+if __name__ == "__main__":
+    main()

--- a/test_unit.py
+++ b/test_unit.py
@@ -13,8 +13,8 @@ from uuid import UUID
 from uuid import uuid4
 
 from api import api_operation
-from api.host import _order_how
-from api.host import _params_to_order_by
+from api.host_query_db import _order_how
+from api.host_query_db import params_to_order_by
 from app import create_app
 from app.auth.identity import from_auth_header
 from app.auth.identity import from_bearer_token
@@ -22,7 +22,8 @@ from app.auth.identity import Identity
 from app.auth.identity import SHARED_SECRET_ENV_VAR
 from app.auth.identity import validate
 from app.config import Config
-from app.culling import StalenessOffset
+from app.culling import _Config as CullingConfig
+from app.culling import Timestamps
 from app.exceptions import InputFormatException
 from app.exceptions import ValidationException
 from app.models import Host
@@ -298,51 +299,51 @@ class HostOrderHowTestCase(TestCase):
                     _order_how(Mock(), invalid_value)
 
 
-@patch("api.host._order_how")
+@patch("api.host_query_db._order_how")
 @patch("api.host.Host.id")
 @patch("api.host.Host.modified_on")
 class HostParamsToOrderByTestCase(TestCase):
     def test_default_is_updated_desc(self, modified_on, id_, order_how):
-        actual = _params_to_order_by(None, None)
+        actual = params_to_order_by(None, None)
         expected = (modified_on.desc.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_not_called()
 
     def test_default_for_updated_is_desc(self, modified_on, id_, order_how):
-        actual = _params_to_order_by("updated", None)
+        actual = params_to_order_by("updated", None)
         expected = (modified_on.desc.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_not_called()
 
     def test_order_by_updated_asc(self, modified_on, id_, order_how):
-        actual = _params_to_order_by("updated", "ASC")
+        actual = params_to_order_by("updated", "ASC")
         expected = (order_how.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_called_once_with(modified_on, "ASC")
 
     def test_order_by_updated_desc(self, modified_on, id_, order_how):
-        actual = _params_to_order_by("updated", "DESC")
+        actual = params_to_order_by("updated", "DESC")
         expected = (order_how.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_called_once_with(modified_on, "DESC")
 
     @patch("api.host.Host.display_name")
     def test_default_for_display_name_is_asc(self, display_name, modified_on, id_, order_how):
-        actual = _params_to_order_by("display_name")
+        actual = params_to_order_by("display_name")
         expected = (display_name.asc.return_value, modified_on.desc.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_not_called()
 
     @patch("api.host.Host.display_name")
     def test_order_by_display_name_asc(self, display_name, modified_on, id_, order_how):
-        actual = _params_to_order_by("display_name", "ASC")
+        actual = params_to_order_by("display_name", "ASC")
         expected = (order_how.return_value, modified_on.desc.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_called_once_with(display_name, "ASC")
 
     @patch("api.host.Host.display_name")
     def test_order_by_display_name_desc(self, display_name, modified_on, id_, order_how):
-        actual = _params_to_order_by("display_name", "DESC")
+        actual = params_to_order_by("display_name", "DESC")
         expected = (order_how.return_value, modified_on.desc.return_value, id_.desc.return_value)
         self.assertEqual(actual, expected)
         order_how.assert_called_once_with(display_name, "DESC")
@@ -351,11 +352,11 @@ class HostParamsToOrderByTestCase(TestCase):
 class HostParamsToOrderByErrorsTestCase(TestCase):
     def test_order_by_bad_field_raises_error(self):
         with self.assertRaises(ValueError):
-            _params_to_order_by(Mock(), "fqdn")
+            params_to_order_by(Mock(), "fqdn")
 
     def test_order_by_only_how_raises_error(self):
         with self.assertRaises(ValueError):
-            _params_to_order_by(Mock(), order_how="ASC")
+            params_to_order_by(Mock(), order_how="ASC")
 
 
 class TagUtilsTestCase(TestCase):
@@ -923,10 +924,8 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
         for k, v in host_attr_data.items():
             setattr(host, k, v)
 
-        stale_warning_offset_days = 7
-        culled_offset_days = 14
-        staleness_offset = StalenessOffset(stale_warning_offset_days, culled_offset_days)
-        actual = serialize_host(host, staleness_offset)
+        config = CullingConfig(stale_warning_offset_days=7, culled_offset_days=14)
+        actual = serialize_host(host, Timestamps(config))
         expected = {
             **canonical_facts,
             **unchanged_data,
@@ -938,10 +937,10 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
             "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
             "stale_timestamp": self._timestamp_to_str(host_init_data["stale_timestamp"]),
             "stale_warning_timestamp": self._timestamp_to_str(
-                self._add_days(host_init_data["stale_timestamp"], stale_warning_offset_days)
+                self._add_days(host_init_data["stale_timestamp"], config.stale_warning_offset_days)
             ),
             "culled_timestamp": self._timestamp_to_str(
-                self._add_days(host_init_data["stale_timestamp"], culled_offset_days)
+                self._add_days(host_init_data["stale_timestamp"], config.culled_offset_days)
             ),
         }
         self.assertEqual(expected, actual)
@@ -955,8 +954,8 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
         for k, v in host_attr_data.items():
             setattr(host, k, v)
 
-        staleness_offset = StalenessOffset(7, 14)
-        actual = serialize_host(host, staleness_offset)
+        config = CullingConfig(stale_warning_offset_days=7, culled_offset_days=14)
+        actual = serialize_host(host, Timestamps(config))
         expected = {
             **host_init_data["canonical_facts"],
             "insights_id": None,
@@ -991,8 +990,8 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
                 for k, v in (("id", uuid4()), ("created_on", datetime.utcnow()), ("modified_on", datetime.utcnow())):
                     setattr(host, k, v)
 
-                staleness_offset = StalenessOffset(stale_warning_offset_days, culled_offset_days)
-                serialized = serialize_host(host, staleness_offset)
+                config = CullingConfig(stale_warning_offset_days, culled_offset_days)
+                serialized = serialize_host(host, Timestamps(config))
                 self.assertEqual(
                     self._timestamp_to_str(self._add_days(stale_timestamp, stale_warning_offset_days)),
                     serialized["stale_warning_timestamp"],


### PR DESCRIPTION
Add [_xjoin-search_](https://github.com/RedHatInsights/xjoin-search) as an alternative data source for the host search query. This is configured by [an environment variable](https://github.com/Glutexo/insights-host-inventory/blob/bd014f0faed3bf7c0d4eef15534ef303c754b984/app/config.py#L67). Extract the _xjoin-search_ GraphQL code from the tags queries. Extract common parts from the database queries.