### PR TITLE
Always push qa and latest tags for v3 and Clowder compatibility

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -18,7 +18,9 @@ docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOK
 docker --config="$DOCKER_CONF" build -f dev.dockerfile -t "${IMAGE}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
 
-if [ "${PUSH_TO_LATEST:=true}" == "true" ]; then
-    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SMOKE_TEST_TAG}"
-    docker --config="$DOCKER_CONF" push "${IMAGE}:${SMOKE_TEST_TAG}"
-fi
+# To enable backwards compatibility with ci, qa, and smoke, always push latest and qa tags
+docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
+docker --config="$DOCKER_CONF" push "${IMAGE}:latest"
+docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:qa"
+docker --config="$DOCKER_CONF" push "${IMAGE}:qa"
+

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -23,4 +23,3 @@ docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
 docker --config="$DOCKER_CONF" push "${IMAGE}:latest"
 docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:qa"
 docker --config="$DOCKER_CONF" push "${IMAGE}:qa"
-


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-11665).
To ensure that the ci, qa, and smoke envs have the newest images, we need to push those to quay. We will be updating e2e deploy soon after this merge once we can verify the tags exist. 
