### PR TITLE
Use direct comparison for host matching

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -9,6 +9,7 @@ from app.culling import staleness_to_conditions
 from app.logging import get_logger
 from app.models import Host
 from app.utils import Tag
+from lib.host_repository import canonical_fact_host_query
 from lib.host_repository import canonical_facts_host_query
 from lib.host_repository import stale_timestamp_filter
 
@@ -23,13 +24,13 @@ def get_host_list(
     display_name, fqdn, hostname_or_id, insights_id, tags, page, per_page, order_by, order_how, staleness
 ):
     if fqdn:
-        query = _find_hosts_by_canonical_facts({"fqdn": fqdn})
+        query = _find_hosts_by_canonical_fact("fqdn", fqdn)
     elif display_name:
         query = _find_hosts_by_display_name(display_name)
     elif hostname_or_id:
         query = _find_hosts_by_hostname_or_id(hostname_or_id)
     elif insights_id:
-        query = _find_hosts_by_canonical_facts({"insights_id": insights_id})
+        query = _find_hosts_by_canonical_fact("insights_id", insights_id)
     else:
         query = _find_all_hosts()
 
@@ -93,6 +94,10 @@ def _order_how(column, order_how):
 
 def _find_all_hosts():
     return Host.query.filter(Host.account == current_identity.account_number)
+
+
+def _find_hosts_by_canonical_fact(canonical_fact, value):
+    return canonical_fact_host_query(current_identity.account_number, canonical_fact, value)
 
 
 def _find_hosts_by_canonical_facts(canonical_facts):

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -64,11 +64,15 @@ def _find_host_by_elevated_ids(account_number, canonical_facts):
     for elevated_cf_name in ELEVATED_CANONICAL_FACT_FIELDS:
         cf_value = canonical_facts.get(elevated_cf_name)
         if cf_value:
-            existing_host = find_host_by_canonical_facts(account_number, {elevated_cf_name: cf_value})
+            existing_host = find_host_by_canonical_fact(account_number, elevated_cf_name, cf_value)
             if existing_host:
                 return existing_host
 
     return None
+
+
+def canonical_fact_host_query(account_number, canonical_fact, value):
+    return Host.query.filter((Host.account == account_number) & (Host.canonical_facts[canonical_fact].astext == value))
 
 
 def canonical_facts_host_query(account_number, canonical_facts):
@@ -79,6 +83,20 @@ def canonical_facts_host_query(account_number, canonical_facts):
             | Host.canonical_facts.comparator.contained_by(canonical_facts)
         )
     )
+
+
+def find_host_by_canonical_fact(account_number, canonical_fact, value):
+    """
+    Returns first match for a host containing given canonical facts
+    """
+    logger.debug("find_host_by_canonical_fact(%s, %s)", canonical_fact, value)
+
+    host = canonical_fact_host_query(account_number, canonical_fact, value).first()
+
+    if host:
+        logger.debug("Found existing host using canonical_fact match: %s", host)
+
+    return host
 
 
 def find_host_by_canonical_facts(account_number, canonical_facts):

--- a/test_api.py
+++ b/test_api.py
@@ -15,6 +15,7 @@ from unittest import main
 from unittest import mock
 from unittest import TestCase
 from unittest.mock import ANY
+from unittest.mock import call
 from unittest.mock import patch
 from urllib.parse import parse_qs
 from urllib.parse import quote_plus as url_quote
@@ -36,6 +37,8 @@ from app.utils import HostWrapper
 from app.utils import Tag
 from host_reaper import run as host_reaper_run
 from lib.host_delete import delete_hosts
+from lib.host_repository import canonical_fact_host_query
+from lib.host_repository import canonical_facts_host_query
 from tasks import msg_handler
 from test_utils import rename_host_table_and_indexes
 from test_utils import set_environment
@@ -409,6 +412,33 @@ class CreateHostsTestCase(DBAPITestCase):
         data = self.get(f"{HOST_URL}/{original_id}", 200)
 
         self._validate_host(data["results"][0], host_data, expected_id=original_id)
+
+    @patch("lib.host_repository.canonical_fact_host_query", wraps=canonical_fact_host_query)
+    @patch("lib.host_repository.canonical_facts_host_query", wraps=canonical_facts_host_query)
+    def test_match_host_by_elevated_id_performance(self, canonical_facts_host_query, canonical_fact_host_query):
+        subscription_manager_id = generate_uuid()
+        host_data = HostWrapper(test_data(subscription_manager_id=subscription_manager_id))
+        create_response = self.post(HOST_URL, [host_data.data()], 207)
+        self._verify_host_status(create_response, 0, 201)
+
+        # Create a host with Subscription Manager ID
+        insights_id = generate_uuid()
+        host_data = HostWrapper(test_data(insights_id=insights_id, subscription_manager_id=subscription_manager_id))
+
+        canonical_fact_host_query.reset_mock()
+        canonical_facts_host_query.reset_mock()
+
+        # Update a host with Insights ID and Subscription Manager ID
+        update_response = self.post(HOST_URL, [host_data.data()], 207)
+        self._verify_host_status(update_response, 0, 200)
+
+        expected_calls = (
+            call(ACCOUNT, "insights_id", insights_id),
+            call(ACCOUNT, "subscription_manager_id", subscription_manager_id),
+        )
+        canonical_fact_host_query.assert_has_calls(expected_calls)
+        self.assertEqual(canonical_fact_host_query.call_count, len(expected_calls))
+        canonical_facts_host_query.assert_not_called()
 
     def test_create_host_with_empty_facts_display_name_then_update(self):
         # Create a host with empty facts, and display_name
@@ -2154,6 +2184,22 @@ class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
         test_url = HOST_URL + "?insights_id=" + valid_insights_id + "&branch_id=123"
 
         self.get(test_url, 200)
+
+
+@patch("api.host_query_db.canonical_fact_host_query", wraps=canonical_fact_host_query)
+@patch("api.host_query_db.canonical_facts_host_query", wraps=canonical_facts_host_query)
+class QueryByCanonicalFactPerformanceTestCase(DBAPITestCase):
+    def test_query_using_fqdn_not_subset_match(self, canonical_facts_host_query, canonical_fact_host_query):
+        fqdn = "some fqdn"
+        self.get(f"{HOST_URL}?fqdn={fqdn}")
+        canonical_facts_host_query.assert_not_called()
+        canonical_fact_host_query.assert_called_once_with(ACCOUNT, "fqdn", fqdn)
+
+    def test_query_using_insights_id_not_subset_match(self, canonical_facts_host_query, canonical_fact_host_query):
+        insights_id = "ff13a346-19cb-42ae-9631-44c42927fb92"
+        self.get(f"{HOST_URL}?insights_id={insights_id}")
+        canonical_facts_host_query.assert_not_called()
+        canonical_fact_host_query.assert_called_once_with(ACCOUNT, "insights_id", insights_id)
 
 
 class QueryByTagTestCase(PreCreatedHostsBaseTestCase, PaginationBaseTestCase):


### PR DESCRIPTION
A direct equal comparison (=) used instead of subset matching (@>, <@) when querying host by a single (elevated) canonical fact. Used when

- matching a host by Insights ID or Subscription Manager ID on add
- and matching a host by FQDN or Insights ID on list get.

The tests are only checking that the right query method is called. The only other option would be to examine the composed SQLAlchemy Host query, which I think is not a good way.