### PR TITLE
platform_metadata fix for rhsm-conduit

### DIFF
--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -1209,8 +1209,8 @@ def test_rhsm_reporter_and_no_platform_metadata(mocker, flask_app):
 
     message = wrap_message(host.data(), "add_host")
 
-    with pytest.raises(ValidationException):
-        handle_message(json.dumps(message), mocker.Mock())
+    # We just want to verify that no error gets thrown here.
+    handle_message(json.dumps(message), mocker.Mock())
 
 
 def test_rhsm_reporter_and_no_identity(mocker, event_datetime_mock, flask_app):


### PR DESCRIPTION
## Overview

This is a fix addressing rhsm-conduit's issues regarding not sending platform_metadata.
They weren't made aware that we were making platform_metadata a requirement, and we need to not break our support for them.