### PR TITLE
Add exit code for Host Reaper exception

### DIFF
--- a/host_reaper.py
+++ b/host_reaper.py
@@ -78,6 +78,7 @@ def main(config_name):
     except Exception as exception:
         logger = get_logger(LOGGER_NAME)
         logger.exception(exception)
+        exit(1)
     finally:
         flush()
 


### PR DESCRIPTION
On failure, the Host Reaper now [exits](https://github.com/Glutexo/insights-host-inventory/blob/8652f0f568fa9ece9e179e557938355891c8f801/host_reaper.py#L81) with a status code 1. Just as if the exception wasn’t caught at all.

No tests at the Reaper script scaffold is not tested.