### PR TITLE
Make tags into json string

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -108,7 +108,7 @@ def add_host(host_data):
                         "canonical_facts": input_host.canonical_facts,
                         "reporter": input_host.reporter,
                         "stale_timestamp": input_host.stale_timestamp.isoformat(),
-                        "tags": input_host.tags,
+                        "tags": json.dumps(input_host.tags),
                     }
                 },
             )


### PR DESCRIPTION
I'd like to open this up for discussion. In the Kibana instance of the crcp01ue1  cluster, a large quantity (Kibana is showing 8400 / 11000) of the field mappings are being taken up by the input.* fields. By swapping to a json string, we can keep the data and limit the fields that are being created. Let me know your thoughts on the change here. I'll include the ticket below. 

https://issues.redhat.com/browse/RHCLOUD-9488
