### PR TITLE
Implement repository changes to system_profile

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -246,10 +246,16 @@ class DiskDeviceSchema(Schema):
 
 
 class YumRepoSchema(Schema):
+    id = fields.Str(validate=validate.Length(max=256))
     name = fields.Str(validate=validate.Length(max=1024))
     gpgcheck = fields.Bool()
     enabled = fields.Bool()
     base_url = fields.Str(validate=validate.Length(max=2048))
+
+
+class DnfModuleSchema(Schema):
+    name = fields.Str(validate=validate.Length(max=128))
+    stream = fields.Str(validate=validate.Length(max=128))
 
 
 class InstalledProductSchema(Schema):
@@ -293,6 +299,7 @@ class SystemProfileSchema(Schema):
     satellite_managed = fields.Bool()
     cloud_provider = fields.Str(validate=validate.Length(max=100))
     yum_repos = fields.List(fields.Nested(YumRepoSchema()))
+    dnf_modules = fields.List(fields.Nested(DnfModuleSchema()))
     installed_products = fields.List(fields.Nested(InstalledProductSchema()))
     insights_client_version = fields.Str(validate=validate.Length(max=50))
     insights_egg_version = fields.Str(validate=validate.Length(max=50))

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -864,6 +864,8 @@ components:
       title: Yum Repository
       description: Representation of one yum repository
       properties:
+        id:
+          type: string
         name:
           type: string
         gpgcheck:
@@ -873,6 +875,14 @@ components:
         baseurl:
           type: string
           format: uri
+    DnfModule:
+      title: DNF Module
+      description: Representation of one DNF module
+      properties:
+        name:
+          type: string
+        stream:
+          type: string
     InstalledProduct:
       title: Installed Product
       description: Representation of one installed product
@@ -987,6 +997,10 @@ components:
           type: array  # technically a set, ordering is not important
           items:
             $ref: '#/components/schemas/YumRepo'
+        dnf_modules:
+          type: array # technically a set, ordering is not important
+          items:
+            $ref: '#/components/schemas/DnfModule'
         installed_products:
           type: array  # technically a set, ordering is not important
           items:
@@ -1000,7 +1014,7 @@ components:
           items:
             description: a NEVRA string for a single installed package
             type: string
-            example: "0:krb5-libs-1.16.1-23.fc29.i686"
+            example: "krb5-libs-0:-1.16.1-23.fc29.i686"
         installed_services:
           type: array
           items:

--- a/test_api.py
+++ b/test_api.py
@@ -31,6 +31,7 @@ from app.utils import Tag
 from tasks import msg_handler
 from test_utils import rename_host_table_and_indexes
 from test_utils import set_environment
+from test_utils import valid_system_profile
 
 HOST_URL = "/api/inventory/v1/hosts"
 HEALTH_URL = "/health"
@@ -1143,73 +1144,6 @@ class PaginationBaseTestCase(APIBaseTestCase):
 
 
 class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase):
-    def _valid_system_profile(self):
-        return {
-            "number_of_cpus": 1,
-            "number_of_sockets": 2,
-            "cores_per_socket": 4,
-            "system_memory_bytes": 1024,
-            "infrastructure_type": "massive cpu",
-            "infrastructure_vendor": "dell",
-            "network_interfaces": [
-                {
-                    "ipv4_addresses": ["10.10.10.1"],
-                    "state": "UP",
-                    "ipv6_addresses": ["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
-                    "mtu": 1500,
-                    "mac_address": "aa:bb:cc:dd:ee:ff",
-                    "type": "loopback",
-                    "name": "eth0",
-                }
-            ],
-            "disk_devices": [
-                {
-                    "device": "/dev/sdb1",
-                    "label": "home drive",
-                    "options": {"uid": "0", "ro": True},
-                    "mount_point": "/home",
-                    "type": "ext3",
-                }
-            ],
-            "bios_vendor": "AMI",
-            "bios_version": "1.0.0uhoh",
-            "bios_release_date": "10/31/2013",
-            "cpu_flags": ["flag1", "flag2"],
-            "os_release": "Red Hat EL 7.0.1",
-            "os_kernel_version": "Linux 2.0.1",
-            "arch": "x86-64",
-            "last_boot_time": "12:25 Mar 19, 2019",
-            "kernel_modules": ["i915", "e1000e"],
-            "running_processes": ["vim", "gcc", "python"],
-            "subscription_status": "valid",
-            "subscription_auto_attach": "yes",
-            "katello_agent_running": False,
-            "satellite_managed": False,
-            "cloud_provider": "Maclean's Music",
-            "yum_repos": [
-                {
-                    "id": "repo1",
-                    "name": "repo1",
-                    "gpgcheck": True,
-                    "enabled": True,
-                    "base_url": "http://rpms.redhat.com",
-                }
-            ],
-            "dnf_modules": [
-                {"name": "postgresql", "stream": "11"},
-                {"name": "java", "stream": "8"}
-            ],
-            "installed_products": [
-                {"name": "eap", "id": "123", "status": "UP"},
-                {"name": "jbws", "id": "321", "status": "DOWN"},
-            ],
-            "insights_client_version": "12.0.12",
-            "insights_egg_version": "120.0.1",
-            "installed_packages": ["rpm1-0:0.0.1.el7.i686", "rpm1-2:0.0.1.el7.i686"],
-            "installed_services": ["ndb", "krb5"],
-            "enabled_services": ["ndb", "krb5"],
-        }
-
     def test_create_host_with_system_profile(self):
         facts = None
 
@@ -1217,7 +1151,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
         host["ip_addresses"] = ["10.0.0.1"]
         host["rhel_machine_id"] = generate_uuid()
 
-        host["system_profile"] = self._valid_system_profile()
+        host["system_profile"] = valid_system_profile()
 
         # Create the host
         response = self.post(HOST_URL, [host], 207)
@@ -1245,7 +1179,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
         host["ip_addresses"] = ["10.0.0.1"]
         host["rhel_machine_id"] = generate_uuid()
 
-        host["system_profile"] = self._valid_system_profile()
+        host["system_profile"] = valid_system_profile()
 
         # Create the host
         response = self.post(HOST_URL, [host], 207)
@@ -1291,7 +1225,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
 
         # Set the entire system profile...overwriting the enabled_service
         # set from before
-        full_system_profile = self._valid_system_profile()
+        full_system_profile = valid_system_profile()
         system_profiles.append((full_system_profile, full_system_profile))
 
         # Change the enabled_services
@@ -1447,7 +1381,7 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
             host = test_data(display_name="host1", facts=facts)
             host["ip_addresses"] = [f"10.0.0.{i}"]
             host["rhel_machine_id"] = generate_uuid()
-            host["system_profile"] = self._valid_system_profile()
+            host["system_profile"] = valid_system_profile()
             host["system_profile"]["number_of_cpus"] = i
 
             response = self.post(HOST_URL, [host], 207)

--- a/test_api.py
+++ b/test_api.py
@@ -1186,14 +1186,26 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
             "katello_agent_running": False,
             "satellite_managed": False,
             "cloud_provider": "Maclean's Music",
-            "yum_repos": [{"name": "repo1", "gpgcheck": True, "enabled": True, "base_url": "http://rpms.redhat.com"}],
+            "yum_repos": [
+                {
+                    "id": "repo1",
+                    "name": "repo1",
+                    "gpgcheck": True,
+                    "enabled": True,
+                    "base_url": "http://rpms.redhat.com",
+                }
+            ],
+            "dnf_modules": [
+                {"name": "postgresql", "stream": "11"},
+                {"name": "java", "stream": "8"}
+            ],
             "installed_products": [
                 {"name": "eap", "id": "123", "status": "UP"},
                 {"name": "jbws", "id": "321", "status": "DOWN"},
             ],
             "insights_client_version": "12.0.12",
             "insights_egg_version": "120.0.1",
-            "installed_packages": ["rpm1", "rpm2"],
+            "installed_packages": ["rpm1-0:0.0.1.el7.i686", "rpm1-2:0.0.1.el7.i686"],
             "installed_services": ["ndb", "krb5"],
             "enabled_services": ["ndb", "krb5"],
         }

--- a/test_utils.py
+++ b/test_utils.py
@@ -31,3 +31,62 @@ def rename_host_table_and_indexes():
     for index in Host.__table_args__:
         if temp_table_name_suffix not in index.name:
             index.name = index.name + temp_table_name_suffix
+
+
+def valid_system_profile():
+    return {
+        "number_of_cpus": 1,
+        "number_of_sockets": 2,
+        "cores_per_socket": 4,
+        "system_memory_bytes": 1024,
+        "infrastructure_type": "massive cpu",
+        "infrastructure_vendor": "dell",
+        "network_interfaces": [
+            {
+                "ipv4_addresses": ["10.10.10.1"],
+                "state": "UP",
+                "ipv6_addresses": ["2001:0db8:85a3:0000:0000:8a2e:0370:7334"],
+                "mtu": 1500,
+                "mac_address": "aa:bb:cc:dd:ee:ff",
+                "type": "loopback",
+                "name": "eth0",
+            }
+        ],
+        "disk_devices": [
+            {
+                "device": "/dev/sdb1",
+                "label": "home drive",
+                "options": {"uid": "0", "ro": True},
+                "mount_point": "/home",
+                "type": "ext3",
+            }
+        ],
+        "bios_vendor": "AMI",
+        "bios_version": "1.0.0uhoh",
+        "bios_release_date": "10/31/2013",
+        "cpu_flags": ["flag1", "flag2"],
+        "os_release": "Red Hat EL 7.0.1",
+        "os_kernel_version": "Linux 2.0.1",
+        "arch": "x86-64",
+        "last_boot_time": "12:25 Mar 19, 2019",
+        "kernel_modules": ["i915", "e1000e"],
+        "running_processes": ["vim", "gcc", "python"],
+        "subscription_status": "valid",
+        "subscription_auto_attach": "yes",
+        "katello_agent_running": False,
+        "satellite_managed": False,
+        "cloud_provider": "Maclean's Music",
+        "yum_repos": [
+            {"id": "repo1", "name": "repo1", "gpgcheck": True, "enabled": True, "base_url": "http://rpms.redhat.com"}
+        ],
+        "dnf_modules": [{"name": "postgresql", "stream": "11"}, {"name": "java", "stream": "8"}],
+        "installed_products": [
+            {"name": "eap", "id": "123", "status": "UP"},
+            {"name": "jbws", "id": "321", "status": "DOWN"},
+        ],
+        "insights_client_version": "12.0.12",
+        "insights_egg_version": "120.0.1",
+        "installed_packages": ["rpm1-0:0.0.1.el7.i686", "rpm1-2:0.0.1.el7.i686"],
+        "installed_services": ["ndb", "krb5"],
+        "enabled_services": ["ndb", "krb5"],
+    }


### PR DESCRIPTION
Implement schema changes, which correspond to `system_profile` changes from https://github.com/RedHatInsights/insights-puptoo/pull/36


- Added local repo-id into `yum_repos` objects
- Added the `dnf_modules` key containing information about modules.
- Fixed swagger doc, schemas and test to reflect these changes.