### PR TITLE
RHCLOUD-10247: Allow for case insensitivity on Inventory name search

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -8,6 +8,7 @@ from app.xjoin import graphql_query
 from app.xjoin import pagination_params
 from app.xjoin import staleness_filter
 from app.xjoin import string_contains
+from app.xjoin import string_contains_lc
 
 __all__ = ("get_host_list",)
 
@@ -143,10 +144,11 @@ def _query_filters(fqdn, display_name, hostname_or_id, insights_id, tags, stalen
     if fqdn:
         query_filters = ({"fqdn": {"eq": fqdn}},)
     elif display_name:
-        query_filters = ({"display_name": string_contains(display_name)},)
+        query_filters = ({"display_name": string_contains_lc(display_name)},)
     elif hostname_or_id:
         contains = string_contains(hostname_or_id)
-        hostname_or_id_filters = ({"display_name": contains}, {"fqdn": contains})
+        contains_lc = string_contains_lc(hostname_or_id)
+        hostname_or_id_filters = ({"display_name": contains_lc}, {"fqdn": contains})
         try:
             id = UUID(hostname_or_id)
         except ValueError:

--- a/app/xjoin.py
+++ b/app/xjoin.py
@@ -12,7 +12,7 @@ from app import REQUEST_ID_HEADER
 from app import UNKNOWN_REQUEST_ID_VALUE
 from app.culling import staleness_to_conditions
 
-__all__ = ("graphql_query", "pagination_params", "staleness_filter", "string_contains", "url")
+__all__ = ("graphql_query", "pagination_params", "staleness_filter", "string_contains", "string_contains_lc", "url")
 
 logger = getLogger("graphql")
 outbound_http_metric = outbound_http_response_time.labels("xjoin")
@@ -54,6 +54,10 @@ def staleness_filter(staleness):
 
 def string_contains(string):
     return {"matches": f"*{string}*"}
+
+
+def string_contains_lc(string):
+    return {"matches_lc": f"*{string}*"}
 
 
 def url():

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -94,7 +94,7 @@ def test_query_variables_display_name(mocker, query_source_xjoin, graphql_query_
             "order_how": mocker.ANY,
             "limit": mocker.ANY,
             "offset": mocker.ANY,
-            "filter": ({"display_name": {"matches": f"*{display_name}*"}}, mocker.ANY),
+            "filter": ({"display_name": {"matches_lc": f"*{display_name}*"}}, mocker.ANY),
         },
     )
 
@@ -117,7 +117,7 @@ def test_query_variables_hostname_or_id_non_uuid(mocker, query_source_xjoin, gra
             "filter": (
                 {
                     "OR": (
-                        {"display_name": {"matches": f"*{hostname_or_id}*"}},
+                        {"display_name": {"matches_lc": f"*{hostname_or_id}*"}},
                         {"fqdn": {"matches": f"*{hostname_or_id}*"}},
                     )
                 },
@@ -145,7 +145,7 @@ def test_query_variables_hostname_or_id_uuid(mocker, query_source_xjoin, graphql
             "filter": (
                 {
                     "OR": (
-                        {"display_name": {"matches": f"*{hostname_or_id}*"}},
+                        {"display_name": {"matches_lc": f"*{hostname_or_id}*"}},
                         {"fqdn": {"matches": f"*{hostname_or_id}*"}},
                         {"id": {"eq": hostname_or_id}},
                     )


### PR DESCRIPTION
Modified xjoin filter to allow for case insensitive Inventory name search.

JIRA:  https://issues.redhat.com/browse/RHCLOUD-10247