### PR TITLE
Add deprecation notice to host create/update in API spec

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -65,8 +65,9 @@ paths:
         hosts. A host is updated if there is already one with the same
         canonicals facts and belonging to the same account.
         <br /><br />
-        NOTICE: This operation is deprecated. We suggest you create and update hosts
-        using the [message queue interface](https://platform-docs.cloud.paas.psi.redhat.com/backend/inventory.html#mq-host-insertion) instead.
+        NOTICE: This operation is deprecated. The explicit creation of hosts is
+        no longer supported. Hosts are created automatically based on uploads
+        processed by the [payload ingress service](/docs/api/ingress#operations-default-post_upload) instead.
       security:
         - ApiKeyAuth: []
         - BearerAuth: []

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -55,6 +55,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/HostQueryOutput'
     post:
+      deprecated: true
       operationId: api.host.add_host_list
       tags:
         - hosts
@@ -63,6 +64,9 @@ paths:
         Create a new host and add it to the host list or update an existing
         hosts. A host is updated if there is already one with the same
         canonicals facts and belonging to the same account.
+        <br /><br />
+        NOTICE: This operation is deprecated. We suggest you create and update hosts
+        using the [message queue interface](https://platform-docs.cloud.paas.psi.redhat.com/backend/inventory.html#mq-host-insertion) instead.
       security:
         - ApiKeyAuth: []
         - BearerAuth: []


### PR DESCRIPTION
As part of the deprecation of the host update/create functionality on the REST API we want to make sure users know about the deprecation. This PR marks the POST operation as deprecated in the swagger docs. Below is a preview of the change.

![API_POST_deprecation](https://user-images.githubusercontent.com/26419550/85498009-eb01fd80-b5ac-11ea-9628-242bdeae2441.png)
