### PR TITLE
Schema changes to support system-profile MQ service

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -136,7 +136,7 @@ class LimitedHost(db.Model):
 
     def __init__(
         self,
-        canonical_facts,
+        canonical_facts=None,
         display_name=None,
         ansible_host=None,
         account=None,
@@ -144,11 +144,6 @@ class LimitedHost(db.Model):
         tags=None,
         system_profile_facts=None,
     ):
-
-        if not canonical_facts:
-            raise InventoryException(
-                title="Invalid request", detail="At least one of the canonical fact fields must be present."
-            )
 
         self.canonical_facts = canonical_facts
 
@@ -198,6 +193,11 @@ class Host(LimitedHost):
         reporter=None,
     ):
         super().__init__(canonical_facts, display_name, ansible_host, account, facts, tags, system_profile_facts)
+
+        if not canonical_facts:
+            raise InventoryException(
+                title="Invalid request", detail="At least one of the canonical fact fields must be present."
+            )
 
         if not stale_timestamp or not reporter:
             raise InventoryException(
@@ -497,7 +497,7 @@ class LimitedHostSchema(CanonicalFactsSchema):
 
     def build_model(data, canonical_facts, facts, tags):
         return LimitedHost(
-            canonical_facts,
+            canonical_facts=canonical_facts,
             display_name=data.get("display_name"),
             ansible_host=data.get("ansible_host"),
             account=data.get("account"),

--- a/app/models.py
+++ b/app/models.py
@@ -495,6 +495,7 @@ class LimitedHostSchema(CanonicalFactsSchema):
         normalize(system_profile)
         return {**data, "system_profile": system_profile}
 
+    @staticmethod
     def build_model(data, canonical_facts, facts, tags):
         return LimitedHost(
             canonical_facts=canonical_facts,
@@ -530,17 +531,18 @@ class HostSchema(LimitedHostSchema):
     stale_timestamp = fields.DateTime(required=True, timezone=True)
     reporter = fields.Str(required=True, validate=marshmallow_validate.Length(min=1, max=255))
 
+    @staticmethod
     def build_model(data, canonical_facts, facts, tags):
         return Host(
             canonical_facts,
-            display_name=data.get("display_name"),
-            ansible_host=data.get("ansible_host"),
-            account=data.get("account"),
-            facts=facts,
-            tags=tags,
-            system_profile_facts=data.get("system_profile", {}),
-            stale_timestamp=data["stale_timestamp"],
-            reporter=data["reporter"],
+            data.get("display_name"),
+            data.get("ansible_host"),
+            data.get("account"),
+            facts,
+            tags,
+            data.get("system_profile", {}),
+            data["stale_timestamp"],
+            data["reporter"],
         )
 
     @validates("stale_timestamp")

--- a/app/models.py
+++ b/app/models.py
@@ -192,8 +192,6 @@ class Host(LimitedHost):
         stale_timestamp=None,
         reporter=None,
     ):
-        super().__init__(canonical_facts, display_name, ansible_host, account, facts, tags, system_profile_facts)
-
         if not canonical_facts:
             raise InventoryException(
                 title="Invalid request", detail="At least one of the canonical fact fields must be present."
@@ -204,6 +202,7 @@ class Host(LimitedHost):
                 title="Invalid request", detail="Both stale_timestamp and reporter fields must be present."
             )
 
+        super().__init__(canonical_facts, display_name, ansible_host, account, facts, tags, system_profile_facts)
         self.stale_timestamp = stale_timestamp
         self.reporter = reporter
         self._update_per_reporter_staleness(stale_timestamp, reporter)

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -24,6 +24,7 @@ from app.instrumentation import log_update_system_profile_failure
 from app.instrumentation import log_update_system_profile_success
 from app.logging import get_logger
 from app.logging import threadctx
+from app.models import LimitedHostSchema
 from app.payload_tracker import get_payload_tracker
 from app.payload_tracker import PayloadTrackerContext
 from app.payload_tracker import PayloadTrackerProcessingContext
@@ -166,7 +167,7 @@ def update_system_profile(host_data, identity):
     ) as payload_tracker_processing_ctx:
 
         try:
-            input_host = deserialize_host(host_data)
+            input_host = deserialize_host(host_data, schema=LimitedHostSchema)
             input_host.id = host_data.get("id")
             staleness_timestamps = Timestamps.from_config(inventory_config())
             output_host, host_id, insights_id, update_result = host_repository.update_system_profile(

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -196,6 +196,10 @@ def add_host(host_data, identity):
     ) as payload_tracker_processing_ctx:
 
         try:
+            # basic-auth does not need owner_id
+            if identity.identity_type == IdentityType.SYSTEM:
+                host_data = _set_owner(host_data, identity)
+
             input_host = deserialize_host(host_data)
             staleness_timestamps = Timestamps.from_config(inventory_config())
             log_add_host_attempt(logger, input_host)
@@ -229,10 +233,6 @@ def handle_message(message, event_producer, message_operation=add_host):
 
     if host.get("account") != identity.account_number:
         raise ValidationException("The account number in identity does not match the number in the host.")
-
-    # basic-auth does not need owner_id
-    if identity.identity_type == IdentityType.SYSTEM:
-        host = _set_owner(host, identity)
 
     request_id = platform_metadata.get("request_id", "-1")
     initialize_thread_local_storage(request_id)

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -50,17 +50,7 @@ def deserialize_host(raw_data, schema=HostSchema, system_profile_spec=None):
     canonical_facts = _deserialize_canonical_facts(validated_data)
     facts = _deserialize_facts(validated_data.get("facts"))
     tags = _deserialize_tags(validated_data.get("tags"))
-    return Host(
-        canonical_facts,
-        validated_data.get("display_name"),
-        validated_data.get("ansible_host"),
-        validated_data.get("account"),
-        facts,
-        tags,
-        validated_data.get("system_profile", {}),
-        validated_data["stale_timestamp"],
-        validated_data["reporter"],
-    )
+    return schema.build_model(validated_data, canonical_facts, facts, tags)
 
 
 def deserialize_canonical_facts(raw_data):

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -206,6 +206,11 @@ def update_query_for_owner_id(identity, query):
 
 
 def update_system_profile(input_host, identity, staleness_offset, fields):
+    if not input_host.system_profile_facts:
+        raise InventoryException(
+            title="Invalid request", detail="Cannot update System Profile, since no System Profile data was provided."
+        )
+
     with session_guard(db.session):
         if input_host.id:
             existing_host = find_existing_host_by_id(identity, input_host.id)

--- a/tests/helpers/system_profile_utils.py
+++ b/tests/helpers/system_profile_utils.py
@@ -7,6 +7,7 @@ from yaml import safe_dump
 from yaml import safe_load
 
 from app.models import HostSchema
+from app.models import LimitedHostSchema
 from app.models import SPECIFICATION_DIR
 from app.models import SYSTEM_PROFILE_SPECIFICATION_FILE
 
@@ -70,6 +71,7 @@ def system_profile_specification():
 def clear_schema_cache():
     try:
         delattr(HostSchema, "system_profile_normalizer")
+        delattr(LimitedHostSchema, "system_profile_normalizer")
     except AttributeError:
         pass
 

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -1112,6 +1112,8 @@ def test_update_system_profile(mq_create_or_update_host, db_get_host, id_type):
     input_host = minimal_host(
         **{id_type: expected_ids[id_type]}, system_profile={"number_of_cpus": 4, "number_of_sockets": 8}
     )
+    input_host.stale_timestamp = None
+    input_host.reporter = None
     second_host_from_event = mq_create_or_update_host(input_host, message_operation=update_system_profile)
     second_host_from_db = db_get_host(second_host_from_event.id)
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -907,7 +907,9 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             "stale_timestamp": datetime.now(timezone.utc).isoformat(),
             "reporter": "some reporter",
         }
-        host_schema = Mock(**{"return_value.load.return_value.data": host_input})
+        host_schema = Mock(
+            **{"return_value.load.return_value.data": host_input, "build_model": HostSchema.build_model}
+        )
         result = deserialize_host({}, host_schema)
         self.assertEqual(host.return_value, result)
 
@@ -944,7 +946,9 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             "stale_timestamp": datetime.now(timezone.utc).isoformat(),
             "reporter": "some reporter",
         }
-        host_schema = Mock(**{"return_value.load.return_value.data": host_input})
+        host_schema = Mock(
+            **{"return_value.load.return_value.data": host_input, "build_model": HostSchema.build_model}
+        )
 
         result = deserialize_host({}, host_schema)
         self.assertEqual(host.return_value, result)
@@ -982,7 +986,9 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             "stale_timestamp": datetime.now(timezone.utc).isoformat(),
             "reporter": "some reporter",
         }
-        host_schema = Mock(**{"return_value.load.return_value.data": host_input})
+        host_schema = Mock(
+            **{"return_value.load.return_value.data": host_input, "build_model": HostSchema.build_model}
+        )
 
         result = deserialize_host({}, host_schema)
         self.assertEqual(host.return_value, result)
@@ -1023,7 +1029,9 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             "stale_timestamp": datetime.now(timezone.utc).isoformat(),
             "reporter": "some reporter",
         }
-        host_schema = Mock(**{"return_value.load.return_value.data": host_input})
+        host_schema = Mock(
+            **{"return_value.load.return_value.data": host_input, "build_model": HostSchema.build_model}
+        )
 
         result = deserialize_host({}, host_schema)
         self.assertEqual(host.return_value, result)
@@ -1059,7 +1067,9 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             "stale_timestamp": datetime.now(timezone.utc).isoformat(),
             "reporter": "some reporter",
         }
-        host_schema = Mock(**{"return_value.load.return_value.data": host_input})
+        host_schema = Mock(
+            **{"return_value.load.return_value.data": host_input, "build_model": HostSchema.build_model}
+        )
 
         result = deserialize_host({}, host_schema)
         self.assertEqual(host.return_value, result)
@@ -1105,7 +1115,9 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                     mock.reset_mock()
 
                 all_data = {**common_data, **additional_data}
-                host_schema = Mock(**{"return_value.load.return_value.data": all_data})
+                host_schema = Mock(
+                    **{"return_value.load.return_value.data": all_data, "build_model": HostSchema.build_model}
+                )
 
                 with self.assertRaises(KeyError):
                     deserialize_host({}, host_schema)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -856,7 +856,7 @@ class SerializationDeserializeHostCompoundTestCase(TestCase):
         self.assertEqual(tags, host.tags)
 
 
-@patch("app.serialization.Host")
+@patch("app.models.Host")
 @patch("app.serialization._deserialize_tags")
 @patch("app.serialization._deserialize_facts")
 @patch("app.serialization._deserialize_canonical_facts")


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-13461](https://issues.redhat.com/browse/RHCLOUD-13461), [RHCLOUD-13466](https://issues.redhat.com/browse/RHCLOUD-13466), and [RHCLOUD-13505](https://issues.redhat.com/browse/RHCLOUD-13505).
Separates out a functionality-restricted version of the Host schema and model, named LimitedHost. LimitedHost acts as a bean of sorts, and cannot be added/updated in the DB. Host extends LimitedHost, but requires the reporter and stale_timestamp fields, and has all the usual access.

I created `model_builder()` in LimitedHostSchema and HostSchema so that we could keep our generic Host-deserialization functionality, while having it generate the correct model type.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Input Validation
- [x] Error Handling and Logging
- [x] General Coding Practices
