### PR TITLE
Consolidate APP_SETTINGS and RuntimeEnvironment

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,6 @@ from prometheus_flask_exporter import PrometheusMetrics
 from api.mgmt import monitoring_blueprint
 from app import payload_tracker
 from app.config import Config
-from app.config import RuntimeEnvironment
 from app.exceptions import InventoryException
 from app.logging import configure_logging
 from app.logging import get_logger
@@ -35,15 +34,15 @@ def inventory_config():
     return current_app.config["INVENTORY_CONFIG"]
 
 
-def create_app(config_name, start_tasks=False, start_payload_tracker=False):
+def create_app(runtime_environment):
     connexion_options = {"swagger_ui": True}
 
     # This feels like a hack but it is needed.  The logging configuration
     # needs to be setup before the flask app is initialized.
-    configure_logging(config_name)
+    configure_logging(runtime_environment)
 
-    app_config = Config(RuntimeEnvironment.server)
-    app_config.log_configuration(config_name)
+    app_config = Config(runtime_environment)
+    app_config.log_configuration()
 
     connexion_app = connexion.App("inventory", specification_dir="./swagger/", options=connexion_options)
 
@@ -85,7 +84,7 @@ def create_app(config_name, start_tasks=False, start_payload_tracker=False):
     def set_request_id():
         threadctx.request_id = request.headers.get(REQUEST_ID_HEADER, UNKNOWN_REQUEST_ID_VALUE)
 
-    if start_tasks:
+    if runtime_environment.event_producer_enabled:
         init_tasks(app_config)
     else:
         logger.warning(
@@ -94,7 +93,7 @@ def create_app(config_name, start_tasks=False, start_payload_tracker=False):
         )
 
     payload_tracker_producer = None
-    if start_payload_tracker is False:
+    if not runtime_environment.payload_tracker_enabled:
         # If we are running in "testing" mode, then inject the NullProducer.
         payload_tracker_producer = payload_tracker.NullProducer()
 
@@ -106,7 +105,7 @@ def create_app(config_name, start_tasks=False, start_payload_tracker=False):
     payload_tracker.init_payload_tracker(app_config, producer=payload_tracker_producer)
 
     # HTTP request metrics
-    if config_name != "testing":
+    if runtime_environment.metrics_endpoint_enabled:
         PrometheusMetrics(
             flask_app,
             defaults_prefix="inventory",

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -55,7 +55,7 @@ def validate(identity):
         # a warning should go into the Config class
         shared_secret = os.getenv(SHARED_SECRET_ENV_VAR)
         if not shared_secret:
-            logger.warning(f"%s environment variable is not set", SHARED_SECRET_ENV_VAR)
+            logger.warning("%s environment variable is not set", SHARED_SECRET_ENV_VAR)
         if identity.token != shared_secret:
             raise ValueError("Invalid credentials")
     else:

--- a/app/environment.py
+++ b/app/environment.py
@@ -1,0 +1,32 @@
+from enum import auto
+from enum import Enum
+
+__all__ = ("RuntimeEnvironment",)
+
+
+class RuntimeEnvironment(Enum):
+    SERVER = auto()
+    SERVICE = auto()
+    JOB = auto()
+    COMMAND = auto()
+    TEST = auto()
+
+    @property
+    def logging_enabled(self):
+        return self != self.TEST
+
+    @property
+    def event_producer_enabled(self):
+        return self in (self.SERVER, self.JOB)
+
+    @property
+    def metrics_endpoint_enabled(self):
+        return self == self.SERVER
+
+    @property
+    def metrics_pushgateway_enabled(self):
+        return self == self.JOB
+
+    @property
+    def payload_tracker_enabled(self):
+        return self in (self.SERVER, self.SERVICE)

--- a/app/logging.py
+++ b/app/logging.py
@@ -14,7 +14,7 @@ LOGGER_PREFIX = "inventory."
 threadctx = local()
 
 
-def configure_logging(config_name):
+def configure_logging(runtime_environment):
     env_var_name = "INVENTORY_LOGGING_CONFIG_FILE"
     log_config_file = os.getenv(env_var_name)
     if log_config_file is not None:
@@ -32,7 +32,7 @@ def configure_logging(config_name):
 
         logging.config.fileConfig(fname=log_config_file)
 
-    if config_name != "testing":
+    if runtime_environment.logging_enabled:
         _configure_watchtower_logging_handler()
         _configure_contextual_logging_filter()
 

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@ from pytest import fixture
 
 from app import create_app
 from app import db
+from app.environment import RuntimeEnvironment
 from test_utils import rename_host_table_and_indexes
 
 
@@ -9,7 +10,7 @@ from test_utils import rename_host_table_and_indexes
 def flask_app_fixture():
     rename_host_table_and_indexes()
 
-    app = create_app(config_name="testing")
+    app = create_app(RuntimeEnvironment.TEST)
 
     # binds the app to the current context
     with app.app_context() as ctx:

--- a/host_dumper.py
+++ b/host_dumper.py
@@ -5,10 +5,11 @@ import pprint
 from app import create_app
 from app import inventory_config
 from app.culling import Timestamps
+from app.environment import RuntimeEnvironment
 from app.models import Host
 from app.serialization import serialize_host
 
-application = create_app("cli")
+application = create_app(RuntimeEnvironment.COMMAND)
 
 parser = argparse.ArgumentParser(
     description="Util that dumps a host from the hosts table.  The db configuration is read from the environment.  "

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -1,6 +1,5 @@
 import sys
 from functools import partial
-from os import getenv
 
 from prometheus_client import CollectorRegistry
 from prometheus_client import push_to_gateway
@@ -9,8 +8,8 @@ from sqlalchemy.orm import sessionmaker
 
 from app import UNKNOWN_REQUEST_ID_VALUE
 from app.config import Config
-from app.config import RuntimeEnvironment
 from app.culling import Conditions
+from app.environment import RuntimeEnvironment
 from app.logging import configure_logging
 from app.logging import get_logger
 from app.logging import threadctx
@@ -29,11 +28,12 @@ __all__ = ("main", "run")
 PROMETHEUS_JOB = "inventory-reaper"
 LOGGER_NAME = "host_reaper"
 COLLECTED_METRICS = (delete_host_count, delete_host_processing_time, host_reaper_fail_count)
+RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
 
 
-def _init_config(config_name):
-    config = Config(RuntimeEnvironment.job)
-    config.log_configuration(config_name)
+def _init_config():
+    config = Config(RUNTIME_ENVIRONMENT)
+    config.log_configuration()
     return config
 
 
@@ -65,8 +65,8 @@ def run(config, logger_, session):
             logger_.info("Host %s already deleted. Delete event not emitted.", host_id)
 
 
-def main(config_name, logger):
-    config = _init_config(config_name)
+def main(logger):
+    config = _init_config()
     init_tasks(config)
 
     registry = CollectorRegistry()
@@ -87,11 +87,10 @@ def main(config_name, logger):
 
 
 if __name__ == "__main__":
-    config_name = getenv("APP_SETTINGS", "development")
-    configure_logging(config_name)
+    configure_logging(RUNTIME_ENVIRONMENT)
 
     logger = get_logger(LOGGER_NAME)
     sys.excepthook = partial(_excepthook, logger)
 
     threadctx.request_id = UNKNOWN_REQUEST_ID_VALUE
-    main(config_name, logger)
+    main(logger)

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -1,12 +1,10 @@
-import os
 from signal import Signals
 
 from kafka import KafkaConsumer
 from prometheus_client import start_http_server
 
 from app import create_app
-from app.config import Config
-from app.config import RuntimeEnvironment
+from app.environment import RuntimeEnvironment
 from app.logging import get_logger
 from app.queue.egress import KafkaEventProducer
 from app.queue.ingress import event_loop
@@ -29,11 +27,10 @@ class ShutdownHandler:
 
 
 def main():
-    config_name = os.getenv("APP_SETTINGS", "development")
-    application = create_app(config_name, start_tasks=False, start_payload_tracker=True)
+    application = create_app(RuntimeEnvironment.SERVICE)
     start_http_server(9126)
 
-    config = Config(RuntimeEnvironment.server)
+    config = application.config["INVENTORY_CONFIG"]
 
     consumer = KafkaConsumer(
         config.host_ingress_topic,

--- a/manage.py
+++ b/manage.py
@@ -1,14 +1,13 @@
-import os
-
 from flask_migrate import Migrate
 from flask_migrate import MigrateCommand
 from flask_script import Manager  # class for handling a set of commands
 
 from app import create_app
 from app import db
+from app.environment import RuntimeEnvironment
 
 
-app = create_app(config_name=os.getenv("APP_SETTINGS"))
+app = create_app(RuntimeEnvironment.COMMAND)
 migrate = Migrate(app, db)
 manager = Manager(app)
 

--- a/run.py
+++ b/run.py
@@ -2,10 +2,10 @@
 import os
 
 from app import create_app
+from app.environment import RuntimeEnvironment
 
-config_name = os.getenv("APP_SETTINGS", "development")
-application = create_app(config_name, start_tasks=True, start_payload_tracker=True)
-listen_port = os.getenv("LISTEN_PORT", 8080)
+application = create_app(RuntimeEnvironment.SERVER)
 
 if __name__ == "__main__":
+    listen_port = int(os.getenv("LISTEN_PORT", 8080))
     application.run(host="0.0.0.0", port=listen_port)

--- a/test_api.py
+++ b/test_api.py
@@ -33,6 +33,7 @@ from app import create_app
 from app import db
 from app.auth.identity import Identity
 from app.culling import Timestamps
+from app.environment import RuntimeEnvironment
 from app.models import Host
 from app.serialization import serialize_host
 from app.utils import HostWrapper
@@ -185,7 +186,7 @@ class APIBaseTestCase(TestCase):
         """
         Creates the application and a test client to make requests.
         """
-        self.app = create_app(config_name="testing")
+        self.app = create_app(RuntimeEnvironment.TEST)
         self.client = self.app.test_client
 
     def get(self, path, status=200, return_response_as_json=True, extra_headers={}):

--- a/test_mq_service.py
+++ b/test_mq_service.py
@@ -15,6 +15,7 @@ import marshmallow
 
 from app import create_app
 from app import db
+from app.environment import RuntimeEnvironment
 from app.exceptions import InventoryException
 from app.exceptions import ValidationException
 from app.models import Host
@@ -43,7 +44,7 @@ class MQServiceBaseTestCase(TestCase):
         """
         Creates the application and a test client to make requests.
         """
-        self.app = create_app(config_name="testing")
+        self.app = create_app(RuntimeEnvironment.TEST)
 
 
 class MQServiceTestCase(MQServiceBaseTestCase):

--- a/test_payload_tracker.py
+++ b/test_payload_tracker.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 from app.config import Config
-from app.config import RuntimeEnvironment
+from app.environment import RuntimeEnvironment
 from app.payload_tracker import _UNKNOWN_REQUEST_ID
 from app.payload_tracker import get_payload_tracker
 from app.payload_tracker import init_payload_tracker
@@ -339,7 +339,7 @@ class PayloadTrackerTestCase(TestCase):
                 producer.reset_mock()
 
     def _get_tracker(self, account=None, request_id=None, producer=None):
-        config = Config(RuntimeEnvironment.server)
+        config = Config(RuntimeEnvironment.SERVER)
         init_payload_tracker(config, producer=producer)
         return get_payload_tracker(account=account, request_id=request_id)
 

--- a/test_unit.py
+++ b/test_unit.py
@@ -22,9 +22,9 @@ from app.auth.identity import Identity
 from app.auth.identity import SHARED_SECRET_ENV_VAR
 from app.auth.identity import validate
 from app.config import Config
-from app.config import RuntimeEnvironment
 from app.culling import _Config as CullingConfig
 from app.culling import Timestamps
+from app.environment import RuntimeEnvironment
 from app.exceptions import InputFormatException
 from app.exceptions import ValidationException
 from app.models import Host
@@ -215,7 +215,7 @@ class TrustedIdentityTestCase(TestCase):
 class ConfigTestCase(TestCase):
     @staticmethod
     def _config():
-        return Config(RuntimeEnvironment.server)
+        return Config(RuntimeEnvironment.SERVER)
 
     def test_configuration_with_env_vars(self):
         app_name = "brontocrane"
@@ -255,7 +255,7 @@ class ConfigTestCase(TestCase):
         expected_api_path = "/api/inventory/v1"
         expected_mgmt_url_path_prefix = "/"
 
-        # Make sure the environment variables are not set
+        # Make sure the runtime_environment variables are not set
         with set_environment(None):
 
             conf = self._config()
@@ -279,7 +279,7 @@ class ConfigTestCase(TestCase):
 @patch("app.Config", **{"return_value.mgmt_url_path_prefix": "/"})
 class CreateAppConfigTestCase(TestCase):
     def test_config_is_assigned(self, config):
-        app = create_app("testing")
+        app = create_app(RuntimeEnvironment.TEST)
         self.assertIn("INVENTORY_CONFIG", app.config)
         self.assertEqual(config.return_value, app.config["INVENTORY_CONFIG"])
 

--- a/utils/validate_hosts_for_delete.py
+++ b/utils/validate_hosts_for_delete.py
@@ -1,6 +1,7 @@
 from app import create_app
 from app import events
 from app import UNKNOWN_REQUEST_ID_VALUE
+from app.environment import RuntimeEnvironment
 from app.events import HostEvent
 from app.logging import get_logger
 from app.logging import threadctx
@@ -17,7 +18,7 @@ def test_validations(host):
 
 
 def main():
-    flask_app = create_app(config_name="validation_script")
+    flask_app = create_app(RuntimeEnvironment.COMMAND)
     with flask_app.app_context() as ctx:
         threadctx.request_id = UNKNOWN_REQUEST_ID_VALUE
         ctx.push()

--- a/utils/validate_hosts_for_delete.py
+++ b/utils/validate_hosts_for_delete.py
@@ -23,8 +23,8 @@ def main():
         threadctx.request_id = UNKNOWN_REQUEST_ID_VALUE
         ctx.push()
     query = Host.query
-    logger.info(f"Validating delete event for hosts.")
-    logger.info(f"Total number of hosts: %i", query.count())
+    logger.info("Validating delete event for hosts.")
+    logger.info("Total number of hosts: %i", query.count())
 
     number_of_errors = 0
     for host in query.yield_per(1000):


### PR DESCRIPTION
There were two ways of configuring the application runtime.

- _APP_SETTINGS_ environment variable, which is not used anywhere. Even in production, its value is `"development"`. It is assigned various values across the codebase, but only "testing" value actually does something.
- _RuntimeEnvironment_ enumerable that was intended to control what subsystems are used, but was only used for configuration logging.

Replaced the _APP_SETTINGS_ value and the boolean application parameters with an extended version of _RuntimeEnviroment_ enumerable. Its value determines what subsystems are launched.

- _SERVER_: Connexion/Flask HTTP server, uses Event Producer and Payload Tracker and exposes Prometheus metrics. Handles everything inside the app.
- _SERVICE_: Kafka Ingress/Egress service, uses Payload Tracker from the
  app and Event Producer outside of it. Exposes Prometheus metrics
  without Flask.
- _JOB_: Host Reaper scheduled task, doesn’t create the app at all. The
  variable is used only for Config. Uses Event Producer by itself,
  pushes Prometheus metrics via Pushgateway.
- _COMMAND_: CLI tasks to migrate database or dump hosts. Use the app
  without any subsystem.
- _TEST_: Application running in a test mode. Doesn’t log the
  configuration on startup, doesn’t send logs to CloudWatch.

I was not trying to ultimately figure out what environments we need or to consolidate them. My goal was to keep the existing behavior while merging the two control variables and increate readability.