### PR TITLE
rhc-10807: record count when a host is synchronized

### DIFF
--- a/host_synchronizer.py
+++ b/host_synchronizer.py
@@ -67,7 +67,8 @@ def run(config, logger, session, event_producer, shutdown_handler):
     for host_id in events:
         logger.info("Synchronized host: %s", host_id)
         update_count += 1
-    logger.info(f"Number of hosts synchronized: {update_count}")
+        logger.info(f"Number of hosts synchronized: {update_count}")
+    logger.info(f"Total number of hosts synchronized: {update_count}")
     return update_count
 
 


### PR DESCRIPTION
@jharting, to get some idea of how many hosts are updated in 20 minutes with 100 chunk size, the host_synchronizer script has been updated to log count after each host is synchronized.  

You can approve this PR and submit an MR against app-interface using `fb671e6e566c4ec1b513c3dbbd153320d5eb61ae` for the `inventory-host-synchronizer` saas template.   It will attempt to run the job once for 20 minutes.  The pod log should show "Number of hosts synchronized".  Stopping the job normally may yield some useful info.

I watched the pod log and it synchronized 1322 hosts in 8 minutes when console stopped the watch even the pod was running.  This very likely was caused by xterm running out of resources.

FWIIW, in my dev environment, I have successfully processed 3115 hosts with local DB and Kafka and no prometheus.