### PR TITLE
Add details to Identity errors, and re-add host.reporter structure

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -116,13 +116,13 @@ def validate(identity):
             if not identity.system.get("cert_type"):
                 raise ValueError("The cert_type field is mandatory.")
             if identity.system.get("cert_type") not in CertType.__members__.values():
-                raise ValueError("The cert_type is invalid.")
+                raise ValueError(f"The cert_type {identity.system.get('cert_type')} is invalid.")
             if not identity.system.get("cn"):
                 raise ValueError("The cn field is mandatory.")
             if not identity.auth_type:
                 raise ValueError("The auth_type field is mandatory.")
             if identity.auth_type not in AuthType.__members__.values():
-                raise ValueError("The auth_type is invalid.")
+                raise ValueError(f"The auth_type {identity.auth_type} is invalid.")
 
         elif identity.identity_type == IdentityType.USER:
             if not identity.user:

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -258,7 +258,9 @@ def handle_message(message, event_producer, message_operation=add_host):
             event_producer.write_event(event, str(host_id), headers)
         except ValidationException as ve:
             logger.error(
-                "Validation error while adding or updating host: %s", ve, extra={"reporter": host.get("reporter")}
+                "Validation error while adding or updating host: %s",
+                ve,
+                extra={"host": {"reporter": host.get("reporter")}},
             )
             raise
 


### PR DESCRIPTION
## Overview

This PR is being created to add details to our logging, which will help us debug issues in Stage/Prod.
It adds the input values for invalid cert_type and auth_type, and re-adds the "host.reporter" structure to validation error logs.
Omitted the rest of the description this time, as it's kind of a hotfix.