### PR TITLE
Fix Xjoin test on Python >=3.7

### DIFF
--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1,3 +1,5 @@
+from re import escape
+
 import pytest
 
 from api.host_query_xjoin import QUERY as HOST_QUERY
@@ -912,7 +914,8 @@ def test_query_variables_tags_with_only_key(mocker, query_source_xjoin, graphql_
 
 
 def test_tags_query_variables_search(mocker, query_source_xjoin, graphql_tag_query_empty_response, api_get):
-    url = build_tags_url(query=f"?search={quote('Δwithčhar!/~|+ ')}")
+    query = "Δwithčhar!/~|+ "
+    url = build_tags_url(query=f"?search={quote(query)}")
     response_status, response_data = api_get(url)
 
     assert response_status == 200
@@ -924,7 +927,7 @@ def test_tags_query_variables_search(mocker, query_source_xjoin, graphql_tag_que
             "order_how": "ASC",
             "limit": 50,
             "offset": 0,
-            "filter": {"search": {"regex": ".*\\Δwith\\čhar\\!\\/\\~\\|\\+\\ .*"}},
+            "filter": {"search": {"regex": f".*{escape(query)}.*"}},
             "hostFilter": {"OR": mocker.ANY},
         },
     )


### PR DESCRIPTION
Python 3.7 changed _re.escape_ to escape only regular expression control characters. See the note [here](https://docs.python.org/3.8/library/re.html#re.escape). That means that non-ASCII characters and some special ASCII characters like ! or / are no longer escaped. In one test, the escaped string was passed as a literal, not itself using the re.escape function. Fixed by reusing re.escape in the test.

This is still not 100% correct, because we are using Python _re.escape_ to escape a regular expression that is passed to Crossjoin. The Inventory does not know what regex engine does Crossjoin use and it should not matter at all. Crossjoin should describe its regex engine including what characters need to be escaped. The current behavior incorrectly assumes that whatever engine Crossjoin uses, it is compatible with the Python engine. This is a potential problem if Crossjoin uses or starts using an engine that uses control characters not considered as such by _re.escape_.