### PR TITLE
Replica identity full

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ pytest test_json_validators.py
 Depending on the environment, it might be necessary to set the DB related environment
 variables (INVENTORY_DB_NAME, INVENTORY_DB_HOST, etc).
 
+## Generate migration script
+
+Run this command to generate a new revision in `migrations/versions`
+```
+python manage.py db revision -m "Description of revision"
+```
+
 ## Running the server
 
 Prometheus was designed to run in a multi-threaded

--- a/migrations/versions/5544cd265053_set_replica_identity_to_full_on_hosts_.py
+++ b/migrations/versions/5544cd265053_set_replica_identity_to_full_on_hosts_.py
@@ -15,6 +15,13 @@ branch_labels = None
 depends_on = None
 
 
+# Can be verified by:
+#
+#   SELECT "relreplident" FROM "pg_class" WHERE "oid" = 'hosts'::regclass;
+#
+# 'd' means DEFAULT, 'f' means FULL.
+
+
 def upgrade():
     op.execute('ALTER TABLE "hosts" REPLICA IDENTITY FULL')
 

--- a/migrations/versions/5544cd265053_set_replica_identity_to_full_on_hosts_.py
+++ b/migrations/versions/5544cd265053_set_replica_identity_to_full_on_hosts_.py
@@ -1,0 +1,23 @@
+"""Set REPLICA_IDENTITY to FULL on hosts table
+
+Revision ID: 5544cd265053
+Revises: f48f739902ed
+Create Date: 2020-03-02 09:21:32.938401
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "5544cd265053"
+down_revision = "f48f739902ed"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('ALTER TABLE "hosts" REPLICA IDENTITY FULL')
+
+
+def downgrade():
+    op.execute('ALTER TABLE "hosts" REPLICA IDENTITY DEFAULT')


### PR DESCRIPTION
This is required to prevent truncated messages from being sent through the xjoin pipeline. See https://debezium.io/blog/2019/10/08/handling-unchanged-postgres-toast-values/