### PR TITLE
Updated the smoke tests jenkins file

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -9,7 +9,7 @@ if (env.CHANGE_ID) {
     execSmokeTest (
         ocDeployerBuilderPath: "platform/insights-inventory",
         ocDeployerComponentPath: "platform/insights-inventory",
-        ocDeployerServiceSets: "advisor,platform,platform-mq",
+        ocDeployerServiceSets: "advisor,ingress,inventory,platform-mq",
         iqePlugins: ["iqe-advisor-plugin", "iqe-upload-plugin", "iqe-host-inventory-plugin"],
         pytestMarker: "smoke",
     )


### PR DESCRIPTION
This change is necessary because the platform set was split into multiple sets:

- ingress -- contains upload service, pup, storage broker, etc.
- inventory -- any app related to inventory (including reaper and host-delete)
- engine -- the shared engine app
- buck-it -- buck-it
- payload-tracker -- payload-tracker front-end/back-end/db