### PR TITLE
RHCLOUD-6643 - Query extra Host parameters via sparse fieldset

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -48,7 +48,7 @@ TAG_OPERATIONS = ("apply", "remove")
 GET_HOST_LIST_FUNCTIONS = {BulkQuerySource.db: get_host_list_db, BulkQuerySource.xjoin: get_host_list_xjoin}
 XJOIN_HEADER = "x-rh-cloud-bulk-query-source"  # will be xjoin or db
 REFERAL_HEADER = "referer"
-SUPPORTED_FIELDS = {"system_profile", "host"}
+SUPPORTED_FIELDSETS = {"system_profile", "host"}
 
 logger = get_logger(__name__)
 
@@ -172,14 +172,16 @@ def get_host_list(
     except ValueError as e:
         flask.abort(400, str(e))
 
-    unsupported_fields = fields.keys() - SUPPORTED_FIELDS
-    if unsupported_fields:
-        flask.abort(400, f"Unsupported fields {unsupported_fields}. Supported fields include {SUPPORTED_FIELDS}.")
+    unsupported_fieldsets = fields.keys() - SUPPORTED_FIELDSETS
+    if unsupported_fieldsets:
+        flask.abort(
+            400, f"Unsupported fields {unsupported_fieldsets}. Supported fields include {SUPPORTED_FIELDSETS}."
+        )
 
     try:
         json_data = build_paginated_host_list_response(total, page, per_page, host_list, fields)
     except KeyError as error:
-        flask.abort(400, f"Unsupported field {error}. Supported fields include {SUPPORTED_FIELDS}.")
+        flask.abort(400, f"Unsupported field: {error}. Supported fields include {SUPPORTED_FIELDSETS}.")
     return flask_json_response(json_data)
 
 

--- a/api/host.py
+++ b/api/host.py
@@ -48,6 +48,7 @@ TAG_OPERATIONS = ("apply", "remove")
 GET_HOST_LIST_FUNCTIONS = {BulkQuerySource.db: get_host_list_db, BulkQuerySource.xjoin: get_host_list_xjoin}
 XJOIN_HEADER = "x-rh-cloud-bulk-query-source"  # will be xjoin or db
 REFERAL_HEADER = "referer"
+SUPPORTED_FIELDS = ("system_profile", "host", "canonical_facts")
 
 logger = get_logger(__name__)
 
@@ -170,6 +171,10 @@ def get_host_list(
         )
     except ValueError as e:
         flask.abort(400, str(e))
+
+    for field in fields:
+        if field not in SUPPORTED_FIELDS:
+            flask.abort(400, "Supported fields include %s", SUPPORTED_FIELDS)
 
     json_data = build_paginated_host_list_response(total, page, per_page, host_list, fields)
     return flask_json_response(json_data)

--- a/api/host.py
+++ b/api/host.py
@@ -48,7 +48,7 @@ TAG_OPERATIONS = ("apply", "remove")
 GET_HOST_LIST_FUNCTIONS = {BulkQuerySource.db: get_host_list_db, BulkQuerySource.xjoin: get_host_list_xjoin}
 XJOIN_HEADER = "x-rh-cloud-bulk-query-source"  # will be xjoin or db
 REFERAL_HEADER = "referer"
-SUPPORTED_FIELDS = ("system_profile", "host")
+SUPPORTED_FIELDS = {"system_profile", "host"}
 
 logger = get_logger(__name__)
 
@@ -172,9 +172,9 @@ def get_host_list(
     except ValueError as e:
         flask.abort(400, str(e))
 
-    for field in fields:
-        if field not in SUPPORTED_FIELDS:
-            flask.abort(400, "Supported fields include %s", SUPPORTED_FIELDS)
+    unsupported_fields = fields.keys() - SUPPORTED_FIELDS
+    if unsupported_fields:
+        flask.abort(400, f"Supported fields include {SUPPORTED_FIELDS}")
 
     json_data = build_paginated_host_list_response(total, page, per_page, host_list, fields)
     return flask_json_response(json_data)

--- a/api/host.py
+++ b/api/host.py
@@ -175,13 +175,14 @@ def get_host_list(
     unsupported_fieldsets = fields.keys() - SUPPORTED_FIELDSETS
     if unsupported_fieldsets:
         flask.abort(
-            400, f"Unsupported fields {unsupported_fieldsets}. Supported fields include {SUPPORTED_FIELDSETS}."
+            400,
+            f"Unsupported fields {unsupported_fieldsets}. Supported fields include {', '.join(SUPPORTED_FIELDSETS)}.",
         )
 
     try:
         json_data = build_paginated_host_list_response(total, page, per_page, host_list, fields)
     except KeyError as error:
-        flask.abort(400, f"Unsupported field: {error}. Supported fields include {SUPPORTED_FIELDSETS}.")
+        flask.abort(400, f"Unsupported field: {error}. Supported fields include {', '.join(SUPPORTED_FIELDSETS)}.")
     return flask_json_response(json_data)
 
 

--- a/api/host.py
+++ b/api/host.py
@@ -145,6 +145,7 @@ def get_host_list(
     order_how=None,
     staleness=None,
     registered_with=None,
+    fields=None,
 ):
     total = 0
     host_list = ()
@@ -170,7 +171,7 @@ def get_host_list(
     except ValueError as e:
         flask.abort(400, str(e))
 
-    json_data = build_paginated_host_list_response(total, page, per_page, host_list)
+    json_data = build_paginated_host_list_response(total, page, per_page, host_list, fields)
     return flask_json_response(json_data)
 
 

--- a/api/host.py
+++ b/api/host.py
@@ -48,7 +48,7 @@ TAG_OPERATIONS = ("apply", "remove")
 GET_HOST_LIST_FUNCTIONS = {BulkQuerySource.db: get_host_list_db, BulkQuerySource.xjoin: get_host_list_xjoin}
 XJOIN_HEADER = "x-rh-cloud-bulk-query-source"  # will be xjoin or db
 REFERAL_HEADER = "referer"
-SUPPORTED_FIELDS = ("system_profile", "host", "canonical_facts")
+SUPPORTED_FIELDS = ("system_profile", "host")
 
 logger = get_logger(__name__)
 

--- a/api/host.py
+++ b/api/host.py
@@ -174,9 +174,12 @@ def get_host_list(
 
     unsupported_fields = fields.keys() - SUPPORTED_FIELDS
     if unsupported_fields:
-        flask.abort(400, f"Supported fields include {SUPPORTED_FIELDS}")
+        flask.abort(400, f"Unsupported fields {unsupported_fields}. Supported fields include {SUPPORTED_FIELDS}.")
 
-    json_data = build_paginated_host_list_response(total, page, per_page, host_list, fields)
+    try:
+        json_data = build_paginated_host_list_response(total, page, per_page, host_list, fields)
+    except KeyError as error:
+        flask.abort(400, f"Unsupported field {error}. Supported fields include {SUPPORTED_FIELDS}.")
     return flask_json_response(json_data)
 
 

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -4,6 +4,7 @@ from enum import Enum
 from app import inventory_config
 from app.culling import Timestamps
 from app.serialization import serialize_host
+from app.serialization import serialize_host_sparse
 
 __all__ = ("build_paginated_host_list_response", "staleness_timestamps")
 
@@ -12,9 +13,12 @@ OrderHow = Enum("OrderHow", ("ASC", "DESC"))
 Order = namedtuple("Order", ("by", "how"))
 
 
-def build_paginated_host_list_response(total, page, per_page, host_list, sparse_fieldset=None):
+def build_paginated_host_list_response(total, page, per_page, host_list, fields=None):
     timestamps = staleness_timestamps()
-    json_host_list = [serialize_host(host, timestamps, sparse_fieldset=sparse_fieldset) for host in host_list]
+    if fields:
+        json_host_list = [serialize_host_sparse(host, timestamps, fields) for host in host_list]
+    else:
+        json_host_list = [serialize_host(host, timestamps) for host in host_list]
 
     return {
         "total": total,

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -12,9 +12,9 @@ OrderHow = Enum("OrderHow", ("ASC", "DESC"))
 Order = namedtuple("Order", ("by", "how"))
 
 
-def build_paginated_host_list_response(total, page, per_page, host_list, extra_fields=None):
+def build_paginated_host_list_response(total, page, per_page, host_list, sparse_fieldset=None):
     timestamps = staleness_timestamps()
-    json_host_list = [serialize_host(host, timestamps, extra_fields=extra_fields) for host in host_list]
+    json_host_list = [serialize_host(host, timestamps, sparse_fieldset=sparse_fieldset) for host in host_list]
 
     return {
         "total": total,

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -5,7 +5,6 @@ from app import inventory_config
 from app.culling import Timestamps
 from app.serialization import serialize_host
 
-
 __all__ = ("build_paginated_host_list_response", "staleness_timestamps")
 
 OrderBy = Enum("OrderBy", ("display_name", "id", "modified_on"))
@@ -13,9 +12,10 @@ OrderHow = Enum("OrderHow", ("ASC", "DESC"))
 Order = namedtuple("Order", ("by", "how"))
 
 
-def build_paginated_host_list_response(total, page, per_page, host_list):
+def build_paginated_host_list_response(total, page, per_page, host_list, extra_fields=None):
     timestamps = staleness_timestamps()
-    json_host_list = [serialize_host(host, timestamps) for host in host_list]
+    json_host_list = [serialize_host(host, timestamps, extra_fields=extra_fields) for host in host_list]
+
     return {
         "total": total,
         "count": len(json_host_list),

--- a/app/models.py
+++ b/app/models.py
@@ -66,6 +66,7 @@ class Host(db.Model):
     tags = db.Column(JSONB)
     canonical_facts = db.Column(JSONB)
     system_profile_facts = db.Column(JSONB)
+    system_profile = orm.synonym("system_profile_facts")
     stale_timestamp = db.Column(db.DateTime(timezone=True))
     reporter = db.Column(db.String(255))
 

--- a/app/models.py
+++ b/app/models.py
@@ -66,7 +66,6 @@ class Host(db.Model):
     tags = db.Column(JSONB)
     canonical_facts = db.Column(JSONB)
     system_profile_facts = db.Column(JSONB)
-    system_profile = orm.synonym("system_profile_facts")
     stale_timestamp = db.Column(db.DateTime(timezone=True))
     reporter = db.Column(db.String(255))
 

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -40,8 +40,6 @@ DEFAULT_FIELDS = (
     "updated",
 )
 
-BASIC_FIELDS = ("id", "account")
-
 
 def deserialize_host(raw_data, schema):
     try:
@@ -115,8 +113,7 @@ def _sparse_fieldset_serialization(host, staleness_timestamps, sparse_fieldset):
         for host_attribute in host_attributes:
             _serialize_host_field(host, host_attribute, staleness_timestamps, serialized_host)
 
-    for field in BASIC_FIELDS:
-        _serialize_host_field(host, field, staleness_timestamps, serialized_host)
+    _serialize_host_field(host, "id", staleness_timestamps, serialized_host)
 
     if "system_profile" in sparse_fieldset:
         system_profile_attributes = sparse_fieldset["system_profile"].replace(" ", "").split(",")

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -105,7 +105,14 @@ def serialize_host(host, staleness_timestamps, fields=DEFAULT_FIELDS, sparse_fie
 
 
 def _sparse_fieldset_serialization(host, staleness_timestamps, sparse_fieldset):
-    serialized_host = {**serialize_canonical_facts(host.canonical_facts, canonical_fields=BASIC_CANONICAL_FIELDS)}
+    serialized_host = {}
+
+    if "canonical_facts" in sparse_fieldset:
+        canonical_facts_attributes = sparse_fieldset["canonical_facts"].replace(" ", "").split(",")
+        serialized_host = {
+            **serialize_canonical_facts(host.canonical_facts, canonical_fields=canonical_facts_attributes)
+        }
+
     for field in BASIC_FIELDS:
         _serialize_host_field(host, field, staleness_timestamps, serialized_host)
 

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -89,7 +89,7 @@ def deserialize_host_xjoin(data):
     return host
 
 
-def serialize_host(host, staleness_timestamps, fields=DEFAULT_FIELDS):
+def serialize_host(host, staleness_timestamps, fields=DEFAULT_FIELDS, extra_fields=None):
     if host.stale_timestamp:
         stale_timestamp = staleness_timestamps.stale_timestamp(host.stale_timestamp)
         stale_warning_timestamp = staleness_timestamps.stale_warning_timestamp(host.stale_timestamp)
@@ -129,6 +129,21 @@ def serialize_host(host, staleness_timestamps, fields=DEFAULT_FIELDS):
         serialized_host["tags"] = _serialize_tags(host.tags)
     if "system_profile" in fields:
         serialized_host["system_profile"] = host.system_profile_facts or {}
+    if extra_fields:
+        if "system_profile" in extra_fields:
+            system_profile_attributes = extra_fields["system_profile"].replace(" ", "").split(",")
+            serialized_host["system_profile"] = {}
+            for system_profile_attribute in system_profile_attributes:
+                if system_profile_attribute not in host.system_profile_facts:
+                    continue
+                if host.system_profile_facts and system_profile_attribute in host.system_profile_facts:
+                    serialized_host["system_profile"][system_profile_attribute] = host.system_profile_facts[
+                        system_profile_attribute
+                    ]
+                elif host.system_profile_facts and system_profile_attribute == "*":
+                    serialized_host["system_profile"] = host.system_profile_facts
+                else:
+                    serialized_host["system_profile"][system_profile_attribute] = "not found"
 
     return serialized_host
 

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -133,6 +133,8 @@ def serialize_host_sparse(host, staleness_timestamps, sparse_fieldset):
                 ]
             elif system_profile_attribute not in SystemProfileSchema(strict=True).fields:
                 _error_invalid_attribute(list(SystemProfileSchema(strict=True).fields))
+            else:
+                serialized_host["system_profile"][system_profile_attribute] = None
 
     return serialized_host
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -486,10 +486,12 @@ components:
       name: fields
       style: deepObject
       allowReserved: true
-      description: "Include extra fields for each host. If the requested field does not exist, it will be omitted.
-      Request by passing a JSON object, or in the URL via `?fields[system_profile]=os_release, arch`.
-      **Currently only extra fields for system_profile can be queried.**
-      See [System profile fields]('#/components/schemas/SystemProfileIn' ) for a list of possible fields to include."
+      description: "Include extra fields for each host. If the requested field does not exist, it will return null.
+      Request by passing a JSON object, or in the URL via `?fields[system_profile]=os_release, arch`. Notice requesting
+      extra fields will only display the requested fields plus id, account, display_name, fqdn, insights_id and subscription_manager_id.
+      **Currently extra fields for system_profile or host can be queried.**
+      See [System profile fields]('#/components/schemas/SystemProfileIn') for a list of possible fields to include for system_profile.
+      See [Host fields]('#/components/schemas/CreateHostOut') for a list of possible fields to include for host."
       schema:
         type: object
         example:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -712,8 +712,6 @@ components:
         Data of a single host belonging to an account. Represents the hosts
         without its Inventory metadata.
       type: object
-      required:
-        - account
       properties:
         display_name:
           description: >-

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -47,6 +47,7 @@ paths:
         - $ref: '#/components/parameters/stalenessParam'
         - $ref: '#/components/parameters/tagsParam'
         - $ref: '#/components/parameters/registered_with'
+        - $ref: '#/components/parameters/fieldsParam'
       responses:
         '200':
           description: Successfully read the hosts list.
@@ -480,8 +481,22 @@ components:
         type: string
         enum:
           - insights
-
-
+    fieldsParam:
+      in: query
+      name: fields
+      style: deepObject
+      allowReserved: true
+      description: "Include extra fields for each host. If the requested field does not exist, it will be omitted.
+      Request by passing a JSON object, or in the URL via `?fields[system_profile]=os_release, arch`.
+      **Currently only extra fields for system_profile can be queried.**
+      See [System profile fields]('#/components/schemas/SystemProfileIn' ) for a list of possible fields to include."
+      schema:
+        type: object
+        example:
+          system_profile: 'os_release, arch'
+        properties:
+          system_profile:
+            type: string
   schemas:
     TagsOut:
       type: object
@@ -830,6 +845,7 @@ components:
       description: A database entry representing a single host with its Inventory metadata.
       allOf:
         - $ref: '#/components/schemas/CreateHostOut'
+        - $ref: '#/components/schemas/SystemProfileIn'
         - type: object
           properties:
             facts:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -494,10 +494,6 @@ components:
       See [Host fields]('#/components/schemas/CreateHostOut') for a list of possible fields to include for host."
       schema:
         type: object
-        enum:
-          - system_profile
-          - host
-          - canonical_facts
         example:
           system_profile: 'os_release, arch'
         properties:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -486,7 +486,7 @@ components:
       name: fields
       style: deepObject
       allowReserved: true
-      description: "Include extra fields for each host. If the requested field does not exist, it will return null.
+      description: "Include extra fields for each host. If a valid requested field cannot be found, it will return null.
       Request by passing a JSON object, or in the URL via `?fields[system_profile]=os_release,arch`. Notice requesting
       extra fields will only display the requested fields plus id.
       **Currently extra fields for system_profile or host can be queried.**
@@ -503,27 +503,16 @@ components:
             type: string
   schemas:
     TagsOut:
-      type: object
-      properties:
-        total:
-          type: integer
-          description: Total number of items in the "data" list.
-        count:
-          description: A number of entries on the current page.
-          type: integer
-        page:
-          description: A current page number.
-          type: integer
-        per_page:
-          description: A page size – a number of entries per single page.
-          type: integer
-        results:
-          description: The list of tags on the systems
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/StructuredTag'
+      allOf:
+        - $ref: '#/components/schemas/Paginated'
+        - properties:
+            results:
+              description: The list of tags on the systems
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StructuredTag'
     StructuredTag:
       type: object
       properties:
@@ -536,25 +525,14 @@ components:
           type: string
           nullable: true
     TagCountOut:
-      type: object
-      properties:
-        total:
-          type: integer
-          description: Total number of items in the "data" list.
-        count:
-          description: A number of entries on the current page.
-          type: integer
-        page:
-          description: A current page number.
-          type: integer
-        per_page:
-          description: A page size – a number of entries per single page.
-          type: integer
-        results:
-          description: The list of tags on the systems
-          type: object
-          additionalProperties:
-            type: integer
+      allOf:
+        - $ref: '#/components/schemas/Paginated'
+        - properties:
+            results:
+              description: The list of tags on the systems
+              type: object
+              additionalProperties:
+                type: integer
     BulkHostOut:
       type: object
       properties:
@@ -708,8 +686,8 @@ components:
         reporter:
           description: Reporting source of the host. Used when updating the stale_timestamp.
           type: string
-    CreateHostOut:
-      title: Create Host Out
+    BaseHostOut:
+      title: Base Host Out
       description: >-
         Data of a single host belonging to an account. Represents the hosts
         without its Inventory metadata.
@@ -842,77 +820,44 @@ components:
           description: Reporting source of the host. Used when updating the stale_timestamp.
           type: string
           nullable: true
-    HostOut:
-      title: A Host Inventory entry
-      description: A database entry representing a single host with its Inventory metadata.
+    CreateHostOut:
+      title: Create Host Out
+      allOf:
+        - $ref: '#/components/schemas/BaseHostOut'
+    HostQueryHostOut:
+      title: Host query Host Out
       allOf:
         - $ref: '#/components/schemas/CreateHostOut'
-        - $ref: '#/components/schemas/SystemProfileIn'
-        - type: object
-          properties:
-            facts:
-              description: A set of facts belonging to the host.
-              type: array
-              items:
-                $ref: '#/components/schemas/FactSet'
+        - properties:
+            system_profile:
+              $ref: '#/components/schemas/SystemProfileIn'
     HostQueryOutput:
       title: A Host Inventory query result
       description: >-
         A paginated host search query result with host entries and their
         Inventory metadata.
-      type: object
-      required:
-        - count
-        - page
-        - per_page
-        - total
-        - results
-      properties:
-        count:
-          description: A number of entries on the current page.
-          type: integer
-        page:
-          description: A current page number.
-          type: integer
-        per_page:
-          description: A page size – a number of entries per single page.
-          type: integer
-        total:
-          description: A total count of the found entries.
-          type: integer
-        results:
-          description: Actual host search query result entries.
-          type: array
-          items:
-            $ref: '#/components/schemas/HostOut'
+      allOf:
+        - $ref: '#/components/schemas/Paginated'
+        - properties:
+            results:
+              anyOf:
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/BaseHostOut'
+                - type: array
+                  items:
+                    $ref: '#/components/schemas/CreateHostOut'
     SystemProfileByHostOut:
       title: A host system profile query result
       description: Structure of the output of the host system profile query
-      type: object
-      required:
-        - count
-        - page
-        - per_page
-        - total
-        - results
-      properties:
-        count:
-          description: A number of entries on the current page.
-          type: integer
-        page:
-          description: A current page number.
-          type: integer
-        per_page:
-          description: A page size – a number of entries per single page.
-          type: integer
-        total:
-          description: A total count of the found entries.
-          type: integer
-        results:
-          description: Actual host search query result entries.
-          type: array
-          items:
-            $ref: '#/components/schemas/HostSystemProfileOut'
+      allOf:
+        - $ref: '#/components/schemas/Paginated'
+        - properties:
+            results:
+              description: Actual host search query result entries.
+              type: array
+              items:
+                $ref: '#/components/schemas/HostSystemProfileOut'
     HostSystemProfileOut:
       title: Structure of an individual host system profile output
       description: Individual host record that contains only the host id and system profile
@@ -1136,38 +1081,25 @@ components:
 
     ActiveTags:
       title: Host data
-      type: object
-      required:
-        - total
-        - count
-        - page
-        - per_page
-        - results
-      properties:
-        total:
-          $ref: '#/components/schemas/Total'
-        count:
-          $ref: '#/components/schemas/Count'
-        page:
-          $ref: '#/components/schemas/Page'
-        per_page:
-          $ref: '#/components/schemas/PerPage'
-        results:
-          type: array
-          items:
-            title: ActiveTag
-            description: Information about a host tag
-            type: object
-            required:
-              - tag
-              - count
-            properties:
-              tag:
-                $ref: '#/components/schemas/StructuredTag'
-              count:
-                description: The number of hosts with the given tag. If the value is null this indicates that the count is unknown.
-                type: integer
-                nullable: true
+      allOf:
+        - $ref: '#/components/schemas/Paginated'
+        - properties:
+            results:
+              type: array
+              items:
+                title: ActiveTag
+                description: Information about a host tag
+                type: object
+                required:
+                  - tag
+                  - count
+                properties:
+                  tag:
+                    $ref: '#/components/schemas/StructuredTag'
+                  count:
+                    description: The number of hosts with the given tag. If the value is null this indicates that the count is unknown.
+                    type: integer
+                    nullable: true
       example:
         total: 3
         count: 3
@@ -1189,6 +1121,33 @@ components:
               key: web
               value: null
             count: -1
+    Paginated:
+      type: object
+      required:
+        - total
+        - count
+        - page
+        - per_page
+        - results
+      properties:
+        total:
+          $ref: '#/components/schemas/Total'
+        count:
+          $ref: '#/components/schemas/Count'
+        page:
+          $ref: '#/components/schemas/Page'
+        per_page:
+          $ref: '#/components/schemas/PerPage'
+        results:
+          anyOf:
+            - type: array
+            - type: object
+      example:
+        total: 3
+        count: 3
+        page: 1
+        per_page: 50
+        results: []
     Total:
       type: integer
       description: Total number of items

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -494,6 +494,10 @@ components:
       See [Host fields]('#/components/schemas/CreateHostOut') for a list of possible fields to include for host."
       schema:
         type: object
+        enum:
+          - system_profile
+          - host
+          - canonical_facts
         example:
           system_profile: 'os_release, arch'
         properties:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -487,16 +487,18 @@ components:
       style: deepObject
       allowReserved: true
       description: "Include extra fields for each host. If the requested field does not exist, it will return null.
-      Request by passing a JSON object, or in the URL via `?fields[system_profile]=os_release, arch`. Notice requesting
-      extra fields will only display the requested fields plus id, account, display_name, fqdn, insights_id and subscription_manager_id.
+      Request by passing a JSON object, or in the URL via `?fields[system_profile]=os_release,arch`. Notice requesting
+      extra fields will only display the requested fields plus id.
       **Currently extra fields for system_profile or host can be queried.**
       See [System profile fields]('#/components/schemas/SystemProfileIn') for a list of possible fields to include for system_profile.
       See [Host fields]('#/components/schemas/CreateHostOut') for a list of possible fields to include for host."
       schema:
         type: object
         example:
-          system_profile: 'os_release, arch'
+          system_profile: 'os_release,arch'
         properties:
+          host:
+            type: string
           system_profile:
             type: string
   schemas:

--- a/test_api.py
+++ b/test_api.py
@@ -4514,23 +4514,27 @@ class SparseFieldsetTestCase(DBAPITestCase):
     def test_canonical_facts_sparse_attributes(self):
         insights_ids = []
         fqdns = []
+        display_names = []
         for i in range(4):
             insights_id = generate_uuid()
             fqdn = f"fqdn{i}"
-            host = test_data(fqdn=fqdn, insights_id=insights_id, display_name=f"host{i}", facts=None)
+            display_name = f"host{i}"
+            host = test_data(fqdn=fqdn, insights_id=insights_id, display_name=display_name, facts=None)
             host["rhel_machine_id"] = generate_uuid()
             host["ip_addresses"] = ["10.0.0.1"]
             response = self.post(HOST_URL, [host], 207)
             self._verify_host_status(response, 0, 201)
             insights_ids.append(insights_id)
             fqdns.append(fqdn)
+            display_names.append(display_name)
 
-        test_url = f"{HOST_URL}?fields[canonical_facts]=fqdn,insights_id"
+        test_url = f"{HOST_URL}?fields[host]=fqdn,insights_id,display_name"
         host_lookup_results = self.get(test_url, 200)
 
         for i, host in enumerate(host_lookup_results["results"]):
             self.assertIn(host["fqdn"], fqdns)
             self.assertIn(host["insights_id"], insights_ids)
+            self.assertIn(host["display_name"], display_names)
 
     def test_hosts_sparse_attributes(self):
         createds = []

--- a/test_api.py
+++ b/test_api.py
@@ -4603,7 +4603,7 @@ class SparseFieldsetTestCase(DBAPITestCase):
         test_url = f"{HOST_URL}?fields[system_profile]=foounsupported"
         host_lookup_results = self.get(test_url, 400)
         self.assertIn(
-            "Unsupported field: 'Requested system profile attribute not present in schema. Valid attributes include:",
+            "Unsupported field: 'Requested attribute not present in schema. Valid attributes include:",
             host_lookup_results["detail"],
         )
         self.assertIn("os_release", host_lookup_results["detail"])

--- a/test_unit.py
+++ b/test_unit.py
@@ -32,6 +32,7 @@ from app.exceptions import ValidationException
 from app.models import Host
 from app.models import HttpHostSchema
 from app.models import MqHostSchema
+from app.serialization import _CANONICAL_FACTS_FIELDS
 from app.serialization import _deserialize_canonical_facts
 from app.serialization import _deserialize_facts
 from app.serialization import _deserialize_tags
@@ -1291,7 +1292,7 @@ class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTes
         }
         self.assertEqual(expected, actual)
 
-        serialize_canonical_facts.assert_called_once_with(host_init_data["canonical_facts"])
+        serialize_canonical_facts.assert_called_once_with(host_init_data["canonical_facts"], _CANONICAL_FACTS_FIELDS)
         serialize_facts.assert_called_once_with(host_init_data["facts"])
         serialize_tags.assert_called_once_with(host_init_data["tags"])
 


### PR DESCRIPTION
Inspiration from https://jsonapi.org/format/#fetching-sparse-fieldsets

This allows to query attributes via `hosts?fields[system_profile]=os_release,arch`. It includes support for `hosts?fields[system_profile]=*` which includes all of the fields. The method is generic enough to support any sort of possible extra field in the future. 