### PR TITLE
Revert "Always push qa and latest tags for v3 and Clowder compatibility"

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -18,8 +18,7 @@ docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOK
 docker --config="$DOCKER_CONF" build -f dev.dockerfile -t "${IMAGE}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
 
-# To enable backwards compatibility with ci, qa, and smoke, always push latest and qa tags
-docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
-docker --config="$DOCKER_CONF" push "${IMAGE}:latest"
-docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:qa"
-docker --config="$DOCKER_CONF" push "${IMAGE}:qa"
+if [ "${PUSH_TO_LATEST:=true}" == "true" ]; then
+    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SMOKE_TEST_TAG}"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:${SMOKE_TEST_TAG}"
+fi


### PR DESCRIPTION
Reverts RedHatInsights/insights-host-inventory#786
We don't want every PR check to push to `latest` and `qa`, so we'll need to figure out a different approach (or the same approach, but with additional changes).