### PR TITLE
Final touches to unit test refactor step 1

### DIFF
--- a/tests/test_api_hosts_create.py
+++ b/tests/test_api_hosts_create.py
@@ -16,7 +16,7 @@ from lib.host_repository import canonical_fact_host_query
 from lib.host_repository import canonical_facts_host_query
 from tests.test_api_utils import ACCOUNT
 from tests.test_api_utils import build_valid_auth_header
-from tests.test_api_utils import DbApiTestCase
+from tests.test_api_utils import DbApiBaseTestCase
 from tests.test_api_utils import FACTS
 from tests.test_api_utils import generate_uuid
 from tests.test_api_utils import HOST_URL
@@ -29,7 +29,7 @@ from tests.test_utils import set_environment
 from tests.test_utils import valid_system_profile
 
 
-class CreateHostsTestCase(DbApiTestCase):
+class CreateHostsTestCase(DbApiBaseTestCase):
     def test_create_and_update(self):
         facts = None
 
@@ -675,7 +675,7 @@ class CreateHostsTestCase(DbApiTestCase):
         )
 
 
-class ResolveDisplayNameOnCreationTestCase(DbApiTestCase):
+class ResolveDisplayNameOnCreationTestCase(DbApiBaseTestCase):
     def test_create_host_without_display_name_and_without_fqdn(self):
         """
         This test should verify that the display_name is set to the id
@@ -729,7 +729,7 @@ class ResolveDisplayNameOnCreationTestCase(DbApiTestCase):
         self._validate_host(host_lookup_results["results"][0], host_data, expected_id=original_id)
 
 
-class BulkCreateHostsTestCase(DbApiTestCase):
+class BulkCreateHostsTestCase(DbApiBaseTestCase):
     def _get_valid_auth_header(self):
         return build_valid_auth_header()
 
@@ -784,7 +784,7 @@ class BulkCreateHostsTestCase(DbApiTestCase):
                 i += 1
 
 
-class CreateHostsWithSystemProfileTestCase(DbApiTestCase, PaginationBaseTestCase):
+class CreateHostsWithSystemProfileTestCase(DbApiBaseTestCase, PaginationBaseTestCase):
     def test_create_host_with_system_profile(self):
         facts = None
 
@@ -1012,7 +1012,7 @@ class CreateHostsWithSystemProfileTestCase(DbApiTestCase, PaginationBaseTestCase
                 self.verify_error_response(response, expected_title="Bad Request", expected_status=400)
 
 
-class CreateHostsWithStaleTimestampTestCase(DbApiTestCase):
+class CreateHostsWithStaleTimestampTestCase(DbApiBaseTestCase):
     def _add_host(self, expected_status, **values):
         host_data = HostWrapper(test_data(fqdn="match this host", **values))
         response = self.post(HOST_URL, [host_data.data()], 207)

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -6,14 +6,14 @@ from unittest.mock import patch
 
 from app.models import Host
 from lib.host_delete import delete_hosts
-from tests.test_api_utils import DbApiTestCase
+from tests.test_api_utils import DbApiBaseTestCase
 from tests.test_api_utils import generate_uuid
 from tests.test_api_utils import HOST_URL
 from tests.test_api_utils import PreCreatedHostsBaseTestCase
 from tests.test_delete_utils import DeleteHostsBaseTestCase
 
 
-class DeleteHostsErrorTestCase(DbApiTestCase):
+class DeleteHostsErrorTestCase(DbApiBaseTestCase):
     def test_delete_non_existent_host(self):
         url = HOST_URL + "/" + generate_uuid()
 

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -15,7 +15,7 @@ from app.serialization import serialize_host
 from app.utils import HostWrapper
 from lib.host_repository import canonical_fact_host_query
 from tests.test_api_utils import ACCOUNT
-from tests.test_api_utils import DbApiTestCase
+from tests.test_api_utils import DbApiBaseTestCase
 from tests.test_api_utils import generate_uuid
 from tests.test_api_utils import HOST_URL
 from tests.test_api_utils import inject_qs
@@ -254,7 +254,7 @@ class QueryByInsightsIdTestCase(PreCreatedHostsBaseTestCase):
 
 
 @patch("api.host_query_db.canonical_fact_host_query", wraps=canonical_fact_host_query)
-class QueryByCanonicalFactPerformanceTestCase(DbApiTestCase):
+class QueryByCanonicalFactPerformanceTestCase(DbApiBaseTestCase):
     def test_query_using_fqdn_not_subset_match(self, canonical_fact_host_query):
         fqdn = "some fqdn"
         self.get(f"{HOST_URL}?fqdn={fqdn}")

--- a/tests/test_api_management.py
+++ b/tests/test_api_management.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+from tempfile import TemporaryDirectory
+from unittest import main
+
+from tests.test_api_utils import ApiBaseTestCase
+from tests.test_utils import set_environment
+
+
+HEALTH_URL = "/health"
+METRICS_URL = "/metrics"
+VERSION_URL = "/version"
+
+
+class ManagementTestCase(ApiBaseTestCase):
+    """
+    Tests the health check endpoint.
+    """
+
+    def test_health(self):
+        """
+        The health check simply returns 200 to any GET request. The response body is
+        irrelevant.
+        """
+        response = self.client().get(HEALTH_URL)  # No identity header.
+        self.assertEqual(200, response.status_code)
+
+    def test_metrics(self):
+        """
+        The metrics endpoint simply returns 200 to any GET request.
+        """
+        with TemporaryDirectory() as temp_dir:
+            with set_environment({"prometheus_multiproc_dir": temp_dir}):
+                response = self.client().get(METRICS_URL)  # No identity header.
+                self.assertEqual(200, response.status_code)
+
+    def test_version(self):
+        response = self.get(VERSION_URL, 200)
+        assert response["version"] is not None
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import json
-import tempfile
 import uuid
 from base64 import b64encode
 from datetime import datetime
@@ -25,13 +24,9 @@ from app.environment import RuntimeEnvironment
 from app.queue.queue import handle_message
 from app.utils import HostWrapper
 from tests.test_utils import MockEventProducer
-from tests.test_utils import set_environment
 
 HOST_URL = "/api/inventory/v1/hosts"
 TAGS_URL = "/api/inventory/v1/tags"
-HEALTH_URL = "/health"
-METRICS_URL = "/metrics"
-VERSION_URL = "/version"
 
 NS = "testns"
 ID = "whoabuddy"
@@ -351,33 +346,6 @@ class PreCreatedHostsBaseTestCase(DbApiBaseTestCase, PaginationBaseTestCase):
             host_list.append(HostWrapper(host_data))
 
         return host_list
-
-
-class HealthTestCase(ApiBaseTestCase):
-    """
-    Tests the health check endpoint.
-    """
-
-    def test_health(self):
-        """
-        The health check simply returns 200 to any GET request. The response body is
-        irrelevant.
-        """
-        response = self.client().get(HEALTH_URL)  # No identity header.
-        self.assertEqual(200, response.status_code)
-
-    def test_metrics(self):
-        """
-        The metrics endpoint simply returns 200 to any GET request.
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            with set_environment({"prometheus_multiproc_dir": temp_dir}):
-                response = self.client().get(METRICS_URL)  # No identity header.
-                self.assertEqual(200, response.status_code)
-
-    def test_version(self):
-        response = self.get(VERSION_URL, 200)
-        assert response["version"] is not None
 
 
 if __name__ == "__main__":

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -176,7 +176,7 @@ class ApiBaseTestCase(TestCase):
             return response
 
 
-class DbApiTestCase(ApiBaseTestCase):
+class DbApiBaseTestCase(ApiBaseTestCase):
     @classmethod
     def setUpClass(cls):
         # create test database
@@ -271,7 +271,7 @@ class PaginationBaseTestCase(ApiBaseTestCase):
                     self.get(test_url, 400)
 
 
-class PreCreatedHostsBaseTestCase(DbApiTestCase, PaginationBaseTestCase):
+class PreCreatedHostsBaseTestCase(DbApiBaseTestCase, PaginationBaseTestCase):
     def setUp(self):
         super().setUp()
         self.added_hosts = self.create_hosts()

--- a/tests/test_culling.py
+++ b/tests/test_culling.py
@@ -12,7 +12,7 @@ from app import db
 from app.utils import HostWrapper
 from host_reaper import run as host_reaper_run
 from tests.test_api_utils import ACCOUNT
-from tests.test_api_utils import DbApiTestCase
+from tests.test_api_utils import DbApiBaseTestCase
 from tests.test_api_utils import generate_uuid
 from tests.test_api_utils import HOST_URL
 from tests.test_api_utils import now
@@ -22,7 +22,7 @@ from tests.test_delete_utils import DeleteHostsBaseTestCase
 from tests.test_utils import MockEventProducer
 
 
-class QueryStaleTimestampTestCase(DbApiTestCase):
+class QueryStaleTimestampTestCase(DbApiBaseTestCase):
     def test_with_stale_timestamp(self):
         def _assert_values(response_host):
             self.assertIn("stale_timestamp", response_host)

--- a/tests/test_culling_utils.py
+++ b/tests/test_culling_utils.py
@@ -5,7 +5,7 @@ from app.utils import HostWrapper
 from tests.test_api_utils import ACCOUNT
 from tests.test_api_utils import ApiBaseTestCase
 from tests.test_api_utils import db
-from tests.test_api_utils import DbApiTestCase
+from tests.test_api_utils import DbApiBaseTestCase
 from tests.test_api_utils import generate_uuid
 from tests.test_api_utils import HOST_URL
 from tests.test_api_utils import now
@@ -21,7 +21,7 @@ class CullingBaseTestCase(ApiBaseTestCase):
             db.session.commit()
 
 
-class HostStalenessBaseTestCase(DbApiTestCase, CullingBaseTestCase):
+class HostStalenessBaseTestCase(DbApiBaseTestCase, CullingBaseTestCase):
     def _create_host(self, stale_timestamp):
         data = {
             "account": ACCOUNT,

--- a/tests/test_delete_utils.py
+++ b/tests/test_delete_utils.py
@@ -2,11 +2,11 @@ from datetime import timezone
 from json import loads
 
 from app.models import Host
-from tests.test_api_utils import DbApiTestCase
+from tests.test_api_utils import DbApiBaseTestCase
 from tests.test_api_utils import HOST_URL
 
 
-class DeleteHostsBaseTestCase(DbApiTestCase):
+class DeleteHostsBaseTestCase(DbApiBaseTestCase):
     def _get_hosts(self, host_ids):
         url_part = ",".join(host_ids)
         return self.get(f"{HOST_URL}/{url_part}", 200)

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 from api.host_query_xjoin import QUERY as HOST_QUERY
 from api.tag import TAGS_QUERY
 from tests.test_api_utils import ApiBaseTestCase
-from tests.test_api_utils import DbApiTestCase
+from tests.test_api_utils import DbApiBaseTestCase
 from tests.test_api_utils import generate_uuid
 from tests.test_api_utils import HOST_URL
 from tests.test_api_utils import quote
@@ -1007,7 +1007,7 @@ class TagsResponseTestCase(ApiBaseTestCase):
         )
 
 
-class XjoinBulkSourceSwitchTestCaseEnvXjoin(DbApiTestCase):
+class XjoinBulkSourceSwitchTestCaseEnvXjoin(DbApiBaseTestCase):
     def setUp(self):
         with set_environment({"BULK_QUERY_SOURCE": "xjoin", "BULK_QUERY_SOURCE_BETA": "db"}):
             super().setUp()
@@ -1040,7 +1040,7 @@ class XjoinBulkSourceSwitchTestCaseEnvXjoin(DbApiTestCase):
         graphql_query.assert_called_once()
 
 
-class XjoinBulkSourceSwitchTestCaseEnvDb(DbApiTestCase):
+class XjoinBulkSourceSwitchTestCaseEnvDb(DbApiBaseTestCase):
     def setUp(self):
         with set_environment({"BULK_QUERY_SOURCE": "db", "BULK_QUERY_SOURCE_BETA": "xjoin"}):
             super().setUp()


### PR DESCRIPTION
Two little follow-up changes to #655.

- Consolidated abstract test names, so they all end with _BaseTestCase_.
- Extracted the Management test case from the Utils file.

The database locking should not be a problem. When an exception is raised, Pytest still tears down the fixtures gracefully. The problems happens only if the process is killed unconditionally before it even manages to do the teardown. Nothing we should care about.

Resolves [RHCLOUD-7870](https://projects.engineering.redhat.com/browse/RHCLOUD-7870), a subtask of [RHCLOUD-7076](https://projects.engineering.redhat.com/browse/RHCLOUD-7076).