### PR TITLE
Add github bot that validates SP schemas

### DIFF
--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -208,7 +208,7 @@ def validate_schema(repo_fork="RedHatInsights", repo_branch="master", days=1):
         **config.kafka_consumer,
     )
     try:
-        response = validate_sp_for_branch(config, consumer, repo_fork, repo_branch, days)
+        response = validate_sp_for_branch(consumer, repo_fork, repo_branch, days)
         consumer.close()
         return flask_json_response(response)
     except (ValueError, AttributeError) as e:

--- a/lib/system_profile_validate.py
+++ b/lib/system_profile_validate.py
@@ -88,7 +88,7 @@ def get_hosts_from_kafka_messages(consumer, days):
     if len(parsed_hosts) == 0:
         raise ValueError("No data available at the provided date.")
 
-    logger.info(f"Parsed {len(parsed_hosts)} hosts from message queue.")
+    logger.info(f"Parsed {len(parsed_hosts)} of {len(list(msgs.values())[0])} hosts from message queue.")
     return parsed_hosts
 
 

--- a/lib/system_profile_validate.py
+++ b/lib/system_profile_validate.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from datetime import timedelta
 
 from kafka.common import TopicPartition
+from marshmallow import ValidationError
 from requests import get
 from yaml import safe_load
 
@@ -21,27 +22,20 @@ class TestResult:
         self.fail_count = 0
 
 
-def _get_schema_from_url(url):
+def get_schema_from_url(url):
     response = get(url)
     if response.status_code != 200:
         raise ValueError(f"Schema not found at URL: {url}")
     return safe_load(get(url).content.decode("utf-8"))
 
 
-def _validate_host_list(host_list, repo_config):
-    system_profile_spec = _get_schema_from_url(
-        f"https://raw.githubusercontent.com/{repo_config['fork']}/inventory-schemas/"
-        f"{repo_config['branch']}/schemas/system_profile/v1.yaml"
-    )
-
-    logger.info(f"Validating host against {repo_config['fork']}/{repo_config['branch']} schema...")
+def validate_host_list_against_spec(host_list, sp_spec):
     test_results = {}
-
     for host in host_list:
         if host["reporter"] not in test_results.keys():
             test_results[host["reporter"]] = TestResult()
         try:
-            deserialize_host_mq(host, system_profile_spec)
+            deserialize_host_mq(host, sp_spec)
             test_results[host["reporter"]].pass_count += 1
         except Exception as e:
             test_results[host["reporter"]].fail_count += 1
@@ -50,10 +44,19 @@ def _validate_host_list(host_list, repo_config):
     return test_results
 
 
-def validate_sp_for_branch(config, consumer, repo_fork="RedHatInsights", repo_branch="master", days=1):
+def _validate_host_list(host_list, repo_config):
+    system_profile_spec = get_schema_from_url(
+        f"https://raw.githubusercontent.com/{repo_config['fork']}/inventory-schemas/"
+        f"{repo_config['branch']}/schemas/system_profile/v1.yaml"
+    )
+
+    logger.info(f"Validating host against {repo_config['fork']}/{repo_config['branch']} schema...")
+    return validate_host_list_against_spec(host_list, system_profile_spec)
+
+
+def get_hosts_from_kafka_messages(consumer, days):
     msgs = {}
     partitions = []
-    hosts_parsed = 0
     parsed_hosts = []
     seek_date = datetime.now() + timedelta(days=(-1 * days))
 
@@ -74,20 +77,28 @@ def validate_sp_for_branch(config, consumer, repo_fork="RedHatInsights", repo_br
 
     for topic_partition, messages in msgs.items():
         for message in messages:
-            parsed_message = json.loads(message.value)
-            parsed_operation = OperationSchema(strict=True).load(parsed_message).data
-            parsed_hosts.append(parsed_operation["data"])
-            hosts_parsed += 1
+            try:
+                parsed_message = json.loads(message.value)
+                parsed_operation = OperationSchema(strict=True).load(parsed_message).data
+                parsed_hosts.append(parsed_operation["data"])
+            except ValidationError as e:
+                logger.info("Could not parse host!")
+                logger.error(e)
 
-    if hosts_parsed == 0:
+    if len(parsed_hosts) == 0:
         raise ValueError("No data available at the provided date.")
 
-    logger.info(f"Parsed {hosts_parsed} hosts from message queue.")
+    logger.info(f"Parsed {len(parsed_hosts)} hosts from message queue.")
+    return parsed_hosts
+
+
+def validate_sp_for_branch(consumer, repo_fork="RedHatInsights", repo_branch="master", days=1):
+    parsed_hosts = get_hosts_from_kafka_messages(consumer, days)
 
     validation_results = {}
     for item in [{"fork": repo_fork, "branch": repo_branch}, {"fork": "RedHatInsights", "branch": "master"}]:
         validation_results[f"{item['fork']}/{item['branch']}"] = (
-            _validate_host_list(parsed_hosts, item) if hosts_parsed > 0 else {}
+            _validate_host_list(parsed_hosts, item) if len(parsed_hosts) > 0 else {}
         )
 
     return validation_results

--- a/system_profile_validator.py
+++ b/system_profile_validator.py
@@ -1,0 +1,170 @@
+import json
+import sys
+from functools import partial
+from os import getenv
+
+from dateutil import parser
+from kafka import KafkaConsumer
+from requests import get
+from requests import post
+from requests.auth import HTTPBasicAuth
+
+from app import UNKNOWN_REQUEST_ID_VALUE
+from app.config import Config
+from app.environment import RuntimeEnvironment
+from app.logging import configure_logging
+from app.logging import get_logger
+from app.logging import threadctx
+from lib.system_profile_validate import get_hosts_from_kafka_messages
+from lib.system_profile_validate import get_schema_from_url
+from lib.system_profile_validate import validate_host_list_against_spec
+
+
+__all__ = "main"
+
+LOGGER_NAME = "inventory_sp_validator"
+REPO_OWNER = "RedHatInsights"
+REPO_NAME = "inventory-schemas"
+SP_SPEC_PATH = "schemas/system_profile/v1.yaml"
+RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
+GIT_USER = getenv("GIT_USER")
+GIT_TOKEN = getenv("GIT_TOKEN")
+VALIDATE_DAYS = getenv("VALIDATE_DAYS", 3)
+
+
+def _init_config():
+    config = Config(RUNTIME_ENVIRONMENT)
+    config.log_configuration()
+    return config
+
+
+def _excepthook(logger, type, value, traceback):
+    logger.exception("System Profile Validator failed", exc_info=value)
+
+
+def _get_git_response(path):
+    return json.loads(
+        get(f"https://api.github.com{path}", auth=HTTPBasicAuth(GIT_USER, GIT_TOKEN)).content.decode("utf-8")
+    )
+
+
+def _post_git_response(path, content):
+    return post(f"https://api.github.com{path}", auth=HTTPBasicAuth(GIT_USER, GIT_TOKEN), json={"body": content})
+
+
+def _validation_results_plaintext(test_results):
+    text = ""
+    for reporter, result in test_results.items():
+        text += f"{reporter}:\n\tPass:{result.pass_count}\n\tFail:{result.fail_count}\n\t"
+    return text
+
+
+def _post_git_results_comment(pr_number, control_results, test_results):
+    content = (
+        f"Here are the System Profile validation results using the past {VALIDATE_DAYS} days of data.\n"
+        f"Validating against the {REPO_OWNER}/{REPO_NAME} master spec:\n```\n"
+        f"{_validation_results_plaintext(control_results)}\n```\n"
+        f"Validating against this PR's spec:\n```\n"
+        f"{_validation_results_plaintext(test_results)}\n```\n"
+    )
+    response = _post_git_response(f"/repos/{REPO_OWNER}/{REPO_NAME}/issues/{pr_number}/comments", content)
+    logger.info(f"Posted a comment to PR #{pr_number}, with response status {response.status_code}")
+    logger.info(response.text)
+
+
+def _get_latest_commit_datetime_for_pr(owner, repo, pr_number):
+    pr_commits = _get_git_response(f"/repos/{owner}/{repo}/pulls/{pr_number}/commits")
+    latest_commit = pr_commits[len(pr_commits) - 1]
+    return parser.isoparse(latest_commit["commit"]["author"]["date"])
+
+
+def _get_latest_self_comment_datetime_for_pr(owner, repo, pr_number):
+    pr_comments = _get_git_response(f"/repos/{owner}/{repo}/issues/{pr_number}/comments")
+    for comment in reversed(pr_comments):
+        if comment["user"]["login"] == GIT_USER:
+            return parser.isoparse(comment["created_at"])
+    return None
+
+
+def _get_prs_that_require_validation(owner, repo):
+    logger.info(f"Checking whether {owner}/{repo} PRs need schema validation...")
+    prs_to_validate = []
+
+    for pr_number in [pr["number"] for pr in _get_git_response(f"/repos/{owner}/{repo}/pulls?state=open")]:
+        latest_commit_datetime = _get_latest_commit_datetime_for_pr(owner, repo, pr_number)
+        latest_self_comment_datetime = _get_latest_self_comment_datetime_for_pr(owner, repo, pr_number)
+        sp_spec_modified = SP_SPEC_PATH in [
+            file["filename"] for file in _get_git_response(f"/repos/{owner}/{repo}/pulls/{pr_number}/files")
+        ]
+        logger.info(f"SP spec modified: {sp_spec_modified}")
+        if sp_spec_modified and (
+            latest_self_comment_datetime is None or latest_commit_datetime > latest_self_comment_datetime
+        ):
+            logger.info(f"- PR #{pr_number} requires validation!")
+            prs_to_validate.append(pr_number)
+        else:
+            logger.info(f"- PR #{pr_number} does not need validation.")
+
+    return prs_to_validate
+
+
+def main(logger):
+
+    config = _init_config()
+
+    # Get list of PRs that require validation
+    logger.info("Starting validation check.")
+    prs_to_validate = _get_prs_that_require_validation(REPO_OWNER, REPO_NAME)
+    if len(prs_to_validate) == 0:
+        logger.info("No PRs to validate! Exiting.")
+        sys.exit(0)
+
+    # Get the list of parsed hosts from the last VALIDATE_DAYS worth of Kafka messages
+    consumer = KafkaConsumer(
+        group_id=config.host_ingress_consumer_group,
+        bootstrap_servers=config.bootstrap_servers,
+        api_version=(0, 10, 1),
+        value_deserializer=lambda m: m.decode(),
+        **config.kafka_consumer,
+    )
+
+    try:
+        parsed_hosts = get_hosts_from_kafka_messages(consumer, VALIDATE_DAYS)
+        consumer.close()
+    except ValueError as ve:
+        logger.error(ve)
+        consumer.close()
+        sys.exit(1)
+
+    # For each PR in prs_to_validate, validate the parsed hosts and leave a comment on the PR
+    for pr_number in prs_to_validate:
+        # Get spec file from PR
+        file_list = _get_git_response(f"/repos/{REPO_OWNER}/{REPO_NAME}/pulls/{pr_number}/files")
+        for file in file_list:
+            if file["filename"] == SP_SPEC_PATH:
+                logger.info(f"Getting SP spec from {file['raw_url']}")
+                sp_spec = get_schema_from_url(file["raw_url"])
+                break
+
+        control_results = validate_host_list_against_spec(
+            parsed_hosts,
+            get_schema_from_url(
+                f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/" f"master/schemas/system_profile/v1.yaml"
+            ),
+        )
+        test_results = validate_host_list_against_spec(parsed_hosts, sp_spec)
+
+        _post_git_results_comment(pr_number, control_results, test_results)
+
+    logger.info("The validator has finished. Bye!")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    configure_logging()
+
+    logger = get_logger(LOGGER_NAME)
+    sys.excepthook = partial(_excepthook, logger)
+
+    threadctx.request_id = UNKNOWN_REQUEST_ID_VALUE
+    main(logger)

--- a/system_profile_validator.py
+++ b/system_profile_validator.py
@@ -69,7 +69,6 @@ def _post_git_results_comment(pr_number, control_results, test_results):
     )
     response = _post_git_response(f"/repos/{REPO_OWNER}/{REPO_NAME}/issues/{pr_number}/comments", content)
     logger.info(f"Posted a comment to PR #{pr_number}, with response status {response.status_code}")
-    logger.info(response.text)
 
 
 def _get_latest_commit_datetime_for_pr(owner, repo, pr_number):

--- a/system_profile_validator.py
+++ b/system_profile_validator.py
@@ -73,7 +73,7 @@ def _post_git_results_comment(pr_number, control_results, test_results):
 
 def _get_latest_commit_datetime_for_pr(owner, repo, pr_number):
     pr_commits = _get_git_response(f"/repos/{owner}/{repo}/pulls/{pr_number}/commits")
-    latest_commit = pr_commits[len(pr_commits) - 1]
+    latest_commit = pr_commits[-1]
     return parser.isoparse(latest_commit["commit"]["author"]["date"])
 
 

--- a/tests/test_system_profile.py
+++ b/tests/test_system_profile.py
@@ -203,14 +203,14 @@ def test_get_system_profile_with_invalid_host_id(api_get, invalid_host_id):
 @pytest.mark.parametrize("messages", [10, 25, 50])
 def test_validate_sp_for_branch(mocker, messages):
     # Mock schema fetch
-    get_schema_from_url_mock = mocker.patch("lib.system_profile_validate._get_schema_from_url")
+    get_schema_from_url_mock = mocker.patch("lib.system_profile_validate.get_schema_from_url")
     mock_schema = system_profile_specification()
     get_schema_from_url_mock.return_value = mock_schema
     config = Config(RuntimeEnvironment.SERVICE)
     fake_consumer = create_kafka_consumer_mock(mocker, config, 1, messages)
 
     validation_results = validate_sp_for_branch(
-        config, fake_consumer, repo_fork="test_repo", repo_branch="test_branch", days=3
+        fake_consumer, repo_fork="test_repo", repo_branch="test_branch", days=3
     )
 
     assert "test_repo/test_branch" in validation_results
@@ -226,14 +226,14 @@ def test_validate_sp_for_branch(mocker, messages):
 @pytest.mark.parametrize("messages_per_partition", [10, 25, 50])
 def test_validate_sp_for_branch_multiple_partitions(mocker, partitions, messages_per_partition):
     # Mock schema fetch
-    get_schema_from_url_mock = mocker.patch("lib.system_profile_validate._get_schema_from_url")
+    get_schema_from_url_mock = mocker.patch("lib.system_profile_validate.get_schema_from_url")
     mock_schema = system_profile_specification()
     get_schema_from_url_mock.return_value = mock_schema
     config = Config(RuntimeEnvironment.SERVICE)
     fake_consumer = create_kafka_consumer_mock(mocker, config, partitions, messages_per_partition)
 
     validation_results = validate_sp_for_branch(
-        config, fake_consumer, repo_fork="test_repo", repo_branch="test_branch", days=3
+        fake_consumer, repo_fork="test_repo", repo_branch="test_branch", days=3
     )
 
     assert "test_repo/test_branch" in validation_results
@@ -250,19 +250,19 @@ def test_validate_sp_no_data(api_post, mocker):
     fake_consumer = create_kafka_consumer_mock(mocker, config, 1, 0)
 
     with pytest.raises(expected_exception=ValueError) as excinfo:
-        validate_sp_for_branch(config, fake_consumer, repo_fork="foo", repo_branch="bar", days=3)
+        validate_sp_for_branch(fake_consumer, repo_fork="foo", repo_branch="bar", days=3)
     assert "No data available at the provided date." in str(excinfo.value)
 
 
 def test_validate_sp_for_missing_branch_or_repo(api_post, mocker):
     # Mock schema fetch
-    get_schema_from_url_mock = mocker.patch("lib.system_profile_validate._get_schema_from_url")
+    get_schema_from_url_mock = mocker.patch("lib.system_profile_validate.get_schema_from_url")
     get_schema_from_url_mock.side_effect = ValueError("Schema not found at URL!")
     config = Config(RuntimeEnvironment.SERVICE)
     fake_consumer = create_kafka_consumer_mock(mocker, config, 1, 10)
 
     with pytest.raises(expected_exception=ValueError) as excinfo:
-        validate_sp_for_branch(config, fake_consumer, repo_fork="foo", repo_branch="bar", days=3)
+        validate_sp_for_branch(fake_consumer, repo_fork="foo", repo_branch="bar", days=3)
     assert "Schema not found at URL" in str(excinfo.value)
 
 


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-11720).
`system_profile_validator.py` is a script that checks, validates, and comments on PRs opened to the inventory-schemas repo. If you set `GIT_USER` and `GIT_TOKEN`, it will log in as that user (preferably a bot account) and validate. I intend to set this up as a CronJob in Prod using the NachoBot account, unless there's a better bot to use.

The script looks all open PRs in the repo. If the PR modifies the System Profile spec file, and either the supplied account has not yet commented on the PR, or the PR has a commit more recent than its most recent comment, it will run validation. It uses a KafkaConsumer to parse host data from the past 3 days of Kafka messages. Then, it runs validation against the PR's version of the system profile spec, and against the spec from the master branch (similar to the endpoint). Once it has the test results, it posts a comment to the PR summarizing the validation results.

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Output Encoding
- [x] Error Handling and Logging
- [x] Communication Security
- [x] General Coding Practices
