### PR TITLE
Host List Sparse System Profile Response - RHCLOUD-12849

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -129,7 +129,7 @@ def get_host_list(
         log_get_host_list_failed(logger)
         flask.abort(400, str(e))
 
-    json_data = build_paginated_host_list_response(total, page, per_page, host_list)
+    json_data = build_paginated_host_list_response(total, page, per_page, host_list, bulk_query_source)
     return flask_json_response(json_data)
 
 

--- a/api/host.py
+++ b/api/host.py
@@ -110,7 +110,7 @@ def get_host_list(
     get_host_list = GET_HOST_LIST_FUNCTIONS[bulk_query_source]
 
     try:
-        host_list, total, response_type = get_host_list(
+        host_list, total, additional_fields = get_host_list(
             display_name,
             fqdn,
             hostname_or_id,
@@ -129,7 +129,7 @@ def get_host_list(
         log_get_host_list_failed(logger)
         flask.abort(400, str(e))
 
-    json_data = build_paginated_host_list_response(total, page, per_page, host_list, response_type)
+    json_data = build_paginated_host_list_response(total, page, per_page, host_list, additional_fields)
     return flask_json_response(json_data)
 
 

--- a/api/host.py
+++ b/api/host.py
@@ -17,6 +17,7 @@ from api.host_query_db import params_to_order_by
 from api.host_query_xjoin import get_host_list as get_host_list_xjoin
 from api.sparse_host_list_system_profile import get_sparse_system_profile
 from app import db
+from app import HostListResponse
 from app import inventory_config
 from app import Permission
 from app.auth import get_current_identity
@@ -110,7 +111,7 @@ def get_host_list(
     get_host_list = GET_HOST_LIST_FUNCTIONS[bulk_query_source]
 
     try:
-        host_list, total = get_host_list(
+        host_list, total, response_type = get_host_list(
             display_name,
             fqdn,
             hostname_or_id,
@@ -129,7 +130,7 @@ def get_host_list(
         log_get_host_list_failed(logger)
         flask.abort(400, str(e))
 
-    json_data = build_paginated_host_list_response(total, page, per_page, host_list, bulk_query_source)
+    json_data = build_paginated_host_list_response(total, page, per_page, host_list, response_type)
     return flask_json_response(json_data)
 
 

--- a/api/host.py
+++ b/api/host.py
@@ -17,7 +17,6 @@ from api.host_query_db import params_to_order_by
 from api.host_query_xjoin import get_host_list as get_host_list_xjoin
 from api.sparse_host_list_system_profile import get_sparse_system_profile
 from app import db
-from app import HostListResponse
 from app import inventory_config
 from app import Permission
 from app.auth import get_current_identity

--- a/api/host.py
+++ b/api/host.py
@@ -100,6 +100,7 @@ def get_host_list(
     staleness=None,
     registered_with=None,
     filter=None,
+    fields=None
 ):
     total = 0
     host_list = ()
@@ -122,6 +123,7 @@ def get_host_list(
             staleness,
             registered_with,
             filter,
+            fields
         )
     except ValueError as e:
         log_get_host_list_failed(logger)

--- a/api/host.py
+++ b/api/host.py
@@ -100,7 +100,7 @@ def get_host_list(
     staleness=None,
     registered_with=None,
     filter=None,
-    fields=None
+    fields=None,
 ):
     total = 0
     host_list = ()
@@ -123,7 +123,7 @@ def get_host_list(
             staleness,
             registered_with,
             filter,
-            fields
+            fields,
         )
     except ValueError as e:
         log_get_host_list_failed(logger)

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from enum import Enum
 
-from app import HostListResponse
 from app import inventory_config
 from app.culling import Timestamps
 from app.serialization import DEFAULT_FIELDS
@@ -14,15 +13,10 @@ OrderBy = Enum("OrderBy", ("display_name", "id", "modified_on"))
 OrderHow = Enum("OrderHow", ("ASC", "DESC"))
 Order = namedtuple("Order", ("by", "how"))
 
-type_mapper = {
-    HostListResponse.generic: DEFAULT_FIELDS,
-    HostListResponse.sparse_sp: DEFAULT_FIELDS + ("system_profile",),
-}
 
-
-def build_paginated_host_list_response(total, page, per_page, host_list, response_type=HostListResponse.generic):
+def build_paginated_host_list_response(total, page, per_page, host_list, additional_fields=tuple()):
     timestamps = staleness_timestamps()
-    json_host_list = [serialize_host(host, timestamps, type_mapper[response_type]) for host in host_list]
+    json_host_list = [serialize_host(host, timestamps, DEFAULT_FIELDS + additional_fields) for host in host_list]
     return {
         "total": total,
         "count": len(json_host_list),

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -1,8 +1,8 @@
 from collections import namedtuple
 from enum import Enum
 
-from app import inventory_config
 from app import HostListResponse
+from app import inventory_config
 from app.culling import Timestamps
 from app.serialization import DEFAULT_FIELDS
 from app.serialization import serialize_host
@@ -14,14 +14,14 @@ OrderBy = Enum("OrderBy", ("display_name", "id", "modified_on"))
 OrderHow = Enum("OrderHow", ("ASC", "DESC"))
 Order = namedtuple("Order", ("by", "how"))
 
-type_mapper = {HostListResponse.generic: DEFAULT_FIELDS, HostListResponse.sparse_sp: DEFAULT_FIELDS+("system_profile",)}
+type_mapper = {
+    HostListResponse.generic: DEFAULT_FIELDS,
+    HostListResponse.sparse_sp: DEFAULT_FIELDS + ("system_profile",),
+}
 
 
 def build_paginated_host_list_response(total, page, per_page, host_list, response_type=HostListResponse.generic):
     timestamps = staleness_timestamps()
-    # if source == BulkQuerySource.xjoin:
-    #     json_host_list = [serialize_host(host, timestamps, DEFAULT_FIELDS + ("system_profile",)) for host in host_list]
-    # else:
     json_host_list = [serialize_host(host, timestamps, type_mapper[response_type]) for host in host_list]
     return {
         "total": total,

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -2,7 +2,9 @@ from collections import namedtuple
 from enum import Enum
 
 from app import inventory_config
+from app.config import BulkQuerySource
 from app.culling import Timestamps
+from app.serialization import DEFAULT_FIELDS
 from app.serialization import serialize_host
 
 
@@ -13,9 +15,12 @@ OrderHow = Enum("OrderHow", ("ASC", "DESC"))
 Order = namedtuple("Order", ("by", "how"))
 
 
-def build_paginated_host_list_response(total, page, per_page, host_list):
+def build_paginated_host_list_response(total, page, per_page, host_list, source=BulkQuerySource.db):
     timestamps = staleness_timestamps()
-    json_host_list = [serialize_host(host, timestamps) for host in host_list]
+    if source == BulkQuerySource.xjoin:
+        json_host_list = [serialize_host(host, timestamps, DEFAULT_FIELDS + ("system_profile",)) for host in host_list]
+    else:
+        json_host_list = [serialize_host(host, timestamps) for host in host_list]
     return {
         "total": total,
         "count": len(json_host_list),

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from enum import Enum
 
 from app import inventory_config
-from app.config import BulkQuerySource
+from app import HostListResponse
 from app.culling import Timestamps
 from app.serialization import DEFAULT_FIELDS
 from app.serialization import serialize_host
@@ -14,13 +14,15 @@ OrderBy = Enum("OrderBy", ("display_name", "id", "modified_on"))
 OrderHow = Enum("OrderHow", ("ASC", "DESC"))
 Order = namedtuple("Order", ("by", "how"))
 
+type_mapper = {HostListResponse.generic: DEFAULT_FIELDS, HostListResponse.sparse_sp: DEFAULT_FIELDS+("system_profile",)}
 
-def build_paginated_host_list_response(total, page, per_page, host_list, source=BulkQuerySource.db):
+
+def build_paginated_host_list_response(total, page, per_page, host_list, response_type=HostListResponse.generic):
     timestamps = staleness_timestamps()
-    if source == BulkQuerySource.xjoin:
-        json_host_list = [serialize_host(host, timestamps, DEFAULT_FIELDS + ("system_profile",)) for host in host_list]
-    else:
-        json_host_list = [serialize_host(host, timestamps) for host in host_list]
+    # if source == BulkQuerySource.xjoin:
+    #     json_host_list = [serialize_host(host, timestamps, DEFAULT_FIELDS + ("system_profile",)) for host in host_list]
+    # else:
+    json_host_list = [serialize_host(host, timestamps, type_mapper[response_type]) for host in host_list]
     return {
         "total": total,
         "count": len(json_host_list),

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -4,7 +4,6 @@ import flask
 from sqlalchemy import and_
 from sqlalchemy import or_
 
-from app import HostListResponse
 from app.auth import get_current_identity
 from app.instrumentation import log_get_host_list_succeeded
 from app.logging import get_logger
@@ -66,7 +65,7 @@ def get_host_list(
 
     log_get_host_list_succeeded(logger, query_results.items)
 
-    return query_results.items, query_results.total, HostListResponse.generic
+    return query_results.items, query_results.total, tuple()
 
 
 def find_hosts_with_insights_enabled(query):

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -33,6 +33,7 @@ def get_host_list(
     staleness,
     registered_with,
     filter,
+    fields
 ):
     if filter:
         flask.abort(503)

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -4,6 +4,7 @@ import flask
 from sqlalchemy import and_
 from sqlalchemy import or_
 
+from app import HostListResponse
 from app.auth import get_current_identity
 from app.instrumentation import log_get_host_list_succeeded
 from app.logging import get_logger
@@ -65,7 +66,7 @@ def get_host_list(
 
     log_get_host_list_succeeded(logger, query_results.items)
 
-    return query_results.items, query_results.total
+    return query_results.items, query_results.total, HostListResponse.generic
 
 
 def find_hosts_with_insights_enabled(query):

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -33,7 +33,7 @@ def get_host_list(
     staleness,
     registered_with,
     filter,
-    fields
+    fields,
 ):
     if filter:
         flask.abort(503)

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -62,10 +62,11 @@ def get_host_list(
     order_by = params_to_order_by(order_by, order_how)
     query = query.order_by(*order_by)
     query_results = query.paginate(page, per_page, True)
+    additional_fields = tuple()
 
     log_get_host_list_succeeded(logger, query_results.items)
 
-    return query_results.items, query_results.total, tuple()
+    return query_results.items, query_results.total, additional_fields
 
 
 def find_hosts_with_insights_enabled(query):

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -23,7 +23,7 @@ QUERY = """query Query(
     $order_by: HOSTS_ORDER_BY,
     $order_how: ORDER_DIR,
     $filter: [HostFilter!],
-    $fields: [String!]=[]
+    $fields: [String!]
 ) {
     hosts(
         limit: $limit,

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -1,6 +1,5 @@
 from uuid import UUID
 
-from app import HostListResponse
 from app.auth import get_current_identity
 from app.auth.identity import AuthType
 from app.auth.identity import CertType
@@ -102,11 +101,11 @@ def get_host_list(
     ):
         all_filters += owner_id_filter()
 
-    response_type = HostListResponse.generic
+    additional_fields = tuple()
 
     system_profile_fields = []
     if fields.get("system_profile"):
-        response_type = HostListResponse.sparse_sp
+        additional_fields = ("system_profile",)
         system_profile_fields = list(fields.get("system_profile").keys())
 
     variables = {
@@ -122,7 +121,7 @@ def get_host_list(
     total = response["meta"]["total"]
     check_pagination(offset, total)
 
-    return map(deserialize_host, response["data"]), total, response_type
+    return map(deserialize_host, response["data"]), total, additional_fields
 
 
 def _params_to_order(param_order_by=None, param_order_how=None):

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from app import HostListResponse
 from app.auth import get_current_identity
 from app.instrumentation import log_get_host_list_failed
 from app.logging import get_logger
@@ -115,7 +116,7 @@ def get_host_list(
     total = response["meta"]["total"]
     check_pagination(offset, total)
 
-    return map(deserialize_host, response["data"]), total
+    return map(deserialize_host, response["data"]), total, HostListResponse.sparse_sp
 
 
 def _params_to_order(param_order_by=None, param_order_how=None):

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -99,8 +99,11 @@ def get_host_list(
     ):
         all_filters += owner_id_filter()
 
+    response_type = HostListResponse.generic
+
     system_profile_fields = []
     if fields.get("system_profile"):
+        response_type = HostListResponse.sparse_sp
         system_profile_fields = list(fields.get("system_profile").keys())
 
     variables = {
@@ -116,7 +119,7 @@ def get_host_list(
     total = response["meta"]["total"]
     check_pagination(offset, total)
 
-    return map(deserialize_host, response["data"]), total, HostListResponse.sparse_sp
+    return map(deserialize_host, response["data"]), total, response_type
 
 
 def _params_to_order(param_order_by=None, param_order_how=None):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -39,6 +39,7 @@ UNKNOWN_REQUEST_ID_VALUE = "-1"
 
 SPECIFICATION_FILE = join(SPECIFICATION_DIR, "api.spec.yaml")
 
+HostListResponse = Enum("HostListResponse", ("generic", "sparse_sp"))
 
 class Permission(Enum):
     READ = "inventory:hosts:read"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -41,6 +41,7 @@ SPECIFICATION_FILE = join(SPECIFICATION_DIR, "api.spec.yaml")
 
 HostListResponse = Enum("HostListResponse", ("generic", "sparse_sp"))
 
+
 class Permission(Enum):
     READ = "inventory:hosts:read"
     WRITE = "inventory:hosts:write"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -39,8 +39,6 @@ UNKNOWN_REQUEST_ID_VALUE = "-1"
 
 SPECIFICATION_FILE = join(SPECIFICATION_DIR, "api.spec.yaml")
 
-HostListResponse = Enum("HostListResponse", ("generic", "sparse_sp"))
-
 
 class Permission(Enum):
     READ = "inventory:hosts:read"

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -79,7 +79,7 @@ def deserialize_host_xjoin(data):
         account=data["account"],
         facts=data["facts"] or {},
         tags={},  # Not a part of host list output
-        system_profile_facts=data["system_profile_facts"],
+        system_profile_facts=data["system_profile_facts"] or {},
         stale_timestamp=_deserialize_datetime(data["stale_timestamp"]),
         reporter=data["reporter"],
     )

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -38,6 +38,7 @@ DEFAULT_FIELDS = (
     "culled_timestamp",
     "created",
     "updated",
+    "system_profile",
 )
 
 
@@ -79,7 +80,7 @@ def deserialize_host_xjoin(data):
         account=data["account"],
         facts=data["facts"] or {},
         tags={},  # Not a part of host list output
-        system_profile_facts={},  # Not a part of host list output
+        system_profile_facts=data["system_profile_facts"],
         stale_timestamp=_deserialize_datetime(data["stale_timestamp"]),
         reporter=data["reporter"],
     )

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -38,7 +38,6 @@ DEFAULT_FIELDS = (
     "culled_timestamp",
     "created",
     "updated",
-    "system_profile",
 )
 
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -52,6 +52,7 @@ paths:
         - $ref: '#/components/parameters/tagsParam'
         - $ref: '#/components/parameters/registered_with'
         - $ref: '#/components/parameters/filter_param'
+        - $ref: '#/components/parameters/fields_param'
       responses:
         '200':
           description: Successfully read the hosts list.

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -30,6 +30,7 @@ XJOIN_HOSTS_RESPONSE = {
                 "facts": None,
                 "stale_timestamp": "2020-02-10T08:07:03.354307Z",
                 "reporter": "puptoo",
+                "system_profile_facts": {},
             },
             {
                 "id": "22cd8e39-13bb-4d02-8316-84b850dc5136",
@@ -53,6 +54,7 @@ XJOIN_HOSTS_RESPONSE = {
                 },
                 "stale_timestamp": "2020-01-10T08:07:03.354307Z",
                 "reporter": "puptoo",
+                "system_profile_facts": {},
             },
         ],
     }
@@ -123,6 +125,7 @@ def assert_graph_query_single_call_with_staleness(mocker, graphql_query, stalene
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": ({"OR": conditions},),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -30,7 +30,7 @@ XJOIN_HOSTS_RESPONSE = {
                 "facts": None,
                 "stale_timestamp": "2020-02-10T08:07:03.354307Z",
                 "reporter": "puptoo",
-                "system_profile_facts": {},
+                "system_profile_facts": {"test_data": "1.2.3", "random": ["data"]},
             },
             {
                 "id": "22cd8e39-13bb-4d02-8316-84b850dc5136",
@@ -54,7 +54,7 @@ XJOIN_HOSTS_RESPONSE = {
                 },
                 "stale_timestamp": "2020-01-10T08:07:03.354307Z",
                 "reporter": "puptoo",
-                "system_profile_facts": {},
+                "system_profile_facts": {"test_data": "1.2.3", "random": ["data"]},
             },
         ],
     }

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1075,12 +1075,15 @@ def test_validate_sp_sparse_fields_invalid_requests(query_source_xjoin, api_get)
 
 def test_host_list_sp_fields_requested(patch_xjoin_post, query_source_xjoin, api_get):
     patch_xjoin_post(response={"data": XJOIN_HOSTS_RESPONSE})
-    response_status, response_data = api_get(HOST_URL + "?fields[system_profile]=test_data,random")
+    fields = ["test_data", "random"]
+    response_status, response_data = api_get(HOST_URL + f"?fields[system_profile]={','.join(fields)}")
 
     assert response_status == 200
 
     for host_data in response_data["results"]:
         assert "system_profile" in host_data
+        for key in host_data["system_profile"].keys():
+            assert key in fields
 
 
 def test_host_list_sp_fields_not_requested(patch_xjoin_post, query_source_xjoin, api_get):

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -31,6 +31,7 @@ from tests.helpers.api_utils import UUID_2
 from tests.helpers.api_utils import UUID_3
 from tests.helpers.db_utils import serialize_db_host
 from tests.helpers.db_utils import update_host_in_db
+from tests.helpers.graphql_utils import XJOIN_HOSTS_RESPONSE
 from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import minimal_host
 from tests.helpers.test_utils import now
@@ -1070,3 +1071,23 @@ def test_validate_sp_sparse_fields_invalid_requests(query_source_xjoin, api_get)
 
         response_status, response_data = api_get(build_system_profile_url(hosts, query=query))
         assert response_status == 400
+
+
+def test_host_list_sp_fields_requested(patch_xjoin_post, query_source_xjoin, api_get):
+    patch_xjoin_post(response={"data": XJOIN_HOSTS_RESPONSE})
+    response_status, response_data = api_get(HOST_URL + "?fields[system_profile]=test_data,random")
+
+    assert response_status == 200
+
+    for host_data in response_data["results"]:
+        assert "system_profile" in host_data
+
+
+def test_host_list_sp_fields_not_requested(patch_xjoin_post, query_source_xjoin, api_get):
+    patch_xjoin_post(response={"data": XJOIN_HOSTS_RESPONSE})
+    response_status, response_data = api_get(HOST_URL)
+
+    assert response_status == 200
+
+    for host_data in response_data["results"]:
+        assert "system_profile" not in host_data

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -84,6 +84,7 @@ def test_query_variables_fqdn(mocker, query_source_xjoin, graphql_query_empty_re
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": ({"fqdn": {"eq": fqdn}}, mocker.ANY),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -105,6 +106,7 @@ def test_query_variables_display_name(mocker, query_source_xjoin, graphql_query_
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": ({"display_name": {"matches_lc": f"*{display_name}*"}}, mocker.ANY),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -134,6 +136,7 @@ def test_query_variables_hostname_or_id_non_uuid(mocker, query_source_xjoin, gra
                 },
                 mocker.ANY,
             ),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -164,6 +167,7 @@ def test_query_variables_hostname_or_id_uuid(mocker, query_source_xjoin, graphql
                 },
                 mocker.ANY,
             ),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -185,6 +189,7 @@ def test_query_variables_insights_id(mocker, query_source_xjoin, graphql_query_e
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": ({"insights_id": {"eq": insights_id}}, mocker.ANY),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -203,6 +208,7 @@ def test_query_variables_none(mocker, query_source_xjoin, graphql_query_empty_re
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": (mocker.ANY,),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -233,6 +239,7 @@ def test_query_variables_priority(filter_, query, mocker, query_source_xjoin, gr
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": ({filter_: mocker.ANY}, mocker.ANY),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -273,6 +280,7 @@ def test_query_variables_tags(tags, query_param, mocker, query_source_xjoin, gra
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": tag_filters + (mocker.ANY,),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -298,6 +306,7 @@ def test_query_variables_tags_with_search(field, mocker, query_source_xjoin, gra
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": (search_any, tag_filter, mocker.ANY),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -317,6 +326,7 @@ def test_query_variables_registered_with_insights(mocker, query_source_xjoin, gr
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": (mocker.ANY, {"NOT": {"insights_id": {"eq": None}}}),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -337,6 +347,7 @@ def test_query_variables_ordering_dir(direction, mocker, query_source_xjoin, gra
             "order_by": mocker.ANY,
             "order_how": direction,
             "filter": mocker.ANY,
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -368,6 +379,7 @@ def test_query_variables_ordering_by(
             "order_by": xjoin_order_by,
             "order_how": default_xjoin_order_how,
             "filter": mocker.ANY,
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -409,7 +421,14 @@ def test_response_pagination(page, limit, offset, mocker, query_source_xjoin, gr
 
     graphql_query_empty_response.assert_called_once_with(
         HOST_QUERY,
-        {"order_by": mocker.ANY, "order_how": mocker.ANY, "limit": limit, "offset": offset, "filter": mocker.ANY},
+        {
+            "order_by": mocker.ANY,
+            "order_how": mocker.ANY,
+            "limit": limit,
+            "offset": offset,
+            "filter": mocker.ANY,
+            "fields": mocker.ANY,
+        },
         mocker.ANY,
     )
 
@@ -431,7 +450,14 @@ def test_query_variables_default_except_staleness(mocker, query_source_xjoin, gr
 
     graphql_query_empty_response.assert_called_once_with(
         HOST_QUERY,
-        {"order_by": "modified_on", "order_how": "DESC", "limit": 50, "offset": 0, "filter": mocker.ANY},
+        {
+            "order_by": "modified_on",
+            "order_how": "DESC",
+            "limit": 50,
+            "offset": 0,
+            "filter": mocker.ANY,
+            "fields": mocker.ANY,
+        },
         mocker.ANY,
     )
 
@@ -521,6 +547,7 @@ def test_query_variables_staleness_with_search(
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": (search_any, staleness_any),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -1362,6 +1389,7 @@ def test_query_hosts_filter_spf_sap_system(
                         "limit": mocker.ANY,
                         "offset": mocker.ANY,
                         "filter": ({"OR": mocker.ANY}, query),
+                        "fields": mocker.ANY,
                     },
                     mocker.ANY,
                 )
@@ -1459,6 +1487,7 @@ def test_query_hosts_filter_spf_sap_sids(mocker, subtests, query_source_xjoin, g
                         "limit": mocker.ANY,
                         "offset": mocker.ANY,
                         "filter": ({"OR": mocker.ANY}, *query),
+                        "fields": mocker.ANY,
                     },
                     mocker.ANY,
                 )
@@ -1560,6 +1589,7 @@ def test_query_hosts_system_identity(mocker, subtests, query_source_xjoin, graph
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": ({"OR": mocker.ANY}, {"spf_owner_id": {"eq": OWNER_ID}}),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )
@@ -1636,6 +1666,7 @@ def test_query_hosts_insights_classic_system_identity(
             "limit": mocker.ANY,
             "offset": mocker.ANY,
             "filter": ({"OR": mocker.ANY},),
+            "fields": mocker.ANY,
         },
         mocker.ANY,
     )

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1811,3 +1811,36 @@ def test_sp_sparse_xjoin_query_translation(
 
     assert response_status == 200
     graphql_sparse_system_profile_empty_response.assert_called_once_with(SYSTEM_PROFILE_QUERY, variables, mocker.ANY)
+
+
+@pytest.mark.parametrize(
+    "query,fields",
+    (
+        ("?fields[system_profile]=sp_field1", ["sp_field1"]),
+        ("?fields[system_profile]=sp_field1,sp_field2,sp_field3", ["sp_field1", "sp_field2", "sp_field3"]),
+        (
+            "?fields[system_profile]=sp_field1&fields[system_profile]=sp_field2,sp_field3",
+            ["sp_field1", "sp_field2", "sp_field3"],
+        ),
+    ),
+)
+def test_query_variables_system_profile(
+    query, fields, mocker, query_source_xjoin, graphql_query_empty_response, api_get
+):
+    url = build_hosts_url(query=query)
+    response_status, response_data = api_get(url)
+
+    assert response_status == 200
+
+    graphql_query_empty_response.assert_called_once_with(
+        HOST_QUERY,
+        {
+            "order_by": mocker.ANY,
+            "order_how": mocker.ANY,
+            "limit": mocker.ANY,
+            "offset": mocker.ANY,
+            "filter": mocker.ANY,
+            "fields": fields,
+        },
+        mocker.ANY,
+    )

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1604,6 +1604,7 @@ def test_query_hosts_filter_spf_is_marketplace(
                         "limit": mocker.ANY,
                         "offset": mocker.ANY,
                         "filter": ({"OR": mocker.ANY}, query),
+                        "fields": mocker.ANY,
                     },
                     mocker.ANY,
                 )
@@ -1639,6 +1640,7 @@ def test_query_hosts_filter_spf_rhc_client_id(
                         "limit": mocker.ANY,
                         "offset": mocker.ANY,
                         "filter": ({"OR": mocker.ANY}, query),
+                        "fields": mocker.ANY,
                     },
                     mocker.ANY,
                 )
@@ -1675,6 +1677,7 @@ def test_query_hosts_filter_spf_insights_client_version(
                         "limit": mocker.ANY,
                         "offset": mocker.ANY,
                         "filter": ({"OR": mocker.ANY}, query),
+                        "fields": mocker.ANY,
                     },
                     mocker.ANY,
                 )


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-12849).
The goal of this PR is to enable fetching of some system_profile fields from the `/hosts` endpoint using sparse fields.

This PR does not intend on  changing the current response in `host_list` endpoint. Users will need to mention the `fields` query parameter if they want to fetch system_profile data through the `host_list` endpoint. If HBI is using the `db` and/or the user does not mention the `fields` query parameter, the response should remain same as it is today.

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Input Validation
- [x] Output Encoding
- [x] General Coding Practices
