### PR TITLE
fixed event producer throwing error when event is successfully produced

### DIFF
--- a/app/queue/event_producer.py
+++ b/app/queue/event_producer.py
@@ -27,7 +27,7 @@ class EventProducer:
             h = [(hk, hv.encode("utf-8")) for hk, hv in headers.items()]
             send_future = self._kafka_producer.send(self.topics[topic], key=k, value=v, headers=h)
             send_future.add_callback(message_produced, logger, event, key, headers)
-            send_future.add_errback(message_not_produced, logger, self._topic, event, key, headers)
+            send_future.add_errback(message_not_produced, logger, self.topics[topic], event, key, headers)
             metrics.egress_message_handler_success.inc()
         except Exception:
             logger.exception("Failed to send event")


### PR DESCRIPTION
The issue was with using a variable that was no longer defined. Updated it to fit in with the new variables.

Verified that the PATCH produces a message and produces the info log message in the `message_produced` function.

Log output below: 
> [2020-06-23 22:37:12,360] [3985] [140457689134784] [inventory.api] [DEBUG] Leaving patch_by_id
> [2020-06-23 22:37:12,368] [3985] [140457413465856] [inventory.app.queue.event_producer] [INFO] Message PRODUCED offset=95 timestamp=1592966232358 topic=platform.inventory.events, key=358e5aff-8ee1-45cc-80e7-fc8ff7277903, headers={'event_type': 'updated'}