### PR TITLE
Push Host Reaper metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ from inside of the deployment cluster.
 * _/version_ responds with a json doc that contains the build version info
   (the value of the OPENSHIFT_BUILD_COMMIT environment variable)
 
+Cron jobs push their metrics to a
+[Prometheus Pushgateway](https://github.com/prometheus/pushgateway/) instance
+running at _PROMETHEUS_PUSHGATEWAY_. Defaults to _localhost:9091_.
+
 ## API Documentation
 
 The API is described by an OpenAPI specification file

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -3,10 +3,6 @@ from prometheus_client import Summary
 
 api_request_time = Summary("inventory_request_processing_seconds", "Time spent processing request")
 api_request_count = Counter("inventory_request_count", "The total amount of API requests")
-delete_host_count = Counter("inventory_delete_host_count", "The total amount of hosts deleted")
-delete_host_processing_time = Summary(
-    "inventory_delete_host_commit_seconds", "Time spent deleting hosts from the database"
-)
 login_failure_count = Counter("inventory_login_failure_count", "The total amount of failed login attempts")
 system_profile_deserialization_time = Summary(
     "inventory_system_profile_deserialization_time", "Time spent deserializing system profile documents"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ from prometheus_flask_exporter import PrometheusMetrics
 from api.mgmt import monitoring_blueprint
 from app import payload_tracker
 from app.config import Config
+from app.config import RuntimeEnvironment
 from app.exceptions import InventoryException
 from app.logging import configure_logging
 from app.logging import get_logger
@@ -41,7 +42,7 @@ def create_app(config_name, start_tasks=False, start_payload_tracker=False):
     # needs to be setup before the flask app is initialized.
     configure_logging(config_name)
 
-    app_config = Config()
+    app_config = Config(RuntimeEnvironment.server)
     app_config.log_configuration(config_name)
 
     connexion_app = connexion.App("inventory", specification_dir="./swagger/", options=connexion_options)

--- a/app/config.py
+++ b/app/config.py
@@ -5,12 +5,14 @@ from app.common import get_build_version
 from app.logging import get_logger
 
 BulkQuerySource = Enum("BulkQuerySource", ("db", "xjoin"))
+RuntimeEnvironment = Enum("RuntimeEnvironment", ("server", "job"))
 
 
 class Config:
     SSL_VERIFY_FULL = "verify-full"
 
-    def __init__(self):
+    def __init__(self, environment):
+        self._environment = environment
         self.logger = get_logger(__name__)
 
         self._db_user = os.getenv("INVENTORY_DB_USER", "insights")
@@ -40,6 +42,8 @@ class Config:
         self.bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
         self.event_topic = os.environ.get("KAFKA_EVENT_TOPIC", "platform.inventory.events")
         self.kafka_enabled = all(map(os.environ.get, ["KAFKA_GROUP", "KAFKA_BOOTSTRAP_SERVERS"]))
+
+        self.prometheus_pushgateway = os.environ.get("PROMETHEUS_PUSHGATEWAY", "localhost:9091")
 
         # https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html#kafka.KafkaConsumer
         self.kafka_consumer = {
@@ -95,8 +99,6 @@ class Config:
         if config_name != "testing":
             self.logger.info("Insights Host Inventory Configuration:")
             self.logger.info("Build Version: %s", get_build_version())
-            self.logger.info("API URL Path: %s", self.api_url_path_prefix)
-            self.logger.info("Management URL Path Prefix: %s", self.mgmt_url_path_prefix)
             self.logger.info("DB Host: %s", self._db_host)
             self.logger.info("DB Name: %s", self._db_name)
             self.logger.info("DB Connection URI: %s", self._build_db_uri(self._db_ssl_mode, hide_password=True))
@@ -104,12 +106,17 @@ class Config:
                 self.logger.info("Using SSL for DB connection:")
                 self.logger.info("Postgresql SSL verification type: %s", self._db_ssl_mode)
                 self.logger.info("Path to certificate: %s", self._db_ssl_cert)
-            self.logger.info("Kafka Host Ingress Topic: %s" % self.host_ingress_topic)
-            self.logger.info("Kafka Host Ingress Group: %s" % self.host_ingress_consumer_group)
-            self.logger.info("Kafka Host Egress Topic: %s" % self.host_egress_topic)
-            self.logger.info("Kafka Event Topic: %s" % self.event_topic)
-            self.logger.info("Kafka Consumer Group: %s" % self.consumer_group)
-            self.logger.info("Kafka Bootstrap Servers: %s" % self.bootstrap_servers)
-            self.logger.info("Payload Tracker Kafka Topic: %s", self.payload_tracker_kafka_topic)
-            self.logger.info("Payload Tracker Service Name: %s", self.payload_tracker_service_name)
-            self.logger.info("Payload Tracker Enabled: %s", self.payload_tracker_enabled)
+            if self._environment == RuntimeEnvironment.server:
+                self.logger.info("API URL Path: %s", self.api_url_path_prefix)
+                self.logger.info("Management URL Path Prefix: %s", self.mgmt_url_path_prefix)
+                self.logger.info("Kafka Host Ingress Topic: %s" % self.host_ingress_topic)
+                self.logger.info("Kafka Host Ingress Group: %s" % self.host_ingress_consumer_group)
+                self.logger.info("Kafka Host Egress Topic: %s" % self.host_egress_topic)
+                self.logger.info("Kafka Event Topic: %s" % self.event_topic)
+                self.logger.info("Kafka Consumer Group: %s" % self.consumer_group)
+                self.logger.info("Kafka Bootstrap Servers: %s" % self.bootstrap_servers)
+                self.logger.info("Payload Tracker Kafka Topic: %s", self.payload_tracker_kafka_topic)
+                self.logger.info("Payload Tracker Service Name: %s", self.payload_tracker_service_name)
+                self.logger.info("Payload Tracker Enabled: %s", self.payload_tracker_enabled)
+            elif self._environment == RuntimeEnvironment.job:
+                self.logger.info("Metrics Pushgateway: %s", self.prometheus_pushgateway)

--- a/app/config.py
+++ b/app/config.py
@@ -44,6 +44,7 @@ class Config:
         self.kafka_enabled = all(map(os.environ.get, ["KAFKA_GROUP", "KAFKA_BOOTSTRAP_SERVERS"]))
 
         self.prometheus_pushgateway = os.environ.get("PROMETHEUS_PUSHGATEWAY", "localhost:9091")
+        self.kubernetes_namespace = os.environ.get("NAMESPACE")
 
         # https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html#kafka.KafkaConsumer
         self.kafka_consumer = {
@@ -120,3 +121,4 @@ class Config:
                 self.logger.info("Payload Tracker Enabled: %s", self.payload_tracker_enabled)
             elif self._environment == RuntimeEnvironment.job:
                 self.logger.info("Metrics Pushgateway: %s", self.prometheus_pushgateway)
+                self.logger.info("Kubernetes Namespace: %s", self.kubernetes_namespace)

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -1,10 +1,15 @@
 from os import getenv
 
+from prometheus_client import CollectorRegistry
+from prometheus_client import push_to_gateway
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from api.metrics import delete_host_count
+from api.metrics import delete_host_processing_time
 from app import UNKNOWN_REQUEST_ID_VALUE
 from app.config import Config
+from app.config import RuntimeEnvironment
 from app.culling import Conditions
 from app.logging import configure_logging
 from app.logging import get_logger
@@ -18,9 +23,12 @@ from tasks import init_tasks
 
 __all__ = ("main",)
 
+PROMETHEUS_JOB = "host_reaper"
+COLLECTED_METRICS = (delete_host_count, delete_host_processing_time)
+
 
 def _init_config(config_name):
-    config = Config()
+    config = Config(RuntimeEnvironment.job)
     config.log_configuration(config_name)
     return config
 
@@ -30,32 +38,44 @@ def _init_db(config):
     return sessionmaker(bind=engine)
 
 
-def main(config_name):
-    config = _init_config(config_name)
-    Session = _init_db(config)
-    logger = get_logger("host_reaper")
-    init_tasks(config)
-
+def _run(config, logger, session):
     conditions = Conditions.from_config(config)
     query_filter = stale_timestamp_filter(*conditions.culled())
 
-    session = Session()
     query = session.query(Host).filter(query_filter)
 
     events = delete_hosts(query)
+
     if events:
         for deleted_host in events:
             if deleted_host:
                 logger.info("Deleted host: %s", deleted_host.id)
             else:
                 logger.info("Host already deleted. Delete event not emitted.")
-
-        flush()
     else:
         logger.info("No hosts deleted.")
 
+
+def main(config_name):
+    config = _init_config(config_name)
+    init_tasks(config)
+
+    logger = get_logger("host_reaper")
+
+    registry = CollectorRegistry()
+    for metric in COLLECTED_METRICS:
+        registry.register(metric)
+
+    Session = _init_db(config)
+    session = Session()
+
+    _run(config, logger, session)
+
     session.commit()
     session.close()
+
+    flush()
+    push_to_gateway(config.prometheus_pushgateway, PROMETHEUS_JOB, registry)
 
 
 if __name__ == "__main__":

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -5,6 +5,7 @@ from prometheus_client import start_http_server
 
 from app import create_app
 from app.config import Config
+from app.config import RuntimeEnvironment
 from app.logging import get_logger
 from app.queue.egress import create_event_producer
 from app.queue.ingress import event_loop
@@ -17,7 +18,7 @@ def main():
     application = create_app(config_name, start_tasks=False, start_payload_tracker=True)
     start_http_server(9126)
 
-    config = Config()
+    config = Config(RuntimeEnvironment.server)
 
     consumer = KafkaConsumer(
         config.host_ingress_topic,

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -1,10 +1,9 @@
 from sqlalchemy.orm.base import instance_state
 
-from api.metrics import delete_host_count
-from api.metrics import delete_host_processing_time
 from app.events import delete as delete_event
+from lib.metrics import delete_host_count
+from lib.metrics import delete_host_processing_time
 from tasks import emit_event
-
 
 __all__ = ("delete_hosts",)
 

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -16,3 +16,8 @@ update_host_commit_processing_time = Summary(
 )
 create_host_count = Counter("inventory_create_host_count", "The total amount of hosts created")
 update_host_count = Counter("inventory_update_host_count", "The total amount of hosts updated")
+delete_host_count = Counter("inventory_delete_host_count", "The total amount of hosts deleted")
+delete_host_processing_time = Summary(
+    "inventory_delete_host_commit_seconds", "Time spent deleting hosts from the database"
+)
+host_reaper_fail_count = Counter("inventory_reaper_fail_count", "The total amount of Host Reaper failures.")

--- a/test_api.py
+++ b/test_api.py
@@ -35,7 +35,7 @@ from app.models import Host
 from app.serialization import serialize_host
 from app.utils import HostWrapper
 from app.utils import Tag
-from host_reaper import main as host_reaper_main
+from host_reaper import run as host_reaper_run
 from tasks import msg_handler
 from test_utils import rename_host_table_and_indexes
 from test_utils import set_environment
@@ -1105,7 +1105,8 @@ class HostReaperTestCase(DeleteHostsBaseTestCase):
 
     def _run_host_reaper(self):
         with patch("app.events.datetime", **{"utcnow.return_value": self.timestamp}):
-            host_reaper_main("testing")
+            with self.app.app_context():
+                host_reaper_run(self.app.config["INVENTORY_CONFIG"], db.session)
 
     def _add_hosts(self, data):
         post = []

--- a/test_payload_tracker.py
+++ b/test_payload_tracker.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 from app.config import Config
+from app.config import RuntimeEnvironment
 from app.payload_tracker import _UNKNOWN_PAYLOAD_ID
 from app.payload_tracker import get_payload_tracker
 from app.payload_tracker import init_payload_tracker
@@ -338,7 +339,7 @@ class PayloadTrackerTestCase(TestCase):
                 producer.reset_mock()
 
     def _get_tracker(self, account=None, payload_id=None, producer=None):
-        config = Config()
+        config = Config(RuntimeEnvironment.server)
         init_payload_tracker(config, producer=producer)
         return get_payload_tracker(account=account, payload_id=payload_id)
 

--- a/test_unit.py
+++ b/test_unit.py
@@ -22,6 +22,7 @@ from app.auth.identity import Identity
 from app.auth.identity import SHARED_SECRET_ENV_VAR
 from app.auth.identity import validate
 from app.config import Config
+from app.config import RuntimeEnvironment
 from app.culling import _Config as CullingConfig
 from app.culling import Timestamps
 from app.exceptions import InputFormatException
@@ -212,6 +213,10 @@ class TrustedIdentityTestCase(TestCase):
 
 
 class ConfigTestCase(TestCase):
+    @staticmethod
+    def _config():
+        return Config(RuntimeEnvironment.server)
+
     def test_configuration_with_env_vars(self):
         app_name = "brontocrane"
         path_prefix = "r/slaterock/platform"
@@ -236,8 +241,7 @@ class ConfigTestCase(TestCase):
         }
 
         with set_environment(new_env):
-
-            conf = Config()
+            conf = self._config()
 
             self.assertEqual(conf.db_uri, "postgresql://fredflintstone:bedrock1234@localhost/SlateRockAndGravel")
             self.assertEqual(conf.db_pool_timeout, 3)
@@ -254,7 +258,7 @@ class ConfigTestCase(TestCase):
         # Make sure the environment variables are not set
         with set_environment(None):
 
-            conf = Config()
+            conf = self._config()
 
             self.assertEqual(conf.db_uri, "postgresql://insights:insights@localhost/insights")
             self.assertEqual(conf.api_url_path_prefix, expected_api_path)
@@ -267,7 +271,7 @@ class ConfigTestCase(TestCase):
     def test_config_development_settings(self):
         with set_environment({"INVENTORY_DB_POOL_TIMEOUT": "3"}):
 
-            conf = Config()
+            conf = self._config()
 
             self.assertEqual(conf.db_pool_timeout, 3)
 


### PR DESCRIPTION
Use a Prometheus Pushgateway to report metrics from the [Host Reaper](https://github.com/Glutexo/insights-host-inventory/blob/2fc6fd481bd3841d6fa40149f231146a0ae76192/host_reaper.py). A new [configuration value / environment variable](https://github.com/Glutexo/insights-host-inventory/blob/2fc6fd481bd3841d6fa40149f231146a0ae76192/app/config.py#L46) is used for the target.