### PR TITLE
Improve logging of db access failures

### DIFF
--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -176,5 +176,5 @@ def rbac_permission_denied(logger, required_permission, user_permissions):
 
 
 def log_db_access_failure(logger, message, host_data):
-    logger.error("Error adding host ", f"{host_data['insights_id']}: {message}")
+    logger.error("Failure to access database ", f"{message}")
     metrics.db_communication_error.labels("OperationalError", host_data.get("insights_id", message)).inc()


### PR DESCRIPTION
## Overview

This should avoid some `KeyError` I was seeing during the prod outage this past weekend. This also makes the log message more meaningful.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] General Coding Practices
