### PR TITLE
Add a metric to track POST requests on the REST API [RHCLOUD-5004]

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -14,6 +14,7 @@ from api.host_query import staleness_timestamps
 from api.host_query_db import get_host_list as get_host_list_db
 from api.host_query_db import params_to_order_by
 from api.host_query_xjoin import get_host_list as get_host_list_xjoin
+from api.metrics import rest_post_request_count
 from api.metrics import tags_ignored_from_http_count
 from app import db
 from app import inventory_config
@@ -55,6 +56,8 @@ logger = get_logger(__name__)
 @api_operation
 @metrics.api_request_time.time()
 def add_host_list(host_list):
+    rest_post_request_count.inc()
+
     response_host_list = []
     number_of_errors = 0
 

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -7,3 +7,6 @@ login_failure_count = Counter("inventory_login_failure_count", "The total amount
 tags_ignored_from_http_count = Counter(
     "inventory_tags_ignored_from_http_count", "Number of times we have ignored tags sent through HTTP"
 )
+rest_post_request_count = Counter(
+    "rest_post_request_count", "The number of times a REST POST request has been recieved"
+)

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -8,5 +8,5 @@ tags_ignored_from_http_count = Counter(
     "inventory_tags_ignored_from_http_count", "Number of times we have ignored tags sent through HTTP"
 )
 rest_post_request_count = Counter(
-    "rest_post_request_count", "The number of times a REST POST request has been recieved"
+    "rest_post_request_count", "The number of times a REST POST request has been recieved", ["reporter"]
 )


### PR DESCRIPTION
To prepare to deprecate host creation through the REST API we want to have some metrics to know how many people are still using it. This PR adds a new counter `rest_post_request_counter` to Prometheus.