### PR TITLE
Don't allow empty key names

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -7,6 +7,7 @@ from marshmallow import fields
 from marshmallow import Schema
 from marshmallow import validate
 from marshmallow import validates
+from marshmallow import validates_schema
 from marshmallow import ValidationError
 from sqlalchemy import Index
 from sqlalchemy import orm
@@ -339,6 +340,24 @@ class HostSchema(Schema):
     def validate_mac_addresses(self, mac_address_list):
         if len(mac_address_list) < 1:
             raise ValidationError("Array must contain at least one item")
+
+    @validates_schema(pass_original=True)
+    def check_unknown_fields(self, data, original_data):
+
+        def emptycheck(d):
+            for k, v in d.items():
+                if isinstance(v, dict):
+                    emptycheck(v)
+                elif isinstance(v, list):
+                    for l in v:
+                        if isinstance(l, dict):
+                            emptycheck(l)
+                else:
+                    if (k == ""):
+                        print("invalid")
+                        raise ValidationError('Empty key names are not allowed.')
+
+        emptycheck(original_data)
 
 
 class PatchHostSchema(Schema):

--- a/test_api.py
+++ b/test_api.py
@@ -961,6 +961,39 @@ class CreateHostsTestCase(DBAPITestCase):
 
         self._verify_host_status(response, 0, 400)
 
+    def test_create_host_with_empty_json_key_in_nested_array(self):
+        system_profile = {
+            "network_interfaces": [{"": "invalid"}]
+        }
+
+        host_data = HostWrapper(test_data(system_profile=system_profile))
+
+        response = self.post(HOST_URL, [host_data.data()], 207)
+
+        self._verify_host_status(response, 0, 400)
+
+    def test_create_host_with_empty_json_key_in_nested_object(self):
+        system_profile = {
+            "a-key": {"": "invalid"}
+        }
+
+        host_data = HostWrapper(test_data(system_profile=system_profile))
+
+        response = self.post(HOST_URL, [host_data.data()], 207)
+
+        self._verify_host_status(response, 0, 400)
+
+    def test_create_host_with_empty_json_key_in_root(self):
+        system_profile = {
+            "": "invalid"
+        }
+
+        host_data = HostWrapper(test_data(system_profile=system_profile))
+
+        response = self.post(HOST_URL, [host_data.data()], 207)
+
+        self._verify_host_status(response, 0, 400)
+
 
 class CreateHostsWithStaleTimestampTestCase(DBAPITestCase):
     def _add_host(self, expected_status, **values):


### PR DESCRIPTION
This is a potential fix for ES not allowing empty string keys. I'm not sure if we have a way to test the performance of this. While it will need to look through the entire body of each request, the comparison is very simple.