### PR TITLE
Fix 500 error when adding host with tags in string format (RHCLOUD-3342)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -307,9 +307,15 @@ class FactsSchema(Schema):
 
 
 class TagsSchema(Schema):
-    namespace = fields.Str(required=False, allow_none=True)
-    key = fields.Str(required=True)
-    value = fields.Str(required=False, allow_none=True)
+    namespace = fields.Str(
+        required=False, allow_none=True, validate=[validate.Length(min=1, max=255), validate.Regexp(r"\S+")]
+    )
+    key = fields.Str(
+        required=True, allow_none=False, validate=[validate.Length(min=1, max=255), validate.Regexp(r"\S+")]
+    )
+    value = fields.Str(
+        required=False, allow_none=True, validate=[validate.Length(min=1, max=255), validate.Regexp(r"\S+")]
+    )
 
 
 class HostSchema(Schema):

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -442,8 +442,6 @@ components:
         value:
           type: string
           nullable: true
-    MarshmallowError:
-      type: string
     TagCountOut:
       type: object
       properties:
@@ -606,6 +604,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FactSet'
+        tags:
+          description: The tags on a host
+          type: array
+          items:
+            $ref: '#/components/schemas/StructuredTag'
         system_profile:
           $ref: '#/components/schemas/SystemProfileIn'
         stale_timestamp:
@@ -734,9 +737,7 @@ components:
           description: An array of the tags on the host
           type: array
           items:
-            oneOf:
-              - $ref: '#/components/schemas/StructuredTag'
-              - $ref: '#/components/schemas/MarshmallowError'
+            - $ref: '#/components/schemas/StructuredTag'
         stale_timestamp:
           description: Timestamp from which the host is considered stale.
           type: string

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -737,7 +737,7 @@ components:
           description: An array of the tags on the host
           type: array
           items:
-            - $ref: '#/components/schemas/StructuredTag'
+            $ref: '#/components/schemas/StructuredTag'
         stale_timestamp:
           description: Timestamp from which the host is considered stale.
           type: string

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -442,6 +442,8 @@ components:
         value:
           type: string
           nullable: true
+    MarshmallowError:
+      type: string
     TagCountOut:
       type: object
       properties:
@@ -729,9 +731,12 @@ components:
           items:
             $ref: '#/components/schemas/FactSet'
         tags:
+          description: An array of the tags on the host
           type: array
           items:
-            $ref: '#/components/schemas/StructuredTag'
+            oneOf:
+              - $ref: '#/components/schemas/StructuredTag'
+              - $ref: '#/components/schemas/MarshmallowError'
         stale_timestamp:
           description: Timestamp from which the host is considered stale.
           type: string

--- a/test_api.py
+++ b/test_api.py
@@ -762,9 +762,14 @@ class CreateHostsTestCase(DBAPITestCase):
 
         host_data = HostWrapper(test_data(tags=[tag]))
 
-        response = self.post(HOST_URL, [host_data.data()], 207)
+        self.post(HOST_URL, [host_data.data()], 400)
 
-        assert "'status': 400" in str(response)
+    def test_create_host_with_invalid_tag_format(self):
+        tag = {"namespace": "spam", "key": {"foo": "bar"}, "value": "eggs"}
+
+        host_data = HostWrapper(test_data(tags=[tag]))
+
+        self.post(HOST_URL, [host_data.data()], 400)
 
     def test_create_host_with_tags(self):
         host_data = HostWrapper(

--- a/test_api.py
+++ b/test_api.py
@@ -757,6 +757,15 @@ class CreateHostsTestCase(DBAPITestCase):
 
             assert "'status': 400" in str(response)
 
+    def test_create_host_with_invalid_string_tag_format(self):
+        tag = "string/tag=format"
+
+        host_data = HostWrapper(test_data(tags=[tag]))
+
+        response = self.post(HOST_URL, [host_data.data()], 207)
+
+        assert "'status': 400" in str(response)
+
     def test_create_host_with_tags(self):
         host_data = HostWrapper(
             test_data(


### PR DESCRIPTION
Fixes 500 error when sending string formatted tag instead of structured tag while creating host. Now returns 400