### PR TITLE
Fill in stale_timestamp and reporter

### DIFF
--- a/migrations/helpers.py
+++ b/migrations/helpers.py
@@ -1,0 +1,20 @@
+from contextlib import contextmanager
+
+from alembic import op
+from sqlalchemy.orm.session import Session
+
+
+__all__ = ("session",)
+
+
+@contextmanager
+def session():
+    bind = op.get_bind()
+    session = Session(bind)
+    try:
+        yield session
+    except Exception:
+        session.rollback()
+        raise
+    else:
+        session.commit()

--- a/migrations/versions/f48f739902ed_alter_stale_timestamp_and_reporter_to_.py
+++ b/migrations/versions/f48f739902ed_alter_stale_timestamp_and_reporter_to_.py
@@ -1,0 +1,28 @@
+"""alter_stale_timestamp_and_reporter_to_not_null
+
+Revision ID: f48f739902ed
+Revises: ff39a83abac3
+Create Date: 2020-02-20 15:37:06.363012
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "f48f739902ed"
+down_revision = "ff39a83abac3"
+branch_labels = None
+depends_on = None
+
+
+COLUMNS = ("stale_timestamp", "reporter")
+
+
+def upgrade():
+    for column in COLUMNS:
+        op.alter_column("hosts", column, nullable=False)
+
+
+def downgrade():
+    for column in COLUMNS:
+        op.alter_column("hosts", column, nullable=True)

--- a/migrations/versions/ff39a83abac3_fill_in_stale_timestamp_and_reporter.py
+++ b/migrations/versions/ff39a83abac3_fill_in_stale_timestamp_and_reporter.py
@@ -1,0 +1,55 @@
+"""fill_in_stale_timestamp_and_reporter
+
+Revision ID: ff39a83abac3
+Revises: c6bfa7ebeaee
+Create Date: 2020-02-20 14:07:13.460270
+
+"""
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.ext.declarative import declarative_base
+
+from migrations.helpers import session
+
+# revision identifiers, used by Alembic.
+revision = "ff39a83abac3"
+down_revision = "c6bfa7ebeaee"
+branch_labels = None
+depends_on = None
+
+
+Base = declarative_base()
+NULL = None
+STALE_TIMESTAMP_DELTA = timedelta(days=-14)
+REPORTER = "migration"
+
+
+class Host(Base):
+    __tablename__ = "hosts"
+
+    id = Column(UUID, primary_key=True)
+    stale_timestamp = Column(DateTime)
+    reporter = Column(String)
+
+
+def _stale_timestamp():
+    return datetime.now(timezone.utc) + STALE_TIMESTAMP_DELTA
+
+
+def upgrade():
+    stale_timestamp = _stale_timestamp()
+
+    with session() as s:
+        s.query(Host).filter(Host.stale_timestamp == NULL).update({Host.stale_timestamp: stale_timestamp})
+        s.query(Host).filter(Host.reporter == NULL).update({Host.reporter: REPORTER})
+
+
+def downgrade():
+    with session() as s:
+        s.query(Host).filter(Host.reporter == REPORTER).update({Host.stale_timestamp: NULL, Host.reporter: NULL})


### PR DESCRIPTION
Added migrations that

* [fill](https://github.com/Glutexo/insights-host-inventory/blob/08689b9e27528b239293f79659b876fb0fa7ad3c/migrations/versions/ff39a83abac3_fill_in_stale_timestamp_and_reporter.py) the missing stale timestamp a reporter.
* [alter](https://github.com/Glutexo/insights-host-inventory/blob/08689b9e27528b239293f79659b876fb0fa7ad3c/migrations/versions/f48f739902ed_alter_stale_timestamp_and_reporter_to_.py) the columns to not accept a NULL value.

The [downgrade](https://github.com/Glutexo/insights-host-inventory/blob/08689b9e27528b239293f79659b876fb0fa7ad3c/migrations/versions/ff39a83abac3_fill_in_stale_timestamp_and_reporter.py#L53) is not 100% symmetric: the values are cleared for all records marked as migrated. It shouldn’t have been ever possible though to add hosts with only stale timestamp or only reporter filled in.