### PR TITLE
RHCLOUD-8795 use "dependency" instead of "service" as the label name …

### DIFF
--- a/api/metrics.py
+++ b/api/metrics.py
@@ -15,5 +15,5 @@ rest_post_request_count = Counter(
 outbound_http_response_time = Histogram(
     "inventory_outbound_http_response_time_seconds",
     "Time spent waiting for an external service to respond",
-    ["service"],
+    ["dependency"],
 )


### PR DESCRIPTION
…as "service" is reserved (and gets overridden) by prometheus

https://projects.engineering.redhat.com/browse/RHCLOUD-8795