### PR TITLE
Reduce max records per poll; improve log-browsing experience

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -96,7 +96,7 @@ class Config:
 
         self.host_ingress_consumer_group = os.environ.get("KAFKA_HOST_INGRESS_GROUP", "inventory-mq")
         self.secondary_topic_enabled = os.environ.get("KAFKA_SECONDARY_TOPIC_ENABLED", "false").lower() == "true"
-        self.sp_validator_max_messages = int(os.environ.get("KAFKA_SP_VALIDATOR_MAX_MESSAGES", "1000000"))
+        self.sp_validator_max_messages = int(os.environ.get("KAFKA_SP_VALIDATOR_MAX_MESSAGES", "10000"))
 
         self.prometheus_pushgateway = os.environ.get("PROMETHEUS_PUSHGATEWAY", "localhost:9091")
         self.kubernetes_namespace = os.environ.get("NAMESPACE")

--- a/lib/system_profile_validate.py
+++ b/lib/system_profile_validate.py
@@ -70,8 +70,6 @@ def validate_sp_schemas(consumer, topics, schemas, days=1, max_messages=10000):
 
             new_message_count += len(partition_messages)
             logger.info(f"Polled {new_message_count} messages from the queue.")
-            if new_message_count == 0:
-                break
 
             for message in partition_messages:
                 try:
@@ -91,6 +89,9 @@ def validate_sp_schemas(consumer, topics, schemas, days=1, max_messages=10000):
                     logger.exception("Unable to parse json message from message queue.")
                 except ValidationError:
                     logger.exception("Unable to parse operation from message.")
+
+        if new_message_count == 0:
+            break
 
         total_message_count += new_message_count
         logger.info(f"{total_message_count} messages processed so far, out of a maximum {max_messages}.")

--- a/lib/system_profile_validate.py
+++ b/lib/system_profile_validate.py
@@ -35,7 +35,7 @@ def get_schema(fork, branch):
     )
 
 
-def validate_sp_schemas(consumer, topics, schemas, days=1, max_messages=1000000):
+def validate_sp_schemas(consumer, topics, schemas, days=1, max_messages=10000):
     total_message_count = 0
     partitions = []
     test_results = {branch: {} for branch in schemas.keys()}
@@ -67,8 +67,12 @@ def validate_sp_schemas(consumer, topics, schemas, days=1, max_messages=1000000)
         for partition, partition_messages in consumer.poll(timeout_ms=60000, max_records=100).items():
             if consumer.position(partition) >= end_offsets[partition]:
                 continue
+
             new_message_count += len(partition_messages)
             logger.info(f"Polled {new_message_count} messages from the queue.")
+            if new_message_count == 0:
+                break
+
             for message in partition_messages:
                 try:
                     host = OperationSchema(strict=True).load(json.loads(message.value)).data["data"]
@@ -88,9 +92,8 @@ def validate_sp_schemas(consumer, topics, schemas, days=1, max_messages=1000000)
                 except ValidationError:
                     logger.exception("Unable to parse operation from message.")
 
-        if new_message_count == 0:
-            break
         total_message_count += new_message_count
+        logger.info(f"{total_message_count} messages processed so far, out of a maximum {max_messages}.")
 
     if total_message_count == 0:
         raise ValueError("No data available at the provided date.")
@@ -101,7 +104,7 @@ def validate_sp_schemas(consumer, topics, schemas, days=1, max_messages=1000000)
 
 
 def validate_sp_for_branch(
-    consumer, topics, repo_fork="RedHatInsights", repo_branch="master", days=1, max_messages=1000000
+    consumer, topics, repo_fork="RedHatInsights", repo_branch="master", days=1, max_messages=10000
 ):
     schemas = {"RedHatInsights/master": get_schema("RedHatInsights", "master")}
 


### PR DESCRIPTION
## Overview

This PR will make it easier to debug, and may possibly address, [this Jira](https://issues.redhat.com/browse/RHCLOUD-12982).

First and foremost, this PR greatly reduces the number of messages returned by the poll (down to 100). I had overestimated how well the pods would be able to churn through the data, so this will make it easier for them. It also reduces the default maximum number of hosts to 10,000 (configurable through env vars).

Secondly, this will improve the logging experience. I removed the stacktrace from the expected validation error logs, and moved the informational "Polled x hosts from queue" to right after the poll occurs (for easier Prod troubleshooting).

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Memory Management
- [x] General Coding Practices
