### PR TITLE
RHC-10807: Adding flush() to slow down events production to Kafka and avoid OOM …

### DIFF
--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -3,6 +3,7 @@ import os
 from collections import namedtuple
 from datetime import timedelta
 from datetime import timezone
+from unittest.mock import Mock
 
 from app.utils import Tag
 
@@ -17,6 +18,8 @@ class MockEventProducer:
         self.headers = None
         self.topic = None
         self.wait = None
+        self._kafka_producer = Mock()
+        self._kafka_producer.flush = Mock(return_value=True)
 
     def write_event(self, event, key, headers, topic, wait=False):
         self.event = event


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-10807).  It is for testing host_synchronization job which is experiencing out-of-memory problems on the stage OpenShift cluster.  Need Job deployment tested by Monday morning.
## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
