### PR TITLE
Use request_id instead of payload_id

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -51,7 +51,7 @@ def add_host_list(host_list):
     response_host_list = []
     number_of_errors = 0
 
-    payload_tracker = get_payload_tracker(account=current_identity.account_number, payload_id=threadctx.request_id)
+    payload_tracker = get_payload_tracker(account=current_identity.account_number, request_id=threadctx.request_id)
 
     with PayloadTrackerContext(payload_tracker, received_status_message="add host operation"):
 
@@ -166,7 +166,7 @@ def get_host_list(
 @api_operation
 @metrics.api_request_time.time()
 def delete_by_id(host_id_list):
-    payload_tracker = get_payload_tracker(account=current_identity.account_number, payload_id=threadctx.request_id)
+    payload_tracker = get_payload_tracker(account=current_identity.account_number, request_id=threadctx.request_id)
 
     with PayloadTrackerContext(payload_tracker, received_status_message="delete operation"):
         query = _get_host_list_by_id_list(current_identity.account_number, host_id_list)

--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -88,7 +88,7 @@ def parse_operation_message(message):
 
 
 def add_host(host_data):
-    payload_tracker = get_payload_tracker(payload_id=threadctx.request_id)
+    payload_tracker = get_payload_tracker(request_id=threadctx.request_id)
 
     with PayloadTrackerProcessingContext(
         payload_tracker, processing_status_message="adding/updating host"
@@ -139,7 +139,7 @@ def handle_message(message, event_producer):
     metadata = validated_operation_msg.get("platform_metadata") or {}
     initialize_thread_local_storage(metadata)
 
-    payload_tracker = get_payload_tracker(payload_id=threadctx.request_id)
+    payload_tracker = get_payload_tracker(request_id=threadctx.request_id)
 
     with PayloadTrackerContext(payload_tracker, received_status_message="message received"):
         (output_host, add_results) = add_host(validated_operation_msg["data"])


### PR DESCRIPTION
The Payload Tracker is transitioning to using the new "request_id" terminology instead of the legacy "payload_id." This renames that field.