### PR TITLE
disable filtering based on owner_id

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -87,13 +87,14 @@ def get_host_list(
         fqdn, display_name, hostname_or_id, insights_id, tags, staleness, registered_with, filter
     )
 
-    current_identity = get_current_identity()
-    if (
-        current_identity.identity_type == "System"
-        and current_identity.auth_type != "classic-proxy"
-        and current_identity.system["cert_type"] == "system"
-    ):
-        all_filters += owner_id_filter()
+    # TODO enable owner_id filtering after all hosts've been updated with "owner_id"
+    # current_identity = get_current_identity()
+    # if (
+    #     current_identity.identity_type == "System"
+    #     and current_identity.auth_type != "classic-proxy"
+    #     and current_identity.system["cert_type"] == "system"
+    # ):
+    #     all_filters += owner_id_filter()
 
     variables = {
         "limit": limit,
@@ -194,5 +195,6 @@ def _query_filters(fqdn, display_name, hostname_or_id, insights_id, tags, stalen
     return query_filters
 
 
+# TODO enable after all hosts've been updated with "owner_id"
 def owner_id_filter():
     return ({"spf_owner_id": {"eq": get_current_identity().system["cn"]}},)

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -11,9 +11,7 @@ from api.host import get_bulk_query_source
 from api.host_query_xjoin import build_sap_sids_filter
 from api.host_query_xjoin import build_sap_system_filters
 from api.host_query_xjoin import build_tag_query_dict_tuple
-from api.host_query_xjoin import owner_id_filter
 from app import Permission
-from app.auth import get_current_identity
 from app.config import BulkQuerySource
 from app.config import Config
 from app.environment import RuntimeEnvironment
@@ -28,6 +26,9 @@ from app.xjoin import pagination_params
 from app.xjoin import staleness_filter
 from lib.middleware import rbac
 from lib.system_profile_validate import validate_sp_for_branch
+
+# from api.host_query_xjoin import owner_id_filter
+# from app.auth import get_current_identity
 
 logger = get_logger(__name__)
 
@@ -112,13 +113,14 @@ def get_sap_system(tags=None, page=None, per_page=None, staleness=None, register
             if filter["system_profile"].get("sap_sids"):
                 hostfilter_and_variables += build_sap_sids_filter(filter["system_profile"]["sap_sids"])
 
-    current_identity = get_current_identity()
-    if (
-        current_identity.identity_type == "System"
-        and current_identity.auth_type != "classic-proxy"
-        and current_identity.system["cert_type"] == "system"
-    ):
-        hostfilter_and_variables += owner_id_filter()
+    # TODO enable owner_id filtering after all hosts've been updated with "owner_id"
+    # current_identity = get_current_identity()
+    # if (
+    #     current_identity.identity_type == "System"
+    #     and current_identity.auth_type != "classic-proxy"
+    #     and current_identity.system["cert_type"] == "system"
+    # ):
+    #     hostfilter_and_variables += owner_id_filter()
 
     if hostfilter_and_variables != ():
         variables["hostFilter"]["AND"] = hostfilter_and_variables
@@ -172,13 +174,14 @@ def get_sap_sids(search=None, tags=None, page=None, per_page=None, staleness=Non
             if filter["system_profile"].get("sap_sids"):
                 hostfilter_and_variables += build_sap_sids_filter(filter["system_profile"]["sap_sids"])
 
-    current_identity = get_current_identity()
-    if (
-        current_identity.identity_type == "System"
-        and current_identity.auth_type != "classic-proxy"
-        and current_identity.system["cert_type"] == "system"
-    ):
-        hostfilter_and_variables += owner_id_filter()
+    # TODO enable owner_id filtering after all hosts've been updated with "owner_id"
+    # current_identity = get_current_identity()
+    # if (
+    #     current_identity.identity_type == "System"
+    #     and current_identity.auth_type != "classic-proxy"
+    #     and current_identity.system["cert_type"] == "system"
+    # ):
+    #     hostfilter_and_variables += owner_id_filter()
 
     if hostfilter_and_variables != ():
         variables["hostFilter"]["AND"] = hostfilter_and_variables

--- a/api/tag.py
+++ b/api/tag.py
@@ -10,9 +10,7 @@ from api.host import get_bulk_query_source
 from api.host_query_xjoin import build_sap_sids_filter
 from api.host_query_xjoin import build_sap_system_filters
 from api.host_query_xjoin import build_tag_query_dict_tuple
-from api.host_query_xjoin import owner_id_filter
 from app import Permission
-from app.auth import get_current_identity
 from app.config import BulkQuerySource
 from app.instrumentation import log_get_tags_failed
 from app.instrumentation import log_get_tags_succeeded
@@ -22,6 +20,9 @@ from app.xjoin import graphql_query
 from app.xjoin import pagination_params
 from app.xjoin import staleness_filter
 from lib.middleware import rbac
+
+# from api.host_query_xjoin import owner_id_filter
+# from app.auth import get_current_identity
 
 
 logger = get_logger(__name__)
@@ -112,13 +113,14 @@ def get_tags(
             if filter["system_profile"].get("sap_sids"):
                 hostfilter_and_variables += build_sap_sids_filter(filter["system_profile"]["sap_sids"])
 
-    current_identity = get_current_identity()
-    if (
-        current_identity.identity_type == "System"
-        and current_identity.auth_type != "classic-proxy"
-        and current_identity.system["cert_type"] == "system"
-    ):
-        hostfilter_and_variables += owner_id_filter()
+    # TODO enable owner_id filtering after all hosts've been updated with "owner_id"
+    # current_identity = get_current_identity()
+    # if (
+    #     current_identity.identity_type == "System"
+    #     and current_identity.auth_type != "classic-proxy"
+    #     and current_identity.system["cert_type"] == "system"
+    # ):
+    #     hostfilter_and_variables += owner_id_filter()
 
     if hostfilter_and_variables != ():
         variables["hostFilter"]["AND"] = hostfilter_and_variables

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -185,15 +185,18 @@ def stale_timestamp_filter(gt=None, lte=None):
 
 
 def update_query_for_owner_id(identity, query):
-    # kafka based requests have dummy identity for working around the identity requirement for CRUD operations
-    # TODO: 'identity.auth_type is not 'classic-proxy' is a temporary fix. Remove when workaround is no longer needed
-    logger.debug("identity auth type: %s", identity.auth_type)
-    if (
-        identity
-        and identity.identity_type == "System"
-        and identity.auth_type != "classic-proxy"
-        and identity.system["cert_type"] == "system"
-    ):
-        return query.filter(and_(Host.system_profile_facts["owner_id"].as_string() == identity.system["cn"]))
-    else:
-        return query
+    # TODO enable owner_id filtering after all hosts've been updated with "owner_id"
+    # # kafka based requests have dummy identity for working around the identity requirement for CRUD operations
+    # # TODO: 'identity.auth_type is not 'classic-proxy' is a temporary fix. Remove when workaround is no longer needed
+    # logger.debug("identity auth type: %s", identity.auth_type)
+    # if (
+    #     identity
+    #     and identity.identity_type == "System"
+    #     and identity.auth_type != "classic-proxy"
+    #     and identity.system["cert_type"] == "system"
+    # ):
+    #     return query.filter(and_(Host.system_profile_facts["owner_id"].as_string() == identity.system["cn"]))
+    # else:
+    #     return query
+
+    return query

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1523,59 +1523,63 @@ def test_query_system_profile_sap_sids_with_search(
 #     )
 
 
-def test_query_tags_system_identity(mocker, subtests, query_source_xjoin, graphql_tag_query_empty_response, api_get):
-    url = build_tags_url()
+# TODO enable after all hosts've been updated with "owner_id"
+# def test_query_tags_system_identity(mocker, subtests, query_source_xjoin, graphql_tag_query_empty_response, api_get):
+#     url = build_tags_url()
 
-    response_status, response_data = api_get(url, identity_type="System")
+#     response_status, response_data = api_get(url, identity_type="System")
 
-    assert response_status == 200
+#     assert response_status == 200
 
-    graphql_tag_query_empty_response.assert_called_once_with(
-        TAGS_QUERY,
-        {
-            "order_by": mocker.ANY,
-            "order_how": mocker.ANY,
-            "limit": mocker.ANY,
-            "offset": mocker.ANY,
-            "hostFilter": {
-                "OR": mocker.ANY,
-                "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},),
-            },
-        },
-        mocker.ANY,
-    )
-
-
-def test_query_system_profile_sap_sids_system_identity(
-    mocker, subtests, query_source_xjoin, graphql_system_profile_sap_sids_query_with_response, api_get
-):
-    url = build_system_profile_sap_sids_url()
-
-    response_status, response_data = api_get(url, identity_type="System")
-
-    assert response_status == 200
-
-    graphql_system_profile_sap_sids_query_with_response.assert_called_once_with(
-        SAP_SIDS_QUERY,
-        {"hostFilter": {"OR": mocker.ANY, "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},)}},
-        mocker.ANY,
-    )
+#     graphql_tag_query_empty_response.assert_called_once_with(
+#         TAGS_QUERY,
+#         {
+#             "order_by": mocker.ANY,
+#             "order_how": mocker.ANY,
+#             "limit": mocker.ANY,
+#             "offset": mocker.ANY,
+#             "hostFilter": {
+#                 "OR": mocker.ANY,
+#                 "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},),
+#             },
+#         },
+#         mocker.ANY,
+#     )
 
 
-def test_query_system_profile_sap_system_system_identity(
-    mocker, subtests, query_source_xjoin, graphql_system_profile_sap_system_query_with_response, api_get
-):
-    url = build_system_profile_sap_system_url()
+# TODO enable after all hosts've been updated with "owner_id"
+# def test_query_system_profile_sap_sids_system_identity(
+#     mocker, subtests, query_source_xjoin, graphql_system_profile_sap_sids_query_with_response, api_get
+# ):
+#     url = build_system_profile_sap_sids_url()
 
-    response_status, response_data = api_get(url, identity_type="System")
+#     response_status, response_data = api_get(url, identity_type="System")
 
-    assert response_status == 200
+#     assert response_status == 200
 
-    graphql_system_profile_sap_system_query_with_response.assert_called_once_with(
-        SAP_SYSTEM_QUERY,
-        {"hostFilter": {"OR": mocker.ANY, "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},)}},
-        mocker.ANY,
-    )
+#     graphql_system_profile_sap_sids_query_with_response.assert_called_once_with(
+#         SAP_SIDS_QUERY,
+#         {"hostFilter": {"OR": mocker.ANY, "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},)\
+# }},
+#         mocker.ANY,
+#     )
+
+
+# def test_query_system_profile_sap_system_system_identity(
+#     mocker, subtests, query_source_xjoin, graphql_system_profile_sap_system_query_with_response, api_get
+# ):
+#     url = build_system_profile_sap_system_url()
+
+#     response_status, response_data = api_get(url, identity_type="System")
+
+#     assert response_status == 200
+
+#     graphql_system_profile_sap_system_query_with_response.assert_called_once_with(
+#         SAP_SYSTEM_QUERY,
+#         {"hostFilter": {"OR": mocker.ANY, "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},)\
+# }},
+#         mocker.ANY,
+#     )
 
 
 # TODO: Remove the tests related to insights classic workaround (the next 4 below)

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1502,24 +1502,25 @@ def test_query_system_profile_sap_sids_with_search(
     )
 
 
-def test_query_hosts_system_identity(mocker, subtests, query_source_xjoin, graphql_query_empty_response, api_get):
-    url = build_hosts_url()
+# TODO enable after all hosts've been updated with "owner_id"
+# def test_query_hosts_system_identity(mocker, subtests, query_source_xjoin, graphql_query_empty_response, api_get):
+#     url = build_hosts_url()
 
-    response_status, response_data = api_get(url, identity_type="System")
+#     response_status, response_data = api_get(url, identity_type="System")
 
-    assert response_status == 200
+#     assert response_status == 200
 
-    graphql_query_empty_response.assert_called_once_with(
-        HOST_QUERY,
-        {
-            "order_by": mocker.ANY,
-            "order_how": mocker.ANY,
-            "limit": mocker.ANY,
-            "offset": mocker.ANY,
-            "filter": ({"OR": mocker.ANY}, {"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}}),
-        },
-        mocker.ANY,
-    )
+#     graphql_query_empty_response.assert_called_once_with(
+#         HOST_QUERY,
+#         {
+#             "order_by": mocker.ANY,
+#             "order_how": mocker.ANY,
+#             "limit": mocker.ANY,
+#             "offset": mocker.ANY,
+#             "filter": ({"OR": mocker.ANY}, {"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}}),
+#         },
+#         mocker.ANY,
+#     )
 
 
 def test_query_tags_system_identity(mocker, subtests, query_source_xjoin, graphql_tag_query_empty_response, api_get):


### PR DESCRIPTION
## Overview

This PR disables filtering based on `owner_id`.  It will remain disabled until all existing hosts in Prod have been updated with system_profile containing owner_id.

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
