### PR TITLE
Add "metadata" back to host events

### DIFF
--- a/app/queue/egress.py
+++ b/app/queue/egress.py
@@ -47,6 +47,7 @@ def _build_event(event_type, host, *, platform_metadata=None, request_id=None):
                     "type": event_type,
                     "host": host,
                     "platform_metadata": platform_metadata,
+                    "metadata": {"request_id": request_id},
                     "timestamp": datetime.now(timezone.utc),
                 }
             )
@@ -102,3 +103,4 @@ class HostEvent(Schema):
     host = fields.Nested(HostSchema())
     timestamp = fields.DateTime(format="iso8601")
     platform_metadata = fields.Dict()
+    metadata = fields.Nested(HostEventMetadataSchema())

--- a/test_api.py
+++ b/test_api.py
@@ -1942,6 +1942,7 @@ class PatchHostTestCase(PreCreatedHostsBaseTestCase):
                 "updated": self.added_hosts[0].updated,
             },
             "platform_metadata": None,
+            "metadata": {"request_id": expected_request_id},
             "timestamp": self.now_timestamp.isoformat(),
         }
 

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -111,6 +111,7 @@ class MQServiceTestCase(MQServiceBaseTestCase):
                     json.loads(mock_event_producer.write_event.call_args[0][0]),
                     {
                         "host": {"id": str(host_id), "insights_id": None},
+                        "metadata": {"request_id": None},
                         "platform_metadata": {},
                         "timestamp": timestamp_iso,
                         "type": "created",


### PR DESCRIPTION
Reverts RedHatInsights/insights-host-inventory#643

Now that https://github.com/RedHatInsights/insights-host-inventory/commit/57a17c9fd26d350b43eba7acb0491e2f9716f642 has been released this is a second phase of RHCLOUD-1102 rollout where the new "metadata" top-level field is added to host events.