### PR TITLE
Add model name as cpu_model to system profile

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -364,6 +364,7 @@ class NetworkInterfaceSchema(MarshmallowSchema):
 
 class SystemProfileSchema(MarshmallowSchema):
     owner_id = fields.Str(validate=verify_uuid_format)
+    cpu_model = fields.Str(validate=marshmallow_validate.Length(max=100))
     number_of_cpus = fields.Int()
     number_of_sockets = fields.Int()
     cores_per_socket = fields.Int()

--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -139,6 +139,11 @@ $defs:
         pattern: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
         maxLength: 36
         example: 22cd8e39-13bb-4d02-8316-84b850dc5136
+      cpu_model:
+        description: The cpu model name
+        type: string
+        maxLength: 100
+        example: 'Intel(R) Xeon(R) CPU E5-2690 0 @ 2.90GHz'
       number_of_cpus:
         type: integer
       number_of_sockets:

--- a/tests/helpers/system_profile_utils.py
+++ b/tests/helpers/system_profile_utils.py
@@ -54,6 +54,7 @@ INVALID_SYSTEM_PROFILES = (
     {"sap_sids": ["123"]},
     {"sap_sids": ["abc"]},
     {"sap_sids": ["ABC", "ABC"]},
+    {"cpu_model": "x" * 101},
 )
 
 

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -85,6 +85,7 @@ def minimal_host(**values):
 def valid_system_profile():
     return {
         "owner_id": "afe768a2-1c5e-4480-988b-21c3d6cfacf4",
+        "cpu_model": "Intel(R) Xeon(R) CPU E5-2690 0 @ 2.90GHz",
         "number_of_cpus": 1,
         "number_of_sockets": 2,
         "cores_per_socket": 4,

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -374,6 +374,7 @@ def rpm_list():
 def create_system_profile():
     return {
         "owner_id": "1b36b20f-7fa0-4454-a6d2-008294e06378",
+        "cpu_model": "Intel(R) Xeon(R) CPU E5-2690 0 @ 2.90GHz",
         "number_of_cpus": 1,
         "number_of_sockets": 2,
         "cores_per_socket": 4,


### PR DESCRIPTION
Add cpu model name as cpu_model to system profile as requested:
https://issues.redhat.com/browse/HBISPSC-39

Related PRs:
https://github.com/RedHatInsights/inventory-schemas/pull/44
https://github.com/RedHatInsights/insights-puptoo/pull/117