### PR TITLE
Allow reporters to update display_name if insights_id isn't set

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -195,8 +195,11 @@ class Host(db.Model):
         self.update_canonical_facts(input_host.canonical_facts)
 
         # TODO: Remove this eventually when Sat 6.7 stops sending fqdns as display_names (See RHCLOUD-5954)
-        # NOTE: For this particular issue, display_name changes from "puptoo" and "yupana" are ignored
-        if input_host.reporter != "yupana" and input_host.reporter != "rhsm-conduit":
+        # NOTE: For this particular issue, display_name changes from "puptoo" and "yupana" are ignored,
+        # unless the Insights ID isn't set (See RHCLOUD-13105)
+        if "insights_id" not in self.canonical_facts or (
+            input_host.reporter != "yupana" and input_host.reporter != "rhsm-conduit"
+        ):
             self.update_display_name(input_host.display_name)
 
         self._update_ansible_host(input_host.ansible_host)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -110,16 +110,36 @@ def test_update_existing_host_fix_display_name_using_id(db_create_host):
 def test_update_existing_host_dont_change_display_name(db_create_host):
     # Create an "existing" host
     fqdn = "host1.domain1.com"
-    display_name = "foo"
-    existing_host = db_create_host(extra_data={"canonical_facts": {"fqdn": fqdn}, "display_name": display_name})
+    insights_id = generate_uuid()
+    old_display_name = "foo"
+    existing_host = db_create_host(
+        extra_data={"canonical_facts": {"fqdn": fqdn, "insights_id": insights_id}, "display_name": old_display_name}
+    )
 
-    # Attempt to update the display name from Satellite reporter (shouldn't change)
+    # Attempt to update the display name from Satellite reporter.
+    # Should't update because Insights ID was set
     expected_fqdn = "different.domain1.com"
     input_host = Host({"fqdn": expected_fqdn}, display_name="dont_change_me", reporter="yupana", stale_timestamp=now())
     existing_host.update(input_host)
 
     # assert display name hasn't changed
-    assert existing_host.display_name == display_name
+    assert existing_host.display_name == old_display_name
+
+
+def test_update_existing_host_non_insights_display_name(db_create_host):
+    # Create an "existing" host
+    fqdn = "host1.domain1.com"
+    existing_host = db_create_host(extra_data={"canonical_facts": {"fqdn": fqdn}, "display_name": "foo"})
+
+    # Attempt to update the display name from Satellite reporter.
+    # Should update because Insights ID isn't set.
+    expected_fqdn = "different.domain1.com"
+    new_display_name = "change_me"
+    input_host = Host({"fqdn": expected_fqdn}, display_name=new_display_name, reporter="yupana", stale_timestamp=now())
+    existing_host.update(input_host)
+
+    # assert display name has changed
+    assert existing_host.display_name == new_display_name
 
 
 def test_create_host_without_system_profile(db_create_host):


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-13105](https://issues.redhat.com/browse/RHCLOUD-13105).
It allows reporters to update a Host's `display_name` if the Insights ID hasn't been set.
This functionality is required to support rhsm-conduit's hypervisor/vsphere implementation.

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Input Validation
- [x] Access Control
- [x] General Coding Practices
