### PR TITLE
Deploy to stage and/or production environments

### DIFF
--- a/utils/deploy.py
+++ b/utils/deploy.py
@@ -11,7 +11,8 @@ RESOURCE_TEMPLATES = ("insights-inventory-reaper", "insights-inventory-mq-servic
 TARGETS = {0: "prod", 1: "stage"}
 # Note: insights-host-delete resource template uses a different image. Not updated by this script.
 
-State = namedtuple("State", ("name", "target"))
+
+State = namedtuple("State", ("name", "target", "processed", "remaining"))
 
 
 def _parse_args():
@@ -32,30 +33,30 @@ sponge is part of moreutils""",
     return parser.parse_args()
 
 
-def _set_name(state, line, match, args):
-    return State(match[1], state.target), line
+def _set_name(name, target, line, match, args):
+    return match[1], target, line
 
 
-def _reset_target(state, line, match, args):
-    return State(state.name, None), line
+def _reset_target(name, target, line, match, args):
+    return name, None, line
 
 
-def _increment_target(state, line, match, args):
-    target = 0 if state.target is None else state.target + 1
-    return State(state.name, target), line
+def _increment_target(name, target, line, match, args):
+    target = 0 if target is None else target + 1
+    return name, target, line
 
 
-def _set_image_tag(state, original_line, match, args):
-    if state.name in RESOURCE_TEMPLATES and state.target is not None and TARGETS[state.target] in (args.targets or []):
+def _set_image_tag(name, target, original_line, match, args):
+    if name in RESOURCE_TEMPLATES and target is not None and TARGETS[target] in (args.targets or []):
         updated_line = f"{match[1]}{args.promo_code}"
     else:
         updated_line = original_line
 
-    return state, updated_line
+    return name, target, updated_line
 
 
-def _do_nothing(state, original_line, match, args):
-    return state, original_line
+def _do_nothing(name, target, line, match, args):
+    return name, target, line
 
 
 LINE_MATCHES = (
@@ -74,15 +75,19 @@ def _match_line(line):
     return _do_nothing, None
 
 
-def _deploy(original_yml, args):
-    updated_lines = []
-    state = State(None, None)
-    for original_line in original_yml.split("\n"):
-        func, match = _match_line(original_line)
-        state, updated_line = func(state, original_line, match, args)
-        updated_lines.append(updated_line)
+def _step(state, args):
+    current = state.remaining[0]
+    func, match = _match_line(current)
+    name, target, line = func(state.name, state.target, current, match, args)
+    return State(name, target, state.processed + [line], state.remaining[1:])
 
-    return "\n".join(updated_lines)
+
+def _deploy(original_yml, args):
+    state = State(None, None, [], original_yml.split("\n"))
+    while state.remaining:
+        state = _step(state, args)
+
+    return "\n".join(state.processed)
 
 
 def main(args, inp, outp):


### PR DESCRIPTION
Follow up to #693.

Added _-s/--stage_ and _-p/--prod_ switches to limit deployment only to the specified targets. If none is provided, no change is done. Provide both to deploy to both environments.

How to test:

1. `$ pipenv run python utils/deploy.py abc1234  < ../app-interface/data/services/insights/host-inventory/deploy.yml`
2. See that nothing changed.
3. `$ pipenv run python utils/deploy.py -s abc1234  < ../app-interface/data/services/insights/host-inventory/deploy.yml`
4. See that only staging deployments image tags changed.
5. `$ pipenv run python utils/deploy.py -p abc1234  < ../app-interface/data/services/insights/host-inventory/deploy.yml`
6. See that only production deployments image tags changed.
7. `$ pipenv run python utils/deploy.py -s -p abc1234  < ../app-interface/data/services/insights/host-inventory/deploy.yml`
8. See that both staging and production deployments image tags changed.