### PR TITLE
Use externalized schema for system profile validation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,6 +18,7 @@ from app.logging import configure_logging
 from app.logging import get_logger
 from app.logging import threadctx
 from app.models import db
+from app.models import SPECIFICATION_DIR
 from app.queue.event_producer import EventProducer
 from app.queue.event_producer import Topic
 from app.queue.events import EventType
@@ -31,7 +32,6 @@ IDENTITY_HEADER = "x-rh-identity"
 REQUEST_ID_HEADER = "x-rh-insights-request-id"
 UNKNOWN_REQUEST_ID_VALUE = "-1"
 
-SPECIFICATION_DIR = "./swagger/"
 SPECIFICATION_FILE = join(SPECIFICATION_DIR, "api.spec.yaml")
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -76,7 +76,7 @@ class SystemProfileNormalization:
         if schema_obj.type == cls.Schema.Types.object:
             cls._object_filter(schema_obj, payload)
         elif schema_obj.type == cls.Schema.Types.array:
-            cls._object_filter(schema_obj, payload)
+            cls._array_filter(schema_obj, payload)
 
     @classmethod
     def coerce_types(cls, schema_dict, payload):

--- a/app/models.py
+++ b/app/models.py
@@ -424,6 +424,10 @@ class MqHostSchema(BaseHostSchema):
         except JsonSchemaValidationError as error:
             raise MarshmallowValidationError(f"System profile does not conform to schema.\n{error}") from error
 
+        for dd_i, disk_device in enumerate(system_profile.get("disk_devices", [])):
+            if not check_empty_keys(disk_device.get("options")):
+                raise MarshmallowValidationError(f"Empty key in /system_profile/disk_devices/{dd_i}/options.")
+
 
 class HttpHostSchema(BaseHostSchema):
     system_profile = fields.Nested(SystemProfileSchema)

--- a/app/models.py
+++ b/app/models.py
@@ -64,18 +64,15 @@ class SystemProfileNormalization:
         Types = Enum("SchemaTypes", ("array", "object"))
 
         @property
-        def type(self):
-            type_str = self._asdict()["type"]
-            return self.Types[type_str] if type_str and type_str in self.Types.__members__.keys() else None
-
-    Schema.__new__.__defaults__ = (None,) * len(Schema._fields)
+        def schema_type(self):
+            return self.Types.__members__.get(self.type)
 
     @classmethod
     def filter_keys(cls, schema_dict, payload):
         schema_obj = cls._schema_from_dict(schema_dict)
-        if schema_obj.type == cls.Schema.Types.object:
+        if schema_obj.schema_type == cls.Schema.Types.object:
             cls._object_filter(schema_obj, payload)
-        elif schema_obj.type == cls.Schema.Types.array:
+        elif schema_obj.schema_type == cls.Schema.Types.array:
             cls._array_filter(schema_obj, payload)
 
     @classmethod
@@ -84,7 +81,7 @@ class SystemProfileNormalization:
 
     @classmethod
     def _schema_from_dict(cls, original):
-        filtered = {key: value for key, value in original.items() if key in cls.Schema._fields}
+        filtered = {key: original.get(key) for key in cls.Schema._fields}
         return cls.Schema(**filtered)
 
     @classmethod

--- a/app/models.py
+++ b/app/models.py
@@ -355,7 +355,7 @@ class SystemProfileSchema(Schema):
     installed_services = fields.List(fields.Str(validate=marshmallow_validate.Length(max=512)))
     enabled_services = fields.List(fields.Str(validate=marshmallow_validate.Length(max=512)))
     sap_system = fields.Bool()
-    sap_sids = fields.List(fields.Str(validate=validate.Length(max=3)))
+    sap_sids = fields.List(fields.Str(validate=marshmallow_validate.Length(max=3)))
 
 
 class FactsSchema(Schema):

--- a/app/models.py
+++ b/app/models.py
@@ -426,9 +426,9 @@ class MqHostSchema(BaseHostSchema):
 
     @validates("system_profile")
     def system_profile_is_valid(self, system_profile):
-        schema = self.system_profile_schema
+        schema = self.system_profile_schema()
         try:
-            jsonschema_validate(system_profile, schema())
+            jsonschema_validate(system_profile, schema)
         except JsonSchemaValidationError as error:
             raise MarshmallowValidationError(f"System profile does not conform to schema.\n{error}") from error
 

--- a/app/models.py
+++ b/app/models.py
@@ -412,9 +412,14 @@ class MqHostSchema(BaseHostSchema):
 
     @pre_load
     def coerce_system_profile(self, raw_data):
-        processed_data = deepcopy(raw_data)
-        coerce_type(self.system_profile_spec["$defs"]["SystemProfile"], processed_data["system_profile"], "property")
-        return processed_data
+        if "system_profile" in raw_data:
+            processed_data = deepcopy(raw_data)
+            coerce_type(
+                self.system_profile_spec["$defs"]["SystemProfile"], processed_data["system_profile"], "property"
+            )
+            return processed_data
+        else:
+            return raw_data
 
     @validates("system_profile")
     def system_profile_is_valid(self, system_profile):

--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -4,6 +4,7 @@ $schema: http://json-schema.org/draft-04/schema#
 $defs:
   DiskDevice:
     description: Representation of one mounted device
+    type: object
     properties:
       device:
         example: "/dev/fdd0"
@@ -18,6 +19,7 @@ $defs:
         example:
           uid: "0"
           ro: true
+        type: object
       mount_point:
         description: mount point
         example: "/mnt/remote_nfs_shares"
@@ -30,6 +32,7 @@ $defs:
         maxLength: 256
   YumRepo:
     description: Representation of one yum repository
+    type: object
     properties:
       id:
         type: string
@@ -47,6 +50,7 @@ $defs:
         maxLength: 2048
   DnfModule:
     description: Representation of one DNF module
+    type: object
     properties:
       name:
         type: string
@@ -56,6 +60,7 @@ $defs:
         maxLength: 2048
   InstalledProduct:
     description: Representation of one installed product
+    type: object
     properties:
       name:
         type: string
@@ -72,6 +77,7 @@ $defs:
         maxLength: 256
   NetworkInterface:
     description: Representation of one network interface
+    type: object
     properties:
       ipv4_addresses:
         type: array
@@ -109,6 +115,7 @@ $defs:
         maxLength: 18
   SystemProfile:
     description: Representation of the system profile fields
+    type: object
     properties:
       number_of_cpus:
         type: integer

--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -1,44 +1,44 @@
 ---
 $id: system_profile.spec.yaml
-$version: 1
+$schema: http://json-schema.org/draft-07/schema#
 $defs:
   DiskDevice:
-    title: Disk Device
     description: Representation of one mounted device
     properties:
       device:
         example: "/dev/fdd0"
         type: string
+        maxLength: 2048
       label:
         description: user-defined mount label
         type: string
+        maxLength: 1024
       options:
         description: mount options
         example:
           uid: "0"
           ro: true
-        type: object
-        properties:
-          name:
-            type: string
-          value:
-            type: string
+        propertyNames:
+          minLength: 1
       mount_point:
         description: mount point
         example: "/mnt/remote_nfs_shares"
         type: string
+        maxLength: 2048
       type:
         description: mount type
         example: "ext3"
         type: string
+        maxLength: 256
   YumRepo:
-    title: Yum Repository
     description: Representation of one yum repository
     properties:
       id:
         type: string
+        maxLength: 256
       name:
         type: string
+        maxLength: 1024
       gpgcheck:
         type: boolean
       enabled:
@@ -46,30 +46,33 @@ $defs:
       baseurl:
         type: string
         format: uri
+        maxLength: 2048
   DnfModule:
-    title: DNF Module
     description: Representation of one DNF module
     properties:
       name:
         type: string
+        maxLength: 128
       stream:
         type: string
+        maxLength: 2048
   InstalledProduct:
-    title: Installed Product
     description: Representation of one installed product
     properties:
       name:
         type: string
+        maxLength: 512
       id:
         description: the product ID
         example: "71"
         type: string
+        maxLength: 64
       status:
         description: subscription status for product
         example: "Subscribed"
         type: string
+        maxLength: 256
   NetworkInterface:
-    title: Network Interface
     description: Representation of one network interface
     properties:
       ipv4_addresses:
@@ -89,22 +92,25 @@ $defs:
         description: MAC address (with or without colons)
         example: "00:00:00:00:00:00"
         type: string
+        maxLength: 59
       name:
         description: name of interface
         type: string
         example: eth0
+        minLength: 1
+        maxLength: 50
       state:
         description: interface state (UP, DOWN, UNKNOWN)
         type: string
         example: "UP"
+        maxLength: 25
       type:
         description: interface type (ether, loopback)
         type: string
         example: "ether"
+        maxLength: 18
   SystemProfile:
-    title: System profile fields
     description: Representation of the system profile fields
-    type: object
     properties:
       number_of_cpus:
         type: integer
@@ -117,8 +123,10 @@ $defs:
         format: int64
       infrastructure_type:
         type: string
+        maxLength: 100
       infrastructure_vendor:
         type: string
+        maxLength: 100
       network_interfaces:
         type: array  # techincally a set, ordering is not important
         items:
@@ -129,42 +137,55 @@ $defs:
           $ref: '#/$defs/DiskDevice'
       bios_vendor:
         type: string
+        maxLength: 100
       bios_version:
         type: string
+        maxLength: 100
       bios_release_date:
         type: string
+        maxLength: 50
       cpu_flags:
         items:
           type: string
+          maxLength: 30
         type: array
       os_release:
         type: string
+        maxLength: 100
       os_kernel_version:
         type: string
+        maxLength: 100
       arch:
         type: string
+        maxLength: 50
       kernel_modules:
         type: array
         items:
           type: string
+          maxLength: 255
       last_boot_time:
         type: string
         format: date-time
+        maxLength: 50
       running_processes:
         type: array  # techincally a set, ordering is not important
         items:
           description: a single running process. This will be truncated to 1000 characters when saved.
           type: string
+          maxLength: 1000
       subscription_status:
         type: string
+        maxLength: 100
       subscription_auto_attach:
         type: string
+        maxLength: 100
       katello_agent_running:
         type: boolean
       satellite_managed:
         type: boolean
       cloud_provider:
         type: string
+        maxLength: 100
       yum_repos:
         type: array  # technically a set, ordering is not important
         items:
@@ -179,24 +200,30 @@ $defs:
           $ref: '#/$defs/InstalledProduct'
       insights_client_version:
         type: string
+        maxLength: 50
       insights_egg_version:
         type: string
+        maxLength: 50
       captured_date:
         type: string
+        maxLength: 32
       installed_packages:
         type: array  # technically a set, ordering is not important
         items:
           description: a NEVRA string for a single installed package
           type: string
           example: "krb5-libs-0:-1.16.1-23.fc29.i686"
+          maxLength: 512
       installed_services:
         type: array
         items:
           type: string
+          maxLength: 512
       enabled_services:
         type: array
         items:
           type: string
+          maxLength: 512
       sap_system:
         type: boolean
         description: Indicates if SAP is installed on the system

--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -1,6 +1,6 @@
 ---
 $id: system_profile.spec.yaml
-$schema: http://json-schema.org/draft-07/schema#
+$schema: http://json-schema.org/draft-04/schema#
 $defs:
   DiskDevice:
     description: Representation of one mounted device
@@ -18,8 +18,6 @@ $defs:
         example:
           uid: "0"
           ro: true
-        propertyNames:
-          minLength: 1
       mount_point:
         description: mount point
         example: "/mnt/remote_nfs_shares"

--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -236,4 +236,8 @@ $defs:
         type: array
         description: list of SAP SIDs
         items:
+          description: The SAP system ID (SID)
           type: string
+          example: "H2O"
+          maxLength: 3
+          pattern: '^[A-Z][A-Z0-9]{2}$'

--- a/tests/test_api_hosts_create.py
+++ b/tests/test_api_hosts_create.py
@@ -704,16 +704,9 @@ def test_create_host_with_too_long_mac_address(api_create_or_update_host):
     system_profile = {
         "network_interfaces": [{"mac_address": "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00:11:22:33:44"}]
     }
-
     host = minimal_host(system_profile=system_profile)
-
     multi_response_status, multi_response_data = api_create_or_update_host([host])
-
-    assert_response_status(multi_response_status, 207)
-
-    host_response = get_host_from_multi_response(multi_response_data)
-
-    assert_error_response(host_response, expected_title="Bad Request", expected_status=400)
+    assert_response_status(multi_response_status, 400)
 
 
 @pytest.mark.parametrize(
@@ -941,15 +934,8 @@ def test_create_host_with_null_system_profile(api_create_or_update_host):
 )
 def test_create_host_with_system_profile_with_invalid_data(api_create_or_update_host, api_get, system_profile):
     host = minimal_host(system_profile=system_profile)
-
-    # Create the host
     multi_response_status, multi_response_data = api_create_or_update_host([host])
-
-    assert_response_status(multi_response_status, 207)
-
-    host_response = get_host_from_multi_response(multi_response_data)
-
-    assert_error_response(host_response, expected_title="Bad Request", expected_status=400)
+    assert_response_status(multi_response_status, 400)
 
 
 @pytest.mark.system_profile

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -426,6 +426,14 @@ def test_add_host_not_marshmallow_system_profile(mocker, mq_create_or_update_hos
 
 
 def test_add_host_externalized_system_profile(mocker, mq_create_or_update_host):
+    def reset_schema():
+        try:
+            delattr(MqHostSchema, "_system_profile_schema")
+        except AttributeError:
+            pass
+
+    reset_schema()
+
     orig_file_name = join(SPECIFICATION_DIR, SYSTEM_PROFILE_SPECIFICATION_FILE)
     with open(orig_file_name) as orig_file:
         orig_spec = safe_load(orig_file)
@@ -441,6 +449,8 @@ def test_add_host_externalized_system_profile(mocker, mq_create_or_update_host):
 
         with pytest.raises(ValidationException):
             mq_create_or_update_host(host_to_create)
+
+    reset_schema()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -414,6 +414,18 @@ def test_add_host_type_coercion_system_profile(mq_create_or_update_host):
     assert created_host.system_profile["number_of_cpus"] == 1
 
 
+def test_add_host_key_filtering_system_profile(mq_create_or_update_host):
+    host_to_create = minimal_host(
+        system_profile={
+            "number_of_cpus": 1,
+            "number_of_gpus": 2,
+            "disk_devices": [{"options": {"uid": "0"}, "mount_options": {"ro": True}}],
+        }
+    )
+    created_host = mq_create_or_update_host(host_to_create)
+    assert created_host.system_profile == {"number_of_cpus": 1, "disk_devices": [{"options": {"uid": "0"}}]}
+
+
 def test_add_host_not_marshmallow_system_profile(mocker, mq_create_or_update_host):
     mock_deserialize_host = partial(mocker.Mock, wraps=deserialize_host)
     mock = mocker.patch("app.serialization.deserialize_host", new_callable=mock_deserialize_host)

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -434,23 +434,24 @@ def test_add_host_externalized_system_profile(mocker, mq_create_or_update_host):
 
     reset_schema()
 
-    orig_file_name = join(SPECIFICATION_DIR, SYSTEM_PROFILE_SPECIFICATION_FILE)
-    with open(orig_file_name) as orig_file:
-        orig_spec = safe_load(orig_file)
+    try:
+        orig_file_name = join(SPECIFICATION_DIR, SYSTEM_PROFILE_SPECIFICATION_FILE)
+        with open(orig_file_name) as orig_file:
+            orig_spec = safe_load(orig_file)
 
-    fake_spec = deepcopy(orig_spec)
-    fake_spec["$defs"]["SystemProfile"]["properties"]["number_of_cpus"]["minimum"] = 2
+        fake_spec = deepcopy(orig_spec)
+        fake_spec["$defs"]["SystemProfile"]["properties"]["number_of_cpus"]["minimum"] = 2
 
-    with NamedTemporaryFile("w+") as temp_file:
-        safe_dump(fake_spec, temp_file)
-        mocker.patch("app.models.SYSTEM_PROFILE_SPECIFICATION_FILE", temp_file.name)
+        with NamedTemporaryFile("w+") as temp_file:
+            safe_dump(fake_spec, temp_file)
+            mocker.patch("app.models.SYSTEM_PROFILE_SPECIFICATION_FILE", temp_file.name)
 
-        host_to_create = minimal_host(system_profile={"number_of_cpus": 1})
+            host_to_create = minimal_host(system_profile={"number_of_cpus": 1})
 
-        with pytest.raises(ValidationException):
-            mq_create_or_update_host(host_to_create)
-
-    reset_schema()
+            with pytest.raises(ValidationException):
+                mq_create_or_update_host(host_to_create)
+    finally:
+        reset_schema()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -340,13 +340,68 @@ def test_add_host_with_invalid_tags(tag, mq_create_or_update_host):
         mq_create_or_update_host(host)
 
 
+@pytest.mark.system_profile
 def test_add_host_empty_keys_system_profile(mq_create_or_update_host):
-    insights_id = generate_uuid()
     system_profile = {"disk_devices": [{"options": {"": "invalid"}}]}
-    host = minimal_host(insights_id=insights_id, system_profile=system_profile)
+    host = minimal_host(system_profile=system_profile)
 
     with pytest.raises(ValidationException):
         mq_create_or_update_host(host)
+
+
+@pytest.mark.parametrize(
+    ("system_profile",),
+    (
+        ({"infrastructure_type": "x" * 101},),
+        ({"infrastructure_vendor": "x" * 101},),
+        ({"network_interfaces": [{"mac_address": "x" * 60}]},),
+        ({"network_interfaces": [{"name": "x" * 51}]},),
+        ({"network_interfaces": [{"state": "x" * 26}]},),
+        ({"network_interfaces": [{"type": "x" * 19}]},),
+        ({"disk_devices": [{"device": "x" * 2049}]},),
+        ({"disk_devices": [{"label": "x" * 1025}]},),
+        ({"disk_devices": [{"mount_point": "x" * 2049}]},),
+        ({"disk_devices": [{"type": "x" * 257}]},),
+        ({"bios_vendor": "x" * 101},),
+        ({"bios_version": "x" * 101},),
+        ({"bios_release_date": "x" * 51},),
+        ({"cpu_flags": ["x" * 31]},),
+        ({"os_release": "x" * 101},),
+        ({"os_kernel_version": "x" * 101},),
+        ({"arch": "x" * 51},),
+        ({"kernel_modules": ["x" * 256]},),
+        ({"last_boot_time": ["x" * 51]},),
+        ({"running_processes": ["x" * 1001]},),
+        ({"subscription_status": ["x" * 101]},),
+        ({"cloud_provider": ["x" * 101]},),
+        ({"yum_repos": [{"id": "x" * 257}]},),
+        ({"yum_repos": [{"name": "x" * 1025}]},),
+        ({"yum_repos": [{"baseurl": "x" * 2049}]},),
+        ({"dnf_modules": [{"name": "x" * 129}]},),
+        ({"dnf_modules": [{"stream": "x" * 2049}]},),
+        ({"installed_products": [{"name": "x" * 513}]},),
+        ({"installed_products": [{"id": "x" * 65}]},),
+        ({"installed_products": [{"status": "x" * 257}]},),
+        ({"insights_client_version": "x" * 51},),
+        ({"insights_egg_version": "x" * 51},),
+        ({"captured_date": "x" * 33},),
+        ({"installed_packages": ["x" * 513]},),
+        ({"installed_services": ["x" * 513]},),
+        ({"enabled_services": ["x" * 513]},),
+    ),
+)
+def test_add_host_long_strings_system_profile(mq_create_or_update_host, system_profile):
+    host = minimal_host(system_profile=system_profile)
+
+    with pytest.raises(ValidationException):
+        mq_create_or_update_host(host)
+
+
+def test_add_host_type_coercion_system_profile(mq_create_or_update_host):
+    host_to_create = minimal_host(system_profile={"number_of_cpus": "1"})
+    created_host = mq_create_or_update_host(host_to_create)
+    assert type(created_host.system_profile["number_of_cpus"]) is int
+    assert created_host.system_profile["number_of_cpus"] == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from datetime import timedelta
+from functools import partial
 
 import marshmallow
 import pytest
@@ -9,10 +10,12 @@ from sqlalchemy import null
 from app import db
 from app.exceptions import InventoryException
 from app.exceptions import ValidationException
+from app.models import MqHostSchema
 from app.queue.event_producer import Topic
 from app.queue.queue import _validate_json_object_for_utf8
 from app.queue.queue import event_loop
 from app.queue.queue import handle_message
+from app.serialization import deserialize_host
 from lib.host_repository import AddHostResult
 from tests.helpers.mq_utils import assert_mq_host_data
 from tests.helpers.mq_utils import expected_headers
@@ -402,6 +405,17 @@ def test_add_host_type_coercion_system_profile(mq_create_or_update_host):
     created_host = mq_create_or_update_host(host_to_create)
     assert type(created_host.system_profile["number_of_cpus"]) is int
     assert created_host.system_profile["number_of_cpus"] == 1
+
+
+def test_add_host_not_marshmallow_system_profile(mocker, mq_create_or_update_host):
+    mock_deserialize_host = partial(mocker.Mock, wraps=deserialize_host)
+    mock = mocker.patch("app.serialization.deserialize_host", new_callable=mock_deserialize_host)
+
+    host_to_create = minimal_host(system_profile={"number_of_cpus": 1})
+    mq_create_or_update_host(host_to_create)
+    mock.assert_called_once_with(mocker.ANY, MqHostSchema)
+
+    assert type(MqHostSchema._declared_fields["system_profile"]) is not marshmallow.fields.Nested
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -33,10 +33,10 @@ from app.environment import RuntimeEnvironment
 from app.exceptions import InputFormatException
 from app.exceptions import ValidationException
 from app.logging import threadctx
-from app.models import FilterKeys
 from app.models import Host
 from app.models import HttpHostSchema
 from app.models import MqHostSchema
+from app.models import SystemProfileNormalization
 from app.queue.event_producer import EventProducer
 from app.queue.event_producer import logger as event_producer_logger
 from app.queue.event_producer import Topic
@@ -1766,13 +1766,13 @@ class ModelsFilterKeysTestCase(TestCase):
         schema = {"type": "object", "properties": {"number_of_cpus": {"type": "integer"}}}
         payload = {"number_of_cpus": 1}
         original = deepcopy(payload)
-        FilterKeys(schema)(payload)
+        SystemProfileNormalization.filter_keys(schema, payload)
         self.assertEqual(original, payload)
 
     def test_root_keys_are_removed(self):
         schema = {"type": "object", "properties": {"number_of_cpus": {"type": "integer"}}}
         payload = {"number_of_cpus": 1, "number_of_sockets": 2}
-        FilterKeys(schema)(payload)
+        SystemProfileNormalization.filter_keys(schema, payload)
         expected = {"number_of_cpus": 1}
         self.assertEqual(expected, payload)
 
@@ -1787,7 +1787,7 @@ class ModelsFilterKeysTestCase(TestCase):
             },
         }
         payload = {"network_interfaces": [{"ipv4_addresses": [], "ipv6_addresses": []}]}
-        FilterKeys(schema)(payload)
+        SystemProfileNormalization.filter_keys(schema, payload)
         expected = {"network_interfaces": [{"ipv4_addresses": []}]}
         self.assertEqual(expected, payload)
 
@@ -1795,7 +1795,7 @@ class ModelsFilterKeysTestCase(TestCase):
         schema = {"properties": {"number_of_cpus": {"type": "integer"}}}
         payload = {"number_of_cpus": 1, "number_of_sockets": 2}
         original = deepcopy(payload)
-        FilterKeys(schema)(payload)
+        SystemProfileNormalization.filter_keys(schema, payload)
         self.assertEqual(original, payload)
 
     def test_non_object_keys_in_array_items_are_removed(self):
@@ -1809,7 +1809,7 @@ class ModelsFilterKeysTestCase(TestCase):
             },
         }
         payload = {"network_interfaces": [{"ipv4_addresses": [], "ipv6_addresses": []}]}
-        FilterKeys(schema)(payload)
+        SystemProfileNormalization.filter_keys(schema, payload)
         expected = {"network_interfaces": [{"ipv4_addresses": []}]}
         self.assertEqual(expected, payload)
 
@@ -1825,21 +1825,21 @@ class ModelsFilterKeysTestCase(TestCase):
         }
         payload = {"network_interfaces": [{"ipv4_addresses": ["10.0.0.1"]}]}
         original = deepcopy(payload)
-        FilterKeys(schema)(payload)
+        SystemProfileNormalization.filter_keys(schema, payload)
         self.assertEqual(original, payload)
 
     def test_root_object_keys_without_properties_are_kept(self):
         schema = {"type": "object"}
         payload = {"number_of_cpus": 1}
         original = deepcopy(payload)
-        FilterKeys(schema)(payload)
+        SystemProfileNormalization.filter_keys(schema, payload)
         self.assertEqual(original, payload)
 
     def test_root_object_keys_without_type_are_kept(self):
         schema = {"properties": {"number_of_sockets": {"type": "integer"}}}
         payload = {"number_of_cpus": 1}
         original = deepcopy(payload)
-        FilterKeys(schema)(payload)
+        SystemProfileNormalization.filter_keys(schema, payload)
         self.assertEqual(original, payload)
 
     def test_nested_object_items_without_properties_are_kept(self):
@@ -1854,7 +1854,7 @@ class ModelsFilterKeysTestCase(TestCase):
         }
         payload = {"disk_devices": [{"options": {"uid": "0", "ro": True}}]}
         original = deepcopy(payload)
-        FilterKeys(schema)(payload)
+        SystemProfileNormalization.filter_keys(schema, payload)
         self.assertEqual(original, payload)
 
     def test_additional_properties_are_ignored(self):
@@ -1863,7 +1863,7 @@ class ModelsFilterKeysTestCase(TestCase):
             "properties": {"number_of_sockets": {"type": "integer"}, "additionalProperties": {"type": "integer"}},
         }
         payload = {"number_of_cpus": 1}
-        FilterKeys(schema)(payload)
+        SystemProfileNormalization.filter_keys(schema, payload)
         self.assertEqual({}, payload)
 
     def test_required_properties_are_ignored(self):
@@ -1873,7 +1873,7 @@ class ModelsFilterKeysTestCase(TestCase):
             "properties": {"number_of_sockets": {"type": "integer"}},
         }
         payload = {"number_of_cpus": 1}
-        FilterKeys(schema)(payload)
+        SystemProfileNormalization.filter_keys(schema, payload)
         self.assertEqual({}, payload)
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from base64 import b64encode
+from copy import deepcopy
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -32,7 +33,7 @@ from app.environment import RuntimeEnvironment
 from app.exceptions import InputFormatException
 from app.exceptions import ValidationException
 from app.logging import threadctx
-from app.models import _filter_keys
+from app.models import FilterKeys
 from app.models import Host
 from app.models import HttpHostSchema
 from app.models import MqHostSchema
@@ -1764,15 +1765,16 @@ class ModelsFilterKeysTestCase(TestCase):
     def test_no_keys_are_removed(self):
         schema = {"type": "object", "properties": {"number_of_cpus": {"type": "integer"}}}
         payload = {"number_of_cpus": 1}
-        actual = _filter_keys(schema, payload)
-        self.assertEqual(payload, actual)
+        original = deepcopy(payload)
+        FilterKeys(schema)(payload)
+        self.assertEqual(original, payload)
 
     def test_root_keys_are_removed(self):
         schema = {"type": "object", "properties": {"number_of_cpus": {"type": "integer"}}}
         payload = {"number_of_cpus": 1, "number_of_sockets": 2}
-        actual = _filter_keys(schema, payload)
+        FilterKeys(schema)(payload)
         expected = {"number_of_cpus": 1}
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected, payload)
 
     def test_keys_in_array_items_are_removed(self):
         schema = {
@@ -1785,26 +1787,31 @@ class ModelsFilterKeysTestCase(TestCase):
             },
         }
         payload = {"network_interfaces": [{"ipv4_addresses": [], "ipv6_addresses": []}]}
-        actual = _filter_keys(schema, payload)
+        FilterKeys(schema)(payload)
         expected = {"network_interfaces": [{"ipv4_addresses": []}]}
-        self.assertEqual(expected, actual)
+        self.assertEqual(expected, payload)
 
     def test_root_non_object_keys_are_kept(self):
         schema = {"properties": {"number_of_cpus": {"type": "integer"}}}
         payload = {"number_of_cpus": 1, "number_of_sockets": 2}
-        actual = _filter_keys(schema, payload)
-        self.assertEqual(payload, actual)
+        original = deepcopy(payload)
+        FilterKeys(schema)(payload)
+        self.assertEqual(original, payload)
 
     def test_non_object_keys_in_array_items_are_removed(self):
         schema = {
             "type": "object",
             "properties": {
-                "network_interfaces": {"type": "array", "items": {"properties": {"ipv4_addresses": {"type": "array"}}}}
+                "network_interfaces": {
+                    "type": "array",
+                    "items": {"type": "object", "properties": {"ipv4_addresses": {"type": "array"}}},
+                }
             },
         }
         payload = {"network_interfaces": [{"ipv4_addresses": [], "ipv6_addresses": []}]}
-        actual = _filter_keys(schema, payload)
-        self.assertEqual(payload, actual)
+        FilterKeys(schema)(payload)
+        expected = {"network_interfaces": [{"ipv4_addresses": []}]}
+        self.assertEqual(expected, payload)
 
     def test_non_object_array_items_are_kept(self):
         schema = {
@@ -1817,14 +1824,23 @@ class ModelsFilterKeysTestCase(TestCase):
             },
         }
         payload = {"network_interfaces": [{"ipv4_addresses": ["10.0.0.1"]}]}
-        actual = _filter_keys(schema, payload)
-        self.assertEqual(payload, actual)
+        original = deepcopy(payload)
+        FilterKeys(schema)(payload)
+        self.assertEqual(original, payload)
 
-    def test_root_object_items_without_properties_are_kept(self):
+    def test_root_object_keys_without_properties_are_kept(self):
         schema = {"type": "object"}
         payload = {"number_of_cpus": 1}
-        actual = _filter_keys(schema, payload)
-        self.assertEqual(payload, actual)
+        original = deepcopy(payload)
+        FilterKeys(schema)(payload)
+        self.assertEqual(original, payload)
+
+    def test_root_object_keys_without_type_are_kept(self):
+        schema = {"properties": {"number_of_sockets": {"type": "integer"}}}
+        payload = {"number_of_cpus": 1}
+        original = deepcopy(payload)
+        FilterKeys(schema)(payload)
+        self.assertEqual(original, payload)
 
     def test_nested_object_items_without_properties_are_kept(self):
         schema = {
@@ -1837,8 +1853,9 @@ class ModelsFilterKeysTestCase(TestCase):
             },
         }
         payload = {"disk_devices": [{"options": {"uid": "0", "ro": True}}]}
-        actual = _filter_keys(schema, payload)
-        self.assertEqual(payload, actual)
+        original = deepcopy(payload)
+        FilterKeys(schema)(payload)
+        self.assertEqual(original, payload)
 
     def test_additional_properties_are_ignored(self):
         schema = {
@@ -1846,8 +1863,8 @@ class ModelsFilterKeysTestCase(TestCase):
             "properties": {"number_of_sockets": {"type": "integer"}, "additionalProperties": {"type": "integer"}},
         }
         payload = {"number_of_cpus": 1}
-        actual = _filter_keys(schema, payload)
-        self.assertEqual({}, actual)
+        FilterKeys(schema)(payload)
+        self.assertEqual({}, payload)
 
     def test_required_properties_are_ignored(self):
         schema = {
@@ -1856,8 +1873,8 @@ class ModelsFilterKeysTestCase(TestCase):
             "properties": {"number_of_sockets": {"type": "integer"}},
         }
         payload = {"number_of_cpus": 1}
-        actual = _filter_keys(schema, payload)
-        self.assertEqual({}, actual)
+        FilterKeys(schema)(payload)
+        self.assertEqual({}, payload)
 
 
 if __name__ == "__main__":

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -373,7 +373,7 @@ def rpm_list():
 
 def create_system_profile():
     return {
-        "number_of_cpus": "1",
+        "number_of_cpus": 1,
         "number_of_sockets": 2,
         "cores_per_socket": 4,
         "system_memory_bytes": 1024,

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -372,11 +372,11 @@ def rpm_list():
 
 def create_system_profile():
     return {
-        "number_of_cpus": 1,
+        "number_of_cpus": "1",
         "number_of_sockets": 2,
         "cores_per_socket": 4,
         "system_memory_bytes": 1024,
-        "infrastructure_type": "jingleheimer junction cpu",
+        "infrastructure_type": "jingleheimer junction cpu" * 4,
         "infrastructure_vendor": "dell",
         "network_interfaces": [
             {

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -376,7 +376,7 @@ def create_system_profile():
         "number_of_sockets": 2,
         "cores_per_socket": 4,
         "system_memory_bytes": 1024,
-        "infrastructure_type": "jingleheimer junction cpu" * 4,
+        "infrastructure_type": "jingleheimer junction cpu",
         "infrastructure_vendor": "dell",
         "network_interfaces": [
             {


### PR DESCRIPTION
Message Queue API Ingress uses externalized System Profile schema for validation. The schema has been updated to the [current version](https://github.com/RedHatInsights/inventory-schemas/blob/b4436190454610e93e2d73815d2510e15e817196/schemas/system_profile/v1.yaml) with all Marshmallow constrains included.

There are however some changes, so the schema can be easily used:

* Schema version downgraded to Draft 4 so it is compatible with Connexion that uses the file too.
* The recursive _NestedObject_ definition has been removed. It is not compatible with JSON Schema Draft 4. Empty key validation is done manually.
* Object types are explicitly defined, so Connexion’s type coercion used by our custom validation works properly. There is already a PR to fix this.