### PR TITLE
Use int64 format for system_memory_bytes

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1010,6 +1010,7 @@ components:
           type: integer
         system_memory_bytes:
           type: integer
+          format: int64
         infrastructure_type:
           type: string
         infrastructure_vendor:


### PR DESCRIPTION
Added int64 format specifier for system_memory_bytes. By default, openapi assumes int32, which means, that system profiles with more than 3gb memory weren't parsed by this client: https://github.com/RedHatInsights/patchman-clients, and could not be processed by SPM application