### PR TITLE
short circuit to avoid 500 when no cert type. 

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -90,8 +90,8 @@ def get_host_list(
     current_identity = get_current_identity()
     if (
         current_identity.identity_type == "System"
-        and current_identity.system["cert_type"] == "system"
         and current_identity.auth_type != "classic-proxy"
+        and current_identity.system["cert_type"] == "system"
     ):
         all_filters += owner_id_filter()
 

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -114,8 +114,8 @@ def get_sap_system(tags=None, page=None, per_page=None, staleness=None, register
     current_identity = get_current_identity()
     if (
         current_identity.identity_type == "System"
-        and current_identity.system["cert_type"] == "system"
         and current_identity.auth_type != "classic-proxy"
+        and current_identity.system["cert_type"] == "system"
     ):
         hostfilter_and_variables += owner_id_filter()
 
@@ -174,8 +174,8 @@ def get_sap_sids(search=None, tags=None, page=None, per_page=None, staleness=Non
     current_identity = get_current_identity()
     if (
         current_identity.identity_type == "System"
-        and current_identity.system["cert_type"] == "system"
         and current_identity.auth_type != "classic-proxy"
+        and current_identity.system["cert_type"] == "system"
     ):
         hostfilter_and_variables += owner_id_filter()
 

--- a/api/tag.py
+++ b/api/tag.py
@@ -115,8 +115,8 @@ def get_tags(
     current_identity = get_current_identity()
     if (
         current_identity.identity_type == "System"
-        and current_identity.system["cert_type"] == "system"
         and current_identity.auth_type != "classic-proxy"
+        and current_identity.system["cert_type"] == "system"
     ):
         hostfilter_and_variables += owner_id_filter()
 

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -31,7 +31,7 @@ INSIGHTS_CLASSIC_IDENTITY = {
     "account_number": "test",
     "auth_type": "classic-proxy",
     "internal": {"auth_time": 6300, "org_id": "3340851"},
-    "system": {"cert_type": "system"},
+    "system": {},
     "type": "System",
 }
 


### PR DESCRIPTION

## Overview

Changing the logic to short circuit and avoid a 50 error from classic identity since it actually has not cert type. Updated identity used in tests to reflect that there is not cert_type in classic identity. I want to verify that the system field even exists in these identities before we merge this since it seems odd that they would send us an empty field, and it's emptyness could lead to more problems.


## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
