### PR TITLE
Use test for account_number

### DIFF
--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -9,7 +9,7 @@ from datetime import timezone
 # good
 IDENTITY = {
     "identity": {
-        "account_number": "sysaccount",
+        "account_number": "test",
         "type": "System",
         "auth_type": "cert-auth",
         "system": {"cn": "1b36b20f-7fa0-4454-a6d2-008294e06378", "cert_type": "system"},


### PR DESCRIPTION
## Overview

Using `"test"` as the `account_number` in `payloads.py` allows us to keep using the header we have been using all along and also makes it easier to integrate with `xjoin-search`.

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist
