### PR TITLE
remove metadata field from events

### DIFF
--- a/app/queue/egress.py
+++ b/app/queue/egress.py
@@ -47,7 +47,6 @@ def _build_event(event_type, host, *, platform_metadata=None, request_id=None):
                     "type": event_type,
                     "host": host,
                     "platform_metadata": platform_metadata,
-                    "metadata": {"request_id": request_id},
                     "timestamp": datetime.now(timezone.utc),
                 }
             )
@@ -103,4 +102,3 @@ class HostEvent(Schema):
     host = fields.Nested(HostSchema())
     timestamp = fields.DateTime(format="iso8601")
     platform_metadata = fields.Dict()
-    metadata = fields.Nested(HostEventMetadataSchema())

--- a/test_api.py
+++ b/test_api.py
@@ -1942,7 +1942,6 @@ class PatchHostTestCase(PreCreatedHostsBaseTestCase):
                 "updated": self.added_hosts[0].updated,
             },
             "platform_metadata": None,
-            "metadata": {"request_id": expected_request_id},
             "timestamp": self.now_timestamp.isoformat(),
         }
 

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -111,7 +111,6 @@ class MQServiceTestCase(MQServiceBaseTestCase):
                     json.loads(mock_event_producer.write_event.call_args[0][0]),
                     {
                         "host": {"id": str(host_id), "insights_id": None},
-                        "metadata": {"request_id": None},
                         "platform_metadata": {},
                         "timestamp": timestamp_iso,
                         "type": "created",


### PR DESCRIPTION
There is concern that adding the new metadata field at the same time as the patch event will be too much for consumers. This PR simply removes the metadata fields from the messages and updates some tests to expect that. I did not however go through and remove all of the supporting logic so that when we eventually add the field back it should be simple.