### PR TITLE
Add host reaper script

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -39,7 +39,7 @@ class Config:
         self.consumer_group = os.environ.get("KAFKA_GROUP", "inventory")
         self.bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
         self.event_topic = os.environ.get("KAFKA_EVENT_TOPIC", "platform.inventory.events")
-        self.kafka_enabled = all(map(os.environ.get, ["KAFKA_TOPIC", "KAFKA_GROUP", "KAFKA_BOOTSTRAP_SERVERS"]))
+        self.kafka_enabled = all(map(os.environ.get, ["KAFKA_GROUP", "KAFKA_BOOTSTRAP_SERVERS"]))
 
         # https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html#kafka.KafkaConsumer
         self.kafka_consumer = {
@@ -107,6 +107,7 @@ class Config:
             self.logger.info("Kafka Host Ingress Topic: %s" % self.host_ingress_topic)
             self.logger.info("Kafka Host Ingress Group: %s" % self.host_ingress_consumer_group)
             self.logger.info("Kafka Host Egress Topic: %s" % self.host_egress_topic)
+            self.logger.info("Kafka Event Topic: %s" % self.event_topic)
             self.logger.info("Kafka Consumer Group: %s" % self.consumer_group)
             self.logger.info("Kafka Bootstrap Servers: %s" % self.bootstrap_servers)
             self.logger.info("Payload Tracker Kafka Topic: %s", self.payload_tracker_kafka_topic)

--- a/app/culling.py
+++ b/app/culling.py
@@ -55,6 +55,9 @@ class Conditions(_WithConfig):
     def stale_warning(self):
         return self._culled_timestamp(), self._stale_warning_timestamp()
 
+    def culled(self):
+        return None, self._culled_timestamp()
+
     def _stale_warning_timestamp(self):
         offset = timedelta(days=self.config.stale_warning_offset_days)
         return self.now - offset

--- a/app/payload_tracker/__init__.py
+++ b/app/payload_tracker/__init__.py
@@ -183,6 +183,7 @@ class KafkaPayloadTracker(PayloadTracker):
             return
 
         try:
+            logger.debug("payload tracker message %s", message)
             self._producer.send(self._topic, message.encode("utf-8"))
         except Exception:
             logger.exception("Error sending payload tracker message")

--- a/app/payload_tracker/__init__.py
+++ b/app/payload_tracker/__init__.py
@@ -183,7 +183,6 @@ class KafkaPayloadTracker(PayloadTracker):
             return
 
         try:
-            logger.debug("payload tracker message %s", message)
             self._producer.send(self._topic, message.encode("utf-8"))
         except Exception:
             logger.exception("Error sending payload tracker message")

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -1,0 +1,62 @@
+from logging.config import fileConfig as logging_file_config
+from os import getenv
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app import UNKNOWN_REQUEST_ID_VALUE
+from app.config import Config
+from app.culling import Conditions
+from app.logging import get_logger
+from app.logging import threadctx
+from app.models import Host
+from lib.host_delete import delete_hosts
+from lib.host_repository import stale_timestamp_filter
+from tasks import flush
+from tasks import init_tasks
+
+
+__all__ = ("main",)
+
+
+def _init_config(config_name):
+    config = Config()
+    config.log_configuration(config_name)
+    return config
+
+
+def _init_db(config):
+    engine = create_engine(config.db_uri)
+    return sessionmaker(bind=engine)
+
+
+def main(config_name):
+    config = _init_config(config_name)
+    Session = _init_db(config)
+    logger = get_logger("host_reaper")
+    init_tasks(config)
+
+    conditions = Conditions.from_config(config)
+    query_filter = stale_timestamp_filter(*conditions.culled())
+
+    session = Session()
+    query = session.query(Host).filter(query_filter)
+
+    events = delete_hosts(query)
+    if events:
+        for deleted_host in events:
+            if deleted_host:
+                logger.info("Deleted host: %s", deleted_host.id)
+            else:
+                logger.info("Host already deleted. Delete event not emitted.")
+
+        flush()
+    else:
+        logger.info("No hosts deleted.")
+
+
+if __name__ == "__main__":
+    logging_file_config("logconfig.ini")
+    config_name = getenv("APP_SETTINGS", "development")
+    threadctx.request_id = UNKNOWN_REQUEST_ID_VALUE
+    main(config_name)

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -54,6 +54,9 @@ def main(config_name):
     else:
         logger.info("No hosts deleted.")
 
+    session.commit()
+    session.close()
+
 
 if __name__ == "__main__":
     config_name = getenv("APP_SETTINGS", "development")

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -1,4 +1,3 @@
-from logging.config import fileConfig as logging_file_config
 from os import getenv
 
 from sqlalchemy import create_engine
@@ -7,6 +6,7 @@ from sqlalchemy.orm import sessionmaker
 from app import UNKNOWN_REQUEST_ID_VALUE
 from app.config import Config
 from app.culling import Conditions
+from app.logging import configure_logging
 from app.logging import get_logger
 from app.logging import threadctx
 from app.models import Host
@@ -56,7 +56,7 @@ def main(config_name):
 
 
 if __name__ == "__main__":
-    logging_file_config("logconfig.ini")
     config_name = getenv("APP_SETTINGS", "development")
+    configure_logging(config_name)
     threadctx.request_id = UNKNOWN_REQUEST_ID_VALUE
     main(config_name)

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -1,0 +1,40 @@
+from sqlalchemy.orm.base import instance_state
+
+from api.metrics import delete_host_count
+from api.metrics import delete_host_processing_time
+from app.events import delete as delete_event
+from tasks import emit_event
+
+
+__all__ = ("delete_hosts",)
+
+
+def delete_hosts(query):
+    hosts_to_delete = query.all()
+    if not hosts_to_delete:
+        return None
+
+    with delete_host_processing_time.time():
+        query.delete(synchronize_session="fetch")
+    query.session.commit()
+
+    delete_host_count.inc(len(hosts_to_delete))
+
+    return _emit_events(hosts_to_delete)
+
+
+def _emit_events(deleted_hosts):
+    # This process of checking for an already deleted host relies
+    # on checking the session after it has been updated by the commit()
+    # function and marked the deleted hosts as expired.  It is after this
+    # change that the host is called by a new query and, if deleted by a
+    # different process, triggers the ObjectDeletedError and is not emited.
+    for deleted_host in deleted_hosts:
+        # Prevents ObjectDeletedError from being raised.
+        if instance_state(deleted_host).expired:
+            # Not yielding the host. Accessing any attribute would raise ObjectDeletedError.
+            yield None
+        else:
+            event = delete_event(deleted_host)
+            emit_event(event)
+            yield deleted_host

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -1,11 +1,23 @@
 from enum import Enum
 
+from sqlalchemy import and_
+
 from app.logging import get_logger
 from app.models import db
 from app.models import db_session_guard
 from app.models import Host
 from app.serialization import serialize_host
 from lib import metrics
+
+__all__ = (
+    "add_host",
+    "canonical_facts_host_query",
+    "create_new_host",
+    "find_existing_host",
+    "find_host_by_canonical_facts",
+    "stale_timestamp_filter",
+    "update_existing_host",
+)
 
 # FIXME:  rename this
 AddHostResults = Enum("AddHostResults", ["created", "updated"])
@@ -15,7 +27,6 @@ AddHostResults = Enum("AddHostResults", ["created", "updated"])
 # NOTE: The order of this tuple is important.  The order defines
 # the priority.
 ELEVATED_CANONICAL_FACT_FIELDS = ("insights_id", "subscription_manager_id")
-
 
 logger = get_logger(__name__)
 
@@ -102,3 +113,12 @@ def update_existing_host(existing_host, input_host, staleness_offset, update_sys
     metrics.update_host_count.inc()
     logger.debug("Updated host:%s", existing_host)
     return serialize_host(existing_host, staleness_offset), AddHostResults.updated
+
+
+def stale_timestamp_filter(gte=None, lte=None):
+    filter_ = ()
+    if gte:
+        filter_ += (Host.stale_timestamp >= gte,)
+    if lte:
+        filter_ += (Host.stale_timestamp <= lte,)
+    return and_(*filter_)

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -19,7 +19,7 @@ class NullProducer:
         logger.debug("NullProducer - logging message:  topic (%s) - message: %s", topic, value)
 
     def flush(self):
-        print("NullProducer – flushing")
+        logger.debug("NullProducer – flushing")
 
 
 producer = None

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -18,6 +18,9 @@ class NullProducer:
     def send(self, topic, value=None):
         logger.debug("NullProducer - logging message:  topic (%s) - message: %s", topic, value)
 
+    def flush(self):
+        print("NullProducer – flushing")
+
 
 producer = None
 cfg = None

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -23,14 +23,15 @@ producer = None
 cfg = None
 
 
-def init_tasks(config, flask_app):
+def init_tasks(config, flask_app=None):
     global cfg
     global producer
 
     cfg = config
 
     producer = _init_event_producer(config)
-    _init_system_profile_consumer(config, flask_app)
+    if flask_app:
+        _init_system_profile_consumer(config, flask_app)
 
 
 def _init_event_producer(config):
@@ -44,6 +45,10 @@ def _init_event_producer(config):
 
 def emit_event(e):
     producer.send(cfg.event_topic, value=e.encode("utf-8"))
+
+
+def flush():
+    producer.flush()
 
 
 @metrics.system_profile_commit_processing_time.time()

--- a/test_api.py
+++ b/test_api.py
@@ -1657,7 +1657,7 @@ class DeleteHostsEventTestCase(PreCreatedHostsBaseTestCase):
         self.timestamp = datetime.utcnow()
 
     def _delete(self, url_query="", header=None):
-        with patch("api.host.emit_event", new_callable=self.MockEmitEvent) as m:
+        with patch("lib.host_delete.emit_event", new_callable=self.MockEmitEvent) as m:
             with patch("app.events.datetime", **{"utcnow.return_value": self.timestamp}):
                 url = f"{self.delete_url}{url_query}"
                 self.delete(url, 200, header, return_response_as_json=False)
@@ -1710,7 +1710,7 @@ class DeleteHostsEventTestCase(PreCreatedHostsBaseTestCase):
         self.assertEqual("-1", event["request_id"])
 
 
-@patch("api.host.emit_event")
+@patch("lib.host_delete.emit_event")
 class DeleteHostsRaceConditionTestCase(PreCreatedHostsBaseTestCase):
     class RaceCondition:
         @classmethod

--- a/test_api.py
+++ b/test_api.py
@@ -1106,7 +1106,7 @@ class HostReaperTestCase(DBAPITestCase):
         response = self._get_hosts(added_hosts)
         self.assertEqual(response["count"], len(hosts_to_add))
 
-    def test_unknown_host_ist_not_removed(self):
+    def test_unknown_host_is_not_removed(self):
         added_hosts = self._add_hosts(({},))
         self._run_host_reaper()
 

--- a/test_api.py
+++ b/test_api.py
@@ -35,6 +35,7 @@ from app.models import Host
 from app.serialization import serialize_host
 from app.utils import HostWrapper
 from app.utils import Tag
+from host_reaper import main as host_reaper_main
 from tasks import msg_handler
 from test_utils import rename_host_table_and_indexes
 from test_utils import set_environment
@@ -1053,6 +1054,64 @@ class CreateHostsWithStaleTimestampTestCase(DBAPITestCase):
 
             self.assertEqual(error_host["status"], 400)
             self.verify_error_response(error_host, expected_title="Invalid request")
+
+
+class HostReaperTestCase(DBAPITestCase):
+    def _run_host_reaper(self):
+        host_reaper_main("testing")
+
+    def _add_hosts(self, data):
+        post = []
+        for d in data:
+            host = HostWrapper(test_data(insights_id=generate_uuid(), **d))
+            post.append(host.data())
+
+        response = self.post(HOST_URL, post, 207)
+
+        host_ids = []
+        for i in range(len(data)):
+            self._verify_host_status(response, i, 201)
+            added_host = self._pluck_host_from_response(response, i)
+            host_ids.append(added_host["id"])
+
+        return host_ids
+
+    def _get_hosts(self, host_ids):
+        url_part = ",".join(host_ids)
+        return self.get(f"{HOST_URL}/{url_part}")
+
+    def test_culled_host_is_removed(self):
+        stale_timestamp = datetime.now(timezone.utc) - timedelta(weeks=2)
+        added_hosts = self._add_hosts(({"stale_timestamp": stale_timestamp, "reporter": "some reporter"},))
+
+        self._run_host_reaper()
+
+        response = self._get_hosts(added_hosts)
+        self.assertEqual(response["count"], 0)
+
+    def test_non_culled_host_is_not_removed(self):
+        now = datetime.now(timezone.utc)
+
+        stale_warnning = now - timedelta(weeks=1)
+        stale = now
+        fresh = now + timedelta(hours=1)
+
+        hosts_to_add = []
+        for stale_timestamp in (stale_warnning, stale, fresh):
+            hosts_to_add.append({"stale_timestamp": stale_timestamp, "reporter": "some reporter"})
+        added_hosts = self._add_hosts(hosts_to_add)
+
+        self._run_host_reaper()
+
+        response = self._get_hosts(added_hosts)
+        self.assertEqual(response["count"], len(hosts_to_add))
+
+    def test_unknown_host_ist_not_removed(self):
+        added_hosts = self._add_hosts(({},))
+        self._run_host_reaper()
+
+        response = self._get_hosts(added_hosts)
+        self.assertEqual(response["count"], len(added_hosts))
 
 
 class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):


### PR DESCRIPTION
Created a [“reaper”](https://github.com/Glutexo/insights-host-inventory/blob/2b49d29032359cbacf179194379c4ed624f3ef24/host_reaper.py) script that removes all culled hosts. It is intended to be run periodically to clean up the database. For every deleted host a delete event is emitted.

Extracted the common host delete [part](https://github.com/Glutexo/insights-host-inventory/blob/2b49d29032359cbacf179194379c4ed624f3ef24/lib/host_delete.py) that handles the event [emission](https://github.com/Glutexo/insights-host-inventory/blob/2b49d29032359cbacf179194379c4ed624f3ef24/lib/host_delete.py#L32) and race condition [handling](https://github.com/Glutexo/insights-host-inventory/blob/2b49d29032359cbacf179194379c4ed624f3ef24/lib/host_delete.py#L34).

The script uses SQLAlchemy and its models, but doesn’t use Flask.

- [x] Fix broken existing tests.
- [ ] Add tests for the new code.
- [x] Rebase on current [_master_](https://github.com/RedHatInsights/insights-host-inventory/tree/master).