### PR TITLE
Ultra-Light Check-In

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -449,9 +449,9 @@ def _build_paginated_host_tags_response(total, page, per_page, tags_list):
 @metrics.api_request_time.time()
 def host_checkin(body):
     facts = body.get("canonical_facts")
-    staleness_offset = body.get("staleness_offset")
+    checkin_frequency = body.get("checkin_frequency")
     config = CullingConfig(
-        stale_warning_offset_delta=timedelta(minutes=staleness_offset),
+        stale_warning_offset_delta=timedelta(minutes=checkin_frequency),
         culled_offset_delta=inventory_config().culling_culled_offset_delta,
     )
     timestamps = Timestamps(config)

--- a/api/host.py
+++ b/api/host.py
@@ -449,7 +449,7 @@ def _build_paginated_host_tags_response(total, page, per_page, tags_list):
 @metrics.api_request_time.time()
 def host_checkin(body):
     facts = body.get("canonical_facts")
-    checkin_frequency = body.get("checkin_frequency")
+    checkin_frequency = body.get("checkin_frequency") or 1440
     config = CullingConfig(
         stale_warning_offset_delta=timedelta(minutes=checkin_frequency),
         culled_offset_delta=inventory_config().culling_culled_offset_delta,

--- a/api/host.py
+++ b/api/host.py
@@ -445,7 +445,6 @@ def _build_paginated_host_tags_response(total, page, per_page, tags_list):
 @rbac(Permission.WRITE)
 @metrics.api_request_time.time()
 def add_host_checkin(body):
-    # Get fields from body
     facts = body.get("canonical_facts")
     staleness_offset = body.get("staleness_offset")
     return update_host_staleness(current_identity.account_number, facts, staleness_offset)

--- a/api/host.py
+++ b/api/host.py
@@ -44,6 +44,7 @@ from lib.host_delete import delete_hosts
 from lib.host_repository import add_host
 from lib.host_repository import AddHostResult
 from lib.host_repository import find_non_culled_hosts
+from lib.host_repository import update_host_staleness
 from lib.middleware import rbac
 
 
@@ -438,3 +439,13 @@ def _build_serialized_tags(host_list, search):
 def _build_paginated_host_tags_response(total, page, per_page, tags_list):
     json_output = build_collection_response(tags_list, page, per_page, total)
     return flask_json_response(json_output)
+
+
+@api_operation
+@rbac(Permission.WRITE)
+@metrics.api_request_time.time()
+def add_host_checkin(body):
+    # Get fields from body
+    facts = body.get("canonical_facts")
+    staleness_offset = 60
+    return update_host_staleness(current_identity.account_number, facts, staleness_offset)

--- a/api/host.py
+++ b/api/host.py
@@ -458,5 +458,16 @@ def add_host_checkin(body):
     serialized_host, host_id, insights_id, updated = update_host_staleness(
         current_identity.account_number, facts, timestamps
     )
-    _emit_patch_event(serialized_host, host_id, insights_id)
-    return serialized_host
+    if serialized_host:
+        _emit_patch_event(serialized_host, host_id, insights_id)
+        return flask_json_response(serialized_host, 201)
+    else:
+        return flask_json_response(
+            {
+                "detail": "No hosts match the provided facts.",
+                "status": 400,
+                "title": "Bad Request",
+                "type": "about:blank",
+            },
+            status=400,
+        )

--- a/api/host.py
+++ b/api/host.py
@@ -447,7 +447,7 @@ def _build_paginated_host_tags_response(total, page, per_page, tags_list):
 @api_operation
 @rbac(Permission.WRITE)
 @metrics.api_request_time.time()
-def add_host_checkin(body):
+def host_checkin(body):
     facts = body.get("canonical_facts")
     staleness_offset = body.get("staleness_offset")
     config = CullingConfig(

--- a/api/host.py
+++ b/api/host.py
@@ -447,5 +447,5 @@ def _build_paginated_host_tags_response(total, page, per_page, tags_list):
 def add_host_checkin(body):
     # Get fields from body
     facts = body.get("canonical_facts")
-    staleness_offset = 60
+    staleness_offset = body.get("staleness_offset")
     return update_host_staleness(current_identity.account_number, facts, staleness_offset)

--- a/app/config.py
+++ b/app/config.py
@@ -85,15 +85,13 @@ class Config:
         payload_tracker_enabled = os.environ.get("PAYLOAD_TRACKER_ENABLED", "true")
         self.payload_tracker_enabled = payload_tracker_enabled.lower() == "true"
 
-        self.culling_stale_warning_offset_days = int(os.environ.get("CULLING_STALE_WARNING_OFFSET_DAYS", "7"))
-        self.culling_culled_offset_days = int(os.environ.get("CULLING_CULLED_OFFSET_DAYS", "14"))
-        self.culling_stale_warning_offset_minutes = int(os.environ.get("CULLING_STALE_WARNING_OFFSET_MINUTES", "0"))
-        self.culling_culled_offset_minutes = int(os.environ.get("CULLING_CULLED_OFFSET_MINUTES", "0"))
         self.culling_stale_warning_offset_delta = timedelta(
-            days=self.culling_stale_warning_offset_days, minutes=self.culling_stale_warning_offset_minutes
+            days=int(os.environ.get("CULLING_STALE_WARNING_OFFSET_DAYS", "7")),
+            minutes=int(os.environ.get("CULLING_STALE_WARNING_OFFSET_MINUTES", "0")),
         )
         self.culling_culled_offset_delta = timedelta(
-            days=self.culling_culled_offset_days, minutes=self.culling_culled_offset_minutes
+            days=int(os.environ.get("CULLING_CULLED_OFFSET_DAYS", "14")),
+            minutes=int(os.environ.get("CULLING_CULLED_OFFSET_MINUTES", "0")),
         )
 
         self.xjoin_graphql_url = os.environ.get("XJOIN_GRAPHQL_URL", "http://localhost:4000/graphql")

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 from enum import Enum
 
 from app.common import get_build_version
@@ -86,6 +87,14 @@ class Config:
 
         self.culling_stale_warning_offset_days = int(os.environ.get("CULLING_STALE_WARNING_OFFSET_DAYS", "7"))
         self.culling_culled_offset_days = int(os.environ.get("CULLING_CULLED_OFFSET_DAYS", "14"))
+        self.culling_stale_warning_offset_minutes = int(os.environ.get("CULLING_STALE_WARNING_OFFSET_MINUTES", "0"))
+        self.culling_culled_offset_minutes = int(os.environ.get("CULLING_CULLED_OFFSET_MINUTES", "0"))
+        self.culling_stale_warning_offset_delta = timedelta(
+            days=self.culling_stale_warning_offset_days, minutes=self.culling_stale_warning_offset_minutes
+        )
+        self.culling_culled_offset_delta = timedelta(
+            days=self.culling_culled_offset_days, minutes=self.culling_culled_offset_minutes
+        )
 
         self.xjoin_graphql_url = os.environ.get("XJOIN_GRAPHQL_URL", "http://localhost:4000/graphql")
         self.bulk_query_source = getattr(BulkQuerySource, os.environ.get("BULK_QUERY_SOURCE", "db"))

--- a/app/culling.py
+++ b/app/culling.py
@@ -6,10 +6,10 @@ from datetime import timezone
 __all__ = ("Conditions", "staleness_to_conditions", "Timestamps")
 
 
-class _Config(namedtuple("_Config", ("stale_warning_offset_days", "culled_offset_days"))):
+class _Config(namedtuple("_Config", ("stale_warning_offset_delta", "culled_offset_delta"))):
     @classmethod
     def from_config(cls, config):
-        return cls(config.culling_stale_warning_offset_days, config.culling_culled_offset_days)
+        return cls(config.culling_stale_warning_offset_delta, config.culling_culled_offset_delta)
 
 
 class _WithConfig:
@@ -24,17 +24,17 @@ class _WithConfig:
 
 class Timestamps(_WithConfig):
     @staticmethod
-    def _add_days(timestamp, days):
-        return timestamp + timedelta(days=days)
+    def _add_time(timestamp, delta):
+        return timestamp + delta
 
     def stale_timestamp(self, stale_timestamp):
-        return self._add_days(stale_timestamp, 0)
+        return self._add_time(stale_timestamp, timedelta(days=0))
 
     def stale_warning_timestamp(self, stale_timestamp):
-        return self._add_days(stale_timestamp, self.config.stale_warning_offset_days)
+        return self._add_time(stale_timestamp, self.config.stale_warning_offset_delta)
 
     def culled_timestamp(self, stale_timestamp):
-        return self._add_days(stale_timestamp, self.config.culled_offset_days)
+        return self._add_time(stale_timestamp, self.config.culled_offset_delta)
 
 
 class Conditions(_WithConfig):
@@ -43,8 +43,8 @@ class Conditions(_WithConfig):
         self.now = datetime.now(timezone.utc)
 
     @staticmethod
-    def _sub_days(timestamp, days):
-        return timestamp - timedelta(days=days)
+    def _sub_time(timestamp, delta):
+        return timestamp - delta
 
     def fresh(self):
         return self.now, None
@@ -59,11 +59,11 @@ class Conditions(_WithConfig):
         return None, self._culled_timestamp()
 
     def _stale_warning_timestamp(self):
-        offset = timedelta(days=self.config.stale_warning_offset_days)
+        offset = self.config.stale_warning_offset_delta
         return self.now - offset
 
     def _culled_timestamp(self):
-        offset = timedelta(days=self.config.culled_offset_days)
+        offset = self.config.culled_offset_delta
         return self.now - offset
 
 

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from enum import Enum
 
 from sqlalchemy import and_
@@ -15,6 +16,7 @@ from lib.db import session_guard
 
 __all__ = (
     "add_host",
+    "update_host_staleness",
     "canonical_fact_host_query",
     "canonical_facts_host_query",
     "create_new_host",
@@ -55,6 +57,19 @@ def add_host(input_host, staleness_offset, update_system_profile=True, fields=DE
             return update_existing_host(existing_host, input_host, staleness_offset, update_system_profile, fields)
         else:
             return create_new_host(input_host, staleness_offset, fields)
+
+
+def update_host_staleness(account_number, canonical_facts, staleness_offset):
+    """
+    Updates the staleness timestamp for a host with the specified account number
+    and canonical facts.
+    """
+
+    existing_host = find_host_by_canonical_facts(account_number, canonical_facts)
+    input_host = deepcopy(existing_host)
+    # TODO: Update timestamps
+    new_host = update_existing_host(existing_host, input_host, None, False, DEFAULT_FIELDS)
+    return new_host
 
 
 @metrics.host_dedup_processing_time.time()

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -74,7 +74,7 @@ def update_host_staleness(account_number, canonical_facts, staleness_offset):
             reporter=existing_host.reporter,
         )
         return update_existing_host(
-            existing_host, input_host, Timestamps.from_config(inventory_config()), False, DEFAULT_FIELDS
+            existing_host, input_host, Timestamps.from_config(inventory_config()), True, DEFAULT_FIELDS
         )
     else:
         return None, None, None, None

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from datetime import timezone
 from enum import Enum
 
 from sqlalchemy import and_
@@ -68,7 +70,7 @@ def update_host_staleness(account_number, canonical_facts, staleness_offset):
     if existing_host:
         input_host = Host(
             {"insights_id": existing_host.canonical_facts["insights_id"]},
-            stale_timestamp=existing_host.stale_timestamp + staleness_offset,
+            stale_timestamp=datetime.now(timezone.utc) + staleness_offset,
             reporter=existing_host.reporter,
         )
         return update_existing_host(

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -69,7 +69,7 @@ def update_host_staleness(account_number, canonical_facts, staleness_offset):
     existing_host = find_existing_host(account_number, canonical_facts)
     if existing_host:
         input_host = Host(
-            {"insights_id": existing_host.canonical_facts["insights_id"]},
+            existing_host.canonical_facts,
             stale_timestamp=datetime.now(timezone.utc) + staleness_offset,
             reporter=existing_host.reporter,
         )

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from datetime import timedelta
 from enum import Enum
 
 from sqlalchemy import and_
@@ -68,10 +68,11 @@ def update_host_staleness(account_number, canonical_facts, staleness_offset):
     """
 
     existing_host = find_existing_host(account_number, canonical_facts)
-    input_host = deepcopy(existing_host)
-    # TODO: Update timestamps with minutes, not days
-    config = CullingConfig(stale_warning_offset_days=staleness_offset, culled_offset_days=staleness_offset * 2)
-    new_host = update_existing_host(existing_host, input_host, Timestamps(config), False, DEFAULT_FIELDS)
+    config = CullingConfig(
+        stale_warning_offset_delta=timedelta(minutes=staleness_offset),
+        culled_offset_delta=inventory_config().culled_offset_delta,
+    )
+    new_host = update_existing_host(existing_host, existing_host, Timestamps(config), False, DEFAULT_FIELDS)
     return new_host
 
 

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -5,7 +5,9 @@ from sqlalchemy import and_
 from sqlalchemy import or_
 
 from app import inventory_config
+from app.culling import _Config as CullingConfig
 from app.culling import staleness_to_conditions
+from app.culling import Timestamps
 from app.logging import get_logger
 from app.models import db
 from app.models import Host
@@ -65,10 +67,11 @@ def update_host_staleness(account_number, canonical_facts, staleness_offset):
     and canonical facts.
     """
 
-    existing_host = find_host_by_canonical_facts(account_number, canonical_facts)
+    existing_host = find_existing_host(account_number, canonical_facts)
     input_host = deepcopy(existing_host)
-    # TODO: Update timestamps
-    new_host = update_existing_host(existing_host, input_host, None, False, DEFAULT_FIELDS)
+    # TODO: Update timestamps with minutes, not days
+    config = CullingConfig(stale_warning_offset_days=staleness_offset, culled_offset_days=staleness_offset * 2)
+    new_host = update_existing_host(existing_host, input_host, Timestamps(config), False, DEFAULT_FIELDS)
     return new_host
 
 

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -63,12 +63,11 @@ def update_host_staleness(account_number, canonical_facts, timestamps):
     Updates the staleness timestamp for a host with matching canonical facts.
     """
 
-    with session_guard(db.session):
-        existing_host = find_existing_host(account_number, canonical_facts)
-        if existing_host:
-            return update_existing_host(existing_host, existing_host, timestamps, False, DEFAULT_FIELDS)
-        else:
-            return None, None, None, None
+    existing_host = find_existing_host(account_number, canonical_facts)
+    if existing_host:
+        return update_existing_host(existing_host, existing_host, timestamps, False, DEFAULT_FIELDS)
+    else:
+        return None, None, None, None
 
 
 @metrics.host_dedup_processing_time.time()

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -12,7 +12,6 @@ from app.serialization import DEFAULT_FIELDS
 from app.serialization import serialize_host
 from lib import metrics
 from lib.db import session_guard
-from tests.helpers.test_utils import now
 
 __all__ = (
     "add_host",
@@ -66,7 +65,7 @@ def update_host_staleness(account_number, canonical_facts, timestamps):
 
     existing_host = find_existing_host(account_number, canonical_facts)
     if existing_host:
-        updated_staleness = now() + timestamps.config.stale_warning_offset_delta
+        updated_staleness = existing_host.stale_timestamp + timestamps.config.stale_warning_offset_delta
         input_host = Host(
             {"insights_id": existing_host.canonical_facts["insights_id"]},
             stale_timestamp=updated_staleness,

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -65,7 +65,10 @@ def update_host_staleness(account_number, canonical_facts, timestamps):
 
     with session_guard(db.session):
         existing_host = find_existing_host(account_number, canonical_facts)
-        return update_existing_host(existing_host, existing_host, timestamps, False, DEFAULT_FIELDS)
+        if existing_host:
+            return update_existing_host(existing_host, existing_host, timestamps, False, DEFAULT_FIELDS)
+        else:
+            return None, None, None, None
 
 
 @metrics.host_dedup_processing_time.time()

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -768,7 +768,7 @@ components:
           minimum: 1
           maximum: 2880
           default: 1440
-          example: 45
+          example: 1440
     CreateHostIn:
       title: Host data
       description: >-

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -111,13 +111,13 @@ paths:
         '400':
           description: Invalid request.
   /hosts/checkin:
-    post:
-      operationId: api.host.add_host_checkin
+    put:
+      operationId: api.host.host_checkin
       tags:
         - hosts
-      summary: Create a host check-in record to update staleness timestamps
+      summary: Update staleness timestamps for a host matching the provided facts
       description: >-
-        Create a check-in record to update a host's staleness timestamps.
+        Finds a host and updates its staleness timestamps.
         It uses the supplied canonical facts to determine which host to update.
         By default, the staleness timestamp is set to 1 hour from when the request is received;
         however, this can be overridden by supplying the interval.
@@ -135,7 +135,7 @@ paths:
               $ref: '#/components/schemas/CreateCheckIn'
       responses:
         '201':
-          description: Successfully created check-in record.
+          description: Successfully updated host's timestamps.
           content:
             application/json:
               schema:
@@ -143,18 +143,8 @@ paths:
               examples:
                 update:
                   value:
-                    status: 200
-                    host: Host details
-                create:
-                  value:
                     status: 201
                     host: Host details
-                error:
-                  value:
-                    status: 400
-                    title: Invalid Request
-                    detail: Could not process request
-                    host: Input host data
         '400':
           description: Invalid request.
   '/hosts/{host_id_list}':

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -110,6 +110,55 @@ paths:
                     host: Input host data
         '400':
           description: Invalid request.
+  /hosts/checkin:
+    post:
+      operationId: api.host.add_host_checkin
+      tags:
+        - hosts
+      summary: Create a host check-in record to update staleness timestamps
+      description: >-
+        Create a check-in record to update a host's staleness timestamps.
+        It uses the supplied canonical facts to determine which host to update.
+        By default, the staleness timestamp is set to 1 hour from when the request is received;
+        however, this can be overridden by supplying the interval.
+        <br /><br />
+        Required permissions: inventory:hosts:write
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      requestBody:
+        description: A list of host objects to be added to the host list
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/CreateCheckIn'
+      responses:
+        '201':
+          description: Successfully created check-in record.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkHostOut'
+              examples:
+                update:
+                  value:
+                    status: 200
+                    host: Host details
+                create:
+                  value:
+                    status: 201
+                    host: Host details
+                error:
+                  value:
+                    status: 400
+                    title: Invalid Request
+                    detail: Could not process request
+                    host: Input host data
+        '400':
+          description: Invalid request.
   '/hosts/{host_id_list}':
     get:
       tags:
@@ -621,6 +670,26 @@ components:
       required:
         - namespace
         - facts
+    CreateCheckIn:
+      title: Check-in data
+      description: >-
+        Data required to create a check-in record for a host.
+      type: object
+      required:
+        - canonical_facts
+      properties:
+        canonical_facts:
+          description: A set of canonical_facts belonging to the host.
+          type: array
+          items:
+            $ref: '#/components/schemas/FactSet'
+        staleness_interval:
+          description: Defines how far in the future the host becomes stale (in minutes).
+          type: integer
+          minimum: 1
+          maximum: 1440
+          default: 60
+          example: 45
     CreateHostIn:
       title: Host data
       description: >-

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -678,10 +678,8 @@ components:
       properties:
         canonical_facts:
           description: A set of canonical_facts belonging to the host.
-          type: array
-          items:
-            $ref: '#/components/schemas/Facts'
-        staleness_interval:
+          $ref: '#/components/schemas/Facts'
+        staleness_offset:
           description: Defines how far in the future the host becomes stale (in minutes).
           type: integer
           minimum: 1

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -673,8 +673,8 @@ components:
           description: Defines how far in the future the host becomes stale (in minutes).
           type: integer
           minimum: 1
-          maximum: 1440
-          default: 60
+          maximum: 2880
+          default: 1440
           example: 45
     CreateHostIn:
       title: Host data

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -132,9 +132,7 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/CreateCheckIn'
+              $ref: '#/components/schemas/CreateCheckIn'
       responses:
         '201':
           description: Successfully created check-in record.
@@ -682,7 +680,7 @@ components:
           description: A set of canonical_facts belonging to the host.
           type: array
           items:
-            $ref: '#/components/schemas/FactSet'
+            $ref: '#/components/schemas/Facts'
         staleness_interval:
           description: Defines how far in the future the host becomes stale (in minutes).
           type: integer

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -669,7 +669,7 @@ components:
         canonical_facts:
           description: A set of canonical_facts belonging to the host.
           $ref: '#/components/schemas/Facts'
-        staleness_offset:
+        checkin_frequency:
           description: Defines how far in the future the host becomes stale (in minutes).
           type: integer
           minimum: 1

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -331,6 +331,10 @@ def build_hosts_url(host_list_or_id=None, query=None):
     return _build_url(host_list_or_id=host_list_or_id, query=query)
 
 
+def build_host_checkin_url():
+    return _build_url(base_url=HOST_URL, path="/checkin")
+
+
 def build_host_tags_url(host_list_or_id, query=None):
     return _build_url(path="/tags", host_list_or_id=host_list_or_id, query=query)
 

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -97,7 +97,18 @@ def assert_delete_event_is_valid(event_producer, host, timestamp, expected_reque
         assert event["metadata"] == expected_metadata
 
 
-def assert_patch_event_is_valid(host, event_producer, expected_request_id, expected_timestamp):
+def assert_patch_event_is_valid(
+    host,
+    event_producer,
+    expected_request_id,
+    expected_timestamp,
+    display_name="patch_event_test",
+    stale_timestamp=None,
+    reporter=None,
+):
+    stale_timestamp = stale_timestamp or host.stale_timestamp.astimezone(timezone.utc)
+    reporter = reporter or host.reporter
+
     event = json.loads(event_producer.event)
 
     assert isinstance(event, dict)
@@ -107,7 +118,7 @@ def assert_patch_event_is_valid(host, event_producer, expected_request_id, expec
         "host": {
             "id": str(host.id),
             "account": host.account,
-            "display_name": "patch_event_test",
+            "display_name": display_name,
             "ansible_host": host.ansible_host,
             "fqdn": host.canonical_facts.get("fqdn"),
             "insights_id": host.canonical_facts.get("insights_id"),
@@ -120,12 +131,10 @@ def assert_patch_event_is_valid(host, event_producer, expected_request_id, expec
             "system_profile": host.system_profile_facts,
             "external_id": None,
             "tags": [tag.data() for tag in Tag.create_tags_from_nested(host.tags)],
-            "reporter": host.reporter,
-            "stale_timestamp": host.stale_timestamp.astimezone(timezone.utc).isoformat(),
-            "stale_warning_timestamp": (
-                host.stale_timestamp.astimezone(timezone.utc) + timedelta(weeks=1)
-            ).isoformat(),
-            "culled_timestamp": (host.stale_timestamp.astimezone(timezone.utc) + timedelta(weeks=2)).isoformat(),
+            "reporter": reporter,
+            "stale_timestamp": stale_timestamp.isoformat(),
+            "stale_warning_timestamp": (stale_timestamp + timedelta(weeks=1)).isoformat(),
+            "culled_timestamp": (stale_timestamp + timedelta(weeks=2)).isoformat(),
             "created": host.created_on.astimezone(timezone.utc).isoformat(),
         },
         "platform_metadata": None,

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -69,6 +69,20 @@ def test_checkin(staleness_offset, event_producer_mock, db_create_host, db_get_h
     assert record.stale_timestamp == expected_stale_timestamp
 
 
+@pytest.mark.system_culling
+def test_checkin_no_matching_host(event_producer_mock, db_create_host, db_get_host, api_put):
+    host = db_host(stale_timestamp=now().isoformat(), reporter="some reporter")
+    created_host = db_create_host(host)
+
+    put_doc = {
+        "canonical_facts": {"insights_id": f"nomatch_{created_host.canonical_facts['insights_id']}"},
+        "staleness_offset": 60,
+    }
+
+    response_status, response_data = api_put(build_host_checkin_url(), put_doc)
+    assert_response_status(response_status, expected_status=400)
+
+
 def test_patch_with_branch_id_parameter(event_producer_mock, db_create_multiple_hosts, api_patch):
     patch_doc = {"display_name": "branch_id_test"}
 

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -52,7 +52,10 @@ def test_checkin(staleness_offset, event_producer_mock, db_create_host, db_get_h
     host = db_host()
     created_host = db_create_host(host)
 
-    put_doc = {"canonical_facts": {"insights_id": f'"{created_host.id}"'}, "staleness_offset": staleness_offset}
+    put_doc = {
+        "canonical_facts": {"insights_id": f"{created_host.canonical_facts['insights_id']}"},
+        "staleness_offset": staleness_offset,
+    }
 
     url = build_host_checkin_url()
     response_status, response_data = api_put(url, put_doc)

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -46,25 +46,23 @@ def test_update_fields(patch_doc, event_producer_mock, db_create_host, db_get_ho
         assert getattr(record, key) == patch_doc[key]
 
 
-@pytest.mark.parametrize("staleness_offset", [1, 60, 1440])
+@pytest.mark.parametrize("checkin_frequency", [1, 60, 1440])
 @pytest.mark.system_culling
-def test_checkin(staleness_offset, event_producer_mock, db_create_host, db_get_host, api_put):
+def test_checkin(checkin_frequency, event_producer_mock, db_create_host, db_get_host, api_put):
     host = db_host(stale_timestamp=now().isoformat(), reporter="some reporter")
     created_host = db_create_host(host)
     original_timestamp = created_host.stale_timestamp
 
     put_doc = {
         "canonical_facts": {"insights_id": f"{created_host.canonical_facts['insights_id']}"},
-        "staleness_offset": staleness_offset,
+        "checkin_frequency": checkin_frequency,
     }
 
-    expected_stale_timestamp = host.stale_timestamp + timedelta(minutes=staleness_offset)
     response_status, response_data = api_put(build_host_checkin_url(), put_doc)
 
     assert_response_status(response_status, expected_status=201)
     record = db_get_host(created_host.id)
-
-    expected_stale_timestamp = original_timestamp + timedelta(minutes=staleness_offset)
+    expected_stale_timestamp = original_timestamp + timedelta(minutes=checkin_frequency)
 
     assert record.stale_timestamp == expected_stale_timestamp
 
@@ -76,7 +74,7 @@ def test_checkin_no_matching_host(event_producer_mock, db_create_host, db_get_ho
 
     put_doc = {
         "canonical_facts": {"insights_id": f"nomatch_{created_host.canonical_facts['insights_id']}"},
-        "staleness_offset": 60,
+        "checkin_frequency": 60,
     }
 
     response_status, response_data = api_put(build_host_checkin_url(), put_doc)

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -53,8 +53,6 @@ def test_checkin(staleness_offset, event_producer_mock, db_create_host, db_get_h
     created_host = db_create_host(host)
     original_timestamp = created_host.stale_timestamp
 
-    print(f"Stale timestamp after creation: {original_timestamp}")
-
     put_doc = {
         "canonical_facts": {"insights_id": f"{created_host.canonical_facts['insights_id']}"},
         "staleness_offset": staleness_offset,
@@ -65,8 +63,6 @@ def test_checkin(staleness_offset, event_producer_mock, db_create_host, db_get_h
 
     assert_response_status(response_status, expected_status=201)
     record = db_get_host(created_host.id)
-
-    print(f"Stale timestamp after Check-In: {record.stale_timestamp}")
 
     expected_stale_timestamp = original_timestamp + timedelta(minutes=staleness_offset)
 

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -64,7 +64,9 @@ def test_checkin(checkin_frequency, event_producer_mock, db_create_host, db_get_
     record = db_get_host(created_host.id)
     expected_stale_timestamp = original_timestamp + timedelta(minutes=checkin_frequency)
 
-    assert record.stale_timestamp == expected_stale_timestamp
+    assert (record.stale_timestamp > expected_stale_timestamp) and (
+        record.stale_timestamp < expected_stale_timestamp + timedelta(seconds=1)
+    )
 
 
 @pytest.mark.system_culling

--- a/tests/test_culling.py
+++ b/tests/test_culling.py
@@ -254,10 +254,17 @@ def test_system_profile_doesnt_use_staleness_parameter(mq_create_hosts_in_all_st
 
 
 @pytest.mark.parametrize("culling_stale_warning_offset_days", (1, 7, 12))
+@pytest.mark.parametrize("culling_stale_warning_offset_minutes", (0, 45, 90))
 def test_stale_warning_timestamp(
-    culling_stale_warning_offset_days, inventory_config, mq_create_or_update_host, api_get
+    culling_stale_warning_offset_days,
+    culling_stale_warning_offset_minutes,
+    inventory_config,
+    mq_create_or_update_host,
+    api_get,
 ):
-    inventory_config.culling_stale_warning_offset_delta = timedelta(days=culling_stale_warning_offset_days)
+    inventory_config.culling_stale_warning_offset_delta = timedelta(
+        days=culling_stale_warning_offset_days, minutes=culling_stale_warning_offset_minutes
+    )
 
     stale_timestamp = now() + timedelta(hours=1)
     host = minimal_host(stale_timestamp=stale_timestamp.isoformat())
@@ -267,13 +274,20 @@ def test_stale_warning_timestamp(
     response_status, response_data = api_get(url)
     assert response_status == 200
 
-    stale_warning_timestamp = stale_timestamp + timedelta(days=culling_stale_warning_offset_days)
+    stale_warning_timestamp = stale_timestamp + timedelta(
+        days=culling_stale_warning_offset_days, minutes=culling_stale_warning_offset_minutes
+    )
     assert stale_warning_timestamp.isoformat() == response_data["results"][0]["stale_warning_timestamp"]
 
 
 @pytest.mark.parametrize("culling_culled_offset_days", (8, 14, 20))
-def test_culled_timestamp(culling_culled_offset_days, inventory_config, mq_create_or_update_host, api_get):
-    inventory_config.culling_culled_offset_delta = timedelta(days=culling_culled_offset_days)
+@pytest.mark.parametrize("culling_culled_offset_minutes", (0, 45, 90))
+def test_culled_timestamp(
+    culling_culled_offset_days, culling_culled_offset_minutes, inventory_config, mq_create_or_update_host, api_get
+):
+    inventory_config.culling_culled_offset_delta = timedelta(
+        days=culling_culled_offset_days, minutes=culling_culled_offset_minutes
+    )
 
     stale_timestamp = now() + timedelta(hours=1)
     host = minimal_host(stale_timestamp=stale_timestamp.isoformat())
@@ -283,7 +297,9 @@ def test_culled_timestamp(culling_culled_offset_days, inventory_config, mq_creat
     response_status, response_data = api_get(url)
     assert response_status == 200
 
-    culled_timestamp = stale_timestamp + timedelta(days=culling_culled_offset_days)
+    culled_timestamp = stale_timestamp + timedelta(
+        days=culling_culled_offset_days, minutes=culling_culled_offset_minutes
+    )
     assert culled_timestamp.isoformat() == response_data["results"][0]["culled_timestamp"]
 
 

--- a/tests/test_culling.py
+++ b/tests/test_culling.py
@@ -257,7 +257,7 @@ def test_system_profile_doesnt_use_staleness_parameter(mq_create_hosts_in_all_st
 def test_stale_warning_timestamp(
     culling_stale_warning_offset_days, inventory_config, mq_create_or_update_host, api_get
 ):
-    inventory_config.culling_stale_warning_offset_days = culling_stale_warning_offset_days
+    inventory_config.culling_stale_warning_offset_delta = timedelta(days=culling_stale_warning_offset_days)
 
     stale_timestamp = now() + timedelta(hours=1)
     host = minimal_host(stale_timestamp=stale_timestamp.isoformat())
@@ -273,7 +273,7 @@ def test_stale_warning_timestamp(
 
 @pytest.mark.parametrize("culling_culled_offset_days", (8, 14, 20))
 def test_culled_timestamp(culling_culled_offset_days, inventory_config, mq_create_or_update_host, api_get):
-    inventory_config.culling_culled_offset_days = culling_culled_offset_days
+    inventory_config.culling_culled_offset_delta = timedelta(days=culling_culled_offset_days)
 
     stale_timestamp = now() + timedelta(hours=1)
     host = minimal_host(stale_timestamp=stale_timestamp.isoformat())

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1203,7 +1203,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
         for k, v in host_attr_data.items():
             setattr(host, k, v)
 
-        config = CullingConfig(stale_warning_offset_days=7, culled_offset_days=14)
+        config = CullingConfig(stale_warning_offset_delta=timedelta(days=7), culled_offset_delta=timedelta(days=14))
         actual = serialize_host(host, Timestamps(config), DEFAULT_FIELDS + ("tags",))
         expected = {
             **canonical_facts,
@@ -1222,10 +1222,10 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
             "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
             "stale_timestamp": self._timestamp_to_str(host_init_data["stale_timestamp"]),
             "stale_warning_timestamp": self._timestamp_to_str(
-                self._add_days(host_init_data["stale_timestamp"], config.stale_warning_offset_days)
+                self._add_days(host_init_data["stale_timestamp"], config.stale_warning_offset_delta.days)
             ),
             "culled_timestamp": self._timestamp_to_str(
-                self._add_days(host_init_data["stale_timestamp"], config.culled_offset_days)
+                self._add_days(host_init_data["stale_timestamp"], config.culled_offset_delta.days)
             ),
         }
         self.assertEqual(expected, actual)
@@ -1239,7 +1239,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
         for k, v in host_attr_data.items():
             setattr(host, k, v)
 
-        config = CullingConfig(stale_warning_offset_days=7, culled_offset_days=14)
+        config = CullingConfig(stale_warning_offset_delta=timedelta(days=7), culled_offset_delta=timedelta(days=14))
         actual = serialize_host(host, Timestamps(config), DEFAULT_FIELDS + ("tags",))
         expected = {
             **host_init_data["canonical_facts"],
@@ -1276,7 +1276,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
                 for k, v in (("id", uuid4()), ("created_on", datetime.utcnow()), ("modified_on", datetime.utcnow())):
                     setattr(host, k, v)
 
-                config = CullingConfig(stale_warning_offset_days, culled_offset_days)
+                config = CullingConfig(timedelta(days=stale_warning_offset_days), timedelta(days=culled_offset_days))
                 serialized = serialize_host(host, Timestamps(config))
                 self.assertEqual(
                     self._timestamp_to_str(self._add_days(stale_timestamp, stale_warning_offset_days)),

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -265,8 +265,10 @@ class ConfigTestCase(TestCase):
             self.assertEqual(conf.db_pool_size, 8)
             self.assertEqual(conf.api_url_path_prefix, expected_api_path)
             self.assertEqual(conf.mgmt_url_path_prefix, expected_mgmt_url_path_prefix)
-            self.assertEqual(conf.culling_stale_warning_offset_days, culling_stale_warning_offset_days)
-            self.assertEqual(conf.culling_culled_offset_days, culling_culled_offset_days)
+            self.assertEqual(
+                conf.culling_stale_warning_offset_delta, timedelta(days=culling_stale_warning_offset_days)
+            )
+            self.assertEqual(conf.culling_culled_offset_delta, timedelta(days=culling_culled_offset_days))
 
     def test_config_default_settings(self):
         expected_api_path = "/api/inventory/v1"
@@ -282,8 +284,8 @@ class ConfigTestCase(TestCase):
             self.assertEqual(conf.mgmt_url_path_prefix, expected_mgmt_url_path_prefix)
             self.assertEqual(conf.db_pool_timeout, 5)
             self.assertEqual(conf.db_pool_size, 5)
-            self.assertEqual(conf.culling_stale_warning_offset_days, 7)
-            self.assertEqual(conf.culling_culled_offset_days, 14)
+            self.assertEqual(conf.culling_stale_warning_offset_delta, timedelta(days=7))
+            self.assertEqual(conf.culling_culled_offset_delta, timedelta(days=14))
 
     def test_config_development_settings(self):
         with set_environment({"INVENTORY_DB_POOL_TIMEOUT": "3"}):


### PR DESCRIPTION
This PR is meant to address [RHCLOUD-9412](https://issues.redhat.com/browse/RHCLOUD-9412).

This adds a PUT endpoint that accepts a list of canonical facts and a time offset (in minutes). Given the list of canonical facts, it should find one specific host, and update its staleness timestamp using the supplied time offset.