### PR TITLE
Add checks to Identity constructor

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -3,7 +3,6 @@ import connexion
 from api.metrics import login_failure_count
 from app.auth.identity import from_auth_header
 from app.auth.identity import from_bearer_token
-from app.auth.identity import validate
 from app.logging import get_logger
 
 __all__ = ("authentication_header_handler", "bearer_token_handler")
@@ -14,7 +13,6 @@ logger = get_logger(__name__)
 def authentication_header_handler(apikey, required_scopes=None):
     try:
         identity = from_auth_header(apikey)
-        validate(identity)
     except Exception:
         login_failure_count.inc()
         logger.debug("Failed to validate identity header value", exc_info=True)
@@ -26,7 +24,6 @@ def authentication_header_handler(apikey, required_scopes=None):
 def bearer_token_handler(token):
     try:
         identity = from_bearer_token(token)
-        validate(identity)
     except Exception:
         login_failure_count.inc()
         logger.debug("Failed to validate bearer token value", exc_info=True)

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -13,7 +13,6 @@ from app import inventory_config
 from app import UNKNOWN_REQUEST_ID_VALUE
 from app.auth.identity import Identity
 from app.auth.identity import IdentityType
-from app.auth.identity import validate
 from app.culling import Timestamps
 from app.exceptions import InventoryException
 from app.exceptions import ValidationException
@@ -85,7 +84,6 @@ def _get_identity(host, metadata):
         raise ValidationException("The account number in identity does not match the number in the host.")
 
     identity = Identity(identity)
-    validate(identity)
     return identity
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -62,6 +62,7 @@ from tests.helpers.system_profile_utils import INVALID_SYSTEM_PROFILES
 from tests.helpers.system_profile_utils import mock_system_profile_specification
 from tests.helpers.system_profile_utils import system_profile_specification
 from tests.helpers.test_utils import set_environment
+from tests.helpers.test_utils import SYSTEM_IDENTITY
 from tests.helpers.test_utils import USER_IDENTITY
 
 
@@ -183,12 +184,39 @@ class AuthIdentityValidateTestCase(TestCase):
         except ValueError:
             self.fail()
 
-    def test_invalid(self):
+    def test_invalid_account(self):
         test_identity = deepcopy(USER_IDENTITY)
         account_numbers = [None, ""]
         for account_number in account_numbers:
             with self.subTest(account_number=account_number):
                 test_identity["account_number"] = account_number
+                with self.assertRaises(ValueError):
+                    Identity(test_identity)
+
+    def test_invalid_type(self):
+        test_identity = deepcopy(USER_IDENTITY)
+        identity_types = [None, ""]
+        for identity_type in identity_types:
+            with self.subTest(identity_type=identity_type):
+                test_identity["type"] = identity_type
+                with self.assertRaises(ValueError):
+                    Identity(test_identity)
+
+    def test_invalid_user_obj(self):
+        test_identity = deepcopy(USER_IDENTITY)
+        user_objects = [None, ""]
+        for user_object in user_objects:
+            with self.subTest(user_object=user_object):
+                test_identity["user"] = user_object
+                with self.assertRaises(ValueError):
+                    Identity(test_identity)
+
+    def test_invalid_system_obj(self):
+        test_identity = deepcopy(SYSTEM_IDENTITY)
+        system_objects = [None, ""]
+        for system_object in system_objects:
+            with self.subTest(system_object=system_object):
+                test_identity["system"] = system_object
                 with self.assertRaises(ValueError):
                     Identity(test_identity)
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -27,7 +27,6 @@ from app.auth.identity import from_auth_header
 from app.auth.identity import from_bearer_token
 from app.auth.identity import Identity
 from app.auth.identity import SHARED_SECRET_ENV_VAR
-from app.auth.identity import validate
 from app.config import Config
 from app.culling import _Config as CullingConfig
 from app.culling import Timestamps
@@ -178,8 +177,7 @@ class AuthIdentityFromAuthHeaderTestCase(AuthIdentityConstructorTestCase):
 class AuthIdentityValidateTestCase(TestCase):
     def test_valid(self):
         try:
-            identity = Identity(USER_IDENTITY)
-            validate(identity)
+            Identity(USER_IDENTITY)
             self.assertTrue(True)
         except ValueError:
             self.fail()
@@ -229,23 +227,17 @@ class TrustedIdentityTestCase(TestCase):
         return identity
 
     def test_validation(self):
-        identity = self._build_id()
-
         with set_environment({SHARED_SECRET_ENV_VAR: self.shared_secret}):
-            validate(identity)
+            self._build_id()
 
     def test_validation_with_invalid_identity(self):
-        identity = from_bearer_token("InvalidPassword")
-
         with self.assertRaises(ValueError):
-            validate(identity)
+            from_bearer_token("InvalidPassword")
 
     def test_validation_env_var_not_set(self):
-        identity = self._build_id()
-
         with set_environment({}):
             with self.assertRaises(ValueError):
-                validate(identity)
+                self._build_id()
 
     def test_validation_token_is_None(self):
         tokens = [None, ""]
@@ -255,12 +247,14 @@ class TrustedIdentityTestCase(TestCase):
                     Identity(token=token)
 
     def test_is_trusted_system(self):
-        identity = self._build_id()
+        with set_environment({SHARED_SECRET_ENV_VAR: self.shared_secret}):
+            identity = self._build_id()
 
         self.assertEqual(identity.is_trusted_system, True)
 
     def test_account_number_is_not_set_for_trusted_system(self):
-        identity = self._build_id()
+        with set_environment({SHARED_SECRET_ENV_VAR: self.shared_secret}):
+            identity = self._build_id()
 
         self.assertFalse(hasattr(identity, "account_number"))
 


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-13572](https://issues.redhat.com/browse/RHCLOUD-13572).
It adds checks to the Identity constructor so that we raise ValueErrors instead of KeyErrors. It also simplifies/organizes the logic to make it easier to read.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Error Handling and Logging
- [x] General Coding Practices
