### PR TITLE
Add gpg_pubkey array to system profile

### DIFF
--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -277,17 +277,24 @@ $defs:
         type: string
         maxLength: 32
       installed_packages:
-        type: array  # technically a set, ordering is not important
+        type: array  # technically a set, ordered by RPM sorting algorithm
         items:
           description: A NEVRA string for a single installed package
           example: "krb5-libs-0:-1.16.1-23.fc29.i686"
           type: string
           maxLength: 512
       installed_packages_delta:
-        type: array  # sorted list, rest of packages not in installed_packages
+        type: array  # packages not in installed_packages, ordered by RPM sorting algorithm
         items:
           description: A NEVRA string for a single installed package
           example: "krb5-libs-0:-1.16.1-23.fc29.i686"
+          type: string
+          maxLength: 512
+      gpg_pubkeys:
+        type: array  # technically a set, ordered by RPM sorting algorithm
+        items:
+          description: A package name string of a single imported GPG pubkey
+          example: "gpg-pubkey-11111111-22222222"
           type: string
           maxLength: 512
       installed_services:

--- a/tests/helpers/system_profile_utils.py
+++ b/tests/helpers/system_profile_utils.py
@@ -47,6 +47,7 @@ INVALID_SYSTEM_PROFILES = (
     {"insights_egg_version": "x" * 51},
     {"captured_date": "x" * 33},
     {"installed_packages": ["x" * 513]},
+    {"gpg_pubkeys": ["x" * 513]},
     {"installed_services": ["x" * 513]},
     {"enabled_services": ["x" * 513]},
     {"sap_sids": ["XXXX"]},

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -151,6 +151,7 @@ def valid_system_profile():
         "insights_egg_version": "120.0.1",
         "captured_date": "2020-02-13T12:08:55Z",
         "installed_packages": ["rpm1-0:0.0.1.el7.i686", "rpm1-2:0.0.1.el7.i686"],
+        "gpg_pubkeys": ["gpg-pubkey-11111111-22222222", "gpg-pubkey-33333333-44444444"],
         "installed_services": ["ndb", "krb5"],
         "enabled_services": ["ndb", "krb5"],
         "sap_sids": ["ABC", "DEF", "GHI"],


### PR DESCRIPTION
## Overview

This PR is being created to address https://issues.redhat.com/browse/HBISPSC-51 to split out the gpg_pubkey from the rpms in installed_packages or installed_packages_delta and still keep them as a separate fact.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
