### PR TITLE
Cross-join host query Marshmallow schema deserialization

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -62,15 +62,15 @@ ORDER_HOW_MAPPING = {"modified_on": "DESC", "display_name": "ASC"}
 
 
 class HostQueryResponseHostDataCanonicalFactsSchema(Schema):
-    insights_id = String(validate=verify_uuid_format)
-    rhel_machine_id = String(validate=verify_uuid_format)
-    subscription_manager_id = String(validate=verify_uuid_format)
-    satellite_id = String(validate=verify_uuid_format)
-    bios_uuid = String(validate=verify_uuid_format)
-    ip_addresses = List(String(validate=Length(min=1, max=255)), validate=Length(min=1))
-    fqdn = String(validate=Length(min=1, max=255))
-    mac_addresses = List(String(validate=Length(min=1, max=59)), validate=Length(min=1))
-    external_id = String(validate=Length(min=1, max=500))
+    insights_id = String(allow_none=True, validate=verify_uuid_format)
+    rhel_machine_id = String(allow_none=True, validate=verify_uuid_format)
+    subscription_manager_id = String(allow_none=True, validate=verify_uuid_format)
+    satellite_id = String(allow_none=True, validate=verify_uuid_format)
+    bios_uuid = String(allow_none=True, validate=verify_uuid_format)
+    ip_addresses = List(String(validate=Length(min=1, max=255)))
+    fqdn = String(allow_none=True, validate=Length(min=1, max=255))
+    mac_addresses = List(String(validate=Length(min=1, max=59)))
+    external_id = String(allow_none=True, validate=Length(min=1, max=500))
 
 
 class HostQueryResponseHostDataSchema(Schema):

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -76,7 +76,7 @@ class HostQueryResponseHostDataCanonicalFactsSchema(Schema):
 class HostQueryResponseHostDataSchema(Schema):
     id = String(required=True, validate=verify_uuid_format)
     account = String(required=True, validate=Length(min=1, max=10))
-    display_name = String(required=True, validate=Length(min=1, max=200))
+    display_name = String(required=True, allow_none=True, validate=Length(min=1, max=200))
     ansible_host = String(required=True, allow_none=True, validate=Length(min=0, max=255))
     created_on = DateTime(required=True)
     modified_on = DateTime(required=True)

--- a/test_api.py
+++ b/test_api.py
@@ -3914,7 +3914,8 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
         "stale_timestamp": "2019-02-24T07:08:03.354307Z",
         "reporter": "some reporter",
     }
-    INVALID_VALUES = (None, "", "not a uuid", {})
+    INVALID_CANONICAL_FACT_VALUES = ("", "not a uuid", {})
+    INVALID_ROOT_VALUES = INVALID_CANONICAL_FACT_VALUES + (None,)
 
     def _get_hosts(self, data, code):
         with patch("api.host_query_xjoin.graphql_query", return_value=data):
@@ -3958,7 +3959,7 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
         self._get_hosts(response_data, 500)
 
     def test_invalid_hosts_data_id_invalid(self):
-        for id in self.INVALID_VALUES:
+        for id in self.INVALID_ROOT_VALUES:
             with self.subTest(id=id):
                 host_data = {**self.HOST_DATA, "id": id}
 
@@ -4015,7 +4016,7 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
         self._get_hosts(response_data, 500)
 
     def test_invalid_hosts_data_created_on_invalid(self):
-        for created_on in self.INVALID_VALUES:
+        for created_on in self.INVALID_ROOT_VALUES:
             with self.subTest(created_on=created_on):
                 host_data = {**self.HOST_DATA, "created_on": created_on}
 
@@ -4030,7 +4031,7 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
         self._get_hosts(response_data, 500)
 
     def test_invalid_hosts_data_modified_on_invalid(self):
-        for modified_on in self.INVALID_VALUES:
+        for modified_on in self.INVALID_ROOT_VALUES:
             with self.subTest(modified_on=modified_on):
                 host_data = {**self.HOST_DATA, "modified_on": modified_on}
 
@@ -4079,7 +4080,7 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
                 self._get_hosts(response_data, 500)
 
     def test_invalid_hosts_data_canonical_facts_insights_id_invalid(self):
-        for insights_id in self.INVALID_VALUES:
+        for insights_id in self.INVALID_CANONICAL_FACT_VALUES:
             with self.subTest(insights_id=insights_id):
                 host_data = {**self.HOST_DATA, "canonical_facts": {"insights_id": insights_id}}
 
@@ -4087,7 +4088,7 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
                 self._get_hosts(response_data, 500)
 
     def test_invalid_hosts_data_canonical_facts_rhel_machine_id_invalid(self):
-        for rhel_machine_id in self.INVALID_VALUES:
+        for rhel_machine_id in self.INVALID_CANONICAL_FACT_VALUES:
             with self.subTest(rhel_machine_id=rhel_machine_id):
                 host_data = {**self.HOST_DATA, "canonical_facts": {"rhel_machine_id": rhel_machine_id}}
 
@@ -4095,7 +4096,7 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
                 self._get_hosts(response_data, 500)
 
     def test_invalid_hosts_data_canonical_facts_subscription_manager_id_invalid(self):
-        for subscription_manager_id in self.INVALID_VALUES:
+        for subscription_manager_id in self.INVALID_CANONICAL_FACT_VALUES:
             with self.subTest(subscription_manager_id=subscription_manager_id):
                 host_data = {**self.HOST_DATA, "canonical_facts": {"subscription_manager_id": subscription_manager_id}}
 
@@ -4103,7 +4104,7 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
                 self._get_hosts(response_data, 500)
 
     def test_invalid_hosts_data_canonical_facts_satellite_id_invalid(self):
-        for satellite_id in self.INVALID_VALUES:
+        for satellite_id in self.INVALID_CANONICAL_FACT_VALUES:
             with self.subTest(satellite_id=satellite_id):
                 host_data = {**self.HOST_DATA, "canonical_facts": {"satellite_id": satellite_id}}
 
@@ -4111,7 +4112,7 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
                 self._get_hosts(response_data, 500)
 
     def test_invalid_hosts_data_canonical_facts_bios_uuid_invalid(self):
-        for bios_uuid in self.INVALID_VALUES:
+        for bios_uuid in self.INVALID_CANONICAL_FACT_VALUES:
             with self.subTest(bios_uuid=bios_uuid):
                 host_data = {**self.HOST_DATA, "canonical_facts": {"bios_uuid": bios_uuid}}
 
@@ -4125,11 +4126,6 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
 
                 response_data = {"hosts": {"meta": {"total": 1}, "data": [host_data]}}
                 self._get_hosts(response_data, 500)
-
-    def test_invalid_hosts_data_canonical_facts_ip_addresses_list_invalid(self):
-        host_data = {**self.HOST_DATA, "canonical_facts": {"ip_addresses": []}}
-        response_data = {"hosts": {"meta": {"total": 1}, "data": [host_data]}}
-        self._get_hosts(response_data, 500)
 
     def test_invalid_hosts_data_canonical_facts_ip_addresses_item_invalid(self):
         host_data = {**self.HOST_DATA, "canonical_facts": {"ip_addresses": ["10." * 100 + "1"]}}
@@ -4151,11 +4147,6 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
 
                 response_data = {"hosts": {"meta": {"total": 1}, "data": [host_data]}}
                 self._get_hosts(response_data, 500)
-
-    def test_invalid_hosts_data_canonical_facts_mac_addresses_list_invalid(self):
-        host_data = {**self.HOST_DATA, "canonical_facts": {"mac_addresses": []}}
-        response_data = {"hosts": {"meta": {"total": 1}, "data": [host_data]}}
-        self._get_hosts(response_data, 500)
 
     def test_invalid_hosts_data_canonical_facts_mac_addresses_item_invalid(self):
         host_data = {**self.HOST_DATA, "canonical_facts": {"mac_addresses": ["ff:" * 20 + "ff"]}}
@@ -4180,7 +4171,28 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
             "ip_addresses": ["10.0.0.1", "10.0.0.2"],
             "fqdn": "test01.rhel7.jharting.local",
             "mac_addresses": ["ff:ee:dd:cc:bb:aa", "aa:bb:cc:dd:ee:ff"],
+            "external_id": "i-05d2313e6b9a42b16",
         }
+        host_data = {**self.HOST_DATA, "canonical_facts": canonical_facts}
+        response_data = {"hosts": {"meta": {"total": 1}, "data": [host_data]}}
+        self._get_hosts(response_data, 200)
+
+    def test_valid_with_null_canonical_facts(self):
+        canonical_facts = {
+            "insights_id": None,
+            "rhel_machine_id": None,
+            "subscription_manager_id": None,
+            "satellite_id": None,
+            "bios_uuid": None,
+            "fqdn": None,
+            "external_id": None,
+        }
+        host_data = {**self.HOST_DATA, "canonical_facts": canonical_facts}
+        response_data = {"hosts": {"meta": {"total": 1}, "data": [host_data]}}
+        self._get_hosts(response_data, 200)
+
+    def test_valid_with_empty_addresses(self):
+        canonical_facts = {"ip_addresses": [], "mac_addresses": []}
         host_data = {**self.HOST_DATA, "canonical_facts": canonical_facts}
         response_data = {"hosts": {"meta": {"total": 1}, "data": [host_data]}}
         self._get_hosts(response_data, 200)

--- a/test_api.py
+++ b/test_api.py
@@ -755,7 +755,6 @@ class CreateHostsTestCase(DBAPITestCase):
         # Update the ansible_host
         for ansible_host in ansible_hosts:
             with self.subTest(ansible_host=ansible_host):
-
                 host_data.ansible_host = ansible_host
 
                 # Update the hosts
@@ -1502,7 +1501,6 @@ class CreateHostsWithSystemProfileTestCase(DBAPITestCase, PaginationBaseTestCase
 
         for system_profile in system_profiles:
             with self.subTest(system_profile=system_profile):
-
                 host["system_profile"] = system_profile
 
                 # Create the host
@@ -3990,7 +3988,7 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
         self._get_hosts(response_data, 500)
 
     def test_invalid_hosts_data_display_name_invalid(self):
-        for display_name in (None, "", "x" * 201):
+        for display_name in ("", "x" * 201):
             with self.subTest(display_name=display_name):
                 host_data = {**self.HOST_DATA, "display_name": display_name}
 
@@ -4184,6 +4182,15 @@ class HostsXjoinSchemaTestCase(HostsXjoinBaseTestCase):
             "mac_addresses": ["ff:ee:dd:cc:bb:aa", "aa:bb:cc:dd:ee:ff"],
         }
         host_data = {**self.HOST_DATA, "canonical_facts": canonical_facts}
+        response_data = {"hosts": {"meta": {"total": 1}, "data": [host_data]}}
+        self._get_hosts(response_data, 200)
+
+    def test_valid_without_display_name(self):
+        host_data = {
+            **self.HOST_DATA,
+            "canonical_facts": {"fqdn": "test01.rhel7.jharting.local"},
+            "display_name": None,
+        }
         response_data = {"hosts": {"meta": {"total": 1}, "data": [host_data]}}
         self._get_hosts(response_data, 200)
 

--- a/test_unit.py
+++ b/test_unit.py
@@ -668,7 +668,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "cores_per_socket": 3,
                 "system_memory_bytes": 4,
             },
-            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "stale_timestamp": datetime.now(timezone.utc),
             "reporter": "some reporter",
         }
         host_schema.return_value.load.return_value.data = input
@@ -706,7 +706,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "cores_per_socket": 3,
                 "system_memory_bytes": 4,
             },
-            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "stale_timestamp": datetime.now(timezone.utc),
             "reporter": "some reporter",
         }
         host_schema.return_value.load.return_value.data = input
@@ -749,7 +749,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "cores_per_socket": 3,
                 "system_memory_bytes": 4,
             },
-            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "stale_timestamp": datetime.now(timezone.utc),
             "reporter": "some reporter",
         }
         host_schema.return_value.load.return_value.data = input
@@ -787,7 +787,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "some namespace": {"some key": "some value"},
                 "another namespace": {"another key": "another value"},
             },
-            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "stale_timestamp": datetime.now(timezone.utc),
             "reporter": "some reporter",
         }
         host_schema.return_value.load.return_value.data = input

--- a/utils/validate_hosts_for_xjoin.py
+++ b/utils/validate_hosts_for_xjoin.py
@@ -1,0 +1,73 @@
+from datetime import timezone
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.host_query_xjoin import HostQueryResponseHostDataSchema
+from app.config import Config
+from app.logging import configure_logging
+from app.logging import get_logger
+from app.models import Host
+from app.serialization import _CANONICAL_FACTS_FIELDS
+from lib.db import session_guard
+
+CONFIG_NAME = "validation_script"
+
+logger = get_logger("utils")
+
+
+def _init_db():
+    config = Config(CONFIG_NAME)
+    engine = create_engine(config.db_uri)
+    Session = sessionmaker(engine)
+    return Session()
+
+
+def mock_xjoin_host_data(host):
+    return {
+        **{field: getattr(host, field) for field in ("account", "display_name", "facts", "ansible_host", "reporter")},
+        **{
+            field: getattr(host, field).astimezone(timezone.utc).isoformat() if getattr(host, field) else None
+            for field in ("created_on", "modified_on", "stale_timestamp")
+        },
+        "id": str(host.id),
+        "canonical_facts": {
+            field: host.canonical_facts[field] for field in _CANONICAL_FACTS_FIELDS if field in host.canonical_facts
+        },
+        "facts": None,
+    }
+
+
+def validate_xjoin_host_data(host_data):
+    schema = HostQueryResponseHostDataSchema()
+    result = schema.load(host_data)
+    return result.errors
+
+
+def main():
+    configure_logging(CONFIG_NAME)
+    session = _init_db()
+    with session_guard(session):
+        query = session.query(Host)
+
+        logger.info(f"Validating cross-join retrieval of hosts.")
+        logger.info(f"Total number of hosts: %i", query.count())
+
+        error_count = 0
+        invalid_host_count = 0
+        for host in query.yield_per(1000):
+            xjoin_host_data = mock_xjoin_host_data(host)
+            logger.debug("Cross-join host data: %s", xjoin_host_data)
+
+            host_validation_errors = validate_xjoin_host_data(xjoin_host_data)
+            if host_validation_errors:
+                error_count += len(host_validation_errors)
+                invalid_host_count += 1
+                logger.info("Output validation error host ID %s, error %s", host.id, host_validation_errors)
+
+        logger.info("Number of Host Validation Errors: %i", error_count)
+        logger.info("Number of invalid Hosts: %i", invalid_host_count)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Marshmallow can be used to deserialize timestamps. That fixes a bug with parsing timestamps from Cross-Join responses. Currently, a [specific format](https://github.com/RedHatInsights/insights-host-inventory/blob/313d1c0f2b432a3299a161f69faa6b47d7a111a0/app/serialization.py#L133) is required, but the service sometimes sends timestamps that don’t adhere to this subset. Marshmallow provides full ISO 8601 support. In addition this creates a contract between Inventory and Cross-Join, properly validating the responses. That can prevent processing invalid messages and running into later in the process.