### PR TITLE
add "captured_date" to system profile

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -289,7 +289,7 @@ class SystemProfileSchema(Schema):
     installed_products = fields.List(fields.Nested(InstalledProductSchema()))
     insights_client_version = fields.Str(validate=validate.Length(max=50))
     insights_egg_version = fields.Str(validate=validate.Length(max=50))
-    captured_date = fields.Str(validate=validate.Length(max=30))
+    captured_date = fields.Str(validate=validate.Length(max=32))
     installed_packages = fields.List(fields.Str(validate=validate.Length(max=512)))
     installed_services = fields.List(fields.Str(validate=validate.Length(max=512)))
     enabled_services = fields.List(fields.Str(validate=validate.Length(max=512)))

--- a/app/models.py
+++ b/app/models.py
@@ -289,6 +289,7 @@ class SystemProfileSchema(Schema):
     installed_products = fields.List(fields.Nested(InstalledProductSchema()))
     insights_client_version = fields.Str(validate=validate.Length(max=50))
     insights_egg_version = fields.Str(validate=validate.Length(max=50))
+    captured_date = fields.Str(validate=validate.Length(max=30))
     installed_packages = fields.List(fields.Str(validate=validate.Length(max=512)))
     installed_services = fields.List(fields.Str(validate=validate.Length(max=512)))
     enabled_services = fields.List(fields.Str(validate=validate.Length(max=512)))

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1082,6 +1082,8 @@ components:
           type: string
         insights_egg_version:
           type: string
+        captured_date:
+          type: string
         installed_packages:
           type: array  # technically a set, ordering is not important
           items:

--- a/test_utils.py
+++ b/test_utils.py
@@ -86,6 +86,7 @@ def valid_system_profile():
         ],
         "insights_client_version": "12.0.12",
         "insights_egg_version": "120.0.1",
+        "captured_date": "2020-02-13T12:08:55Z",
         "installed_packages": ["rpm1-0:0.0.1.el7.i686", "rpm1-2:0.0.1.el7.i686"],
         "installed_services": ["ndb", "krb5"],
         "enabled_services": ["ndb", "krb5"],

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -419,6 +419,7 @@ def create_system_profile():
         ],
         "insights_client_version": "12.0.12",
         "insights_egg_version": "120.0.1",
+        "captured_date": "2020-02-13T12:16:00Z",
         # "installed_packages": ["rpm1", "rpm2"],
         # "installed_packages": subprocess.getoutput("rpm -qa").split("\n"),
         # "installed_packages": rpm_list(),


### PR DESCRIPTION
This commit adds a "captured_date" field to the system profile. This
date records when the system profile was captured on the client
system.

For example, if a system upload was created on a Monday but uploaded
on Tuesday, this date would be Monday. PUP will populate this from the
system time in the uploaded tarball.