### PR TITLE
Remove tags from add_host log message

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -108,7 +108,6 @@ def add_host(host_data):
                         "canonical_facts": input_host.canonical_facts,
                         "reporter": input_host.reporter,
                         "stale_timestamp": input_host.stale_timestamp.isoformat(),
-                        "tags": input_host.tags,
                     }
                 },
             )


### PR DESCRIPTION
All of the fields in the "extra" dict passed in to the logger get
created as fields in Elasticsearch, recursively.  This means e.g. both
input_host.account and input_host.display_name are created as fields.

Each index in ES is configured by default to only allow 1024 fields due
to performances reasons.

Unfortunately this means that the whole tag hierarchy gets added as
fields as well.  A couple of the field names look like this:

input_host.tags.insights-client.ynJeCH
input_host.tags.insights-client.yvEXlrsP

Since it seems like every host creates a new field, we run out of fields
in our index every day.