### PR TITLE
Expand the rbac permissions

### DIFF
--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -71,11 +71,14 @@ def rbac(required_permission):
 
             rbac_data = get_rbac_permissions()
 
+            permission_type = required_permission.value.split(":")[2]
+
             for rbac_permission in rbac_data:
                 if (
-                    rbac_permission["permission"] == Permission.ADMIN.value
-                    or rbac_permission["permission"] == Permission.HOSTS_ALL.value
-                    or rbac_permission["permission"] == required_permission.value
+                    rbac_permission["permission"] == Permission.ADMIN.value # inventory:*:*
+                    or rbac_permission["permission"] == Permission.HOSTS_ALL.value # inventory:hosts:*
+                    or rbac_permission["permission"] == f"inventory:*:{permission_type}" # inventory:*:(read | write)
+                    or rbac_permission["permission"] == required_permission.value # inventory:hosts:(read | write)
                 ):
                     return func(*args, **kwargs)
 

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -75,10 +75,10 @@ def rbac(required_permission):
 
             for rbac_permission in rbac_data:
                 if (
-                    rbac_permission["permission"] == Permission.ADMIN.value # inventory:*:*
-                    or rbac_permission["permission"] == Permission.HOSTS_ALL.value # inventory:hosts:*
-                    or rbac_permission["permission"] == f"inventory:*:{permission_type}" # inventory:*:(read | write)
-                    or rbac_permission["permission"] == required_permission.value # inventory:hosts:(read | write)
+                    rbac_permission["permission"] == Permission.ADMIN.value  # inventory:*:*
+                    or rbac_permission["permission"] == Permission.HOSTS_ALL.value  # inventory:hosts:*
+                    or rbac_permission["permission"] == f"inventory:*:{permission_type}"  # inventory:*:(read | write)
+                    or rbac_permission["permission"] == required_permission.value  # inventory:hosts:(read | write)
                 ):
                     return func(*args, **kwargs)
 

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -58,6 +58,7 @@ READ_ALLOWED_RBAC_RESPONSE_FILES = (
 READ_PROHIBITED_RBAC_RESPONSE_FILES = (
     "utils/rbac-mock-data/inv-none.json",
     "utils/rbac-mock-data/inv-write-only.json",
+    "utils/rbac-mock-data/inv-star-write.json",
 )
 WRITE_ALLOWED_RBAC_RESPONSE_FILES = (
     "utils/rbac-mock-data/inv-read-write.json",
@@ -69,6 +70,7 @@ WRITE_ALLOWED_RBAC_RESPONSE_FILES = (
 WRITE_PROHIBITED_RBAC_RESPONSE_FILES = (
     "utils/rbac-mock-data/inv-none.json",
     "utils/rbac-mock-data/inv-read-only.json",
+    "utils/rbac-mock-data/inv-star-read.json",
 )
 
 

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -53,6 +53,7 @@ READ_ALLOWED_RBAC_RESPONSE_FILES = (
     "utils/rbac-mock-data/inv-read-only.json",
     "utils/rbac-mock-data/inv-admin.json",
     "utils/rbac-mock-data/inv-hosts-splat.json",
+    "utils/rbac-mock-data/inv-star-read.json",
 )
 READ_PROHIBITED_RBAC_RESPONSE_FILES = (
     "utils/rbac-mock-data/inv-none.json",

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -64,6 +64,7 @@ WRITE_ALLOWED_RBAC_RESPONSE_FILES = (
     "utils/rbac-mock-data/inv-write-only.json",
     "utils/rbac-mock-data/inv-admin.json",
     "utils/rbac-mock-data/inv-hosts-splat.json",
+    "utils/rbac-mock-data/inv-star-write.json",
 )
 WRITE_PROHIBITED_RBAC_RESPONSE_FILES = (
     "utils/rbac-mock-data/inv-none.json",

--- a/utils/rbac-mock-data/inv-star-read.json
+++ b/utils/rbac-mock-data/inv-star-read.json
@@ -1,0 +1,19 @@
+{
+  "meta": {
+      "count": 1,
+      "limit": 1000,
+      "offset": 0
+  },
+  "links": {
+      "first": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0",
+      "next": null,
+      "previous": null,
+      "last": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0"
+  },
+  "data": [
+      {
+          "resourceDefinitions": [],
+          "permission": "inventory:*:read"
+      }
+  ]
+}

--- a/utils/rbac-mock-data/inv-star-write.json
+++ b/utils/rbac-mock-data/inv-star-write.json
@@ -1,0 +1,19 @@
+{
+  "meta": {
+      "count": 1,
+      "limit": 1000,
+      "offset": 0
+  },
+  "links": {
+      "first": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0",
+      "next": null,
+      "previous": null,
+      "last": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0"
+  },
+  "data": [
+      {
+          "resourceDefinitions": [],
+          "permission": "inventory:*:write"
+      }
+  ]
+}


### PR DESCRIPTION
[Companion change to config](https://github.com/RedHatInsights/rbac-config/pull/95)

This adds support for permissions like `inventory:*:read`