### PR TITLE
Add search to system profile /sap_sids endpoint

### DIFF
--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -75,9 +75,7 @@ def xjoin_enabled():
 @api_operation
 @rbac(Permission.READ)
 @metrics.api_request_time.time()
-def get_sap_system(
-    search=None, tags=None, page=None, per_page=None, staleness=None, registered_with=None, filter=None
-):
+def get_sap_system(tags=None, page=None, per_page=None, staleness=None, registered_with=None, filter=None):
     if not xjoin_enabled():
         flask.abort(503)
 
@@ -96,12 +94,6 @@ def get_sap_system(
 
     if registered_with:
         variables["hostFilter"]["NOT"] = {"insights_id": {"eq": None}}
-
-    if search:
-        variables["filter"] = {
-            # Escaped so that the string literals are not interpretted as regex
-            "search": {"regex": f".*{re.escape(search)}.*"}
-        }
 
     if filter:
         if filter.get("system_profile"):
@@ -127,7 +119,7 @@ def get_sap_system(
 @api_operation
 @rbac(Permission.READ)
 @metrics.api_request_time.time()
-def get_sap_sids(tags=None, page=None, per_page=None, staleness=None, registered_with=None, filter=None):
+def get_sap_sids(search=None, tags=None, page=None, per_page=None, staleness=None, registered_with=None, filter=None):
     if not xjoin_enabled():
         flask.abort(503)
 
@@ -147,6 +139,12 @@ def get_sap_sids(tags=None, page=None, per_page=None, staleness=None, registered
 
     if registered_with:
         variables["hostFilter"]["NOT"] = {"insights_id": {"eq": None}}
+
+    if search:
+        variables["filter"] = {
+            # Escaped so that the string literals are not interpretted as regex
+            "search": {"regex": f".*{re.escape(search)}.*"}
+        }
 
     if filter:
         if filter.get("system_profile"):

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -142,7 +142,7 @@ def get_sap_sids(search=None, tags=None, page=None, per_page=None, staleness=Non
 
     if search:
         variables["filter"] = {
-            # Escaped so that the string literals are not interpretted as regex
+            # Escaped so that the string literals are not interpreted as regex
             "search": {"regex": f".*{re.escape(search)}.*"}
         }
 

--- a/api/tag.py
+++ b/api/tag.py
@@ -91,7 +91,7 @@ def get_tags(
 
     if search:
         variables["filter"] = {
-            # Escaped so that the string literals are not interpretted as regex
+            # Escaped so that the string literals are not interpreted as regex
             "search": {"regex": f".*{re.escape(search)}.*"}
         }
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -444,6 +444,7 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
+        - $ref: '#/components/parameters/searchParam'
         - $ref: '#/components/parameters/tagsParam'
         - $ref: '#/components/parameters/perPageParam'
         - $ref: '#/components/parameters/pageParam'

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1443,3 +1443,17 @@ def test_query_system_profile_sap_sids_filter_spf_sap_sids(
                 graphql_system_profile_sap_sids_query_empty_response.assert_called_once_with(
                     SAP_SIDS_QUERY, {"hostFilter": {"OR": mocker.ANY, "AND": query}}
                 )
+
+
+def test_query_system_profile_sap_sids_with_search(
+    mocker, subtests, query_source_xjoin, graphql_system_profile_sap_sids_query_with_response, api_get
+):
+    url = build_system_profile_sap_sids_url(query="?search=C2")
+
+    response_status, response_data = api_get(url)
+
+    assert response_status == 200
+
+    graphql_system_profile_sap_sids_query_with_response.assert_called_once_with(
+        SAP_SIDS_QUERY, {"hostFilter": {"OR": mocker.ANY}, "filter": {"search": {"regex": ".*C2.*"}}}
+    )


### PR DESCRIPTION
Hooks up inventory to the new xjoin-search feature allowing users to search for sap_sids with partial matching. Because it's reliant on xjoin-search to work I cannot create a full integration test, please test manually to check that it's working (it does on my machine)