### PR TITLE
Event metrics fix

### DIFF
--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -1,3 +1,7 @@
+from app.queue.metrics import egress_message_handler_failure
+from app.queue.metrics import egress_message_handler_success
+
+
 def message_produced(logger, value, key, headers, record_metadata):
     status = "PRODUCED"
     offset = record_metadata.offset
@@ -13,6 +17,8 @@ def message_produced(logger, value, key, headers, record_metadata):
     debug_extra = {**extra, "value": value}
     logger.debug(debug_message, offset, timestamp, topic, key, value, extra=debug_extra)
 
+    egress_message_handler_success.inc()
+
 
 def message_not_produced(logger, topic, value, key, headers, error):
     status = "NOT PRODUCED"
@@ -26,3 +32,5 @@ def message_not_produced(logger, topic, value, key, headers, error):
     debug_message = "Message topic=%s key=%s value=%s"
     debug_extra = {**extra, "value": value}
     logger.debug(debug_message, topic, key, value, extra=debug_extra)
+
+    egress_message_handler_failure.inc()

--- a/app/queue/event_producer.py
+++ b/app/queue/event_producer.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from kafka import KafkaProducer
+from kafka.errors import KafkaError
 
 from app.instrumentation import message_not_produced
 from app.instrumentation import message_produced
@@ -20,15 +21,17 @@ class EventProducer:
     def write_event(self, event, key, headers, topic):
         logger.debug("Topic: %s, key: %s, event: %s, headers: %s", topic, key, event, headers)
 
+        k = key.encode("utf-8") if key else None
+        v = event.encode("utf-8")
+        h = [(hk, hv.encode("utf-8")) for hk, hv in headers.items()]
+
         try:
-            k = key.encode("utf-8") if key else None
-            v = event.encode("utf-8")
-            h = [(hk, hv.encode("utf-8")) for hk, hv in headers.items()]
             send_future = self._kafka_producer.send(self.topics[topic], key=k, value=v, headers=h)
+        except KafkaError as error:
+            message_not_produced(logger, self.topics[topic], event, key, headers, error)
+        else:
             send_future.add_callback(message_produced, logger, event, key, headers)
             send_future.add_errback(message_not_produced, logger, self.topics[topic], event, key, headers)
-        except Exception as error:
-            message_not_produced(logger, self.topics[topic], event, key, headers, error)
 
     def close(self):
         self._kafka_producer.flush()


### PR DESCRIPTION
Fixed error handling and instrumentation in the event producer.

- If the message production fails, it is no longer logged as success. Moved the instrumentation to the callback.
  Steps to reproduce:
  1. Add a sleep before the actual production.
  2. Make the Inventory produce an event.
  3. Shutdown Kafka or somehow block its port.
  4. See that the event is **not immediately** logged as produced.
  5. See that the success count is **not immediately** incremented.
  6. Wait until the production timeouts.
  7. See that the event is **then** logged as not produced.
  8. See that the falure cound is **then** incremented.
  9. See that the success count is still not incremented.
- If there is an immediate error and the future is not even created, this logged as a failure too. No other exception is caught.
  Steps to reproduce:
  1. Make the event producer fail somehow. Potentially use _unittest.mock_ for that.
     `patch.object(self._kafka_producer, "_wait_on_metadata", side_effect=KafkaError("Custom error"))`
  2. Make the Inventory produce an event.
  4. See that the event is **immediately** logged as not produced.
  5. See that the failure count is **immediately** incremented.


I did not add tests as @ryandillinfelton is writing unit tests for the _EventProducer_.

This is a follow-up for #668 and #651, a part of [RHCLOUD-5644](https://projects.engineering.redhat.com/browse/RHCLOUD-5644).