### PR TITLE
Fix mock test assertion

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1329,7 +1329,7 @@ class HostReaperTestCase(DeleteHostsBaseTestCase, CullingBaseTestCase):
 
         self._run_host_reaper()
         self._check_hosts_are_present((added_host_id,))
-        self.assertEqual(len(emit_event.events), 0)
+        emit_event.assert_not_called()
 
 
 class ResolveDisplayNameOnCreationTestCase(DBAPITestCase):


### PR DESCRIPTION
Custom emit event mock class has been [removed](https://github.com/RedHatInsights/insights-host-inventory/pull/633). As a result, _emit_event_ is a plain _MagicMock_ and so is _emit_event.events_. Nothing is stored there in the events attribute, but _len_ returns 0. That makes the [test](https://github.com/Glutexo/insights-host-inventory/blob/f97ea599d6e5e4e4aa61264f551e5c83334360f1/test_api.py#L1332) pass, but the actual not emitting remains untested. Fixed by replacing with assert_not_called.

This is a follow-up to #633.