### PR TITLE
Increment correct metrics for ValidationException

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -183,7 +183,7 @@ def update_system_profile(host_data, identity):
             payload_tracker_processing_ctx.inventory_id = output_host["id"]
             return output_host, host_id, insights_id, update_result
         except ValidationException:
-            metrics.update_system_profile_failure.labels("Exception").inc()
+            metrics.update_system_profile_failure.labels("InventoryException").inc()
             raise
         except InventoryException:
             log_update_system_profile_failure(logger, host_data)
@@ -219,7 +219,7 @@ def add_host(host_data, identity):
             payload_tracker_processing_ctx.inventory_id = output_host["id"]
             return output_host, host_id, insights_id, add_result
         except ValidationException:
-            metrics.add_host_failure.labels("Exception", host_data.get("reporter", "null")).inc()
+            metrics.add_host_failure.labels("InventoryException", host_data.get("reporter", "null")).inc()
             raise
         except InventoryException:
             log_add_host_failure(logger, host_data)


### PR DESCRIPTION
## Overview

Labeling validation exceptions as `Exceptions` increments a different metrics. I think using `InventoryException` should increment the correct one and hopefully the alerts will stop. :pray: 

cc: https://github.com/RedHatInsights/insights-host-inventory/pull/868

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Error Handling and Logging
- [x] General Coding Practices
