### PR TITLE
Kafka producer additions

### DIFF
--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -8,7 +8,8 @@ from ttictoc import TicToc
 
 HOST_INGRESS_TOPIC = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
 BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
-NUM_HOSTS = os.environ.get("NUM_HOSTS", 1)
+NUM_HOSTS = int(os.environ.get("NUM_HOSTS", 1))
+
 
 def main():
     # Create list of host payloads to add to the message queue

--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -8,9 +8,7 @@ from ttictoc import TicToc
 
 HOST_INGRESS_TOPIC = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
 BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
-
-NUM_HOSTS = 1
-
+NUM_HOSTS = os.environ.get("NUM_HOSTS", 1)
 
 def main():
     # Create list of host payloads to add to the message queue

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -1,6 +1,6 @@
 import json
-import uuid
 import os
+import uuid
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -508,7 +508,7 @@ def random_uuid():
 
 def build_host_chunk():
     account = os.environ.get("INVENTORY_HOST_ACCOUNT", "0000001")
-    fqdn = random_uuid() + ".foo.redhat.com"
+    fqdn = random_uuid()[:6] + ".foo.redhat.com"
     payload = {
         "account": account,
         "insights_id": random_uuid(),

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -506,7 +506,7 @@ def random_uuid():
 
 
 def build_host_chunk():
-    fqdn = "fred.flintstone.com"
+    fqdn = random_uuid() + ".foo.redhat.com"
     payload = {
         "account": "0000001",
         "insights_id": random_uuid(),

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+import os
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -506,9 +507,10 @@ def random_uuid():
 
 
 def build_host_chunk():
+    account = os.environ.get("INVENTORY_HOST_ACCOUNT", "0000001")
     fqdn = random_uuid() + ".foo.redhat.com"
     payload = {
-        "account": "0000001",
+        "account": account,
         "insights_id": random_uuid(),
         "bios_uuid": random_uuid(),
         "fqdn": fqdn,


### PR DESCRIPTION
This makes a few adjustments to the Kafka producer to generate hosts to be created in the inventory.

It allows to set the number of hosts as well as the account they should be created for.
It also uses the random uuid to not have them all be named the same.