### PR TITLE
WIP: Add iqe plugin to host-inventory template

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -8,6 +8,8 @@ objects:
   metadata:
     name: host-inventory
   spec:
+    iqe:
+      plugin: host-inventory
     envName: ${ENV_NAME}
     deployments:
     - name: service


### PR DESCRIPTION
For testing purposes. This is not yet ready to be merged until we have a new version of Clowder deployed.