### PR TITLE
Always force ingress topic; fix total message count; log POST errors

### DIFF
--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -208,7 +208,7 @@ def validate_schema(repo_fork="RedHatInsights", repo_branch="master", days=1):
         **config.kafka_consumer,
     )
     try:
-        response = validate_sp_for_branch(consumer, repo_fork, repo_branch, days)
+        response = validate_sp_for_branch(consumer, {config.host_ingress_topic}, repo_fork, repo_branch, days)
         consumer.close()
         return flask_json_response(response)
     except (ValueError, AttributeError) as e:

--- a/lib/system_profile_validate.py
+++ b/lib/system_profile_validate.py
@@ -74,7 +74,7 @@ def get_hosts_from_kafka_messages(consumer, topics, days):
         except AttributeError:
             logger.debug("No data in partition for the given date.")
 
-    msgs = consumer.poll(timeout_ms=10000, max_records=10000)
+    msgs = consumer.poll(timeout_ms=60000, max_records=10000)
 
     for topic_partition, messages in msgs.items():
         for message in messages:

--- a/lib/system_profile_validate.py
+++ b/lib/system_profile_validate.py
@@ -54,13 +54,14 @@ def _validate_host_list(host_list, repo_config):
     return validate_host_list_against_spec(host_list, system_profile_spec)
 
 
-def get_hosts_from_kafka_messages(consumer, days):
+def get_hosts_from_kafka_messages(consumer, topics, days):
     msgs = {}
     partitions = []
     parsed_hosts = []
+    total_messages = 0
     seek_date = datetime.now() + timedelta(days=(-1 * days))
 
-    for topic in consumer.topics():
+    for topic in topics:
         for partition_id in consumer.partitions_for_topic(topic):
             partitions.append(TopicPartition(topic, partition_id))
 
@@ -77,6 +78,7 @@ def get_hosts_from_kafka_messages(consumer, days):
 
     for topic_partition, messages in msgs.items():
         for message in messages:
+            total_messages += 1
             try:
                 parsed_message = json.loads(message.value)
                 parsed_operation = OperationSchema(strict=True).load(parsed_message).data
@@ -88,12 +90,12 @@ def get_hosts_from_kafka_messages(consumer, days):
     if len(parsed_hosts) == 0:
         raise ValueError("No data available at the provided date.")
 
-    logger.info(f"Parsed {len(parsed_hosts)} of {len(list(msgs.values())[0])} hosts from message queue.")
+    logger.info(f"Parsed {len(parsed_hosts)} of {total_messages} hosts from message queue.")
     return parsed_hosts
 
 
-def validate_sp_for_branch(consumer, repo_fork="RedHatInsights", repo_branch="master", days=1):
-    parsed_hosts = get_hosts_from_kafka_messages(consumer, days)
+def validate_sp_for_branch(consumer, topics, repo_fork="RedHatInsights", repo_branch="master", days=1):
+    parsed_hosts = get_hosts_from_kafka_messages(consumer, topics, days)
 
     validation_results = {}
     for item in [{"fork": repo_fork, "branch": repo_branch}, {"fork": "RedHatInsights", "branch": "master"}]:

--- a/system_profile_validator.py
+++ b/system_profile_validator.py
@@ -29,7 +29,7 @@ SP_SPEC_PATH = "schemas/system_profile/v1.yaml"
 RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
 GIT_USER = getenv("GIT_USER")
 GIT_TOKEN = getenv("GIT_TOKEN")
-VALIDATE_DAYS = getenv("VALIDATE_DAYS", 3)
+VALIDATE_DAYS = int(getenv("VALIDATE_DAYS", 3))
 
 
 def _init_config():
@@ -68,7 +68,10 @@ def _post_git_results_comment(pr_number, control_results, test_results):
         f"{_validation_results_plaintext(test_results)}\n```\n"
     )
     response = _post_git_response(f"/repos/{REPO_OWNER}/{REPO_NAME}/issues/{pr_number}/comments", content)
-    logger.info(f"Posted a comment to PR #{pr_number}, with response status {response.status_code}")
+    if response.status_code >= 400:
+        logger.error(f"Could not post a comment to PR #{pr_number}. Response: {response.text}")
+    else:
+        logger.info(f"Posted a comment to PR #{pr_number}, with response status {response.status_code}")
 
 
 def _get_latest_commit_datetime_for_pr(owner, repo, pr_number):
@@ -128,7 +131,7 @@ def main(logger):
     )
 
     try:
-        parsed_hosts = get_hosts_from_kafka_messages(consumer, VALIDATE_DAYS)
+        parsed_hosts = get_hosts_from_kafka_messages(consumer, {config.host_ingress_topic}, VALIDATE_DAYS)
         consumer.close()
     except ValueError as ve:
         logger.error(ve)

--- a/tests/test_system_profile.py
+++ b/tests/test_system_profile.py
@@ -210,7 +210,7 @@ def test_validate_sp_for_branch(mocker, messages):
     fake_consumer = create_kafka_consumer_mock(mocker, config, 1, messages)
 
     validation_results = validate_sp_for_branch(
-        fake_consumer, repo_fork="test_repo", repo_branch="test_branch", days=3
+        fake_consumer, topics={config.host_ingress_topic}, repo_fork="test_repo", repo_branch="test_branch", days=3
     )
 
     assert "test_repo/test_branch" in validation_results
@@ -233,7 +233,7 @@ def test_validate_sp_for_branch_multiple_partitions(mocker, partitions, messages
     fake_consumer = create_kafka_consumer_mock(mocker, config, partitions, messages_per_partition)
 
     validation_results = validate_sp_for_branch(
-        fake_consumer, repo_fork="test_repo", repo_branch="test_branch", days=3
+        fake_consumer, topics={config.host_ingress_topic}, repo_fork="test_repo", repo_branch="test_branch", days=3
     )
 
     assert "test_repo/test_branch" in validation_results
@@ -250,7 +250,9 @@ def test_validate_sp_no_data(api_post, mocker):
     fake_consumer = create_kafka_consumer_mock(mocker, config, 1, 0)
 
     with pytest.raises(expected_exception=ValueError) as excinfo:
-        validate_sp_for_branch(fake_consumer, repo_fork="foo", repo_branch="bar", days=3)
+        validate_sp_for_branch(
+            fake_consumer, topics={config.host_ingress_topic}, repo_fork="foo", repo_branch="bar", days=3
+        )
     assert "No data available at the provided date." in str(excinfo.value)
 
 
@@ -262,7 +264,9 @@ def test_validate_sp_for_missing_branch_or_repo(api_post, mocker):
     fake_consumer = create_kafka_consumer_mock(mocker, config, 1, 10)
 
     with pytest.raises(expected_exception=ValueError) as excinfo:
-        validate_sp_for_branch(fake_consumer, repo_fork="foo", repo_branch="bar", days=3)
+        validate_sp_for_branch(
+            fake_consumer, topics={config.host_ingress_topic}, repo_fork="foo", repo_branch="bar", days=3
+        )
     assert "Schema not found at URL" in str(excinfo.value)
 
 


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-12307).
Some issues remain that can't be seen in local testing environments. This PR aims to fix the following issues:
- Many messages are being read by the validator, but most of them fail to match the OperationSchema format. This leads me to believe that messages from other topics were getting read. I've added code to force the validator to only read from the configured ingress topic.
- For some reason, the total message count works locally, but does not work consistently in Prod. I've changed the way this value is tracked to make it more consistent.
- When dippy-bot wasn't posting comments to PRs, all we would know was the response code (403). Now it logs the specific error, which can help us to solve config/auth issues with GitHub.

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] General Coding Practices
