### PR TITLE
Split event metrics [RHCLOUD-5645]

### DIFF
--- a/app/queue/events.py
+++ b/app/queue/events.py
@@ -9,7 +9,7 @@ from marshmallow import Schema
 from app.logging import threadctx
 from app.models import SystemProfileSchema
 from app.models import TagsSchema
-from app.queue import metrics
+from app.queue.metrics import event_serialization_time
 from app.serialization import serialize_canonical_facts
 
 logger = logging.getLogger(__name__)
@@ -107,7 +107,7 @@ EVENT_TYPE_MAP = {
 
 
 def build_event(event_type, host, **kwargs):
-    with metrics.egress_event_serialization_time.labels(event_type.name).time():
+    with event_serialization_time.labels(event_type.name).time():
         build = EVENT_TYPE_MAP[event_type]
         schema, event = build(event_type, host, **kwargs)
         result = schema(strict=True).dumps(event)

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -35,5 +35,7 @@ egress_message_handler_failure = Counter(
     "inventory_egress_message_handler_failures", "Total amount of failures while writing messages to the egress queue"
 )
 egress_event_serialization_time = Summary(
-    "inventory_egress_event_serialization_seconds", "Time spent parsing a message from the egress queue"
+    "inventory_egress_event_serialization_seconds",
+    "Time spent parsing a message from the egress queue",
+    ["event_type"],
 )

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -34,8 +34,6 @@ egress_message_handler_success = Counter(
 egress_message_handler_failure = Counter(
     "inventory_egress_message_handler_failures", "Total amount of failures while writing messages to the egress queue"
 )
-egress_event_serialization_time = Summary(
-    "inventory_egress_event_serialization_seconds",
-    "Time spent parsing a message from the egress queue",
-    ["event_type"],
+event_serialization_time = Summary(
+    "inventory_event_serialization_seconds", "Time spent parsing a message from the egress queue", ["event_type"]
 )


### PR DESCRIPTION
- Add's `event_type` label to the ~`egress_event_serialization_time`~ `event_serialization_time` metric so that we can compare the serialization times between the different event types. 
- Renames the prometheus metric from `inventory_egress_event_serialization_time` to `inventory_event_serialization_time` to reflect the broader role the metric now serves. It felt inappropriate to have egress in the name when it's also monitoring events built for the `events` topic.

~Dependent on the [event refactor PR](https://github.com/RedHatInsights/insights-host-inventory/pull/651).~