### PR TITLE
Add host.reporter to extra data in ValidationException logs

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -214,7 +214,11 @@ def add_host(host_data, identity):
             payload_tracker_processing_ctx.inventory_id = output_host["id"]
             return output_host, host_id, insights_id, add_result
         except ValidationException as ve:
-            logger.error("Validation error while adding host: %s", ve)
+            logger.error(
+                "Validation error while adding host: %s",
+                ve,
+                extra={"host": {"reporter": host_data.get("reporter", "null")}},
+            )
             metrics.add_host_failure.labels("Exception", host_data.get("reporter", "null")).inc()
             raise
         except InventoryException:


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-13580](https://issues.redhat.com/browse/RHCLOUD-13580).
This just adds `host.reporter` to the extra data in the log, which supports our Kibana queries.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Error Handling and Logging
- [x] General Coding Practices
