### PR TITLE
operating_system fact should be dict not list

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -372,7 +372,7 @@ class SystemProfileSchema(MarshmallowSchema):
     bios_version = fields.Str(validate=marshmallow_validate.Length(max=100))
     bios_release_date = fields.Str(validate=marshmallow_validate.Length(max=50))
     cpu_flags = fields.List(fields.Str(validate=marshmallow_validate.Length(max=30)))
-    operating_system = fields.Nested(OperatingSystemSchema)
+    operating_system = fields.Nested(OperatingSystemSchema())
     os_release = fields.Str(validate=marshmallow_validate.Length(max=100))
     os_kernel_version = fields.Str(validate=marshmallow_validate.Length(max=100))
     arch = fields.Str(validate=marshmallow_validate.Length(max=50))

--- a/app/models.py
+++ b/app/models.py
@@ -372,7 +372,7 @@ class SystemProfileSchema(MarshmallowSchema):
     bios_version = fields.Str(validate=marshmallow_validate.Length(max=100))
     bios_release_date = fields.Str(validate=marshmallow_validate.Length(max=50))
     cpu_flags = fields.List(fields.Str(validate=marshmallow_validate.Length(max=30)))
-    operating_system = fields.List(fields.Nested(OperatingSystemSchema()))
+    operating_system = fields.Nested(OperatingSystemSchema)
     os_release = fields.Str(validate=marshmallow_validate.Length(max=100))
     os_kernel_version = fields.Str(validate=marshmallow_validate.Length(max=100))
     arch = fields.Str(validate=marshmallow_validate.Length(max=50))

--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -30,28 +30,6 @@ $defs:
         example: "ext3"
         type: string
         maxLength: 256
-  OperatingSystem:
-    description: Object for OS details
-    type: object
-    properties:
-      major:
-        description: Major release of OS (aka the x version)
-        example: 6
-        type: integer
-        minimum: 0
-        maximum: 99
-      minor:
-        description: Minor release of OS (aka the y version)
-        example: 8
-        type: integer
-        minimum: 0
-        maximum: 99
-      name:
-        description: Name of the distro/os
-        example: "RHEL"
-        type: string
-        maxLength: 4
-        enum: ["RHEL"]
   YumRepo:
     description: Representation of one yum repository
     type: object
@@ -182,7 +160,25 @@ $defs:
         type: array
       operating_system:
         type: object
-        $ref: '#/$defs/OperatingSystem'
+        properties:
+          major:
+            description: Major release of OS (aka the x version)
+            example: 6
+            type: integer
+            minimum: 0
+            maximum: 99
+          minor:
+            description: Minor release of OS (aka the y version)
+            example: 8
+            type: integer
+            minimum: 0
+            maximum: 99
+          name:
+            description: Name of the distro/os
+            example: "RHEL"
+            type: string
+            maxLength: 4
+            enum: [RHEL]
       os_release:
         type: string
         maxLength: 100


### PR DESCRIPTION
The os major/minor/name PR [0] just merged in puptoo and ci is having issues with it.  We suspect it's due to the use of List not Dict in the Marshmallow portion of the schema.  Could replace with fields.Dict or omit entirely.  Any feedback on this is appreciated, we'd like to get a fix out rather quickly.  Thanks!

Update: it appears to be due to the use of a bare reference instead of inline definition

[0] https://github.com/RedHatInsights/insights-puptoo/pull/82