### PR TITLE
Update description and example properties to match schema repo

### DIFF
--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -11,22 +11,22 @@ $defs:
         type: string
         maxLength: 2048
       label:
-        description: user-defined mount label
+        description: User-defined mount label
         type: string
         maxLength: 1024
       options:
-        description: mount options
+        description: Mount options for nested object
         example:
           uid: "0"
           ro: true
         type: object
       mount_point:
-        description: mount point
+        description: The mount point
         example: "/mnt/remote_nfs_shares"
         type: string
         maxLength: 2048
       type:
-        description: mount type
+        description: The mount type
         example: "ext3"
         type: string
         maxLength: 256
@@ -66,12 +66,12 @@ $defs:
         type: string
         maxLength: 512
       id:
-        description: the product ID
+        description: The product ID
         example: "71"
         type: string
         maxLength: 64
       status:
-        description: subscription status for product
+        description: Subscription status for product
         example: "Subscribed"
         type: string
         maxLength: 256
@@ -82,15 +82,19 @@ $defs:
       ipv4_addresses:
         type: array
         items:
+          description: The ipv4 address of the system
+          example: "123.456.789.012"
           type: string
           format: ipv4
       ipv6_addresses:
         type: array
         items:
+          description: The ipv6 address of the system
+          example: "0123:4567:89ab:cdef:0123:4567:89ab:cdef"
           type: string
           format: ipv6
       mtu:
-        description: MTU
+        description: MTU (Maximum transmission unit)
         type: integer
       mac_address:
         description: MAC address (with or without colons)
@@ -98,18 +102,18 @@ $defs:
         type: string
         maxLength: 59
       name:
-        description: name of interface
+        description: Name of interface
         type: string
         example: eth0
         minLength: 1
         maxLength: 50
       state:
-        description: interface state (UP, DOWN, UNKNOWN)
+        description: Interface state (UP, DOWN, UNKNOWN)
         type: string
         example: "UP"
         maxLength: 25
       type:
-        description: interface type (ether, loopback)
+        description: Interface type (ether, loopback)
         type: string
         example: "ether"
         maxLength: 18
@@ -175,7 +179,7 @@ $defs:
       running_processes:
         type: array  # techincally a set, ordering is not important
         items:
-          description: a single running process. This will be truncated to 1000 characters when saved.
+          description: A single running process. This will be truncated to 1000 characters when saved.
           type: string
           maxLength: 1000
       subscription_status:
@@ -215,9 +219,9 @@ $defs:
       installed_packages:
         type: array  # technically a set, ordering is not important
         items:
-          description: a NEVRA string for a single installed package
-          type: string
+          description: A NEVRA string for a single installed package
           example: "krb5-libs-0:-1.16.1-23.fc29.i686"
+          type: string
           maxLength: 512
       installed_services:
         type: array
@@ -234,7 +238,7 @@ $defs:
         description: Indicates if SAP is installed on the system
       sap_sids:
         type: array
-        description: list of SAP SIDs
+        description: List of SAP SIDs
         items:
           description: The SAP system ID (SID)
           type: string


### PR DESCRIPTION
Bring local `system_profile.spec.yaml`  in closer alignment with https://github.com/RedHatInsights/inventory-schemas/blob/master/schemas/system_profile/v1.yaml.

This PR is only updating the `description` and `example` properties.