### PR TITLE
Fix HTTP status for /checkin endpoint in API spec

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -94,8 +94,8 @@ paths:
                   value:
                     status: 201
                     host: Host details
-        '400':
-          description: Invalid request.
+        '404':
+          description: Not Found.
   '/hosts/{host_id_list}':
     get:
       tags:

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -10,22 +10,11 @@ def flask_client(flask_app):
 
 
 @pytest.fixture(scope="function")
-def api_create_or_update_host(flask_client):
-    def _api_create_or_update_host(
-        host_data, query_parameters=None, extra_headers=None, auth_type="account_number", identity_type="User"
-    ):
-        data = [item.data() for item in host_data]
-        return do_request(flask_client.post, HOST_URL, data, query_parameters, extra_headers, auth_type, identity_type)
-
-    return _api_create_or_update_host
-
-
-@pytest.fixture(scope="function")
 def api_post(flask_client):
-    def _api_post(
-        url, host_data, query_parameters=None, extra_headers=None, auth_type="account_number", identity_type="User"
-    ):
-        return do_request(flask_client.post, url, host_data, query_parameters, extra_headers, auth_type, identity_type)
+    def _api_post(url, host_data, query_parameters=None, extra_headers=None, identity_type="User"):
+        return do_request(
+            flask_client.post, url, host_data, query_parameters, extra_headers, identity_type=identity_type
+        )
 
     return _api_post
 


### PR DESCRIPTION
Addresses @Glutexo 's final comment in this Jira: https://issues.redhat.com/browse/RHCLOUD-10385
It just updates the API spec to expect a 404 instead of a 400.