### PR TITLE
Update namespace in the Grafana dashboard

### DIFF
--- a/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
@@ -124,7 +124,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(increase(inventory_ingress_message_parsing_failures_total{cause=\"error\", kubernetes_namespace='platform-$namespace'}[$__range])) OR vector(0)",
+              "expr": "sum(increase(inventory_ingress_message_parsing_failures_total{cause=\"error\", kubernetes_namespace='host-inventory-$namespace'}[$__range])) OR vector(0)",
               "interval": "5m",
               "refId": "A"
             }


### PR DESCRIPTION
Updates the namespace in the Grafana to "host-inventory-{env}" instead of "platform-{env}". I'm guessing this one wasn't working for Stage before.