### PR TITLE
Add smart_management_enabled boolean to system profile

### DIFF
--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -344,3 +344,6 @@ $defs:
             example: "8.1"
             type: string
             maxLength: 255
+      smart_management_enabled:
+        type: boolean
+        description: Indicates whether Smart Management is enabled

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -429,6 +429,7 @@ def create_system_profile():
         # "installed_packages": rpm_list(),
         "installed_services": ["ndb", "krb5"],
         "enabled_services": ["ndb", "krb5"],
+        "smart_management_enabled": False,
     }
 
 


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-11978).
This just adds the boolean `smart_management_enabled` field to the system profile.
The corresponding inventory-schemas PR [is here](https://github.com/RedHatInsights/inventory-schemas/pull/51).

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] General Coding Practices
