### PR TITLE
Create logger only once

### DIFF
--- a/host_reaper.py
+++ b/host_reaper.py
@@ -51,9 +51,7 @@ def _excepthook(logger, type, value, traceback):
 
 
 @host_reaper_fail_count.count_exceptions()
-def run(config, session):
-    logger = get_logger(LOGGER_NAME)
-
+def run(config, logger, session):
     conditions = Conditions.from_config(config)
     query_filter = stale_timestamp_filter(*conditions.culled())
 
@@ -67,7 +65,7 @@ def run(config, session):
             logger.info("Host %s already deleted. Delete event not emitted.", host_id)
 
 
-def main(config_name):
+def main(config_name, logger):
     config = _init_config(config_name)
     init_tasks(config)
 
@@ -80,7 +78,7 @@ def main(config_name):
 
     try:
         with session_guard(session):
-            run(config, session)
+            run(config, logger, session)
     finally:
         flush()
 
@@ -96,4 +94,4 @@ if __name__ == "__main__":
     sys.excepthook = partial(_excepthook, logger)
 
     threadctx.request_id = UNKNOWN_REQUEST_ID_VALUE
-    main(config_name)
+    main(config_name, logger)

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -51,7 +51,7 @@ def _excepthook(logger, type, value, traceback):
 
 
 @host_reaper_fail_count.count_exceptions()
-def run(config, logger, session):
+def run(config, logger_, session):
     conditions = Conditions.from_config(config)
     query_filter = stale_timestamp_filter(*conditions.culled())
 
@@ -60,9 +60,9 @@ def run(config, logger, session):
     events = delete_hosts(query)
     for host_id, deleted in events:
         if deleted:
-            logger.info("Deleted host: %s", host_id)
+            logger_.info("Deleted host: %s", host_id)
         else:
-            logger.info("Host %s already deleted. Delete event not emitted.", host_id)
+            logger_.info("Host %s already deleted. Delete event not emitted.", host_id)
 
 
 def main(config_name, logger):

--- a/test_api.py
+++ b/test_api.py
@@ -1223,7 +1223,7 @@ class HostReaperTestCase(DeleteHostsBaseTestCase, CullingBaseTestCase):
         with patch("app.events.datetime", **{"utcnow.return_value": self.now_timestamp}):
             with self.app.app_context():
                 config = self.app.config["INVENTORY_CONFIG"]
-                host_reaper_run(config, db.session)
+                host_reaper_run(config, mock.Mock(), db.session)
 
     def _add_hosts(self, data):
         post = []


### PR DESCRIPTION
A little follow-up to #617. This slipped through my finger.

The logger is now [created right after](https://github.com/Glutexo/insights-host-inventory/blob/f6c5bd1853415f204aabf11c34bc220526b227f0/host_reaper.py#L93) logging configuration. Use this logger instance and pass it down to the functions instead of creating a new one.