### PR TITLE
Set More Message Headers (RHCLOUD-5964)

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -242,8 +242,7 @@ def _emit_patch_event(host):
     request_id = threadctx.request_id
     event = build_event_topic_event("updated", host, request_id=request_id)
     headers = message_headers(
-        event_type=UPDATE_EVENT_NAME,
-        registered_with_insights="true" if "insights_id" in host else "false",
+        event_type=UPDATE_EVENT_NAME, registered_with_insights="true" if "insights_id" in host else "false"
     )
     emit_event(event, key, headers)
 

--- a/api/host.py
+++ b/api/host.py
@@ -68,8 +68,9 @@ def add_host_list(host_list):
                     input_host = deserialize_host(host)
                     (output_host, add_result) = _add_host(input_host)
                     status_code = _convert_host_results_to_http_status(add_result)
-                    response_host_list.append({"status": status_code, "host": output_host})
-                    payload_tracker_processing_ctx.inventory_id = output_host["id"]
+                    serialized_host = serialize_host(output_host, staleness_timestamps())
+                    response_host_list.append({"status": status_code, "host": serialized_host})
+                    payload_tracker_processing_ctx.inventory_id = output_host.id
             except ValidationException as e:
                 number_of_errors += 1
                 logger.exception("Input validation error while adding host", extra={"host": host})
@@ -110,7 +111,7 @@ def _add_host(input_host):
             "host",
         )
 
-    return add_host(input_host, staleness_timestamps(), update_system_profile=False)
+    return add_host(input_host, update_system_profile=False)
 
 
 def get_bulk_query_source():

--- a/api/host.py
+++ b/api/host.py
@@ -18,7 +18,6 @@ from app import db
 from app import inventory_config
 from app.auth import current_identity
 from app.config import BulkQuerySource
-from app.events import HOSTNAME
 from app.events import message_headers
 from app.events import UPDATE_EVENT_NAME
 from app.exceptions import InventoryException
@@ -243,8 +242,6 @@ def _emit_patch_event(host):
     event = build_event_topic_event("updated", host, request_id=request_id)
     headers = message_headers(
         event_type=UPDATE_EVENT_NAME,
-        request_id=request_id,
-        producer=HOSTNAME,
         registered_with_insights="true" if "insights_id" in host else "false",
     )
     emit_event(event, key, headers)

--- a/api/host.py
+++ b/api/host.py
@@ -18,6 +18,7 @@ from app import db
 from app import inventory_config
 from app.auth import current_identity
 from app.config import BulkQuerySource
+from app.events import HOSTNAME
 from app.events import message_headers
 from app.events import UPDATE_EVENT_NAME
 from app.exceptions import InventoryException
@@ -238,8 +239,14 @@ def get_host_system_profile_by_id(host_id_list, page=1, per_page=100, order_by=N
 
 def _emit_patch_event(host):
     key = host["id"]
-    event = build_event_topic_event("updated", host, request_id=threadctx.request_id)
-    headers = message_headers(UPDATE_EVENT_NAME)
+    request_id = threadctx.request_id
+    event = build_event_topic_event("updated", host, request_id=request_id)
+    headers = message_headers(
+        event_type=UPDATE_EVENT_NAME,
+        request_id=request_id,
+        producer=HOSTNAME,
+        registered_with_insights="true" if "insights_id" in host else "false",
+    )
     emit_event(event, key, headers)
 
 

--- a/app/events.py
+++ b/app/events.py
@@ -39,5 +39,10 @@ def delete(host):
     )
 
 
-def message_headers(event_type):
-    return {"event_type": event_type}
+def message_headers(event_type, request_id, producer, registered_with_insights):
+    return {
+        "event_type": event_type,
+        "request_id": request_id,
+        "producer": producer,
+        "registered_with_isights": registered_with_insights,
+    }

--- a/app/events.py
+++ b/app/events.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 DELETE_EVENT_NAME = "delete"
 UPDATE_EVENT_NAME = "updated"
 
-HOSTNAME = os.uname().nodename
+def hostname():
+    return os.uname().nodename
 
 
 class HostEvent(Schema):
@@ -42,10 +43,10 @@ def delete(host):
     )
 
 
-def message_headers(event_type, request_id, producer, registered_with_insights):
+def message_headers(event_type, registered_with_insights):
     return {
         "event_type": event_type,
-        "request_id": request_id,
-        "producer": producer,
+        "request_id": threadctx.request_id,
+        "producer": os.uname().nodename,
         "registered_with_insights": registered_with_insights,
     }

--- a/app/events.py
+++ b/app/events.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from datetime import datetime
 
 from marshmallow import fields
@@ -11,6 +12,8 @@ logger = logging.getLogger(__name__)
 
 DELETE_EVENT_NAME = "delete"
 UPDATE_EVENT_NAME = "updated"
+
+HOSTNAME = os.uname()[1]
 
 
 class HostEvent(Schema):

--- a/app/events.py
+++ b/app/events.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 DELETE_EVENT_NAME = "delete"
 UPDATE_EVENT_NAME = "updated"
 
-HOSTNAME = os.uname()[1]
+HOSTNAME = os.uname().nodename
 
 
 class HostEvent(Schema):

--- a/app/events.py
+++ b/app/events.py
@@ -47,5 +47,5 @@ def message_headers(event_type, request_id, producer, registered_with_insights):
         "event_type": event_type,
         "request_id": request_id,
         "producer": producer,
-        "registered_with_isights": registered_with_insights,
+        "registered_with_insights": registered_with_insights,
     }

--- a/app/events.py
+++ b/app/events.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 DELETE_EVENT_NAME = "delete"
 UPDATE_EVENT_NAME = "updated"
 
+
 def hostname():
     return os.uname().nodename
 
@@ -47,6 +48,6 @@ def message_headers(event_type, registered_with_insights):
     return {
         "event_type": event_type,
         "request_id": threadctx.request_id,
-        "producer": os.uname().nodename,
-        "registered_with_insights": registered_with_insights,
+        "producer": hostname(),
+        "registered_with_insights": "true" if registered_with_insights else "false",
     }

--- a/app/models.py
+++ b/app/models.py
@@ -241,6 +241,9 @@ class Host(db.Model):
             self.system_profile_facts = {**self.system_profile_facts, **input_system_profile}
         orm.attributes.flag_modified(self, "system_profile_facts")
 
+    def registered_with_insights(self):
+        return "insights_id" in self.canonical_facts
+
     def __repr__(self):
         return (
             f"<Host id='{self.id}' account='{self.account}' display_name='{self.display_name}' "

--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -153,7 +153,7 @@ def handle_message(message, event_producer):
                 event_type=add_results.name,
                 request_id=threadctx.request_id,
                 producer=HOSTNAME,
-                registered_with_insights="true" if output_host["insights_id"] is not None else "false",
+                registered_with_insights="true" if "insights_id" in output_host else "false",
             ),
         )
 

--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -1,5 +1,4 @@
 import json
-import os
 import signal
 
 from marshmallow import fields
@@ -8,6 +7,7 @@ from marshmallow import ValidationError
 
 from app import inventory_config
 from app.culling import Timestamps
+from app.events import HOSTNAME
 from app.events import message_headers
 from app.exceptions import InventoryException
 from app.logging import get_logger
@@ -152,9 +152,9 @@ def handle_message(message, event_producer):
             message_headers(
                 event_type=add_results.name,
                 request_id=threadctx.request_id,
-                producer=os.uname()[1],
+                producer=HOSTNAME,
                 registered_with_insights="true" if output_host["insights_id"] is not None else "false",
-                )
+            ),
         )
 
 

--- a/app/queue/ingress.py
+++ b/app/queue/ingress.py
@@ -7,7 +7,7 @@ from marshmallow import ValidationError
 
 from app import inventory_config
 from app.culling import Timestamps
-from app.events import HOSTNAME
+from app.events import hostname
 from app.events import message_headers
 from app.exceptions import InventoryException
 from app.logging import get_logger
@@ -153,8 +153,8 @@ def handle_message(message, event_producer):
             message_headers(
                 event_type=add_results.name,
                 request_id=threadctx.request_id,
-                producer=HOSTNAME,
-                registered_with_insights="true" if "insights_id" in output_host else "false",
+                producer=hostname(),
+                registered_with_insights="true" if output_host["insights_id"] else "false",
             ),
         )
 

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -2,7 +2,9 @@ from sqlalchemy.orm.base import instance_state
 
 from app.events import delete as delete_event
 from app.events import DELETE_EVENT_NAME
+from app.events import HOSTNAME
 from app.events import message_headers
+from app.logging import threadctx
 from app.models import Host
 from lib.metrics import delete_host_count
 from lib.metrics import delete_host_processing_time
@@ -45,5 +47,10 @@ def _deleted_by_this_query(host):
 def _emit_event(host):
     event = delete_event(host)
     key = str(host.id)
-    headers = message_headers(DELETE_EVENT_NAME)
+    headers = message_headers(
+        event_type=DELETE_EVENT_NAME,
+        request_id=threadctx.request_id,
+        producer=HOSTNAME,
+        registered_with_insights="true" if "insights_id" in host.canonical_facts else "false",
+    )
     emit_event(event, key, headers)

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -47,10 +47,5 @@ def _deleted_by_this_query(host):
 def _emit_event(host):
     event = delete_event(host)
     key = str(host.id)
-    headers = message_headers(
-        event_type=DELETE_EVENT_NAME,
-        request_id=threadctx.request_id,
-        producer=hostname(),
-        registered_with_insights="true" if "insights_id" in host.canonical_facts else "false",
-    )
+    headers = message_headers(DELETE_EVENT_NAME, host.registered_with_insights)
     emit_event(event, key, headers)

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -2,9 +2,7 @@ from sqlalchemy.orm.base import instance_state
 
 from app.events import delete as delete_event
 from app.events import DELETE_EVENT_NAME
-from app.events import hostname
 from app.events import message_headers
-from app.logging import threadctx
 from app.models import Host
 from lib.metrics import delete_host_count
 from lib.metrics import delete_host_processing_time
@@ -47,5 +45,5 @@ def _deleted_by_this_query(host):
 def _emit_event(host):
     event = delete_event(host)
     key = str(host.id)
-    headers = message_headers(DELETE_EVENT_NAME, host.registered_with_insights)
+    headers = message_headers(DELETE_EVENT_NAME, host.registered_with_insights())
     emit_event(event, key, headers)

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm.base import instance_state
 
 from app.events import delete as delete_event
 from app.events import DELETE_EVENT_NAME
-from app.events import HOSTNAME
+from app.events import hostname
 from app.events import message_headers
 from app.logging import threadctx
 from app.models import Host
@@ -50,7 +50,7 @@ def _emit_event(host):
     headers = message_headers(
         event_type=DELETE_EVENT_NAME,
         request_id=threadctx.request_id,
-        producer=HOSTNAME,
+        producer=hostname(),
         registered_with_insights="true" if "insights_id" in host.canonical_facts else "false",
     )
     emit_event(event, key, headers)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -40,7 +40,7 @@ NULL = None
 logger = get_logger(__name__)
 
 
-def add_host(input_host, staleness_offset, update_system_profile=True, fields=DEFAULT_FIELDS):
+def add_host(input_host, update_system_profile=True):
     """
     Add or update a host
 
@@ -52,9 +52,9 @@ def add_host(input_host, staleness_offset, update_system_profile=True, fields=DE
     with session_guard(db.session):
         existing_host = find_existing_host(input_host.account, input_host.canonical_facts)
         if existing_host:
-            return update_existing_host(existing_host, input_host, staleness_offset, update_system_profile, fields)
+            return update_existing_host(existing_host, input_host, update_system_profile)
         else:
-            return create_new_host(input_host, staleness_offset, fields)
+            return create_new_host(input_host)
 
 
 @metrics.host_dedup_processing_time.time()
@@ -140,24 +140,24 @@ def find_non_culled_hosts(query):
 
 
 @metrics.new_host_commit_processing_time.time()
-def create_new_host(input_host, staleness_offset, fields):
+def create_new_host(input_host):
     logger.debug("Creating a new host")
     input_host.save()
     db.session.commit()
     metrics.create_host_count.inc()
     logger.debug("Created host:%s", input_host)
-    return serialize_host(input_host, staleness_offset, fields), AddHostResults.created
+    return input_host, AddHostResults.created
 
 
 @metrics.update_host_commit_processing_time.time()
-def update_existing_host(existing_host, input_host, staleness_offset, update_system_profile, fields):
+def update_existing_host(existing_host, input_host, update_system_profile):
     logger.debug("Updating an existing host")
     logger.debug(f"existing host = {existing_host}")
     existing_host.update(input_host, update_system_profile)
     db.session.commit()
     metrics.update_host_count.inc()
     logger.debug("Updated host:%s", existing_host)
-    return serialize_host(existing_host, staleness_offset, fields), AddHostResults.updated
+    return existing_host, AddHostResults.updated
 
 
 def stale_timestamp_filter(gt=None, lte=None):

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -8,10 +8,9 @@ from app.culling import staleness_to_conditions
 from app.logging import get_logger
 from app.models import db
 from app.models import Host
-from app.serialization import DEFAULT_FIELDS
-from app.serialization import serialize_host
 from lib import metrics
-from lib.db import session_guard
+
+# from lib.db import session_guard
 
 __all__ = (
     "add_host",
@@ -49,12 +48,11 @@ def add_host(input_host, update_system_profile=True):
      - account number
     """
 
-    with session_guard(db.session):
-        existing_host = find_existing_host(input_host.account, input_host.canonical_facts)
-        if existing_host:
-            return update_existing_host(existing_host, input_host, update_system_profile)
-        else:
-            return create_new_host(input_host)
+    existing_host = find_existing_host(input_host.account, input_host.canonical_facts)
+    if existing_host:
+        return update_existing_host(existing_host, input_host, update_system_profile)
+    else:
+        return create_new_host(input_host)
 
 
 @metrics.host_dedup_processing_time.time()

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -28,6 +28,7 @@ def emit_event(event, key, headers):
     h = [(hk, hv.encode("utf-8")) for hk, hv in headers.items()]
     producer.send(cfg.event_topic, key=k, value=v, headers=h)
     logger.info("Event message produced: topic %s, key %s", cfg.event_topic, key)
+    logger.debug("Event message headers: %s", h)
     logger.debug("Event message body: %s", event)
 
 

--- a/test_api.py
+++ b/test_api.py
@@ -106,7 +106,7 @@ MOCK_XJOIN_HOST_RESPONSE = {
     }
 }
 
-HOSTNAME = os.uname()[1]
+HOSTNAME = os.uname().nodename
 
 Message = namedtuple("Message", ("value", "key", "headers"))
 

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -285,7 +285,7 @@ class MQhandleMessageTestCase(MQAddHostBaseClass):
                     mock_event_producer.headers,
                     {
                         "event_type": add_host_result.name,
-                        "producer": os.uname()[1],
+                        "producer": os.uname().nodename,
                         "registered_with_insights": "true" if "insights_id" in host_data else "false",
                         "request_id": "-1",
                     },

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -1,4 +1,5 @@
 import json
+import os
 import unittest
 import uuid
 from datetime import datetime
@@ -275,8 +276,15 @@ class MQhandleMessageTestCase(MQAddHostBaseClass):
                 mock_event_producer = MockEventProducer()
                 with self.app.app_context():
                     handle_message(json.dumps(message), mock_event_producer)
-
-                self.assertEqual(mock_event_producer.headers, {"event_type": add_host_result.name})
+                self.assertEqual(
+                    mock_event_producer.headers,
+                    {
+                        "event_type": add_host_result.name,
+                        "producer": os.uname()[1],
+                        "registered_with_insights": "true" if "insights_id" in host_data else "false",
+                        "request_id": "-1",
+                    },
+                )
 
 
 class MQAddHostTestCase(MQAddHostBaseClass):


### PR DESCRIPTION
[RHCLOUD-5964](https://projects.engineering.redhat.com/browse/RHCLOUD-5964) asks to add the following headers:

- [x] request_id
- [x] producer
- [x] whether or not a host is associated with insights
- [ ] whether or not a host is triggered by ingress event (we have different producers for ingress and rest, so, do we need this one?)

Also, I couldn't think of any other info that might be a good candidate for message headers. If you have any suggestions, let me know.
