### PR TITLE
RHCLOUD-4217: Add reporter to find existing host log statements

### DIFF
--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -103,7 +103,11 @@ def add_host(host_data):
                 add_results.name, host_data.get("reporter", "null")
             ).inc()  # created vs updated
             # log all the incoming host data except facts and system_profile b/c they can be quite large
-            logger.info("Host %s: %s", add_results.name, {i: host_data[i] for i in host_data if i not in ('facts', 'system_profile')})
+            logger.info(
+                "Host %s: %s",
+                add_results.name,
+                {i: host_data[i] for i in host_data if i not in ("facts", "system_profile")},
+            )
             payload_tracker_processing_ctx.inventory_id = output_host["id"]
             return (output_host, add_results)
         except InventoryException:

--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -106,7 +106,7 @@ def add_host(host_data):
             logger.info(
                 "Host %s: %s",
                 add_results.name,
-                {i: host_data[i] for i in host_data if i not in ("facts", "system_profile")},
+                {i: output_host[i] for i in output_host if i not in ("facts", "system_profile")},
             )
             payload_tracker_processing_ctx.inventory_id = output_host["id"]
             return (output_host, add_results)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -20,7 +20,7 @@ __all__ = (
     "update_existing_host",
 )
 
-# FIXME:  rename this
+# FIXME:  rename this, but more importantly why use Enum over a str constant?
 AddHostResults = Enum("AddHostResults", ["created", "updated"])
 
 # These are the "elevated" canonical facts that are

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -154,6 +154,7 @@ class MQServiceParseMessageTestCase(MQServiceBaseTestCase):
         for message in messages:
             with self.subTest(message=message):
                 add_host.reset_mock()
+                add_host.return_value = ({}, AddHostResults.updated)
                 handle_message(message, Mock())
                 add_host.assert_called_once_with({"display_name": f"{operation_raw}{operation_raw}"})
 

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -154,7 +154,7 @@ class MQServiceParseMessageTestCase(MQServiceBaseTestCase):
         for message in messages:
             with self.subTest(message=message):
                 add_host.reset_mock()
-                add_host.return_value = ({}, AddHostResults.updated)
+                add_host.return_value = ({"id": "d7d92ccd-c281-49b9-b203-190565c45e1b"}, AddHostResults.updated)
                 handle_message(message, Mock())
                 add_host.assert_called_once_with({"display_name": f"{operation_raw}{operation_raw}"})
 


### PR DESCRIPTION
To help with debugging, log more data about the host during ingress.

