### PR TITLE
Internal openapi references resolution

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,7 @@ from flask import current_app
 from flask import jsonify
 from flask import request
 from prance import ResolvingParser
+from prance.util.resolver import RESOLVE_FILES
 from prometheus_flask_exporter import PrometheusMetrics
 
 from api.mgmt import monitoring_blueprint
@@ -52,7 +53,7 @@ def create_app(runtime_environment):
     connexion_app = connexion.App("inventory", specification_dir="./swagger/", options=connexion_options)
 
     # Read the swagger.yml file to configure the endpoints
-    parser = ResolvingParser(SPECIFICATION_FILE)
+    parser = ResolvingParser(SPECIFICATION_FILE, resolve_types=RESOLVE_FILES)
     parser.parse()
 
     for api_url in app_config.api_urls:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -683,7 +683,7 @@ components:
           items:
             $ref: '#/components/schemas/FactSet'
         system_profile:
-          $ref: 'system_profile.spec.yaml#/$defs/SystemProfile'
+          $ref: '#/components/schemas/SystemProfile'
         stale_timestamp:
           description: Timestamp from which the host is considered stale.
           type: string
@@ -904,7 +904,7 @@ components:
         id:
           type: string
         system_profile:
-          $ref: 'system_profile.spec.yaml#/$defs/SystemProfile'
+          $ref: '#/components/schemas/SystemProfile'
     PatchHostIn:
       title: Host data
       description: >-
@@ -990,6 +990,8 @@ components:
     PerPage:
       type: integer
       description: The number of items to return per page
+    SystemProfile:
+      $ref: 'system_profile.spec.yaml#/$defs/SystemProfile'
   responses:
     PageOutOfBounds:
       description: Requested page is outside of the range of available pages


### PR DESCRIPTION
With the system profile schema separation we adopted a new lib to parse the swagger specification.

This new lib messed up the internal references on the generated openapi spec: https://qa.cloud.redhat.com/api/inventory/v1/openapi.json

To avoid this internal reference problem, let's make the lib explicitly only resolve references from files.