### PR TITLE
Relax regex for sap_instance_number to allow 98/99

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -401,7 +401,7 @@ class SystemProfileSchema(MarshmallowSchema):
         )
     )
     sap_instance_number = fields.Str(
-        validate=[marshmallow_validate.Length(max=2), marshmallow_validate.Regexp(regex=r"(?!99)(?!98)^[0-9]{2}$")]
+        validate=[marshmallow_validate.Length(max=2), marshmallow_validate.Regexp(regex=r"^[0-9]{2}$")]
     )
     sap_version = fields.Str(
         validate=[

--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -278,7 +278,7 @@ $defs:
         description: The instance number of the SAP HANA system
         example: '42'
         maxLength: 2
-        pattern: '(?!99)(?!98)^[0-9]{2}$'
+        pattern: '^[0-9]{2}$'
       sap_version:
         type: string
         description: The version of the SAP HANA lifecycle management program


### PR DESCRIPTION
Even though SAP installs cannot have 98 or 99 as their instance number, these are valid coming from diagnostic tools so we need to relax our schema validation and the regex in our model to allow these values.

https://issues.redhat.com/browse/HBISPSC-37