### PR TITLE
rhc-7979: Restart POD when DB is not accessible by inventory-mq

### DIFF
--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -153,3 +153,7 @@ def rbac_permission_denied(logger, required_permission, user_permissions):
         extra={"required_permission": required_permission, "user_permissions": user_permissions},
     )
     rbac_access_denied.labels(required_permission=required_permission).inc()
+
+
+def log_db_access_failure(logger, message):
+    logger.error("Error adding host ", message)

--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -155,5 +155,6 @@ def rbac_permission_denied(logger, required_permission, user_permissions):
     rbac_access_denied.labels(required_permission=required_permission).inc()
 
 
-def log_db_access_failure(logger, message):
-    logger.error("Error adding host ", message)
+def log_db_access_failure(logger, message, host_data):
+    logger.error("Error adding host ", f"{host_data['insights_id']}: {message}")
+    metrics.db_communication_error.labels("OperationalError", host_data.get("insights_id", message)).inc()

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -41,3 +41,8 @@ rbac_fetching_failure = Counter("inventory_rbac_fetching_failures", "Total amoun
 rbac_access_denied = Counter(
     "inventory_rbac_access_denied", "Total amount of failures authorizing with RBAC", ["required_permission"]
 )
+db_communication_error = Counter(
+    "inventory_mq_db_communication_error",
+    "Total number of connection errors between inventory-mq and the DB",
+    ["id", "reporter"],
+)

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -123,7 +123,7 @@ def add_host(host_data, identity):
             log_add_host_failure(logger, host_data)
             raise
         except OperationalError as oe:
-            log_db_access_failure(logger, f"Could not access DB {str(oe)}")
+            log_db_access_failure(logger, f"Could not access DB {str(oe)}", host_data)
             raise oe
         except Exception:
             logger.exception("Error while adding host", extra={"host": host_data})

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -7,6 +7,7 @@ from functools import partial
 import marshmallow
 import pytest
 from sqlalchemy import null
+from sqlalchemy.exc import OperationalError
 
 from app import db
 from app.auth.identity import Identity
@@ -28,6 +29,7 @@ from tests.helpers.system_profile_utils import system_profile_specification
 from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import minimal_host
 from tests.helpers.test_utils import now
+from tests.helpers.test_utils import SYSTEM_IDENTITY
 from tests.helpers.test_utils import USER_IDENTITY
 from tests.helpers.test_utils import valid_system_profile
 
@@ -1029,7 +1031,7 @@ def test_handle_message_with_different_account(mocker, flask_app, subtests):
         f'{{"operation": "", "data": {{"display_name": "{operation_raw}{operation_raw}", "account": "dummy"}}}}',
     )
 
-    identity = Identity(USER_IDENTITY)
+    identity = Identity(SYSTEM_IDENTITY)
     identity.account_number = "dummy"
 
     for message in messages:
@@ -1062,3 +1064,18 @@ def test_host_account_using_mq(mq_create_or_update_host, api_get, db_get_host, d
 
     assert created_host.__dict__ == same_host.__dict__
     assert len(first_batch.all()) == len(second_batch.all())
+
+
+def test_handle_message_side_effect(mocker, flask_app):
+    fake_add_host = mocker.patch(
+        "lib.host_repository.add_host", side_effect=OperationalError("DB Problem", "fake_param", "fake_orig")
+    )
+
+    expected_insights_id = generate_uuid()
+    host = minimal_host(insights_id=expected_insights_id)
+
+    fake_add_host.reset_mock()
+    message = json.dumps(wrap_message(host.data()))
+
+    with pytest.raises(expected_exception=OperationalError):
+        handle_message(message, mocker.MagicMock())


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-7979).  As host-inventory consumes messages from Kafka and updates the DB and produce events, the `inventory-mq` containers may be find RDS inaccessible for any reason.  When that happens, the mq container should exit and the pod be restarted. 

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
