### PR TITLE
Require culling fields in API specification

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -327,8 +327,8 @@ class HostSchema(Schema):
     facts = fields.List(fields.Nested(FactsSchema))
     tags = fields.List(fields.Nested(TagsSchema))
     system_profile = fields.Nested(SystemProfileSchema)
-    stale_timestamp = fields.DateTime(timezone=True)
-    reporter = fields.Str(validate=validate.Length(min=1, max=255))
+    stale_timestamp = fields.DateTime(required=True, timezone=True)
+    reporter = fields.Str(required=True, validate=validate.Length(min=1, max=255))
 
     @validates("ip_addresses")
     def validate_ip_addresses(self, ip_address_list):

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -57,8 +57,8 @@ def deserialize_host(raw_data):
         facts,
         tags,
         validated_data.get("system_profile", {}),
-        validated_data.get("stale_timestamp"),
-        validated_data.get("reporter"),
+        validated_data["stale_timestamp"],
+        validated_data["reporter"],
     )
 
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -586,6 +586,8 @@ components:
       type: object
       required:
         - account
+        - stale_timestamp
+        - reporter
       properties:
         display_name:
           description: >-

--- a/test_db_model.py
+++ b/test_db_model.py
@@ -128,7 +128,14 @@ def test_create_host_with_system_profile(flask_app_fixture):
     ],
 )
 def test_host_schema_valid_tags(tags):
-    host = {"fqdn": "fred.flintstone.com", "display_name": "display_name", "account": "00102", "tags": tags}
+    host = {
+        "fqdn": "fred.flintstone.com",
+        "display_name": "display_name",
+        "account": "00102",
+        "tags": tags,
+        "stale_timestamp": "2019-12-16T10:10:06.754201+00:00",
+        "reporter": "test",
+    }
     validated_host = HostSchema(strict=True).load(host)
 
     assert validated_host.data["tags"] == tags

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -398,7 +398,7 @@ class MQCullingTests(MQAddHostBaseClass):
                     with self.assertRaises(InventoryException):
                         handle_message(json.dumps(message), mock_event_producer)
 
-    def test_add_host_stale_timestamp_invalud_culling_fields(self):
+    def test_add_host_stale_timestamp_invalid_culling_fields(self):
         """
         tests to check the API will reject a host if it doesn’t have both
         culling fields. This should raise InventoryException.
@@ -407,8 +407,10 @@ class MQCullingTests(MQAddHostBaseClass):
 
         additional_host_data = (
             {"stale_timestamp": "2019-12-16T10:10:06.754201+00:00", "reporter": ""},
+            {"stale_timestamp": "2019-12-16T10:10:06.754201+00:00", "reporter": None},
             {"stale_timestamp": "not a timestamp", "reporter": "puptoo"},
             {"stale_timestamp": "", "reporter": "puptoo"},
+            {"stale_timestamp": None, "reporter": "puptoo"},
         )
         for host_data in additional_host_data:
             with self.subTest(host_data=host_data):

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -87,8 +87,16 @@ class MQServiceTestCase(MQServiceBaseTestCase):
     def test_handle_message_happy_path(self, datetime_mock):
         expected_insights_id = str(uuid.uuid4())
         host_id = uuid.uuid4()
-        timestamp_iso = datetime_mock.utcnow.return_value.isoformat() + "+00:00"
-        message = {"operation": "add_host", "data": {"insights_id": expected_insights_id, "account": "0000001"}}
+        timestamp_iso = datetime_mock.utcnow.return_value.replace(tzinfo=timezone.utc).isoformat()
+        message = {
+            "operation": "add_host",
+            "data": {
+                "insights_id": expected_insights_id,
+                "account": "0000001",
+                "stale_timestamp": "2019-12-16T10:10:06.754201+00:00",
+                "reporter": "test",
+            },
+        }
         with self.app.app_context():
             with unittest.mock.patch("app.queue.ingress.host_repository.add_host") as m:
                 m.return_value = ({"id": host_id, "insights_id": None}, AddHostResults.created)
@@ -198,7 +206,13 @@ class MQhandleMessageTestCase(MQAddHostBaseClass):
 
         metadata = {"request_id": request_id, "archive_url": "https://some.url"}
 
-        host_data = {"display_name": "test_host", "insights_id": expected_insights_id, "account": "0000001"}
+        host_data = {
+            "display_name": "test_host",
+            "insights_id": expected_insights_id,
+            "account": "0000001",
+            "stale_timestamp": "2019-12-16T10:10:06.754201+00:00",
+            "reporter": "test",
+        }
 
         message = {"operation": "add_host", "platform_metadata": metadata, "data": host_data}
 
@@ -216,7 +230,13 @@ class MQhandleMessageTestCase(MQAddHostBaseClass):
     def test_handle_message_verify_metadata_is_not_required(self):
         expected_insights_id = str(uuid.uuid4())
 
-        host_data = {"display_name": "test_host", "insights_id": expected_insights_id, "account": "0000001"}
+        host_data = {
+            "display_name": "test_host",
+            "insights_id": expected_insights_id,
+            "account": "0000001",
+            "stale_timestamp": "2019-12-16T10:10:06.754201+00:00",
+            "reporter": "test",
+        }
 
         message = {"operation": "add_host", "data": host_data}
 
@@ -226,9 +246,7 @@ class MQhandleMessageTestCase(MQAddHostBaseClass):
         with self.app.app_context():
             handle_message(json.dumps(message), mock_event_producer)
 
-        host_keys_to_check = ["display_name", "insights_id", "account"]
-
-        for key in host_keys_to_check:
+        for key in host_data.keys():
             self.assertEqual(
                 json.loads(mock_event_producer.get_write_event())["host"][key], expected_results["host"][key]
             )
@@ -241,9 +259,15 @@ class MQAddHostTestCase(MQAddHostBaseClass):
         Tests adding a host with some simple data
         """
         expected_insights_id = str(uuid.uuid4())
-        timestamp_iso = datetime_mock.utcnow.return_value.isoformat() + "+00:00"
+        timestamp_iso = datetime_mock.utcnow.return_value.replace(tzinfo=timezone.utc).isoformat()
 
-        host_data = {"display_name": "test_host", "insights_id": expected_insights_id, "account": "0000001"}
+        host_data = {
+            "display_name": "test_host",
+            "insights_id": expected_insights_id,
+            "account": "0000001",
+            "stale_timestamp": "2019-12-16T10:10:06.754201+00:00",
+            "reporter": "test",
+        }
 
         expected_results = {
             "host": {**host_data},
@@ -262,13 +286,15 @@ class MQAddHostTestCase(MQAddHostBaseClass):
          Tests adding a host with message containing system profile
         """
         expected_insights_id = str(uuid.uuid4())
-        timestamp_iso = datetime_mock.utcnow.return_value.isoformat() + "+00:00"
+        timestamp_iso = datetime_mock.utcnow.return_value.replace(tzinfo=timezone.utc).isoformat()
 
         host_data = {
             "display_name": "test_host",
             "insights_id": expected_insights_id,
             "account": "0000001",
             "system_profile": valid_system_profile(),
+            "stale_timestamp": "2019-12-16T10:10:06.754201+00:00",
+            "reporter": "test",
         }
 
         expected_results = {
@@ -288,12 +314,14 @@ class MQAddHostTestCase(MQAddHostBaseClass):
          Tests adding a host with message containing tags
         """
         expected_insights_id = str(uuid.uuid4())
-        timestamp_iso = datetime_mock.utcnow.return_value.isoformat() + "+00:00"
+        timestamp_iso = datetime_mock.utcnow.return_value.replace(tzinfo=timezone.utc).isoformat()
 
         host_data = {
             "display_name": "test_host",
             "insights_id": expected_insights_id,
             "account": "0000001",
+            "stale_timestamp": "2019-12-16T10:10:06.754201+00:00",
+            "reporter": "test",
             "tags": [
                 {"namespace": "NS1", "key": "key3", "value": "val3"},
                 {"namespace": "NS3", "key": "key2", "value": "val2"},
@@ -348,44 +376,53 @@ class MQCullingTests(MQAddHostBaseClass):
 
         self._base_add_host_test(host_data, expected_results, host_keys_to_check)
 
-    def _base_incomplete_staleness_data_test(self, additional_host_data):
-        expected_insights_id = str(uuid.uuid4())
-
-        host_data = {
-            "display_name": "test_host",
-            "insights_id": expected_insights_id,
-            "account": "0000001",
-            **additional_host_data,
-        }
-
-        message = {"operation": "add_host", "data": host_data}
+    def test_add_host_stale_timestamp_missing_culling_fields(self):
+        """
+        tests to check the API will reject a host if it doesn’t have both
+        culling fields. This should raise InventoryException.
+        """
         mock_event_producer = mockEventProducer()
 
-        with self.app.app_context():
-            with self.assertRaises(InventoryException):
-                handle_message(json.dumps(message), mock_event_producer)
+        additional_host_data = ({"stale_timestamp": "2019-12-16T10:10:06.754201+00:00"}, {"reporter": "puptoo"}, {})
+        for host_data in additional_host_data:
+            with self.subTest(host_data=host_data):
+                host_data = {
+                    "display_name": "test_host",
+                    "insights_id": str(uuid.uuid4()),
+                    "account": "0000001",
+                    **host_data,
+                }
+                message = {"operation": "add_host", "data": host_data}
 
-    def test_add_host_stale_timestamp_no_reporter(self):
+                with self.app.app_context():
+                    with self.assertRaises(InventoryException):
+                        handle_message(json.dumps(message), mock_event_producer)
+
+    def test_add_host_stale_timestamp_invalud_culling_fields(self):
         """
-        tests to check the API will reject a host if it has a stale_timestamp
-        without a reporter. This shoul raise an inventory exception
+        tests to check the API will reject a host if it doesn’t have both
+        culling fields. This should raise InventoryException.
         """
+        mock_event_producer = mockEventProducer()
 
-        stale_timestamp = datetime.now(timezone.utc)
+        additional_host_data = (
+            {"stale_timestamp": "2019-12-16T10:10:06.754201+00:00", "reporter": ""},
+            {"stale_timestamp": "not a timestamp", "reporter": "puptoo"},
+            {"stale_timestamp": "", "reporter": "puptoo"},
+        )
+        for host_data in additional_host_data:
+            with self.subTest(host_data=host_data):
+                host_data = {
+                    "display_name": "test_host",
+                    "insights_id": str(uuid.uuid4()),
+                    "account": "0000001",
+                    **host_data,
+                }
+                message = {"operation": "add_host", "data": host_data}
 
-        additional_host_data = {"stale_timestamp": stale_timestamp.isoformat()}
-
-        self._base_incomplete_staleness_data_test(additional_host_data)
-
-    def test_add_host_reporter_no_stale_timestamp(self):
-        """
-        tests to check the API will reject a host if it has a stale_timestamp
-        without a reporter. This shoul raise an inventory exception
-        """
-
-        additional_host_data = {"reporter": "puptoo"}
-
-        self._base_incomplete_staleness_data_test(additional_host_data)
+                with self.app.app_context():
+                    with self.assertRaises(InventoryException):
+                        handle_message(json.dumps(message), mock_event_producer)
 
 
 class MQValidateJsonObjectForUtf8TestCase(TestCase):


### PR DESCRIPTION
Make _stale_timestamp_ and _reporter_ required fields for new hosts. That makes all hosts without either of the field rejected. Both null values and empty strings are rejected. This applies both to the HTTP REST and to the Message Queue API.

- For the HTTP API, the fields are [required](https://github.com/Glutexo/insights-host-inventory/blob/8aca13f864858a73b08b256258a219fdd1f7b486/swagger/api.spec.yaml#L589) on the [OpenAPI Specification](https://github.com/Glutexo/insights-host-inventory/blob/8aca13f864858a73b08b256258a219fdd1f7b486/swagger/api.spec.yaml) level. If the field is not present, the whole add host request fails with _400 Bad Request_. If it’s there, but is invalid, the request itself succeeds wth _207 Multi-Status_, but the host is not saved _400 Bad Request_.
- For the MQ API, a validation exception is [raised and logged](https://github.com/Glutexo/insights-host-inventory/blob/8aca13f864858a73b08b256258a219fdd1f7b486/app/queue/ingress.py#L73).