### PR TITLE
Check xjoin-search response (RHCLOUD-4272)

### DIFF
--- a/app/xjoin.py
+++ b/app/xjoin.py
@@ -29,7 +29,7 @@ def graphql_query(query_string, variables):
     response = post(url_, json=payload, headers=_forwarded_headers())
     status = response.status_code
     if status != 200:
-        logger.debug("xjoin-search returned status: %s", status)
+        logger.debug("xjoin-search returned status: %s", 500)
         abort(status, "xjoin-search error")
 
     logger.debug("QUERY: response %s", response.text)

--- a/app/xjoin.py
+++ b/app/xjoin.py
@@ -29,8 +29,8 @@ def graphql_query(query_string, variables):
     response = post(url_, json=payload, headers=_forwarded_headers())
     status = response.status_code
     if status != 200:
-        logger.debug("xjoin-search returned status: %s", 500)
-        abort(status, "xjoin-search error")
+        logger.error("xjoin-search returned status: %s", status)
+        abort(500, "Error, request could not be completed")
 
     logger.debug("QUERY: response %s", response.text)
     response_body = response.json()

--- a/app/xjoin.py
+++ b/app/xjoin.py
@@ -27,6 +27,11 @@ def graphql_query(query_string, variables):
     payload = {"query": query_string, "variables": variables}
 
     response = post(url_, json=payload, headers=_forwarded_headers())
+    status = response.status_code
+    if status != 200:
+        logger.debug("xjoin-search returned status: %s", status)
+        abort(status, "xjoin-search error")
+
     logger.debug("QUERY: response %s", response.text)
     response_body = response.json()
     return response_body["data"]

--- a/test_api.py
+++ b/test_api.py
@@ -3299,15 +3299,16 @@ class HostsXjoinRequestHeadersTestCase(HostsXjoinRequestBaseTestCase):
 class XjoinSearchResponseCheckingTestCase(XjoinRequestBaseTestCase, HostsXjoinBaseTestCase):
     EMPTY_RESPONSE = {"hosts": {"meta": {"total": 0}, "data": []}}
 
-    def test_host_request_xjoin_status_403(self):
-        with self._patch_xjoin_post({"data": self.EMPTY_RESPONSE}, 403):
+    def base_xjoin_response_status_test(self, xjoin_res_status, expected_HBI_res_status):
+        with self._patch_xjoin_post({"data": self.EMPTY_RESPONSE}, xjoin_res_status):
             request_id = generate_uuid()
-            self._get_with_request_id(HOST_URL, request_id, 500)
+            self._get_with_request_id(HOST_URL, request_id, expected_HBI_res_status)
+
+    def test_host_request_xjoin_status_403(self):
+        self.base_xjoin_response_status_test(403, 500)
 
     def test_host_request_xjoin_status_200(self):
-        with self._patch_xjoin_post({"data": self.EMPTY_RESPONSE}, 200):
-            request_id = generate_uuid()
-            self._get_with_request_id(HOST_URL, request_id, 200)
+        self.base_xjoin_response_status_test(200, 200)
 
 
 @HostsXjoinRequestBaseTestCase.patch_graphql_query_empty_response()

--- a/test_api.py
+++ b/test_api.py
@@ -3256,7 +3256,12 @@ class XjoinRequestBaseTestCase(APIBaseTestCase):
     @contextmanager
     def _patch_xjoin_post(self, response):
         with patch(
-            "app.xjoin.post", **{"return_value.text": json.dumps(response), "return_value.json.return_value": response}
+            "app.xjoin.post",
+            **{
+                "return_value.text": json.dumps(response),
+                "return_value.json.return_value": response,
+                "return_value.status_code": 200,
+            },
         ) as post:
             yield post
 


### PR DESCRIPTION
When xjoin-search returns a non 200 status code insights-host-inventory still tries to process it as if the request was successful. This behaviour is part of what cause the bug mentioned in the title of the PR.

This PR adds a check to make sure that the request to xjoin was successful, and if not forwards the status code from xjoin. 