### PR TITLE
RHCLOUD-2766 - Graceful shutdown

### DIFF
--- a/app/queue/egress.py
+++ b/app/queue/egress.py
@@ -38,6 +38,10 @@ class KafkaEventProducer:
             logger.exception("Failed to send event")
             metrics.egress_message_handler_failure.inc()
 
+    def close(self):
+        self._kafka_producer.flush()
+        self._kafka_producer.close()
+
 
 class NullEventProducer:
     def __init__(self):

--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -1,4 +1,5 @@
 import json
+import signal
 
 from marshmallow import fields
 from marshmallow import Schema
@@ -21,6 +22,7 @@ from lib import host_repository
 logger = get_logger(__name__)
 
 EGRESS_HOST_FIELDS = DEFAULT_FIELDS + ("tags", "system_profile")
+CONSUMER_POLL_TIMEOUT_MS = 1000
 
 
 class OperationSchema(Schema):
@@ -134,17 +136,22 @@ def handle_message(message, event_producer):
         event_producer.write_event(event, output_host["id"])
 
 
-def event_loop(consumer, flask_app, event_producer, handler=handle_message):
+def event_loop(consumer, flask_app, event_producer, handler, shutdown_handler):
     with flask_app.app_context():
-        logger.debug("Waiting for message")
-        for msg in consumer:
-            logger.debug("Message received")
-            try:
-                handler(msg.value, event_producer)
-                metrics.ingress_message_handler_success.inc()
-            except Exception:
-                metrics.ingress_message_handler_failure.inc()
-                logger.exception("Unable to process message")
+
+        signal.signal(signal.SIGTERM, shutdown_handler.signal_handler)  # For Openshift
+        signal.signal(signal.SIGINT, shutdown_handler.signal_handler)  # For Ctrl+C
+        while not shutdown_handler.shut_down():
+            msgs = consumer.poll(timeout_ms=CONSUMER_POLL_TIMEOUT_MS)
+            for topic_partition, messages in msgs.items():
+                for message in messages:
+                    logger.debug("Message received")
+                    try:
+                        handler(message.value, event_producer)
+                        metrics.ingress_message_handler_success.inc()
+                    except Exception:
+                        metrics.ingress_message_handler_failure.inc()
+                        logger.exception("Unable to process message")
 
 
 def initialize_thread_local_storage(metadata):


### PR DESCRIPTION
Jira: [Here](https://projects.engineering.redhat.com/browse/RHCLOUD-2766)

Current approach: _I am extending the Kafka Consumer class to add a graceful shutdown method and some flags to check and halt shutdown when an in-flight operation is in progress_

There is a failing test that still needs to be addressed. But, please let me know if this approach can be improved or needs to be changed entirely. :slightly_smiling_face: 