### PR TITLE
Remove display_name workaround

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -214,13 +214,7 @@ class Host(LimitedHost):
     def update(self, input_host, update_system_profile=False):
         self.update_canonical_facts(input_host.canonical_facts)
 
-        # TODO: Remove this eventually when Sat 6.7 stops sending fqdns as display_names (See RHCLOUD-5954)
-        # NOTE: For this particular issue, display_name changes from "puptoo" and "yupana" are ignored,
-        # unless the Insights ID isn't set (See RHCLOUD-13105)
-        if "insights_id" not in self.canonical_facts or (
-            input_host.reporter != "yupana" and input_host.reporter != "rhsm-conduit"
-        ):
-            self.update_display_name(input_host.display_name)
+        self.update_display_name(input_host.display_name)
 
         self._update_ansible_host(input_host.ansible_host)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -108,42 +108,6 @@ def test_update_existing_host_fix_display_name_using_id(db_create_host):
     assert existing_host.display_name == existing_host.id
 
 
-# TODO: test for Sat 6.7 hotfix (remove, eventually) See RHCLOUD-5954
-def test_update_existing_host_dont_change_display_name(db_create_host):
-    # Create an "existing" host
-    fqdn = "host1.domain1.com"
-    insights_id = generate_uuid()
-    old_display_name = "foo"
-    existing_host = db_create_host(
-        extra_data={"canonical_facts": {"fqdn": fqdn, "insights_id": insights_id}, "display_name": old_display_name}
-    )
-
-    # Attempt to update the display name from Satellite reporter.
-    # Should't update because Insights ID was set
-    expected_fqdn = "different.domain1.com"
-    input_host = Host({"fqdn": expected_fqdn}, display_name="dont_change_me", reporter="yupana", stale_timestamp=now())
-    existing_host.update(input_host)
-
-    # assert display name hasn't changed
-    assert existing_host.display_name == old_display_name
-
-
-def test_update_existing_host_non_insights_display_name(db_create_host):
-    # Create an "existing" host
-    fqdn = "host1.domain1.com"
-    existing_host = db_create_host(extra_data={"canonical_facts": {"fqdn": fqdn}, "display_name": "foo"})
-
-    # Attempt to update the display name from Satellite reporter.
-    # Should update because Insights ID isn't set.
-    expected_fqdn = "different.domain1.com"
-    new_display_name = "change_me"
-    input_host = Host({"fqdn": expected_fqdn}, display_name=new_display_name, reporter="yupana", stale_timestamp=now())
-    existing_host.update(input_host)
-
-    # assert display name has changed
-    assert existing_host.display_name == new_display_name
-
-
 def test_create_host_without_system_profile(db_create_host):
     # Test the situation where the db/sqlalchemy sets the
     # system_profile_facts to None

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -706,33 +706,6 @@ def test_update_display_name(mq_create_or_update_host, db_get_host_by_insights_i
     assert record.display_name == "better_test_host"
 
 
-@pytest.mark.parametrize("reporter", ["yupana", "rhsm-conduit"])
-def test_display_name_ignored_for_blacklisted_reporters(
-    reporter, mq_create_or_update_host, db_get_host_by_insights_id
-):
-    """
-    Tests the workaround for https://projects.engineering.redhat.com/browse/RHCLOUD-5954
-    """
-    insights_id = generate_uuid()
-    host = minimal_host(
-        account=SYSTEM_IDENTITY["account_number"], display_name="test_host", insights_id=insights_id, reporter="puptoo"
-    )
-    mq_create_or_update_host(host)
-
-    host = minimal_host(
-        account=SYSTEM_IDENTITY["account_number"],
-        display_name="yupana_test_host",
-        insights_id=insights_id,
-        reporter=reporter,
-    )
-    mq_create_or_update_host(host)
-
-    record = db_get_host_by_insights_id(insights_id)
-
-    assert record.display_name == "test_host"
-    assert record.reporter == reporter
-
-
 def test_add_tags_to_host_by_list(mq_create_or_update_host, db_get_host_by_insights_id, subtests):
     insights_id = generate_uuid()
 


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-13330](https://issues.redhat.com/browse/RHCLOUD-13330).
This removes the workarounds we implemented for `display_name`, due to the various restrictions that ended up being required. [RHCLOUD-5954](https://issues.redhat.com/browse/RHCLOUD-5954) added the first workaround because Yupana kept overwriting the `display_name` field. Later, we completed [RHCLOUD-13105](https://issues.redhat.com/browse/RHCLOUD-13105), which allowed some reporters to set the field if they didn't have an Insights ID. We eventually decided that this logic should not be owned by HBI, and that the offending reporter (Yupana) should just stop constantly overwriting that field.

The Yupana team has already merged [their PR](https://github.com/quipucords/yupana/pull/346), which strips `display_name` from the payloads they send to us. 

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
