### PR TITLE
Add metadata to delete events (RHCLOUD-5224)

### DIFF
--- a/app/events.py
+++ b/app/events.py
@@ -13,8 +13,13 @@ DELETE_EVENT_NAME = "delete"
 UPDATE_EVENT_NAME = "updated"
 
 
+class HostEventMetadataSchema(Schema):
+    request_id = fields.Str(required=True)
+
+
 class HostEvent(Schema):
     id = fields.UUID()
+    metadata = fields.Nested(HostEventMetadataSchema())
     timestamp = fields.DateTime(format="iso8601")
     type = fields.Str()
     account = fields.Str()
@@ -27,6 +32,7 @@ def delete(host):
         HostEvent()
         .dumps(
             {
+                "metadata": {"request_id": threadctx.request_id},
                 "timestamp": datetime.utcnow(),
                 "id": host.id,
                 **serialize_canonical_facts(host.canonical_facts),

--- a/app/queue/egress.py
+++ b/app/queue/egress.py
@@ -5,6 +5,7 @@ from kafka import KafkaProducer
 from marshmallow import fields
 from marshmallow import Schema
 
+from app.events import HostEventMetadataSchema
 from app.instrumentation import message_not_produced
 from app.instrumentation import message_produced
 from app.logging import get_logger
@@ -93,10 +94,6 @@ class HostSchema(Schema):
     reporter = fields.Str()
     tags = fields.List(fields.Nested(TagsSchema))
     system_profile = fields.Nested(SystemProfileSchema)
-
-
-class HostEventMetadataSchema(Schema):
-    request_id = fields.Str(required=True)
 
 
 class HostEvent(Schema):


### PR DESCRIPTION
Adding metadata to delete events. From what I could tell, `created` and `updated` events already has it.