### PR TITLE
Change selinux_config_file from enum to allow a string

### DIFF
--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -337,8 +337,7 @@ $defs:
         example: 'enforcing'
       selinux_config_file:
         type: string
-        enum: [enforcing, permissive, disabled]
-        maxLength: 10
+        maxLength: 128
         description: The SELinux mode provided in the config file
         example: 'permissive'
       is_marketplace:

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -144,4 +144,6 @@ def valid_system_profile():
         "installed_services": ["ndb", "krb5"],
         "enabled_services": ["ndb", "krb5"],
         "sap_sids": ["ABC", "DEF", "GHI"],
+        "selinux_current_mode": "enforcing",
+        "selinux_config_file": "enforcing",
     }

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -431,6 +431,8 @@ def create_system_profile():
         # "installed_packages": rpm_list(),
         "installed_services": ["ndb", "krb5"],
         "enabled_services": ["ndb", "krb5"],
+        "selinux_current_mode": "enforcing",
+        "selinux_config_file": "enforcing",
     }
 
 


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-11879](https://issues.redhat.com/browse/RHCLOUD-11879).
> Issue on HBI to process the yupana request "System profile does not conform to schema" - SELinux with "Inappropriate ioctl for device"

The corresponding inventory-schemas PR is https://github.com/RedHatInsights/inventory-schemas/pull/54

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [X] General Coding Practices
