### PR TITLE
Transform subscription_manager_id to have dashes when setting it to owner_id [RHCLOUD-12813]

### DIFF
--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -25,13 +25,14 @@ def mq_create_or_update_host(flask_app, event_producer_mock):
     def _mq_create_or_update_host(
         host_data,
         platform_metadata=None,
+        overwrite_identity=True,
         return_all_data=False,
         event_producer=event_producer_mock,
         message_operation=add_host,
     ):
         if not platform_metadata:
             platform_metadata = get_platform_metadata()
-        else:
+        elif overwrite_identity:
             platform_metadata["b64_identity"] = get_encoded_idstr()
         host_data.data()["account"] = SYSTEM_IDENTITY.get("account_number")
         message = wrap_message(host_data.data(), platform_metadata=platform_metadata)

--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -12,7 +12,6 @@ from tests.helpers.mq_utils import MockEventProducer
 from tests.helpers.mq_utils import MockFuture
 from tests.helpers.mq_utils import wrap_message
 from tests.helpers.test_utils import generate_uuid
-from tests.helpers.test_utils import get_encoded_idstr
 from tests.helpers.test_utils import get_platform_metadata
 from tests.helpers.test_utils import get_staleness_timestamps
 from tests.helpers.test_utils import minimal_host
@@ -25,15 +24,12 @@ def mq_create_or_update_host(flask_app, event_producer_mock):
     def _mq_create_or_update_host(
         host_data,
         platform_metadata=None,
-        overwrite_identity=True,
         return_all_data=False,
         event_producer=event_producer_mock,
         message_operation=add_host,
     ):
         if not platform_metadata:
             platform_metadata = get_platform_metadata()
-        elif overwrite_identity:
-            platform_metadata["b64_identity"] = get_encoded_idstr()
         host_data.data()["account"] = SYSTEM_IDENTITY.get("account_number")
         message = wrap_message(host_data.data(), platform_metadata=platform_metadata)
         handle_message(json.dumps(message), event_producer, message_operation)

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -30,7 +30,6 @@ from tests.helpers.test_utils import minimal_host
 from tests.helpers.test_utils import now
 from tests.helpers.test_utils import SATELLITE_IDENTITY
 from tests.helpers.test_utils import SYSTEM_IDENTITY
-from tests.helpers.test_utils import USER_IDENTITY
 from tests.helpers.test_utils import valid_system_profile
 
 
@@ -301,7 +300,7 @@ def test_add_host_rhsm_conduit_without_cn(event_datetime_mock, mq_create_or_upda
     """
     sub_mangager_id = "09152341475c4671a376df609374c349"
 
-    metadata_without_b64 = get_platform_metadata(identity=USER_IDENTITY)
+    metadata_without_b64 = get_platform_metadata(identity=SYSTEM_IDENTITY)
     del metadata_without_b64["b64_identity"]
 
     host = minimal_host(
@@ -332,7 +331,6 @@ def test_add_host_rhsm_conduit_owner_id(event_datetime_mock, mq_create_or_update
     key, event, headers = mq_create_or_update_host(host, return_all_data=True)
 
     # owner_id gets overwritten and equates to subscription_manager_id with dashes
-    assert event["host"]["system_profile"]["owner_id"] != OWNER_ID
     assert event["host"]["system_profile"]["owner_id"] == "09152341-475c-4671-a376-df609374c349"
 
 

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -218,8 +218,15 @@ def test_handle_message_verify_message_headers(mocker, add_host_result, mq_creat
     host_id = generate_uuid()
     insights_id = generate_uuid()
     request_id = generate_uuid()
+    subscription_manager_id = generate_uuid()
 
-    host = minimal_host(account=SYSTEM_IDENTITY["account_number"], id=host_id, insights_id=insights_id)
+    host = minimal_host(
+        account=SYSTEM_IDENTITY["account_number"],
+        id=host_id,
+        insights_id=insights_id,
+        reporter="rhsm-conduit",
+        subscription_manager_id=subscription_manager_id,
+    )
 
     mock_add_host = mocker.patch(
         "app.queue.queue.add_host", return_value=(host.data(), host_id, insights_id, add_host_result)
@@ -307,9 +314,7 @@ def test_add_host_rhsm_conduit_without_cn(event_datetime_mock, mq_create_or_upda
         account=SYSTEM_IDENTITY["account_number"], reporter="rhsm-conduit", subscription_manager_id=sub_mangager_id
     )
 
-    key, event, headers = mq_create_or_update_host(
-        host, platform_metadata=metadata_without_b64, overwrite_identity=False, return_all_data=True
-    )
+    key, event, headers = mq_create_or_update_host(host, platform_metadata=metadata_without_b64, return_all_data=True)
 
     # owner_id equals subscription_manager_id with dashes
     assert event["host"]["system_profile"]["owner_id"] == "09152341-475c-4671-a376-df609374c349"


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-12813).

Adds dashes to the value of subscription_manager_id when we set that to `system.cn` or `system_profile.owner_id` for hosts reported by `rhsm-conduit`.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Input Validation
- [x] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [x] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
