### PR TITLE
log reporter with cert type value errors (and other value errors)

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -263,6 +263,9 @@ def handle_message(message, event_producer, message_operation=add_host):
                 extra={"host": {"reporter": host.get("reporter")}},
             )
             raise
+        except ValueError as ve:
+            logger.error("Value error while adding or updating host: %s", ve, extra={"reporter": host.get("reporter")})
+            raise
 
 
 def event_loop(consumer, flask_app, event_producer, handler, interrupt):


### PR DESCRIPTION
## Overview

No Jira for this one. Just adds the reporter to the log we create when we get a value error (like cert_type) while trying to create/update a host. This is specifically to help figure out the cert type bug.