### PR TITLE
Add insight classic workaround to xjoin

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -88,7 +88,11 @@ def get_host_list(
     )
 
     current_identity = get_current_identity()
-    if current_identity.identity_type == "System" and current_identity.system["cert_type"] == "system":
+    if (
+        current_identity.identity_type == "System"
+        and current_identity.system["cert_type"] == "system"
+        and current_identity.auth_type != "classic-proxy"
+    ):
         all_filters += owner_id_filter()
 
     variables = {

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -112,7 +112,11 @@ def get_sap_system(tags=None, page=None, per_page=None, staleness=None, register
                 hostfilter_and_variables += build_sap_sids_filter(filter["system_profile"]["sap_sids"])
 
     current_identity = get_current_identity()
-    if current_identity.identity_type == "System" and current_identity.system["cert_type"] == "system":
+    if (
+        current_identity.identity_type == "System"
+        and current_identity.system["cert_type"] == "system"
+        and current_identity.auth_type != "classic-proxy"
+    ):
         hostfilter_and_variables += owner_id_filter()
 
     if hostfilter_and_variables != ():
@@ -168,7 +172,11 @@ def get_sap_sids(search=None, tags=None, page=None, per_page=None, staleness=Non
                 hostfilter_and_variables += build_sap_sids_filter(filter["system_profile"]["sap_sids"])
 
     current_identity = get_current_identity()
-    if current_identity.identity_type == "System" and current_identity.system["cert_type"] == "system":
+    if (
+        current_identity.identity_type == "System"
+        and current_identity.system["cert_type"] == "system"
+        and current_identity.auth_type != "classic-proxy"
+    ):
         hostfilter_and_variables += owner_id_filter()
 
     if hostfilter_and_variables != ():

--- a/api/tag.py
+++ b/api/tag.py
@@ -113,7 +113,11 @@ def get_tags(
                 hostfilter_and_variables += build_sap_sids_filter(filter["system_profile"]["sap_sids"])
 
     current_identity = get_current_identity()
-    if current_identity.identity_type == "System" and current_identity.system["cert_type"] == "system":
+    if (
+        current_identity.identity_type == "System"
+        and current_identity.system["cert_type"] == "system"
+        and current_identity.auth_type != "classic-proxy"
+    ):
         hostfilter_and_variables += owner_id_filter()
 
     if hostfilter_and_variables != ():

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -16,6 +16,7 @@ from urllib.parse import urlunsplit
 import dateutil.parser
 
 from app.auth.identity import Identity
+from tests.helpers.test_utils import INSIGHTS_CLASSIC_IDENTITY
 from tests.helpers.test_utils import SYSTEM_IDENTITY
 from tests.helpers.test_utils import USER_IDENTITY
 
@@ -82,6 +83,9 @@ def do_request(
 ):
     url = inject_qs(url, **query_parameters) if query_parameters else url
     headers = get_required_headers(auth_type, identity_type)
+
+    print("Required Headers: %s", headers)
+
     if extra_headers:
         headers = {**headers, **extra_headers}
 
@@ -99,7 +103,7 @@ def do_request(
 
 
 def get_valid_auth_header(auth_type="account_number", identity_type="User"):
-    if identity_type == "User" or identity_type == "System":
+    if identity_type == "User" or identity_type == "System" or identity_type == "Insights_Classic_System":
         return build_account_auth_header(auth_type, identity_type)
 
     return build_token_auth_header()
@@ -115,8 +119,12 @@ def get_required_headers(auth_type="account_number", identity_type="User"):
 def build_account_auth_header(account=USER_IDENTITY["account_number"], identity_type="User"):
     if identity_type == "User":
         identity = Identity(USER_IDENTITY)
-    else:
+    elif identity_type == "System":
         identity = Identity(SYSTEM_IDENTITY)
+    elif identity_type == "Insights_Classic_System":
+        identity = Identity(INSIGHTS_CLASSIC_IDENTITY)
+    else:
+        raise ValueError("unrecognized identity type")
 
     dict_ = {"identity": identity._asdict()}
 

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1575,3 +1575,77 @@ def test_query_system_profile_sap_system_system_identity(
         {"hostFilter": {"OR": mocker.ANY, "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},)}},
         mocker.ANY,
     )
+
+
+# TODO: Remove the tests related to insights classic workaround (the next 4 below)
+# once we no longer need it
+def test_query_hosts_insights_classic_system_identity(
+    mocker, subtests, query_source_xjoin, graphql_query_empty_response, api_get
+):
+    url = build_hosts_url()
+
+    response_status, response_data = api_get(url, identity_type="Insights_Classic_System")
+
+    assert response_status == 200
+
+    graphql_query_empty_response.assert_called_once_with(
+        HOST_QUERY,
+        {
+            "order_by": mocker.ANY,
+            "order_how": mocker.ANY,
+            "limit": mocker.ANY,
+            "offset": mocker.ANY,
+            "filter": ({"OR": mocker.ANY},),
+        },
+        mocker.ANY,
+    )
+
+
+def test_query_tags_insights_classic_system_identity(
+    mocker, subtests, query_source_xjoin, graphql_tag_query_empty_response, api_get
+):
+    url = build_tags_url()
+
+    response_status, response_data = api_get(url, identity_type="Insights_Classic_System")
+
+    assert response_status == 200
+
+    graphql_tag_query_empty_response.assert_called_once_with(
+        TAGS_QUERY,
+        {
+            "order_by": mocker.ANY,
+            "order_how": mocker.ANY,
+            "limit": mocker.ANY,
+            "offset": mocker.ANY,
+            "hostFilter": {"OR": mocker.ANY},
+        },
+        mocker.ANY,
+    )
+
+
+def test_query_system_profile_sap_sids_insights_classic_system_identity(
+    mocker, subtests, query_source_xjoin, graphql_system_profile_sap_sids_query_with_response, api_get
+):
+    url = build_system_profile_sap_sids_url()
+
+    response_status, response_data = api_get(url, identity_type="Insights_Classic_System")
+
+    assert response_status == 200
+
+    graphql_system_profile_sap_sids_query_with_response.assert_called_once_with(
+        SAP_SIDS_QUERY, {"hostFilter": {"OR": mocker.ANY}}, mocker.ANY
+    )
+
+
+def test_query_system_profile_sap_system_insights_classic_system_identity(
+    mocker, subtests, query_source_xjoin, graphql_system_profile_sap_system_query_with_response, api_get
+):
+    url = build_system_profile_sap_system_url()
+
+    response_status, response_data = api_get(url, identity_type="Insights_Classic_System")
+
+    assert response_status == 200
+
+    graphql_system_profile_sap_system_query_with_response.assert_called_once_with(
+        SAP_SYSTEM_QUERY, {"hostFilter": {"OR": mocker.ANY}}, mocker.ANY
+    )


### PR DESCRIPTION
## Overview

This PR is to fix the issue where the insights classic identity cause 500 errors when xjoin is the data source by expanding our workaround.

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
