### PR TITLE
Fix 500 error on large number page requests [RHCLOUD-4928]

### DIFF
--- a/app/xjoin.py
+++ b/app/xjoin.py
@@ -27,6 +27,12 @@ def graphql_query(query_string, variables):
     payload = {"query": query_string, "variables": variables}
 
     response = post(url_, json=payload, headers=_forwarded_headers())
+
+    error_message = response.json()["errors"][0]["message"]
+    if error_message == "search_phase_execution_exception":
+        logger.error("Elastic Search result window too large")
+        abort(404, "page excedes max")
+
     status = response.status_code
     if status != 200:
         logger.error("xjoin-search returned status: %s", status)


### PR DESCRIPTION
The issue comes from the set max result window setting in elastic search. We can increase the window if we want to be able to receive more than 10,000 hosts in a paginated request. But either way we'll need to check if we're exceeding the limit we have set. This PR adds that check so that a 404 is returned when requesting too large of a page number.