### PR TITLE
Add metadata to delete events (RHCLOUD-5224)

### DIFF
--- a/app/queue/events.py
+++ b/app/queue/events.py
@@ -65,6 +65,7 @@ class HostDeleteEvent(Schema):
     account = fields.Str()
     insights_id = fields.Str()
     request_id = fields.Str()
+    metadata = fields.Nested(HostEventMetadataSchema())
 
 
 def message_headers(event_type):
@@ -94,6 +95,7 @@ def host_delete_event(event_type, host):
             **serialize_canonical_facts(host.canonical_facts),
             "account": host.account,
             "request_id": threadctx.request_id,
+            "metadata": {"request_id": threadctx.request_id},
         },
     )
 

--- a/test_api.py
+++ b/test_api.py
@@ -1841,12 +1841,15 @@ class DeleteHostsEventTestCase(PreCreatedHostsBaseTestCase, DeleteHostsBaseTestC
     def test_create_then_delete_check_metadata(self):
         with self.app.app_context():
             self._check_hosts_are_present((self.host_to_delete.id,))
-            self._delete(header=None)
+
+            request_id = generate_uuid()
+            header = {"x-rh-insights-request-id": request_id}
+            self._delete(header=header)
 
             self._assert_event_is_valid(self.app.event_producer, self.host_to_delete, self.timestamp)
 
             event = json.loads(self.app.event_producer.event)
-            self.assertEqual(self._expected_metadata("-1"), event["metadata"])
+            self.assertEqual(self._expected_metadata(request_id), event["metadata"])
 
 
 class DeleteHostsRaceConditionTestCase(PreCreatedHostsBaseTestCase):

--- a/test_api.py
+++ b/test_api.py
@@ -1797,7 +1797,7 @@ class DeleteHostsEventTestCase(PreCreatedHostsBaseTestCase, DeleteHostsBaseTestC
         with patch("app.queue.events.datetime", **{"now.return_value": self.timestamp}):
             url = f"{self.delete_url}{url_query}"
             self.delete(url, 200, header, return_response_as_json=False)
-    
+
     def _expected_metadata(self, expected_request_id):
         return {"request_id": expected_request_id}
 
@@ -1847,6 +1847,7 @@ class DeleteHostsEventTestCase(PreCreatedHostsBaseTestCase, DeleteHostsBaseTestC
 
             event = json.loads(self.app.event_producer.event)
             self.assertEqual(self._expected_metadata("-1"), event["metadata"])
+
 
 class DeleteHostsRaceConditionTestCase(PreCreatedHostsBaseTestCase):
     class DeleteHostsMock:


### PR DESCRIPTION
`created` and `updated` events already has it.