### PR TITLE
Iterate over hosts to delete

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -141,19 +141,22 @@ def delete_by_id(host_id_list):
 
     with PayloadTrackerContext(payload_tracker, received_status_message="delete operation"):
         query = _get_host_list_by_id_list(current_identity.account_number, host_id_list)
-        events = delete_hosts(query)
-        if events:
-            for deleted_host in events:
-                with PayloadTrackerProcessingContext(
-                    payload_tracker, processing_status_message="deleted host"
-                ) as payload_tracker_processing_ctx:
-                    if deleted_host:
-                        logger.info("Deleted host: %s", deleted_host.id)
-                        payload_tracker_processing_ctx.inventory_id = deleted_host.id
-                    else:
-                        logger.info("Host already deleted. Delete event not emitted.")
-        else:
-            return flask.abort(status.HTTP_404_NOT_FOUND)
+
+        if not query.count():
+            flask.abort(status.HTTP_404_NOT_FOUND)
+
+        for host_id, deleted in delete_hosts(query):
+            if deleted:
+                logger.info("Deleted host: %s", host_id)
+                tracker_message = "deleted host"
+            else:
+                logger.info("Host %s already deleted. Delete event not emitted.", host_id)
+                tracker_message = "not deleted host"
+
+            with PayloadTrackerProcessingContext(
+                payload_tracker, processing_status_message=tracker_message
+            ) as payload_tracker_processing_ctx:
+                payload_tracker_processing_ctx.inventory_id = host_id
 
 
 @api_operation

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,4 @@
 import uuid
-from contextlib import contextmanager
 from datetime import datetime
 from datetime import timezone
 
@@ -23,19 +22,6 @@ from app.validators import verify_uuid_format
 logger = get_logger(__name__)
 
 db = SQLAlchemy()
-
-
-@contextmanager
-def db_session_guard():
-    session = db.session
-    try:
-        yield session
-        session.commit()
-    except Exception:
-        session.rollback()
-        raise
-    finally:
-        session.remove()
 
 
 def _set_display_name_on_save(context):

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -17,6 +17,7 @@ from tasks import init_tasks
 
 
 __all__ = ("main",)
+SELECT_CHUNK_SIZE = 1000
 
 
 def _init_config(config_name):
@@ -35,7 +36,7 @@ def run(config, session):
 
     conditions = Conditions.from_config(config)
     query_filter = stale_timestamp_filter(*conditions.culled())
-    query = session.query(Host).filter(query_filter)
+    query = session.query(Host).filter(query_filter).yield_per(SELECT_CHUNK_SIZE)
 
     events = delete_hosts(query)
     for host_id, deleted in events:

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -17,7 +17,6 @@ from tasks import init_tasks
 
 
 __all__ = ("main",)
-SELECT_CHUNK_SIZE = 1000
 
 
 def _init_config(config_name):
@@ -36,7 +35,7 @@ def run(config, session):
 
     conditions = Conditions.from_config(config)
     query_filter = stale_timestamp_filter(*conditions.culled())
-    query = session.query(Host).filter(query_filter).yield_per(SELECT_CHUNK_SIZE)
+    query = session.query(Host).filter(query_filter)
 
     events = delete_hosts(query)
     for host_id, deleted in events:

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -10,6 +10,7 @@ from app.logging import configure_logging
 from app.logging import get_logger
 from app.logging import threadctx
 from app.models import Host
+from lib.db import session_guard
 from lib.host_delete import delete_hosts
 from lib.host_repository import stale_timestamp_filter
 from tasks import flush
@@ -52,12 +53,10 @@ def main(config_name):
     Session = _init_db(config)
     session = Session()
 
-    run(config, session)
+    with session_guard(session):
+        run(config, session)
 
     flush()
-
-    session.commit()
-    session.close()
 
 
 if __name__ == "__main__":

--- a/lib/db.py
+++ b/lib/db.py
@@ -1,0 +1,13 @@
+from contextlib import contextmanager
+
+
+@contextmanager
+def session_guard(session):
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -14,7 +14,7 @@ def delete_hosts(select_query):
     for host in select_query:
         host_id = host.id
         with delete_host_processing_time.time():
-            _delete_host(select_query, host)
+            _delete_host(select_query.session, host)
 
         host_deleted = _deleted_by_this_query(host)
         if host_deleted:
@@ -24,8 +24,8 @@ def delete_hosts(select_query):
         yield host_id, host_deleted
 
 
-def _delete_host(select_query, host):
-    delete_query = select_query.filter(Host.id == host.id)
+def _delete_host(session, host):
+    delete_query = session.query(Host).filter(Host.id == host.id)
     delete_query.delete(synchronize_session="fetch")
     delete_query.session.commit()
 

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -3,38 +3,42 @@ from sqlalchemy.orm.base import instance_state
 from api.metrics import delete_host_count
 from api.metrics import delete_host_processing_time
 from app.events import delete as delete_event
+from app.models import Host
 from tasks import emit_event
 
 
 __all__ = ("delete_hosts",)
 
 
-def delete_hosts(query):
-    hosts_to_delete = query.all()
-    if not hosts_to_delete:
-        return None
+def delete_hosts(select_query):
+    for host in select_query:
+        host_id = host.id
+        with delete_host_processing_time.time():
+            _delete_host(select_query, host)
 
-    with delete_host_processing_time.time():
-        query.delete(synchronize_session="fetch")
-    query.session.commit()
+        host_deleted = _deleted_by_this_query(host)
+        if host_deleted:
+            delete_host_count.inc()
+            _emit_event(host)
 
-    delete_host_count.inc(len(hosts_to_delete))
-
-    return _emit_events(hosts_to_delete)
+        yield host_id, host_deleted
 
 
-def _emit_events(deleted_hosts):
+def _delete_host(select_query, host):
+    delete_query = select_query.filter(Host.id == host.id)
+    delete_query.delete(synchronize_session="fetch")
+    delete_query.session.commit()
+
+
+def _deleted_by_this_query(host):
     # This process of checking for an already deleted host relies
     # on checking the session after it has been updated by the commit()
     # function and marked the deleted hosts as expired.  It is after this
     # change that the host is called by a new query and, if deleted by a
     # different process, triggers the ObjectDeletedError and is not emited.
-    for deleted_host in deleted_hosts:
-        # Prevents ObjectDeletedError from being raised.
-        if instance_state(deleted_host).expired:
-            # Not yielding the host. Accessing any attribute would raise ObjectDeletedError.
-            yield None
-        else:
-            event = delete_event(deleted_host)
-            emit_event(event)
-            yield deleted_host
+    return not instance_state(host).expired
+
+
+def _emit_event(host):
+    event = delete_event(host)
+    emit_event(event)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -4,10 +4,10 @@ from sqlalchemy import and_
 
 from app.logging import get_logger
 from app.models import db
-from app.models import db_session_guard
 from app.models import Host
 from app.serialization import serialize_host
 from lib import metrics
+from lib.db import session_guard
 
 __all__ = (
     "add_host",
@@ -40,7 +40,7 @@ def add_host(input_host, staleness_offset, update_system_profile=True):
      - account number
     """
 
-    with db_session_guard():
+    with session_guard(db.session):
         existing_host = find_existing_host(input_host.account, input_host.canonical_facts)
         if existing_host:
             return update_existing_host(existing_host, input_host, staleness_offset, update_system_profile)

--- a/logconfig.ini
+++ b/logconfig.ini
@@ -24,7 +24,7 @@ propagate=1
 qualname=gunicorn.access
 
 [logger_sqlalchemy.engine]
-level=WARNING
+level=DEBUG
 handlers=logstash
 propagate=1
 qualname=sqlalchemy.engine

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -5,11 +5,12 @@ from kafka import KafkaConsumer
 from kafka import KafkaProducer
 
 from api import metrics
+from app import db
 from app.logging import get_logger
 from app.logging import threadctx
-from app.models import db_session_guard
 from app.models import Host
 from app.models import SystemProfileSchema
+from lib.db import session_guard
 
 logger = get_logger(__name__)
 
@@ -62,7 +63,7 @@ def msg_handler(parsed):
         logger.error("ID is null, something went wrong.")
         return
 
-    with db_session_guard():
+    with session_guard(db.session):
         host = Host.query.get(id_)
         if host is None:
             logger.error("Host with id [%s] not found!", id_)


### PR DESCRIPTION
Instead of loading all hosts into memory on delete, use SQLAlchemy native iteration. This prevents the app/job getting killed for using too many resources.

Additional advantages include:

- The message queue events are emitted right after the host is deleted from the database.
- Host ID is logged and payload-tracked even if the host is not deleted because of a race condition.

Refactored the race condition tests and the rather cryptic iterator. Modified the Reaper tests so they use the same database connection. That should prevent database locking.