### PR TITLE
SP Validator: fixes, enhancements, performance improvements, tests

### DIFF
--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -195,7 +195,7 @@ def get_sap_sids(search=None, tags=None, page=None, per_page=None, staleness=Non
 
 
 @api_operation
-@rbac(Permission.READ)
+@rbac(Permission.ADMIN)
 @metrics.schema_validation_time.time()
 def validate_schema(repo_fork="RedHatInsights", repo_branch="master", days=1, max_messages=10000):
     config = Config(RuntimeEnvironment.SERVICE)

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -200,7 +200,7 @@ def validate_schema(repo_fork="RedHatInsights", repo_branch="master", days=1, ma
     # Use the identity header to make sure the user is someone from our team.
     config = Config(RuntimeEnvironment.SERVICE)
     if get_current_identity().user.get("username") not in config.sp_authorized_users:
-        flask.abort(401, "This endpoint is restricted to HBI Admins.")
+        flask.abort(403, "This endpoint is restricted to HBI Admins.")
 
     consumer = KafkaConsumer(
         bootstrap_servers=config.bootstrap_servers,

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -197,17 +197,23 @@ def get_sap_sids(search=None, tags=None, page=None, per_page=None, staleness=Non
 @api_operation
 @rbac(Permission.READ)
 @metrics.schema_validation_time.time()
-def validate_schema(repo_fork="RedHatInsights", repo_branch="master", days=1):
+def validate_schema(repo_fork="RedHatInsights", repo_branch="master", days=1, max_messages=10000):
     config = Config(RuntimeEnvironment.SERVICE)
     consumer = KafkaConsumer(
-        group_id=config.host_ingress_consumer_group,
         bootstrap_servers=config.bootstrap_servers,
         api_version=(0, 10, 1),
         value_deserializer=lambda m: m.decode(),
-        **config.kafka_consumer,
+        **config.validator_kafka_consumer,
     )
     try:
-        response = validate_sp_for_branch(consumer, {config.host_ingress_topic}, repo_fork, repo_branch, days)
+        response = validate_sp_for_branch(
+            consumer,
+            {config.host_ingress_topic, config.additional_validation_topic},
+            repo_fork,
+            repo_branch,
+            days,
+            max_messages,
+        )
         consumer.close()
         return flask_json_response(response)
     except (ValueError, AttributeError) as e:

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -199,7 +199,8 @@ def get_sap_sids(search=None, tags=None, page=None, per_page=None, staleness=Non
 def validate_schema(repo_fork="RedHatInsights", repo_branch="master", days=1, max_messages=10000):
     # Use the identity header to make sure the user is someone from our team.
     config = Config(RuntimeEnvironment.SERVICE)
-    if get_current_identity().user.get("username") not in config.sp_authorized_users:
+    identity = get_current_identity()
+    if not hasattr(identity, "user") or identity.user.get("username") not in config.sp_authorized_users:
         flask.abort(403, "This endpoint is restricted to HBI Admins.")
 
     consumer = KafkaConsumer(

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -30,19 +30,6 @@ from lib.system_profile_validate import validate_sp_for_branch
 
 logger = get_logger(__name__)
 
-# The list of users that are allowed to run the SP validator endpoint.
-# We may add the SP team if they find this endpoint useful.
-ADMIN_USERS = [
-    "aprice@redhat.com",
-    "tefaz@redhat.com",
-    "rfelton@redhat.com",
-    "aarif@redhat.com",
-    "gmccullo@redhat.com",
-    "rpfannsc@redhat.com",
-    "jusun@redhat.com",
-    "tuser@redhat.com",
-]
-
 SAP_SYSTEM_QUERY = """
     query hostSystemProfile (
         $hostFilter: HostFilter
@@ -211,10 +198,10 @@ def get_sap_sids(search=None, tags=None, page=None, per_page=None, staleness=Non
 @metrics.schema_validation_time.time()
 def validate_schema(repo_fork="RedHatInsights", repo_branch="master", days=1, max_messages=10000):
     # Use the identity header to make sure the user is someone from our team.
-    if get_current_identity().user.get("username") not in ADMIN_USERS:
+    config = Config(RuntimeEnvironment.SERVICE)
+    if get_current_identity().user.get("username") not in config.sp_authorized_users:
         flask.abort(401, "This endpoint is restricted to HBI Admins.")
 
-    config = Config(RuntimeEnvironment.SERVICE)
     consumer = KafkaConsumer(
         bootstrap_servers=config.bootstrap_servers,
         api_version=(0, 10, 1),

--- a/app/config.py
+++ b/app/config.py
@@ -39,8 +39,10 @@ class Config:
         def topic(t):
             return app_common_python.KafkaTopics[t].name
 
-        requested_ingress_topic = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
-        self.host_ingress_topic = topic(requested_ingress_topic)
+        self.host_ingress_topic = topic(os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress"))
+        self.additional_validation_topic = topic(
+            os.environ.get("KAFKA_ADDITIONAL_VALIDATION_TOPIC", "platform.inventory.host-ingress-p1")
+        )
         self.host_egress_topic = topic("platform.inventory.events")
         self.system_profile_topic = topic("platform.system-profile")
         self.event_topic = topic("platform.inventory.events")
@@ -55,6 +57,9 @@ class Config:
         self._db_name = os.getenv("INVENTORY_DB_NAME", "insights")
         self.rbac_endpoint = os.environ.get("RBAC_ENDPOINT", "http://localhost:8111")
         self.host_ingress_topic = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
+        self.additional_validation_topic = os.environ.get(
+            "KAFKA_ADDITIONAL_VALIDATION_TOPIC", "platform.inventory.host-ingress-p1"
+        )
         self.host_egress_topic = os.environ.get("KAFKA_HOST_EGRESS_TOPIC", "platform.inventory.host-egress")
         self.system_profile_topic = os.environ.get("KAFKA_TOPIC", "platform.system-profile")
         self.bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
@@ -91,6 +96,7 @@ class Config:
 
         self.host_ingress_consumer_group = os.environ.get("KAFKA_HOST_INGRESS_GROUP", "inventory-mq")
         self.secondary_topic_enabled = os.environ.get("KAFKA_SECONDARY_TOPIC_ENABLED", "false").lower() == "true"
+        self.sp_validator_max_messages = int(os.environ.get("KAFKA_SP_VALIDATOR_MAX_MESSAGES", "1000000"))
 
         self.prometheus_pushgateway = os.environ.get("PROMETHEUS_PUSHGATEWAY", "localhost:9091")
         self.kubernetes_namespace = os.environ.get("NAMESPACE")
@@ -104,6 +110,19 @@ class Config:
             "auto_offset_reset": os.environ.get("KAFKA_CONSUMER_AUTO_OFFSET_RESET", "latest"),
             "auto_commit_interval_ms": int(os.environ.get("KAFKA_CONSUMER_AUTO_COMMIT_INTERVAL_MS", "5000")),
             "max_poll_records": int(os.environ.get("KAFKA_CONSUMER_MAX_POLL_RECORDS", "10")),
+            "max_poll_interval_ms": int(os.environ.get("KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS", "300000")),
+            "session_timeout_ms": int(os.environ.get("KAFKA_CONSUMER_SESSION_TIMEOUT_MS", "10000")),
+            "heartbeat_interval_ms": int(os.environ.get("KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS", "3000")),
+        }
+
+        self.validator_kafka_consumer = {
+            "group_id": "inventory-sp-validator",
+            "request_timeout_ms": int(os.environ.get("KAFKA_CONSUMER_REQUEST_TIMEOUT_MS", "305000")),
+            "max_in_flight_requests_per_connection": int(
+                os.environ.get("KAFKA_CONSUMER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION", "5")
+            ),
+            "enable_auto_commit": False,
+            "max_poll_records": int(os.environ.get("KAFKA_CONSUMER_MAX_POLL_RECORDS", "10000")),
             "max_poll_interval_ms": int(os.environ.get("KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS", "300000")),
             "session_timeout_ms": int(os.environ.get("KAFKA_CONSUMER_SESSION_TIMEOUT_MS", "10000")),
             "heartbeat_interval_ms": int(os.environ.get("KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS", "3000")),

--- a/app/config.py
+++ b/app/config.py
@@ -159,6 +159,7 @@ class Config:
 
         self.host_delete_chunk_size = int(os.getenv("HOST_DELETE_CHUNK_SIZE", "1000"))
         self.script_chunk_size = int(os.getenv("SCRIPT_CHUNK_SIZE", "1000"))
+        self.sp_authorized_users = os.getenv("SP_AUTHORIZED_USERS", "tuser@redhat.com").split()
 
     def _build_base_url_path(self):
         app_name = os.getenv("APP_NAME", "inventory")

--- a/lib/system_profile_validate.py
+++ b/lib/system_profile_validate.py
@@ -56,51 +56,52 @@ def _validate_host_list(host_list, repo_config):
     return validate_host_list_against_spec(host_list, system_profile_spec)
 
 
-def get_hosts_from_kafka_messages(consumer, topics, days):
-    msgs = {}
+def get_hosts_from_kafka_messages(consumer, topics, days, max_messages=1000000):
+    total_message_count = 0
     partitions = []
     parsed_hosts = []
-    total_messages = 0
     seek_date = datetime.now() + timedelta(days=(-1 * days))
 
     for topic in topics:
-        for partition_id in consumer.partitions_for_topic(topic):
+        for partition_id in consumer.partitions_for_topic(topic) or []:
             partitions.append(TopicPartition(topic, partition_id))
 
     consumer.assign(partitions)
 
     for tp in consumer.assignment():
         try:
-            seek_position = consumer.offsets_for_times({tp: seek_date.timestamp() * 1000})[tp].offset
-            consumer.seek(tp, seek_position)
+            consumer.seek(tp, consumer.offsets_for_times({tp: seek_date.timestamp() * 1000})[tp].offset)
         except AttributeError:
             logger.debug("No data in partition for the given date.")
 
-    msgs = consumer.poll(timeout_ms=60000, max_records=10000)
+    while total_message_count < max_messages:
+        new_message_count = 0
+        for partition_messages in consumer.poll(timeout_ms=60000, max_records=10000).values():
+            new_message_count += len(partition_messages)
+            for message in partition_messages:
+                try:
+                    parsed_hosts.append(OperationSchema(strict=True).load(json.loads(message.value)).data["data"])
+                except json.JSONDecodeError:
+                    logger.exception("Unable to parse json message from message queue.")
+                except ValidationError:
+                    logger.exception("Unable to parse operation from message.")
 
-    for topic_partition, messages in msgs.items():
-        for message in messages:
-            total_messages += 1
-            try:
-                parsed_message = json.loads(message.value)
-                parsed_operation = OperationSchema(strict=True).load(parsed_message).data
-                parsed_hosts.append(parsed_operation["data"])
-            except json.JSONDecodeError:
-                logger.exception(
-                    "Unable to parse json message from message queue.", extra={"incoming_message": message}
-                )
-            except ValidationError:
-                logger.exception("Could not parse operation.", extra={"parsed_message": parsed_message})
+        logger.debug(f"Polled {new_message_count} messages from the queue.")
+        if new_message_count == 0:
+            break
+        total_message_count += new_message_count
 
-    if len(parsed_hosts) == 0:
+    if total_message_count == 0:
         raise ValueError("No data available at the provided date.")
 
-    logger.info(f"Parsed {len(parsed_hosts)} of {total_messages} hosts from message queue.")
+    logger.info(f"Parsed {len(parsed_hosts)} hosts from {total_message_count} messages.")
     return parsed_hosts
 
 
-def validate_sp_for_branch(consumer, topics, repo_fork="RedHatInsights", repo_branch="master", days=1):
-    parsed_hosts = get_hosts_from_kafka_messages(consumer, topics, days)
+def validate_sp_for_branch(
+    consumer, topics, repo_fork="RedHatInsights", repo_branch="master", days=1, max_messages=1000000
+):
+    parsed_hosts = get_hosts_from_kafka_messages(consumer, topics, days, max_messages)
 
     validation_results = {}
     for item in [{"fork": repo_fork, "branch": repo_branch}, {"fork": "RedHatInsights", "branch": "master"}]:

--- a/lib/system_profile_validate.py
+++ b/lib/system_profile_validate.py
@@ -29,40 +29,22 @@ def get_schema_from_url(url):
     return safe_load(get(url).content.decode("utf-8"))
 
 
-def validate_host_list_against_spec(host_list, sp_spec):
-    test_results = {}
-    for host in host_list:
-        if not host.get("reporter"):
-            host["reporter"] = "unknown_reporter"
-        if host["reporter"] not in test_results.keys():
-            test_results[host["reporter"]] = TestResult()
-        try:
-            deserialize_host(host, system_profile_spec=sp_spec)
-            test_results[host["reporter"]].pass_count += 1
-        except Exception as e:
-            test_results[host["reporter"]].fail_count += 1
-            logger.exception(e)
-
-    return test_results
-
-
-def _validate_host_list(host_list, repo_config):
-    system_profile_spec = get_schema_from_url(
-        f"https://raw.githubusercontent.com/{repo_config['fork']}/inventory-schemas/"
-        f"{repo_config['branch']}/schemas/system_profile/v1.yaml"
+def get_schema(fork, branch):
+    return get_schema_from_url(
+        f"https://raw.githubusercontent.com/{fork}/inventory-schemas/" f"{branch}/schemas/system_profile/v1.yaml"
     )
 
-    logger.info(f"Validating host against {repo_config['fork']}/{repo_config['branch']} schema...")
-    return validate_host_list_against_spec(host_list, system_profile_spec)
 
-
-def get_hosts_from_kafka_messages(consumer, topics, days, max_messages=1000000):
+def validate_sp_schemas(consumer, topics, schemas, days=1, max_messages=1000000):
     total_message_count = 0
     partitions = []
-    parsed_hosts = []
+    test_results = {branch: {} for branch in schemas.keys()}
     seek_date = datetime.now() + timedelta(days=(-1 * days))
 
+    logger.info("Validating messages from these topics:")
+
     for topic in topics:
+        logger.info(topic)
         for partition_id in consumer.partitions_for_topic(topic) or []:
             partitions.append(TopicPartition(topic, partition_id))
 
@@ -78,6 +60,8 @@ def get_hosts_from_kafka_messages(consumer, topics, days, max_messages=1000000):
         except AttributeError:
             logger.debug("No data in partition for the given date.")
 
+    logger.info("Beginning validation...")
+
     while total_message_count < max_messages:
         new_message_count = 0
         for partition, partition_messages in consumer.poll(timeout_ms=60000, max_records=10000).items():
@@ -86,7 +70,18 @@ def get_hosts_from_kafka_messages(consumer, topics, days, max_messages=1000000):
             new_message_count += len(partition_messages)
             for message in partition_messages:
                 try:
-                    parsed_hosts.append(OperationSchema(strict=True).load(json.loads(message.value)).data["data"])
+                    host = OperationSchema(strict=True).load(json.loads(message.value)).data["data"]
+                    if not host.get("reporter"):
+                        host["reporter"] = "unknown_reporter"
+                    for branch, sp_spec in schemas.items():
+                        if host["reporter"] not in test_results[branch].keys():
+                            test_results[branch][host["reporter"]] = TestResult()
+                        try:
+                            deserialize_host(host, system_profile_spec=sp_spec)
+                            test_results[branch][host["reporter"]].pass_count += 1
+                        except Exception as e:
+                            test_results[branch][host["reporter"]].fail_count += 1
+                            logger.exception(e)
                 except json.JSONDecodeError:
                     logger.exception("Unable to parse json message from message queue.")
                 except ValidationError:
@@ -100,19 +95,16 @@ def get_hosts_from_kafka_messages(consumer, topics, days, max_messages=1000000):
     if total_message_count == 0:
         raise ValueError("No data available at the provided date.")
 
-    logger.info(f"Parsed {len(parsed_hosts)} hosts from {total_message_count} messages.")
-    return parsed_hosts
+    logger.info("Validation complete.")
+
+    return test_results
 
 
 def validate_sp_for_branch(
     consumer, topics, repo_fork="RedHatInsights", repo_branch="master", days=1, max_messages=1000000
 ):
-    parsed_hosts = get_hosts_from_kafka_messages(consumer, topics, days, max_messages)
+    schemas = {"RedHatInsights/master": get_schema("RedHatInsights", "master")}
 
-    validation_results = {}
-    for item in [{"fork": repo_fork, "branch": repo_branch}, {"fork": "RedHatInsights", "branch": "master"}]:
-        validation_results[f"{item['fork']}/{item['branch']}"] = (
-            _validate_host_list(parsed_hosts, item) if len(parsed_hosts) > 0 else {}
-        )
+    schemas[f"{repo_fork}/{repo_branch}"] = get_schema(repo_fork, repo_branch)
 
-    return validation_results
+    return validate_sp_schemas(consumer, topics, schemas, days, max_messages)

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -444,8 +444,8 @@ paths:
       responses:
         '200':
             description: Host validation results
-        '401':
-            description: Not Authorized
+        '403':
+            description: Forbidden
 
 
 components:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -432,7 +432,14 @@ paths:
           schema:
             type: integer
             minimum: 1
-          description: How many days worth of kafka messages to validate
+          description: How many days worth of data to validate
+        - in: query
+          name: max_messages
+          schema:
+            type: integer
+            minimum: 1
+            default: 10000
+          description: Stops polling when this number of messages has been collected
       responses:
         '200':
             description: Host validation results

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -411,7 +411,8 @@ paths:
     post:
       summary: validate system profile schema
       description: >-
-        Required permissions: inventory:hosts:read
+        Validates System Profile data from recent Kafka messages against a given spec,
+        and compares it with the current one. Only HBI Admins can access this endpoint.
       operationId: api.system_profile.validate_schema
       security:
         - ApiKeyAuth: []
@@ -443,6 +444,8 @@ paths:
       responses:
         '200':
             description: Host validation results
+        '401':
+            description: Not Authorized
 
 
 components:

--- a/system_profile_validator.py
+++ b/system_profile_validator.py
@@ -123,15 +123,19 @@ def main(logger):
 
     # Get the list of parsed hosts from the last VALIDATE_DAYS worth of Kafka messages
     consumer = KafkaConsumer(
-        group_id=config.host_ingress_consumer_group,
         bootstrap_servers=config.bootstrap_servers,
         api_version=(0, 10, 1),
         value_deserializer=lambda m: m.decode(),
-        **config.kafka_consumer,
+        **config.validator_kafka_consumer,
     )
 
     try:
-        parsed_hosts = get_hosts_from_kafka_messages(consumer, {config.host_ingress_topic}, VALIDATE_DAYS)
+        parsed_hosts = get_hosts_from_kafka_messages(
+            consumer,
+            {config.host_ingress_topic, config.additional_validation_topic},
+            VALIDATE_DAYS,
+            config.sp_validator_max_messages,
+        )
         consumer.close()
     except ValueError as ve:
         logger.exception(ve)

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -206,7 +206,8 @@ def create_kafka_consumer_mock(mocker, config, number_of_partitions, messages_pe
     fake_consumer = mocker.Mock()
     mock_poll = {}
     poll_result_list = []
-    mock_offsets = {}
+    mock_start_offsets = {}
+    mock_end_offsets = {}
     partitions = []
 
     fake_consumer.topics.return_value = {config.host_ingress_topic}
@@ -222,11 +223,14 @@ def create_kafka_consumer_mock(mocker, config, number_of_partitions, messages_pe
             SimpleNamespace(value=json.dumps(wrap_message(minimal_host().data())))
             for _ in range(messages_per_partition)
         ]
-        mock_offsets[partition] = SimpleNamespace(offset=0)
+        mock_start_offsets[partition] = SimpleNamespace(offset=1)
+        mock_end_offsets[partition] = 100
 
     poll_result_list.extend([mock_poll] * number_of_polls)
     poll_result_list.append({})
 
     fake_consumer.poll.side_effect = poll_result_list
-    fake_consumer.offsets_for_times.return_value = mock_offsets
+    fake_consumer.offsets_for_times.return_value = mock_start_offsets
+    fake_consumer.end_offsets.return_value = mock_end_offsets
+    fake_consumer.position.return_value = 1
     return fake_consumer

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -202,9 +202,10 @@ def assert_synchronize_event_is_valid(
         assert event["metadata"] == expected_metadata
 
 
-def create_kafka_consumer_mock(mocker, config, number_of_partitions, messages_per_partition):
+def create_kafka_consumer_mock(mocker, config, number_of_partitions, messages_per_partition, number_of_polls=5):
     fake_consumer = mocker.Mock()
     mock_poll = {}
+    poll_result_list = []
     mock_offsets = {}
     partitions = []
 
@@ -223,6 +224,9 @@ def create_kafka_consumer_mock(mocker, config, number_of_partitions, messages_pe
         ]
         mock_offsets[partition] = SimpleNamespace(offset=0)
 
-    fake_consumer.poll.return_value = mock_poll
+    poll_result_list.extend([mock_poll] * number_of_polls)
+    poll_result_list.append({})
+
+    fake_consumer.poll.side_effect = poll_result_list
     fake_consumer.offsets_for_times.return_value = mock_offsets
     return fake_consumer

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -93,7 +93,7 @@ def test_validate_non_admin_user_identity(flask_client):
     response = flask_client.post(
         f"{SYSTEM_PROFILE_URL}/validate_schema?repo_branch=master&days=1", headers={"x-rh-identity": payload}
     )
-    assert 401 == response.status_code  # OK
+    assert 403 == response.status_code  # User is not an HBI admin
 
 
 def test_validate_valid_system_identity(flask_client):

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -5,6 +5,7 @@ from app.auth.identity import Identity
 from tests.helpers.api_utils import build_token_auth_header
 from tests.helpers.api_utils import HOST_URL
 from tests.helpers.api_utils import SYSTEM_IDENTITY
+from tests.helpers.api_utils import SYSTEM_PROFILE_URL
 from tests.helpers.api_utils import USER_IDENTITY
 from tests.helpers.test_utils import INSIGHTS_CLASSIC_IDENTITY
 
@@ -80,6 +81,19 @@ def test_validate_valid_user_identity(flask_client):
     payload = valid_payload("User")
     response = flask_client.get(HOST_URL, headers={"x-rh-identity": payload})
     assert 200 == response.status_code  # OK
+
+
+def test_validate_non_admin_user_identity(flask_client):
+    """
+    Identity header is valid and user is provided, but is not an Admin
+    """
+    identity = valid_identity("User")
+    identity.user["username"] = "regularjoe@redhat.com"
+    payload = create_identity_payload(identity)
+    response = flask_client.post(
+        f"{SYSTEM_PROFILE_URL}/validate_schema?repo_branch=master&days=1", headers={"x-rh-identity": payload}
+    )
+    assert 401 == response.status_code  # OK
 
 
 def test_validate_valid_system_identity(flask_client):

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -96,6 +96,17 @@ def test_validate_non_admin_user_identity(flask_client):
     assert 403 == response.status_code  # User is not an HBI admin
 
 
+def test_validate_non_user_admin_endpoint(flask_client):
+    """
+    Identity header is valid and user is provided, but is not an Admin
+    """
+    payload = valid_payload("System")
+    response = flask_client.post(
+        f"{SYSTEM_PROFILE_URL}/validate_schema?repo_branch=master&days=1", headers={"x-rh-identity": payload}
+    )
+    assert 403 == response.status_code  # Endpoint not available to Systems
+
+
 def test_validate_valid_system_identity(flask_client):
     """
     Identity header is valid – non-empty in this case

--- a/tests/test_system_profile.py
+++ b/tests/test_system_profile.py
@@ -206,8 +206,7 @@ def test_get_system_profile_with_invalid_host_id(api_get, invalid_host_id):
 def test_validate_sp_for_branch(mocker, partitions, messages_per_partition_per_poll, number_of_polls):
     # Mock schema fetch
     get_schema_from_url_mock = mocker.patch("lib.system_profile_validate.get_schema_from_url")
-    mock_schema = system_profile_specification()
-    get_schema_from_url_mock.return_value = mock_schema
+    get_schema_from_url_mock.return_value = system_profile_specification()
     config = Config(RuntimeEnvironment.SERVICE)
     fake_consumer = create_kafka_consumer_mock(
         mocker, config, partitions, messages_per_partition_per_poll, number_of_polls
@@ -240,6 +239,8 @@ def test_validate_sp_for_branch(mocker, partitions, messages_per_partition_per_p
 def test_validate_sp_no_data(api_post, mocker):
     config = Config(RuntimeEnvironment.SERVICE)
     fake_consumer = create_kafka_consumer_mock(mocker, config, 1, 0)
+    get_schema_from_url_mock = mocker.patch("lib.system_profile_validate.get_schema_from_url")
+    get_schema_from_url_mock.return_value = system_profile_specification()
 
     with pytest.raises(expected_exception=ValueError) as excinfo:
         validate_sp_for_branch(

--- a/tests/test_system_profile.py
+++ b/tests/test_system_profile.py
@@ -200,17 +200,32 @@ def test_get_system_profile_with_invalid_host_id(api_get, invalid_host_id):
     assert_error_response(response_data, expected_title="Bad Request", expected_status=400)
 
 
-@pytest.mark.parametrize("messages", [10, 25, 50])
-def test_validate_sp_for_branch(mocker, messages):
+@pytest.mark.parametrize("partitions", [1, 5])
+@pytest.mark.parametrize("messages_per_partition_per_poll", [1, 10])
+@pytest.mark.parametrize("number_of_polls", [1, 3])
+def test_validate_sp_for_branch(mocker, partitions, messages_per_partition_per_poll, number_of_polls):
     # Mock schema fetch
     get_schema_from_url_mock = mocker.patch("lib.system_profile_validate.get_schema_from_url")
     mock_schema = system_profile_specification()
     get_schema_from_url_mock.return_value = mock_schema
     config = Config(RuntimeEnvironment.SERVICE)
-    fake_consumer = create_kafka_consumer_mock(mocker, config, 1, messages)
+    fake_consumer = create_kafka_consumer_mock(
+        mocker, config, partitions, messages_per_partition_per_poll, number_of_polls
+    )
+    max_messages_to_poll = 50
+
+    # Due to the parameterization, each call to poll() can return 1-50 messages.
+    # number_of_polls is also parameterized, meaning that this simulates a total of
+    # 1-150 messages. Setting max_messages to 50 allows this test to validate
+    # both loop conditions in get_hosts_from_kafka_messages().
 
     validation_results = validate_sp_for_branch(
-        fake_consumer, topics={config.host_ingress_topic}, repo_fork="test_repo", repo_branch="test_branch", days=3
+        fake_consumer,
+        topics={config.host_ingress_topic},
+        repo_fork="test_repo",
+        repo_branch="test_branch",
+        days=3,
+        max_messages=max_messages_to_poll,
     )
 
     assert "test_repo/test_branch" in validation_results
@@ -219,30 +234,7 @@ def test_validate_sp_for_branch(mocker, messages):
     for reporter in validation_results["test_repo/test_branch"]:
         pass_count += validation_results["test_repo/test_branch"][reporter].pass_count
 
-    assert pass_count == messages
-
-
-@pytest.mark.parametrize("partitions", [3, 10, 20])
-@pytest.mark.parametrize("messages_per_partition", [10, 25, 50])
-def test_validate_sp_for_branch_multiple_partitions(mocker, partitions, messages_per_partition):
-    # Mock schema fetch
-    get_schema_from_url_mock = mocker.patch("lib.system_profile_validate.get_schema_from_url")
-    mock_schema = system_profile_specification()
-    get_schema_from_url_mock.return_value = mock_schema
-    config = Config(RuntimeEnvironment.SERVICE)
-    fake_consumer = create_kafka_consumer_mock(mocker, config, partitions, messages_per_partition)
-
-    validation_results = validate_sp_for_branch(
-        fake_consumer, topics={config.host_ingress_topic}, repo_fork="test_repo", repo_branch="test_branch", days=3
-    )
-
-    assert "test_repo/test_branch" in validation_results
-
-    pass_count = 0
-    for reporter in validation_results["test_repo/test_branch"]:
-        pass_count += validation_results["test_repo/test_branch"][reporter].pass_count
-
-    assert pass_count == partitions * messages_per_partition
+    assert pass_count == min(partitions * messages_per_partition_per_poll * number_of_polls, max_messages_to_poll)
 
 
 def test_validate_sp_no_data(api_post, mocker):
@@ -251,7 +243,12 @@ def test_validate_sp_no_data(api_post, mocker):
 
     with pytest.raises(expected_exception=ValueError) as excinfo:
         validate_sp_for_branch(
-            fake_consumer, topics={config.host_ingress_topic}, repo_fork="foo", repo_branch="bar", days=3
+            fake_consumer,
+            topics={config.host_ingress_topic},
+            repo_fork="foo",
+            repo_branch="bar",
+            days=3,
+            max_messages=10,
         )
     assert "No data available at the provided date." in str(excinfo.value)
 
@@ -265,7 +262,12 @@ def test_validate_sp_for_missing_branch_or_repo(api_post, mocker):
 
     with pytest.raises(expected_exception=ValueError) as excinfo:
         validate_sp_for_branch(
-            fake_consumer, topics={config.host_ingress_topic}, repo_fork="foo", repo_branch="bar", days=3
+            fake_consumer,
+            topics={config.host_ingress_topic},
+            repo_fork="foo",
+            repo_branch="bar",
+            days=3,
+            max_messages=10,
         )
     assert "Schema not found at URL" in str(excinfo.value)
 

--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -8,7 +8,7 @@ from ttictoc import TicToc
 
 HOST_INGRESS_TOPIC = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
 BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
-NUM_HOSTS = int(os.environ.get("NUM_HOSTS", 1))
+NUM_HOSTS = int(os.environ.get("NUM_HOSTS", 150))
 
 
 def main():

--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -8,7 +8,7 @@ from ttictoc import TicToc
 
 HOST_INGRESS_TOPIC = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
 BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
-NUM_HOSTS = int(os.environ.get("NUM_HOSTS", 150))
+NUM_HOSTS = int(os.environ.get("NUM_HOSTS", 1))
 
 
 def main():


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-12307) (again).
After discussing with Jozef and Chris Mitchell, I found out that the validator needs a slightly different approach. Here is a summary of changes I made in this PR:

- Changed the validator's consumer_group_id to be distinct from the standard inventory-mq one.
- Added the ability to limit the number of messages the validator processes (for performance reasons).
- Added support for 2 new env vars to make deployment configuration easier and faster.
- Made the validator subscribe to both the host-ingress and host-ingress-p1 topics, by default.
- Changed the validator's behavior to poll repeatedly until there are no new messages, the message limit is reached, or the offset has caught up to the time the request was made.
- Simplified and improved performance for get_hosts_from_kafka_messages().
- Improved coverage of the validator's testing, and combined 2 similar tests.
- Restructured the validator to lower the spatial complexity at the expense of time complexity.
- Restricted the validator's API endpoint to a custom list of users, which is defined in the config.

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] General Coding Practices
