### PR TITLE
add owner_id to event output [RHCLOUD-8583]

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -360,6 +360,7 @@ class NetworkInterfaceSchema(MarshmallowSchema):
 
 
 class SystemProfileSchema(MarshmallowSchema):
+    owner_id = fields.Str(validate=verify_uuid_format)
     number_of_cpus = fields.Int()
     number_of_sockets = fields.Int()
     cores_per_socket = fields.Int()

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -65,6 +65,7 @@ def minimal_host(**values):
 
 def valid_system_profile():
     return {
+        "owner_id": "afe768a2-1c5e-4480-988b-21c3d6cfacf4",
         "number_of_cpus": 1,
         "number_of_sockets": 2,
         "cores_per_socket": 4,

--- a/tests/test_system_profile.py
+++ b/tests/test_system_profile.py
@@ -5,6 +5,7 @@ from tests.helpers.api_utils import assert_error_response
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_system_profile_sap_sids_url
 from tests.helpers.api_utils import build_system_profile_sap_system_url
+from tests.helpers.api_utils import build_system_profile_url
 from tests.helpers.api_utils import create_mock_rbac_response
 from tests.helpers.api_utils import HOST_URL
 from tests.helpers.api_utils import READ_ALLOWED_RBAC_RESPONSE_FILES
@@ -12,8 +13,24 @@ from tests.helpers.api_utils import READ_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.graphql_utils import XJOIN_SYSTEM_PROFILE_SAP_SIDS
 from tests.helpers.graphql_utils import XJOIN_SYSTEM_PROFILE_SAP_SYSTEM
 from tests.helpers.test_utils import generate_uuid
+from tests.helpers.test_utils import minimal_host
+from tests.helpers.test_utils import valid_system_profile
 
 
+# /system_profile tests
+def test_system_profile_includes_owner_id(mq_create_or_update_host, api_get, subtests):
+    system_profile = valid_system_profile()
+    host = minimal_host(system_profile=system_profile)
+    created_host = mq_create_or_update_host(host)
+
+    url = build_system_profile_url(host_list_or_id=created_host.id)
+
+    response_status, response_data = api_get(url)
+    assert response_data["results"][0]["system_profile"] == system_profile
+    assert response_status == 200
+
+
+# sap endpoint tests
 def test_system_profile_sap_system_endpoint_response(
     mocker, query_source_xjoin, graphql_system_profile_sap_system_query_with_response, api_get
 ):


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-8583).

This adds the owner_id into event output, and adds test to check it's present in API responses.

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Input Validation
- [x] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
