### PR TITLE
Add RBAC tests for system_profile

### DIFF
--- a/tests/test_system_profile.py
+++ b/tests/test_system_profile.py
@@ -1,5 +1,9 @@
+from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_system_profile_sap_sids_url
 from tests.helpers.api_utils import build_system_profile_sap_system_url
+from tests.helpers.api_utils import create_mock_rbac_response
+from tests.helpers.api_utils import READ_ALLOWED_RBAC_RESPONSE_FILES
+from tests.helpers.api_utils import READ_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.graphql_utils import XJOIN_SYSTEM_PROFILE_SAP_SIDS
 from tests.helpers.graphql_utils import XJOIN_SYSTEM_PROFILE_SAP_SYSTEM
 
@@ -32,3 +36,73 @@ def test_system_profile_sap_sids_endpoint_response(
     assert response_data["results"] == XJOIN_SYSTEM_PROFILE_SAP_SIDS["hostSystemProfile"]["sap_sids"]["data"]
     assert response_data["total"] == XJOIN_SYSTEM_PROFILE_SAP_SIDS["hostSystemProfile"]["sap_sids"]["meta"]["total"]
     assert response_data["count"] == XJOIN_SYSTEM_PROFILE_SAP_SIDS["hostSystemProfile"]["sap_sids"]["meta"]["count"]
+
+
+def test_get_system_profile_sap_system_with_RBAC_allowed(
+    subtests, mocker, query_source_xjoin, graphql_system_profile_sap_system_query_with_response, api_get, enable_rbac
+):
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+
+    url = build_system_profile_sap_system_url()
+
+    for response_file in READ_ALLOWED_RBAC_RESPONSE_FILES:
+        mock_rbac_response = create_mock_rbac_response(response_file)
+        with subtests.test():
+            get_rbac_permissions_mock.return_value = mock_rbac_response
+
+            response_status, response_data = api_get(url, identity_type="User")
+
+            assert_response_status(response_status, 200)
+
+
+def test_get_system_profile_sap_sids_with_RBAC_allowed(
+    subtests, mocker, query_source_xjoin, graphql_system_profile_sap_sids_query_with_response, api_get, enable_rbac
+):
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+
+    url = build_system_profile_sap_sids_url()
+
+    for response_file in READ_ALLOWED_RBAC_RESPONSE_FILES:
+        mock_rbac_response = create_mock_rbac_response(response_file)
+        with subtests.test():
+            get_rbac_permissions_mock.return_value = mock_rbac_response
+
+            response_status, response_data = api_get(url, identity_type="User")
+
+            assert_response_status(response_status, 200)
+
+
+def test_get_system_profile_with_RBAC_denied(subtests, mocker, query_source_xjoin, api_get, enable_rbac):
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+
+    urls = (build_system_profile_sap_system_url(), build_system_profile_sap_sids_url())
+
+    for url in urls:
+        for response_file in READ_PROHIBITED_RBAC_RESPONSE_FILES:
+            mock_rbac_response = create_mock_rbac_response(response_file)
+            with subtests.test():
+                get_rbac_permissions_mock.return_value = mock_rbac_response
+
+                response_status, response_data = api_get(url, identity_type="User")
+
+                assert_response_status(response_status, 403)
+
+
+def test_get_system_profile_sap_system_with_RBAC_bypassed_as_system(
+    query_source_xjoin, graphql_system_profile_sap_system_query_with_response, api_get, enable_rbac
+):
+    url = build_system_profile_sap_system_url()
+
+    response_status, response_data = api_get(url, identity_type="System")
+
+    assert_response_status(response_status, 200)
+
+
+def test_get_system_profile_sap_sids_with_RBAC_bypassed_as_system(
+    query_source_xjoin, graphql_system_profile_sap_sids_query_with_response, api_get, enable_rbac
+):
+    url = build_system_profile_sap_sids_url()
+
+    response_status, response_data = api_get(url, identity_type="System")
+
+    assert_response_status(response_status, 200)


### PR DESCRIPTION
Since RBAC is getting enabled outside of CI I thought it'd be a good idea to add some tests making sure it works right for the new endpoint