### PR TITLE
OpenAPI schema capitalization fix

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -843,7 +843,7 @@ components:
           $ref: "#/components/schemas/BiosUuid"
         ip_addresses:
           $ref: "#/components/schemas/IpAddresses"
-        Fqdn:
+        fqdn:
           $ref: "#/components/schemas/Fqdn"
         mac_addresses:
           $ref: "#/components/schemas/MacAddresses"


### PR DESCRIPTION
## Overview

This PR is being created to address the issue found by @Glutexo [on this PR](https://github.com/RedHatInsights/insights-host-inventory/pull/744).
It simply changes `Fqdn` to `fqdn`.

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist
