### PR TITLE
fix: add yum update to fix security vulnerabilities at build

### DIFF
--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -1,6 +1,7 @@
 FROM registry.centos.org/centos/python-36-centos7
 
 USER root
+RUN yum update -y
 RUN yum -y install centos-release-scl-rh
 RUN yum -y install rh-postgresql10-postgresql
 RUN sed -i 's/source scl_\(.*\)$/source scl_\1 rh-postgresql10/' /opt/app-root/etc/scl_enable


### PR DESCRIPTION
This is a method I use with a few of the apps in the platform to keep
the packages on our images up to date. I noticed some alerts in the quay
vulnerability channel in slack. You can also update, or remove packages
you don't use, but this is handy at keeping images updated at build.

Signed-off-by: Stephen Adams <tsadams@gmail.com>

## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-xxxxx).
(A description of your PR's changes goes here.)

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
