### PR TITLE
RHCLOUD-6508 - Add support to search by os_release

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -139,7 +139,7 @@ def get_host_list(
     order_how=None,
     staleness=None,
     registered_with=None,
-    os_release=None,
+    os_major=None,
 ):
     total = 0
     host_list = ()
@@ -161,7 +161,7 @@ def get_host_list(
             order_how,
             staleness,
             registered_with,
-            os_release
+            os_major
         )
     except ValueError as e:
         flask.abort(400, str(e))

--- a/api/host.py
+++ b/api/host.py
@@ -139,6 +139,7 @@ def get_host_list(
     order_how=None,
     staleness=None,
     registered_with=None,
+    os_release=None,
 ):
     total = 0
     host_list = ()
@@ -160,6 +161,7 @@ def get_host_list(
             order_how,
             staleness,
             registered_with,
+            os_release
         )
     except ValueError as e:
         flask.abort(400, str(e))

--- a/api/host.py
+++ b/api/host.py
@@ -140,6 +140,7 @@ def get_host_list(
     staleness=None,
     registered_with=None,
     os_major=None,
+    fields=None,
 ):
     total = 0
     host_list = ()
@@ -161,12 +162,12 @@ def get_host_list(
             order_how,
             staleness,
             registered_with,
-            os_major
+            os_major,
         )
     except ValueError as e:
         flask.abort(400, str(e))
 
-    json_data = build_paginated_host_list_response(total, page, per_page, host_list)
+    json_data = build_paginated_host_list_response(total, page, per_page, host_list, fields)
     return flask_json_response(json_data)
 
 

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -5,7 +5,6 @@ from app import inventory_config
 from app.culling import Timestamps
 from app.serialization import serialize_host
 
-
 __all__ = ("build_paginated_host_list_response", "staleness_timestamps")
 
 OrderBy = Enum("OrderBy", ("display_name", "id", "modified_on"))
@@ -13,9 +12,10 @@ OrderHow = Enum("OrderHow", ("ASC", "DESC"))
 Order = namedtuple("Order", ("by", "how"))
 
 
-def build_paginated_host_list_response(total, page, per_page, host_list):
+def build_paginated_host_list_response(total, page, per_page, host_list, extra_fields=None):
     timestamps = staleness_timestamps()
-    json_host_list = [serialize_host(host, timestamps) for host in host_list]
+    json_host_list = [serialize_host(host, timestamps, extra_fields=extra_fields) for host in host_list]
+
     return {
         "total": total,
         "count": len(json_host_list),

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -30,7 +30,7 @@ def get_host_list(
     order_how,
     staleness,
     registered_with,
-    os_release,
+    os_major,
 ):
     if fqdn:
         query = _find_hosts_by_canonical_fact("fqdn", fqdn)
@@ -40,8 +40,8 @@ def get_host_list(
         query = _find_hosts_by_hostname_or_id(hostname_or_id)
     elif insights_id:
         query = _find_hosts_by_canonical_fact("insights_id", insights_id)
-    elif os_release:
-        query = _find_hosts_by_system_profile_fact("os_release", os_release)
+    elif os_major:
+        query = _find_hosts_by_system_profile_fact("os_release", os_major, '((\d)\.*\d*)')
     else:
         query = _find_all_hosts()
 
@@ -108,8 +108,8 @@ def _find_hosts_by_canonical_fact(canonical_fact, value):
     return canonical_fact_host_query(current_identity.account_number, canonical_fact, value)
 
 
-def _find_hosts_by_system_profile_fact(system_profile_fact, value):
-    return system_profile_fact_host_query(current_identity.account_number, system_profile_fact, value)
+def _find_hosts_by_system_profile_fact(system_profile_fact, value, regex=None):
+    return system_profile_fact_host_query(current_identity.account_number, system_profile_fact, value, regex)
 
 
 def _find_hosts_by_tag(string_tags, query):

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -8,6 +8,7 @@ from app.logging import get_logger
 from app.models import Host
 from app.utils import Tag
 from lib.host_repository import canonical_fact_host_query
+from lib.host_repository import system_profile_fact_host_query
 from lib.host_repository import find_hosts_by_staleness
 
 __all__ = ("get_host_list", "params_to_order_by")
@@ -29,6 +30,7 @@ def get_host_list(
     order_how,
     staleness,
     registered_with,
+    os_release,
 ):
     if fqdn:
         query = _find_hosts_by_canonical_fact("fqdn", fqdn)
@@ -38,6 +40,8 @@ def get_host_list(
         query = _find_hosts_by_hostname_or_id(hostname_or_id)
     elif insights_id:
         query = _find_hosts_by_canonical_fact("insights_id", insights_id)
+    elif os_release:
+        query = _find_hosts_by_system_profile_fact("os_release", os_release)
     else:
         query = _find_all_hosts()
 
@@ -102,6 +106,10 @@ def _find_all_hosts():
 
 def _find_hosts_by_canonical_fact(canonical_fact, value):
     return canonical_fact_host_query(current_identity.account_number, canonical_fact, value)
+
+
+def _find_hosts_by_system_profile_fact(system_profile_fact, value):
+    return system_profile_fact_host_query(current_identity.account_number, system_profile_fact, value)
 
 
 def _find_hosts_by_tag(string_tags, query):

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -8,8 +8,8 @@ from app.logging import get_logger
 from app.models import Host
 from app.utils import Tag
 from lib.host_repository import canonical_fact_host_query
-from lib.host_repository import system_profile_fact_host_query
 from lib.host_repository import find_hosts_by_staleness
+from lib.host_repository import system_profile_fact_host_query
 
 __all__ = ("get_host_list", "params_to_order_by")
 
@@ -41,7 +41,7 @@ def get_host_list(
     elif insights_id:
         query = _find_hosts_by_canonical_fact("insights_id", insights_id)
     elif os_major:
-        query = _find_hosts_by_system_profile_fact("os_release", os_major, '((\d)\.*\d*)')
+        query = _find_hosts_by_system_profile_fact("os_release", str(os_major), r"(\d+)(\.\d+)?")
     else:
         query = _find_all_hosts()
 

--- a/app/models.py
+++ b/app/models.py
@@ -66,6 +66,7 @@ class Host(db.Model):
     tags = db.Column(JSONB)
     canonical_facts = db.Column(JSONB)
     system_profile_facts = db.Column(JSONB)
+    system_profile = orm.synonym("system_profile_facts")
     stale_timestamp = db.Column(db.DateTime(timezone=True))
     reporter = db.Column(db.String(255))
 

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -80,7 +80,7 @@ def deserialize_host_xjoin(data):
     return host
 
 
-def serialize_host(host, staleness_timestamps, fields=DEFAULT_FIELDS):
+def serialize_host(host, staleness_timestamps, fields=DEFAULT_FIELDS, extra_fields=None):
     if host.stale_timestamp:
         stale_timestamp = staleness_timestamps.stale_timestamp(host.stale_timestamp)
         stale_warning_timestamp = staleness_timestamps.stale_warning_timestamp(host.stale_timestamp)
@@ -120,6 +120,21 @@ def serialize_host(host, staleness_timestamps, fields=DEFAULT_FIELDS):
         serialized_host["tags"] = _serialize_tags(host.tags)
     if "system_profile" in fields:
         serialized_host["system_profile"] = host.system_profile_facts or {}
+    if extra_fields:
+        if "system_profile" in extra_fields:
+            system_profile_attributes = extra_fields["system_profile"].replace(" ", "").split(",")
+            serialized_host["system_profile"] = {}
+            for system_profile_attribute in system_profile_attributes:
+                if system_profile_attribute not in host.system_profile_facts:
+                    continue
+                if host.system_profile_facts and system_profile_attribute in host.system_profile_facts:
+                    serialized_host["system_profile"][system_profile_attribute] = host.system_profile_facts[
+                        system_profile_attribute
+                    ]
+                elif host.system_profile_facts and system_profile_attribute == "*":
+                    serialized_host["system_profile"] = host.system_profile_facts
+                else:
+                    serialized_host["system_profile"][system_profile_attribute] = "not found"
 
     return serialized_host
 

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -13,6 +13,8 @@ from app.serialization import serialize_host
 from lib import metrics
 from lib.db import session_guard
 
+import re
+
 __all__ = (
     "add_host",
     "canonical_facts_host_query",
@@ -97,10 +99,19 @@ def canonical_facts_host_query(account_number, canonical_facts):
     return find_non_culled_hosts(query)
 
 
-def system_profile_fact_host_query(account_number, system_profile_fact, value):
-    query = Host.query.filter(
-        (Host.account == account_number) & (Host.system_profile_facts[system_profile_fact].astext == value)
-    )
+def system_profile_fact_host_query(account_number, system_profile_fact, value,
+                                   regex=None):
+    if regex:
+        logger.info("FINDING OSMAJOR (%s, %s)", regex, value)
+        logger.info("SYSTEMPROFILEFACTS 2 (%s)", Host.system_profile_facts[system_profile_fact].astext)
+        query = Host.query.filter(
+            (Host.account == account_number) &
+            (re.match(regex, Host.system_profile_facts[system_profile_fact].astext).group(2) == value)
+        )
+    else:
+        query = Host.query.filter(
+            (Host.account == account_number) & (Host.system_profile_facts[system_profile_fact].astext == value)
+        )
     return find_non_culled_hosts(query)
 
 

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -97,6 +97,13 @@ def canonical_facts_host_query(account_number, canonical_facts):
     return find_non_culled_hosts(query)
 
 
+def system_profile_fact_host_query(account_number, system_profile_fact, value):
+    query = Host.query.filter(
+        (Host.account == account_number) & (Host.system_profile_facts[system_profile_fact].astext == value)
+    )
+    return find_non_culled_hosts(query)
+
+
 def find_host_by_canonical_fact(account_number, canonical_fact, value):
     """
     Returns first match for a host containing given canonical facts

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from sqlalchemy import and_
+from sqlalchemy import func
 from sqlalchemy import or_
 
 from app import inventory_config
@@ -12,8 +13,6 @@ from app.serialization import DEFAULT_FIELDS
 from app.serialization import serialize_host
 from lib import metrics
 from lib.db import session_guard
-
-import re
 
 __all__ = (
     "add_host",
@@ -99,20 +98,17 @@ def canonical_facts_host_query(account_number, canonical_facts):
     return find_non_culled_hosts(query)
 
 
-def system_profile_fact_host_query(account_number, system_profile_fact, value,
-                                   regex=None):
-    if regex:
-        logger.info("FINDING OSMAJOR (%s, %s)", regex, value)
-        logger.info("SYSTEMPROFILEFACTS 2 (%s)", Host.system_profile_facts[system_profile_fact].astext)
-        query = Host.query.filter(
-            (Host.account == account_number) &
-            (re.match(regex, Host.system_profile_facts[system_profile_fact].astext).group(2) == value)
-        )
-    else:
-        query = Host.query.filter(
-            (Host.account == account_number) & (Host.system_profile_facts[system_profile_fact].astext == value)
-        )
+def system_profile_fact_host_query(account_number, system_profile_fact, value, regex=None):
+    query = Host.query.filter(
+        (Host.account == account_number) & system_profile_filtering(system_profile_fact, value, regex)
+    )
     return find_non_culled_hosts(query)
+
+
+def system_profile_filtering(system_profile_fact, value, regex=None):
+    if regex is not None:
+        return func.substring(Host.system_profile_facts[system_profile_fact].astext, regex) == value
+    return Host.system_profile_facts[system_profile_fact].astext == value
 
 
 def find_host_by_canonical_fact(account_number, canonical_fact, value):

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -40,11 +40,10 @@ paths:
           description: Search for a host by insights_id
           required: false
         - in: query
-          name: os_release
+          name: os_major
           schema:
             type: string
-            format: string
-          description: Search for a host by os_release
+          description: Search for a host by os_major
           required: false
         - $ref: '#/components/parameters/branchId'
         - $ref: '#/components/parameters/perPageParam'

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -53,6 +53,7 @@ paths:
         - $ref: '#/components/parameters/stalenessParam'
         - $ref: '#/components/parameters/tagsParam'
         - $ref: '#/components/parameters/registered_with'
+        - $ref: '#/components/parameters/fieldsParam'
       responses:
         '200':
           description: Successfully read the hosts list.
@@ -486,8 +487,22 @@ components:
         type: string
         enum:
           - insights
-
-
+    fieldsParam:
+      in: query
+      name: fields
+      style: deepObject
+      allowReserved: true
+      description: "Include extra fields for each host. If the requested field does not exist, it will be omitted.
+      Request by passing a JSON object, or in the URL via `?fields[system_profile]=os_release, arch`.
+      **Currently only extra fields for system_profile can be queried.**
+      See [System profile fields]('#/components/schemas/SystemProfileIn' ) for a list of possible fields to include."
+      schema:
+        type: object
+        example:
+          system_profile: 'os_release, arch'
+        properties:
+          system_profile:
+            type: string
   schemas:
     TagsOut:
       type: object
@@ -846,6 +861,7 @@ components:
       description: A database entry representing a single host with its Inventory metadata.
       allOf:
         - $ref: '#/components/schemas/CreateHostOut'
+        - $ref: '#/components/schemas/SystemProfileIn'
         - type: object
           properties:
             facts:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -42,8 +42,8 @@ paths:
         - in: query
           name: os_major
           schema:
-            type: string
-          description: Search for a host by os_major
+            type: integer
+          description: Search for a host by a major RHEL version
           required: false
         - $ref: '#/components/parameters/branchId'
         - $ref: '#/components/parameters/perPageParam'

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -39,6 +39,13 @@ paths:
             format: uuid
           description: Search for a host by insights_id
           required: false
+        - in: query
+          name: os_release
+          schema:
+            type: string
+            format: string
+          description: Search for a host by os_release
+          required: false
         - $ref: '#/components/parameters/branchId'
         - $ref: '#/components/parameters/perPageParam'
         - $ref: '#/components/parameters/pageParam'


### PR DESCRIPTION
This adds the ability to search systems by os_release, and introduces
searching by any system_profile_fact to the codebase for any future search.

Draft for now because there are a few topics I need to have resolved before getting this in:

 * First and foremost *tests*
 * I've seen hosts have *all sorts* of os_release fields. From compliance (or any app), I guess all I want is to search by `os_release=RHEL7`. But the os_release field contains things like "Red Hat EL 7.0.1", or "Red Hat Enterprise Linux Server release 7.5 (Maipo)".
 * Maybe it's worth having a special param "os" which matches on `(Red*Hat|RHEL).*$version` or something. 