### PR TITLE
Remove percent encoding of the search string in /tags

### DIFF
--- a/api/tag.py
+++ b/api/tag.py
@@ -1,5 +1,4 @@
 import re
-from urllib.parse import quote_plus as url_quote
 
 import flask
 
@@ -74,8 +73,8 @@ def get_tags(search=None, tags=None, order_by=None, order_how=None, page=None, p
 
     if search:
         variables["filter"] = {
-            # Escaped to prevent ReDoS
-            "search": {"regex": f".*{re.escape(url_quote(search, safe=''))}.*"}
+            # Escaped so that the string literals are not interpretted as regex
+            "search": {"regex": f".*{re.escape(search)}.*"}
         }
 
     if tags:

--- a/test_api.py
+++ b/test_api.py
@@ -4402,7 +4402,7 @@ class TagsRequestTestCase(XjoinRequestBaseTestCase):
                 "order_how": "ASC",
                 "limit": 50,
                 "offset": 0,
-                "filter": {"search": {"regex": ".*\\%CE\\%94with\\%C4\\%8Dhar\\%21\\%2F\\%7E\\%7C\\%2B\\+.*"}},
+                "filter": {"search": {"regex": ".*\\Δwith\\čhar\\!\\/\\~\\|\\+\\ .*"}},
                 "hostFilter": {"OR": ANY},
             },
         )


### PR DESCRIPTION
With RHCLOUD-5665 we're removing the need to urlencode the search string when making the request.

This is related to:
https://projects.engineering.redhat.com/browse/RHCLOUD-5656
https://projects.engineering.redhat.com/browse/RHCLOUD-5668