### PR TITLE
Add tag data to host output on egress kafka topic (RHCLOUD-4202, RHCLOUD-3835)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,16 +218,28 @@ If the _platform_metadata_ contains a request_id field, the value of the request
 associated with all of the log messages produced by the service.
 
 The Inventory service will write an event to the _platform.inventory.host-egress_
-kafka topic as a result of adding a host over the message queue.
+kafka topic as a result of adding or updating a host over the message queue.
 
 ```json
-  {"type": "created",
-   "platform_metadata": metadata_json_doc,
-   "data": host_json_doc}
+{
+    "type": "created",
+    "platform_metadata": metadata_json_doc,
+    "host": {
+        "id": ...,
+        "subscription_manager_id": ...,
+        "ansible_host": ...,
+        "display_name": ...,
+        "reporter": ...,
+        "stale_timestamp": ...,
+        "tags": ...,
+        "system_profile": ...,
+        ...
+    }
+}
 ```
   - type: result of the add host operation ("created" and "updated" are only supported currently)
   - platform_metadata: a json doc that contains the metadata associated with the host (s3 url, request_id, etc)
-  - data: a host json doc as defined by the HostSchema in [_app/queue/egress.py_](app/queue/egress.py)
+  - host: a host json doc as defined by the HostSchema in [_app/queue/egress.py_](app/queue/egress.py)
 
 #### Host deletion
 

--- a/app/queue/egress.py
+++ b/app/queue/egress.py
@@ -5,6 +5,8 @@ from marshmallow import fields
 from marshmallow import Schema
 
 from app.logging import get_logger
+from app.models import SystemProfileSchema
+from app.models import TagsSchema
 from app.queue import metrics
 
 
@@ -79,6 +81,8 @@ class HostSchema(Schema):
     stale_warning_timestamp = fields.Str()
     culled_timestamp = fields.Str()
     reporter = fields.Str()
+    tags = fields.List(fields.Nested(TagsSchema))
+    system_profile = fields.Nested(SystemProfileSchema)
 
 
 class HostEvent(Schema):

--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -14,10 +14,13 @@ from app.payload_tracker import PayloadTrackerContext
 from app.payload_tracker import PayloadTrackerProcessingContext
 from app.queue import metrics
 from app.queue.egress import build_event
+from app.serialization import DEFAULT_FIELDS
 from app.serialization import deserialize_host
 from lib import host_repository
 
 logger = get_logger(__name__)
+
+EGRESS_HOST_FIELDS = DEFAULT_FIELDS + ("tags", "system_profile")
 
 
 class OperationSchema(Schema):
@@ -93,7 +96,9 @@ def add_host(host_data):
             logger.info("Attempting to add host...")
             input_host = deserialize_host(host_data)
             staleness_timestamps = Timestamps.from_config(inventory_config())
-            (output_host, add_results) = host_repository.add_host(input_host, staleness_timestamps)
+            (output_host, add_results) = host_repository.add_host(
+                input_host, staleness_timestamps, fields=EGRESS_HOST_FIELDS
+            )
             metrics.add_host_success.labels(
                 add_results.name, host_data.get("reporter", "null")
             ).inc()  # created vs updated

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -25,6 +25,20 @@ _CANONICAL_FACTS_FIELDS = (
     "external_id",
 )
 
+DEFAULT_FIELDS = (
+    "id",
+    "account",
+    "display_name",
+    "ansible_host",
+    "facts",
+    "reporter",
+    "stale_timestamp",
+    "stale_warning_timestamp",
+    "culled_timestamp",
+    "created",
+    "updated",
+)
+
 
 def deserialize_host(raw_data):
     try:
@@ -66,7 +80,7 @@ def deserialize_host_xjoin(data):
     return host
 
 
-def serialize_host(host, staleness_timestamps):
+def serialize_host(host, staleness_timestamps, fields=DEFAULT_FIELDS):
     if host.stale_timestamp:
         stale_timestamp = staleness_timestamps.stale_timestamp(host.stale_timestamp)
         stale_warning_timestamp = staleness_timestamps.stale_warning_timestamp(host.stale_timestamp)
@@ -76,22 +90,38 @@ def serialize_host(host, staleness_timestamps):
         stale_warning_timestamp = None
         culled_timestamp = None
 
-    return {
-        **serialize_canonical_facts(host.canonical_facts),
-        "id": _serialize_uuid(host.id),
-        "account": host.account,
-        "display_name": host.display_name,
-        "ansible_host": host.ansible_host,
-        "facts": _serialize_facts(host.facts),
-        "reporter": host.reporter,
-        "stale_timestamp": stale_timestamp and _serialize_datetime(stale_timestamp),
-        "stale_warning_timestamp": stale_timestamp and _serialize_datetime(stale_warning_timestamp),
-        "culled_timestamp": stale_timestamp and _serialize_datetime(culled_timestamp),
+    serialized_host = {**serialize_canonical_facts(host.canonical_facts)}
+
+    if "id" in fields:
+        serialized_host["id"] = _serialize_uuid(host.id)
+    if "account" in fields:
+        serialized_host["account"] = host.account
+    if "display_name" in fields:
+        serialized_host["display_name"] = host.display_name
+    if "ansible_host" in fields:
+        serialized_host["ansible_host"] = host.ansible_host
+    if "facts" in fields:
+        serialized_host["facts"] = _serialize_facts(host.facts)
+    if "reporter" in fields:
+        serialized_host["reporter"] = host.reporter
+    if "stale_timestamp" in fields:
+        serialized_host["stale_timestamp"] = stale_timestamp and _serialize_datetime(stale_timestamp)
+    if "stale_warning_timestamp" in fields:
+        serialized_host["stale_warning_timestamp"] = stale_timestamp and _serialize_datetime(stale_warning_timestamp)
+    if "culled_timestamp" in fields:
+        serialized_host["culled_timestamp"] = stale_timestamp and _serialize_datetime(culled_timestamp)
         # without astimezone(timezone.utc) the isoformat() method does not include timezone offset even though iso-8601
         # requires it
-        "created": _serialize_datetime(host.created_on),
-        "updated": _serialize_datetime(host.modified_on),
-    }
+    if "created" in fields:
+        serialized_host["created"] = _serialize_datetime(host.created_on)
+    if "updated" in fields:
+        serialized_host["updated"] = _serialize_datetime(host.modified_on)
+    if "tags" in fields:
+        serialized_host["tags"] = _serialize_tags(host.tags)
+    if "system_profile" in fields:
+        serialized_host["system_profile"] = host.system_profile_facts or {}
+
+    return serialized_host
 
 
 def serialize_host_system_profile(host):
@@ -142,3 +172,7 @@ def _serialize_uuid(u):
 def _deserialize_tags(tags):
     # TODO: Move the deserialization logic to this method.
     return Tag.create_nested_from_tags(Tag.create_structered_tags_from_tag_data_list(tags))
+
+
+def _serialize_tags(tags):
+    return [tag.data() for tag in Tag.create_tags_from_nested(tags)]

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -257,10 +257,10 @@ class MQAddHostTestCase(MQAddHostBaseClass):
         self._base_add_host_test(host_data, expected_results, host_keys_to_check)
 
     @patch("app.queue.egress.datetime", **{"utcnow.return_value": datetime.utcnow()})
-    def test_host_add_with_system_profile(self, datetime_mock):
+    def test_add_host_with_system_profile(self, datetime_mock):
         """
          Tests adding a host with message containing system profile
-         """
+        """
         expected_insights_id = str(uuid.uuid4())
         timestamp_iso = datetime_mock.utcnow.return_value.isoformat() + "+00:00"
 
@@ -278,7 +278,38 @@ class MQAddHostTestCase(MQAddHostBaseClass):
             "type": "created",
         }
 
-        host_keys_to_check = ["display_name", "insights_id", "account"]
+        host_keys_to_check = ["display_name", "insights_id", "account", "system_profile"]
+
+        self._base_add_host_test(host_data, expected_results, host_keys_to_check)
+
+    @patch("app.queue.egress.datetime", **{"utcnow.return_value": datetime.utcnow()})
+    def test_add_host_with_tags(self, datetime_mock):
+        """
+         Tests adding a host with message containing tags
+        """
+        expected_insights_id = str(uuid.uuid4())
+        timestamp_iso = datetime_mock.utcnow.return_value.isoformat() + "+00:00"
+
+        host_data = {
+            "display_name": "test_host",
+            "insights_id": expected_insights_id,
+            "account": "0000001",
+            "tags": [
+                {"namespace": "NS1", "key": "key3", "value": "val3"},
+                {"namespace": "NS3", "key": "key2", "value": "val2"},
+                {"namespace": "Sat", "key": "prod", "value": None},
+                {"namespace": None, "key": "key", "value": "val"},
+            ],
+        }
+
+        expected_results = {
+            "host": {**host_data},
+            "platform_metadata": {},
+            "timestamp": timestamp_iso,
+            "type": "created",
+        }
+
+        host_keys_to_check = ["display_name", "insights_id", "account", "tags"]
 
         self._base_add_host_test(host_data, expected_results, host_keys_to_check)
 


### PR DESCRIPTION
This PR adds tags and system_profile to egress messages. This covers changes to the information we put on egress requested by the Advisor team. I've merged both changes into the one PR since they are very similar changes. The relevant tickets are below:

https://projects.engineering.redhat.com/browse/RHCLOUD-4202
https://projects.engineering.redhat.com/browse/RHCLOUD-3835
