### PR TITLE
check incoming messages for invalid unicode sequences

### DIFF
--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -33,7 +33,8 @@ def _validate_json_object_for_utf8(json_object):
     if object_type is str:
         json_object.encode()
     elif object_type is dict:
-        for value in json_object.values():
+        for key, value in json_object.items():
+            _validate_json_object_for_utf8(key)
             _validate_json_object_for_utf8(value)
     elif object_type is list:
         for item in json_object:

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -8,7 +8,7 @@ ingress_message_parsing_time = Summary(
     "inventory_ingress_message_parsing_seconds", "Time spent parsing a message from the ingress queue"
 )
 ingress_message_parsing_failure = Counter(
-    "inventory_ingress_message_parsing_failures", "Total amount of failures parsing ingress messages"
+    "inventory_ingress_message_parsing_failures", "Total amount of failures parsing ingress messages", ["cause"]
 )
 add_host_success = Counter(
     "inventory_ingress_add_host_successes", "Total amount of successfully added hosts", ["result", "reporter"]

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -24,6 +24,7 @@ def main():
         group_id=config.host_ingress_consumer_group,
         bootstrap_servers=config.bootstrap_servers,
         api_version=(0, 10),
+        value_deserializer=lambda m: m.decode(),
     )
 
     event_producer = create_event_producer(config, "kafka")

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -104,6 +104,15 @@ class MQServiceTestCase(TestCase):
                     },
                 )
 
+    def test_handle_message_failure_invalid_unicode_chars(self):
+        invalid_message = "hello\udce2\udce2"
+        mock_event_producer = Mock()
+
+        with self.assertRaises(UnicodeError):
+            handle_message(invalid_message, mock_event_producer)
+
+        mock_event_producer.assert_not_called()
+
     # Leaving this in as a reminder that we need to impliment this test eventually
     # when the problem that it is supposed to test is fixed
     # https://projects.engineering.redhat.com/browse/RHCLOUD-3503


### PR DESCRIPTION
Due to RHCLOUD-3610 we're receiving messages with invalid unicode code points (invalid surrogate pairs).
Python pretty much ignores that but it is not possible to store such strings in the database (db INSERTS blow up)
I added validation logic that looks for such invalid sequences with the intention of marking such messages as invalid (i.e. detect validation error rather than failing later in the db layer)