### PR TITLE
cleanup Sat 6.7 hotfix

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -105,8 +105,7 @@ def _add_host(input_host):
             "host",
         )
 
-    # from_REST_API is part of a hotfix related to a satelite 6.7 bug (see See RHCLOUD-5954)
-    return add_host(input_host, staleness_timestamps(), update_system_profile=False, from_REST_API=True)
+    return add_host(input_host, staleness_timestamps(), update_system_profile=False)
 
 
 def get_bulk_query_source():

--- a/api/host.py
+++ b/api/host.py
@@ -105,7 +105,7 @@ def _add_host(input_host):
             "host",
         )
 
-    # from_REST_API is part of a hotfix related to a satelite 6.7 bug. More info in models.py
+    # from_REST_API is part of a hotfix related to a satelite 6.7 bug (see See RHCLOUD-5954)
     return add_host(input_host, staleness_timestamps(), update_system_profile=False, from_REST_API=True)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -106,11 +106,12 @@ class Host(db.Model):
     def save(self):
         db.session.add(self)
 
-    def update(self, input_host, update_system_profile=False, from_REST_API=False):
+    def update(self, input_host, update_system_profile=False):
         self.update_canonical_facts(input_host.canonical_facts)
 
         # TODO: Remove this eventually when Sat 6.7 stops sending fqdns as display_names (See RHCLOUD-5954)
-        if from_REST_API or (input_host.reporter and input_host.reporter == "puptoo"):
+        # NOTE: For this particular issue, the reporter is set to "yupana"
+        if input_host.reporter != "yupana":
             self.update_display_name(input_host.display_name)
 
         self._update_ansible_host(input_host.ansible_host)

--- a/app/models.py
+++ b/app/models.py
@@ -109,7 +109,7 @@ class Host(db.Model):
     def update(self, input_host, update_system_profile=False, from_REST_API=False):
         self.update_canonical_facts(input_host.canonical_facts)
 
-        # TODO: Address this. Hotfix satellite 6.7 issue wher display name is set to fqdn when it
+        # TODO: Remove this eventually when Sat 6.7 stops sending fqdns as display_names (See RHCLOUD-5954)
         if from_REST_API or (input_host.reporter and input_host.reporter == "puptoo"):
             self.update_display_name(input_host.display_name)
 

--- a/app/models.py
+++ b/app/models.py
@@ -110,8 +110,8 @@ class Host(db.Model):
         self.update_canonical_facts(input_host.canonical_facts)
 
         # TODO: Remove this eventually when Sat 6.7 stops sending fqdns as display_names (See RHCLOUD-5954)
-        # NOTE: For this particular issue, the reporter is set to "yupana"
-        if input_host.reporter != "yupana":
+        # NOTE: For this particular issue, display_name changes from "puptoo" and "yupana" are ignored
+        if input_host.reporter != "yupana" and input_host.reporter != "rhsm-conduit":
             self.update_display_name(input_host.display_name)
 
         self._update_ansible_host(input_host.ansible_host)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -40,8 +40,7 @@ NULL = None
 logger = get_logger(__name__)
 
 
-# from_REST_API is part of a hotfix related to a satelite 6.7 bug (See RHCLOUD-5954)
-def add_host(input_host, staleness_offset, update_system_profile=True, fields=DEFAULT_FIELDS, from_REST_API=False):
+def add_host(input_host, staleness_offset, update_system_profile=True, fields=DEFAULT_FIELDS):
     """
     Add or update a host
 
@@ -53,9 +52,7 @@ def add_host(input_host, staleness_offset, update_system_profile=True, fields=DE
     with session_guard(db.session):
         existing_host = find_existing_host(input_host.account, input_host.canonical_facts)
         if existing_host:
-            return update_existing_host(
-                existing_host, input_host, staleness_offset, update_system_profile, fields, from_REST_API
-            )
+            return update_existing_host(existing_host, input_host, staleness_offset, update_system_profile, fields)
         else:
             return create_new_host(input_host, staleness_offset, fields)
 
@@ -153,11 +150,10 @@ def create_new_host(input_host, staleness_offset, fields):
 
 
 @metrics.update_host_commit_processing_time.time()
-# from_REST_API is part of a hotfix related to a satelite 6.7 bug (See RHCLOUD-5954)
-def update_existing_host(existing_host, input_host, staleness_offset, update_system_profile, fields, from_REST_API):
+def update_existing_host(existing_host, input_host, staleness_offset, update_system_profile, fields):
     logger.debug("Updating an existing host")
     logger.debug(f"existing host = {existing_host}")
-    existing_host.update(input_host, update_system_profile, from_REST_API)
+    existing_host.update(input_host, update_system_profile)
     db.session.commit()
     metrics.update_host_count.inc()
     logger.debug("Updated host:%s", existing_host)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -40,7 +40,7 @@ NULL = None
 logger = get_logger(__name__)
 
 
-# from_REST_API is part of a hotfix related to a satelite 6.7 bug. More info in models.py
+# from_REST_API is part of a hotfix related to a satelite 6.7 bug (See RHCLOUD-5954)
 def add_host(input_host, staleness_offset, update_system_profile=True, fields=DEFAULT_FIELDS, from_REST_API=False):
     """
     Add or update a host
@@ -153,7 +153,7 @@ def create_new_host(input_host, staleness_offset, fields):
 
 
 @metrics.update_host_commit_processing_time.time()
-# from_REST_API is part of a hotfix related to a satelite 6.7 bug. More info in models.py
+# from_REST_API is part of a hotfix related to a satelite 6.7 bug (See RHCLOUD-5954)
 def update_existing_host(existing_host, input_host, staleness_offset, update_system_profile, fields, from_REST_API):
     logger.debug("Updating an existing host")
     logger.debug(f"existing host = {existing_host}")

--- a/test_db_model.py
+++ b/test_db_model.py
@@ -120,7 +120,7 @@ def test_update_existing_host_dont_change_display_name(flask_app_fixture):
     input_host = Host(
         {"fqdn": expected_fqdn},
         display_name="dont_change_me",
-        reporter="satellite",
+        reporter="yupana",
         stale_timestamp=datetime.now(timezone.utc),
     )
     existing_host.update(input_host)

--- a/test_db_model.py
+++ b/test_db_model.py
@@ -87,7 +87,6 @@ def test_update_existing_host_fix_display_name_using_input_fqdn(flask_app_fixtur
     assert existing_host.display_name == expected_fqdn
 
 
-# TODO: test for Sat 6.7 hotfix (remove, eventually) See RHCLOUD-5954
 def test_update_existing_host_fix_display_name_using_id(flask_app_fixture):
     # Create an "existing" host
     existing_host = _create_host(fqdn=None, display_name=None)
@@ -109,14 +108,12 @@ def test_update_existing_host_fix_display_name_using_id(flask_app_fixture):
     assert existing_host.display_name == existing_host.id
 
 
+# TODO: test for Sat 6.7 hotfix (remove, eventually) See RHCLOUD-5954
 def test_update_existing_host_dont_change_display_name(flask_app_fixture):
     # Create an "existing" host
     fqdn = "host1.domain1.com"
-    existing_host = _create_host(fqdn=fqdn, display_name=None)
-
-    # Set the display
-    existing_host.display_name = "foo"
-    db.session.commit()
+    display_name = "foo"
+    existing_host = _create_host(fqdn=fqdn, display_name=display_name)
 
     # Attempt to update the display name from Satellite reporter (shouldn't change)
     expected_fqdn = "different.domain1.com"
@@ -128,7 +125,8 @@ def test_update_existing_host_dont_change_display_name(flask_app_fixture):
     )
     existing_host.update(input_host)
 
-    assert existing_host.display_name != "dont_change_me"
+    # assert display name hasn't changed
+    assert existing_host.display_name == display_name
 
 
 def test_create_host_without_system_profile(flask_app_fixture):


### PR DESCRIPTION
Summary of changes:

- change guard to not update display name for specific reporter == "yupana" (instead of only allowing display name updates for puptoo, which might have been too restrictive)
- remove the `from_REST_API` bool in favor of the change above
- add test an MQ test