### PR TITLE
re-enable owner_id based filtering

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -87,14 +87,13 @@ def get_host_list(
         fqdn, display_name, hostname_or_id, insights_id, tags, staleness, registered_with, filter
     )
 
-    # TODO enable owner_id filtering after all hosts've been updated with "owner_id"
-    # current_identity = get_current_identity()
-    # if (
-    #     current_identity.identity_type == "System"
-    #     and current_identity.auth_type != "classic-proxy"
-    #     and current_identity.system["cert_type"] == "system"
-    # ):
-    #     all_filters += owner_id_filter()
+    current_identity = get_current_identity()
+    if (
+        current_identity.identity_type == "System"
+        and current_identity.auth_type != "classic-proxy"
+        and current_identity.system["cert_type"] == "system"
+    ):
+        all_filters += owner_id_filter()
 
     variables = {
         "limit": limit,
@@ -195,6 +194,5 @@ def _query_filters(fqdn, display_name, hostname_or_id, insights_id, tags, stalen
     return query_filters
 
 
-# TODO enable after all hosts've been updated with "owner_id"
 def owner_id_filter():
     return ({"spf_owner_id": {"eq": get_current_identity().system["cn"]}},)

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -11,7 +11,9 @@ from api.host import get_bulk_query_source
 from api.host_query_xjoin import build_sap_sids_filter
 from api.host_query_xjoin import build_sap_system_filters
 from api.host_query_xjoin import build_tag_query_dict_tuple
+from api.host_query_xjoin import owner_id_filter
 from app import Permission
+from app.auth import get_current_identity
 from app.config import BulkQuerySource
 from app.config import Config
 from app.environment import RuntimeEnvironment
@@ -26,9 +28,6 @@ from app.xjoin import pagination_params
 from app.xjoin import staleness_filter
 from lib.middleware import rbac
 from lib.system_profile_validate import validate_sp_for_branch
-
-# from api.host_query_xjoin import owner_id_filter
-# from app.auth import get_current_identity
 
 logger = get_logger(__name__)
 
@@ -113,14 +112,13 @@ def get_sap_system(tags=None, page=None, per_page=None, staleness=None, register
             if filter["system_profile"].get("sap_sids"):
                 hostfilter_and_variables += build_sap_sids_filter(filter["system_profile"]["sap_sids"])
 
-    # TODO enable owner_id filtering after all hosts've been updated with "owner_id"
-    # current_identity = get_current_identity()
-    # if (
-    #     current_identity.identity_type == "System"
-    #     and current_identity.auth_type != "classic-proxy"
-    #     and current_identity.system["cert_type"] == "system"
-    # ):
-    #     hostfilter_and_variables += owner_id_filter()
+    current_identity = get_current_identity()
+    if (
+        current_identity.identity_type == "System"
+        and current_identity.auth_type != "classic-proxy"
+        and current_identity.system["cert_type"] == "system"
+    ):
+        hostfilter_and_variables += owner_id_filter()
 
     if hostfilter_and_variables != ():
         variables["hostFilter"]["AND"] = hostfilter_and_variables
@@ -174,14 +172,13 @@ def get_sap_sids(search=None, tags=None, page=None, per_page=None, staleness=Non
             if filter["system_profile"].get("sap_sids"):
                 hostfilter_and_variables += build_sap_sids_filter(filter["system_profile"]["sap_sids"])
 
-    # TODO enable owner_id filtering after all hosts've been updated with "owner_id"
-    # current_identity = get_current_identity()
-    # if (
-    #     current_identity.identity_type == "System"
-    #     and current_identity.auth_type != "classic-proxy"
-    #     and current_identity.system["cert_type"] == "system"
-    # ):
-    #     hostfilter_and_variables += owner_id_filter()
+    current_identity = get_current_identity()
+    if (
+        current_identity.identity_type == "System"
+        and current_identity.auth_type != "classic-proxy"
+        and current_identity.system["cert_type"] == "system"
+    ):
+        hostfilter_and_variables += owner_id_filter()
 
     if hostfilter_and_variables != ():
         variables["hostFilter"]["AND"] = hostfilter_and_variables

--- a/api/tag.py
+++ b/api/tag.py
@@ -10,7 +10,9 @@ from api.host import get_bulk_query_source
 from api.host_query_xjoin import build_sap_sids_filter
 from api.host_query_xjoin import build_sap_system_filters
 from api.host_query_xjoin import build_tag_query_dict_tuple
+from api.host_query_xjoin import owner_id_filter
 from app import Permission
+from app.auth import get_current_identity
 from app.config import BulkQuerySource
 from app.instrumentation import log_get_tags_failed
 from app.instrumentation import log_get_tags_succeeded
@@ -20,9 +22,6 @@ from app.xjoin import graphql_query
 from app.xjoin import pagination_params
 from app.xjoin import staleness_filter
 from lib.middleware import rbac
-
-# from api.host_query_xjoin import owner_id_filter
-# from app.auth import get_current_identity
 
 
 logger = get_logger(__name__)
@@ -113,14 +112,13 @@ def get_tags(
             if filter["system_profile"].get("sap_sids"):
                 hostfilter_and_variables += build_sap_sids_filter(filter["system_profile"]["sap_sids"])
 
-    # TODO enable owner_id filtering after all hosts've been updated with "owner_id"
-    # current_identity = get_current_identity()
-    # if (
-    #     current_identity.identity_type == "System"
-    #     and current_identity.auth_type != "classic-proxy"
-    #     and current_identity.system["cert_type"] == "system"
-    # ):
-    #     hostfilter_and_variables += owner_id_filter()
+    current_identity = get_current_identity()
+    if (
+        current_identity.identity_type == "System"
+        and current_identity.auth_type != "classic-proxy"
+        and current_identity.system["cert_type"] == "system"
+    ):
+        hostfilter_and_variables += owner_id_filter()
 
     if hostfilter_and_variables != ():
         variables["hostFilter"]["AND"] = hostfilter_and_variables

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -185,18 +185,15 @@ def stale_timestamp_filter(gt=None, lte=None):
 
 
 def update_query_for_owner_id(identity, query):
-    # TODO enable owner_id filtering after all hosts've been updated with "owner_id"
-    # # kafka based requests have dummy identity for working around the identity requirement for CRUD operations
-    # # TODO: 'identity.auth_type is not 'classic-proxy' is a temporary fix. Remove when workaround is no longer needed
-    # logger.debug("identity auth type: %s", identity.auth_type)
-    # if (
-    #     identity
-    #     and identity.identity_type == "System"
-    #     and identity.auth_type != "classic-proxy"
-    #     and identity.system["cert_type"] == "system"
-    # ):
-    #     return query.filter(and_(Host.system_profile_facts["owner_id"].as_string() == identity.system["cn"]))
-    # else:
-    #     return query
-
-    return query
+    # kafka based requests have dummy identity for working around the identity requirement for CRUD operations
+    # TODO: 'identity.auth_type is not 'classic-proxy' is a temporary fix. Remove when workaround is no longer needed
+    logger.debug("identity auth type: %s", identity.auth_type)
+    if (
+        identity
+        and identity.identity_type == "System"
+        and identity.auth_type != "classic-proxy"
+        and identity.system["cert_type"] == "system"
+    ):
+        return query.filter(and_(Host.system_profile_facts["owner_id"].as_string() == identity.system["cn"]))
+    else:
+        return query

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1502,84 +1502,79 @@ def test_query_system_profile_sap_sids_with_search(
     )
 
 
-# TODO enable after all hosts've been updated with "owner_id"
-# def test_query_hosts_system_identity(mocker, subtests, query_source_xjoin, graphql_query_empty_response, api_get):
-#     url = build_hosts_url()
+def test_query_hosts_system_identity(mocker, subtests, query_source_xjoin, graphql_query_empty_response, api_get):
+    url = build_hosts_url()
 
-#     response_status, response_data = api_get(url, identity_type="System")
+    response_status, response_data = api_get(url, identity_type="System")
 
-#     assert response_status == 200
+    assert response_status == 200
 
-#     graphql_query_empty_response.assert_called_once_with(
-#         HOST_QUERY,
-#         {
-#             "order_by": mocker.ANY,
-#             "order_how": mocker.ANY,
-#             "limit": mocker.ANY,
-#             "offset": mocker.ANY,
-#             "filter": ({"OR": mocker.ANY}, {"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}}),
-#         },
-#         mocker.ANY,
-#     )
-
-
-# TODO enable after all hosts've been updated with "owner_id"
-# def test_query_tags_system_identity(mocker, subtests, query_source_xjoin, graphql_tag_query_empty_response, api_get):
-#     url = build_tags_url()
-
-#     response_status, response_data = api_get(url, identity_type="System")
-
-#     assert response_status == 200
-
-#     graphql_tag_query_empty_response.assert_called_once_with(
-#         TAGS_QUERY,
-#         {
-#             "order_by": mocker.ANY,
-#             "order_how": mocker.ANY,
-#             "limit": mocker.ANY,
-#             "offset": mocker.ANY,
-#             "hostFilter": {
-#                 "OR": mocker.ANY,
-#                 "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},),
-#             },
-#         },
-#         mocker.ANY,
-#     )
+    graphql_query_empty_response.assert_called_once_with(
+        HOST_QUERY,
+        {
+            "order_by": mocker.ANY,
+            "order_how": mocker.ANY,
+            "limit": mocker.ANY,
+            "offset": mocker.ANY,
+            "filter": ({"OR": mocker.ANY}, {"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}}),
+        },
+        mocker.ANY,
+    )
 
 
-# TODO enable after all hosts've been updated with "owner_id"
-# def test_query_system_profile_sap_sids_system_identity(
-#     mocker, subtests, query_source_xjoin, graphql_system_profile_sap_sids_query_with_response, api_get
-# ):
-#     url = build_system_profile_sap_sids_url()
+def test_query_tags_system_identity(mocker, subtests, query_source_xjoin, graphql_tag_query_empty_response, api_get):
+    url = build_tags_url()
 
-#     response_status, response_data = api_get(url, identity_type="System")
+    response_status, response_data = api_get(url, identity_type="System")
 
-#     assert response_status == 200
+    assert response_status == 200
 
-#     graphql_system_profile_sap_sids_query_with_response.assert_called_once_with(
-#         SAP_SIDS_QUERY,
-#         {"hostFilter": {"OR": mocker.ANY, "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},)\
-# }},
-#         mocker.ANY,
-#     )
+    graphql_tag_query_empty_response.assert_called_once_with(
+        TAGS_QUERY,
+        {
+            "order_by": mocker.ANY,
+            "order_how": mocker.ANY,
+            "limit": mocker.ANY,
+            "offset": mocker.ANY,
+            "hostFilter": {
+                "OR": mocker.ANY,
+                "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},),
+            },
+        },
+        mocker.ANY,
+    )
 
 
-# def test_query_system_profile_sap_system_system_identity(
-#     mocker, subtests, query_source_xjoin, graphql_system_profile_sap_system_query_with_response, api_get
-# ):
-#     url = build_system_profile_sap_system_url()
+def test_query_system_profile_sap_sids_system_identity(
+    mocker, subtests, query_source_xjoin, graphql_system_profile_sap_sids_query_with_response, api_get
+):
+    url = build_system_profile_sap_sids_url()
 
-#     response_status, response_data = api_get(url, identity_type="System")
+    response_status, response_data = api_get(url, identity_type="System")
 
-#     assert response_status == 200
+    assert response_status == 200
 
-#     graphql_system_profile_sap_system_query_with_response.assert_called_once_with(
-#         SAP_SYSTEM_QUERY,
-#         {"hostFilter": {"OR": mocker.ANY, "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},)\
-# }},
-#         mocker.ANY,
-#     )
+    graphql_system_profile_sap_sids_query_with_response.assert_called_once_with(
+        SAP_SIDS_QUERY,
+        {"hostFilter": {"OR": mocker.ANY, "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},)}},
+        mocker.ANY,
+    )
+
+
+def test_query_system_profile_sap_system_system_identity(
+    mocker, subtests, query_source_xjoin, graphql_system_profile_sap_system_query_with_response, api_get
+):
+    url = build_system_profile_sap_system_url()
+
+    response_status, response_data = api_get(url, identity_type="System")
+
+    assert response_status == 200
+
+    graphql_system_profile_sap_system_query_with_response.assert_called_once_with(
+        SAP_SYSTEM_QUERY,
+        {"hostFilter": {"OR": mocker.ANY, "AND": ({"spf_owner_id": {"eq": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}},)}},
+        mocker.ANY,
+    )
 
 
 # TODO: Remove the tests related to insights classic workaround (the next 4 below)

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -529,7 +529,7 @@ def build_host_chunk():
         # "ip_addresses": ["1",],
         # "mac_addresses": None,
         # "subscription_manager_id": random_uuid(),
-        "subscription_manager_id": "044e36dc-4e2b-4e69-8948-9c65a7bf4976",
+        # "subscription_manager_id": "044e36dc-4e2b-4e69-8948-9c65a7bf4976",
         "system_profile": create_system_profile(),
         "stale_timestamp": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
         "reporter": "me",


### PR DESCRIPTION
## Overview

This PR reenables hosts filtering based on `owner_id`.  The work involved uncommenting the code commented in https://github.com/RedHatInsights/insights-host-inventory/pull/803.

Executed tests using pytests and all passed.   Yet to verify in the xjoin integrated environment.
@ryandillinfelton, if you have a moment, can you please verify that the xjoin is working.  Thanks.

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
