### PR TITLE
Fix bad id 500

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -451,6 +451,7 @@ components:
         type: array
         items:
           type: string
+          pattern: ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$
           format: uuid
     branchId:
       in: query

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -167,6 +167,18 @@ def test_query_host_id_without_hyphens(mq_create_three_specific_hosts, api_get, 
             api_query_test(api_get, subtests, url, original_host_list)
 
 
+def test_query_host_id_with_incorrect_formats(api_get, subtests):
+    host_id = "6a2f41a3-c54c-fce8-32d2-0324e1c32e22"
+
+    bad_host_ids = (f" {host_id}", f"{{{host_id}", f"{host_id}-")
+
+    for bad_host_id in bad_host_ids:
+        with subtests.test():
+            url = build_hosts_url(host_list_or_id=bad_host_id)
+            response_status, response_data = api_get(url)
+            assert response_status == 400
+
+
 def test_query_with_branch_id_parameter(mq_create_three_specific_hosts, api_get, subtests):
     created_hosts = mq_create_three_specific_hosts
     # branch_id parameter is accepted, but doesn’t affect results.


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-11693).

Right now HBI is responding with 500 errors when it receives improperly formatted UUIDs. It appears that the inbuilt UUID format is not strict enough. This PR introduces a stricter regex pattern that will make the inventory properly reject requests with improper UUID formats and respond with a 400 status. 

I also included a test that verifies that the improper ids that QA identified are now properly rejected.

Here is a link to a regex checker with the pattern for easy verification
https://regex101.com/r/oCLpe8/1

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
