### PR TITLE
Fix HTTP status for /checkin endpoint in API spec

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -94,8 +94,8 @@ paths:
                   value:
                     status: 201
                     host: Host details
-        '400':
-          description: Invalid request.
+        '404':
+          description: Not Found.
   '/hosts/{host_id_list}':
     get:
       tags:


### PR DESCRIPTION
Addresses @Glutexo 's final comment in this Jira: https://issues.redhat.com/browse/RHCLOUD-10385
It just updates the API spec to expect a 404 instead of a 400.