### PR TITLE
Fix patch timestamp [RHC-9545]

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -233,8 +233,8 @@ def patch_by_id(host_id_list, body):
         host.patch(validated_patch_host_data)
 
         if db.session.is_modified(host):
-            serialized_host = serialize_host(host, staleness_timestamps(), EGRESS_HOST_FIELDS)
             db.session.commit()
+            serialized_host = serialize_host(host, staleness_timestamps(), EGRESS_HOST_FIELDS)
             _emit_patch_event(serialized_host, host.id, host.canonical_facts.get("insights_id"))
 
     return 200

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -1,3 +1,4 @@
+import json
 import time
 from threading import Thread
 
@@ -487,3 +488,19 @@ def test_no_event_on_noop(event_producer, db_create_host, db_get_host, api_patch
     api_patch(url, {})
 
     assert event_producer.write_event.call_count == 0
+
+
+def test_patch_updated_timestamp(event_producer, db_create_host, api_get, api_patch, mocker):
+    mocker.patch.object(event_producer, "write_event")
+    host = db_create_host()
+    patch_doc = {"display_name": "update_test"}
+    url = build_hosts_url(host_list_or_id=host.id)
+    patch_response_status, patch_response_data = api_patch(url, patch_doc)
+
+    assert_response_status(patch_response_status, expected_status=200)
+
+    get_response_status, get_response_data = api_get(build_hosts_url(host_list_or_id=host.id))
+
+    updated_timestamp_from_event = json.loads(event_producer.write_event.call_args_list[0][0][0])["host"]["updated"]
+
+    assert updated_timestamp_from_event == get_response_data["results"][0]["updated"]


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-9545).
Currently the patch event emitted when a host is updated is contains the previous `updated` timestamp instead of the current value. This PR fixes that and adds a test to verify that the new `updated` timestamp in the event is up to date.
## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
