### PR TITLE
Remove Identity.auth_type requirement

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -75,8 +75,10 @@ class Identity:
 
             if not self.account_number:
                 raise ValueError("The account_number is mandatory.")
-            if not self.identity_type or self.identity_type not in IdentityType.__members__.values():
+            elif not self.identity_type or self.identity_type not in IdentityType.__members__.values():
                 raise ValueError("Identity type invalid or missing in provided Identity")
+            elif self.auth_type and self.auth_type not in AuthType.__members__.values():
+                raise ValueError(f"The auth_type {self.auth_type} is invalid")
 
             if obj["type"] == IdentityType.USER:
                 self.user = obj.get("user")
@@ -85,9 +87,7 @@ class Identity:
 
             elif obj["type"] == IdentityType.SYSTEM:
                 self.system = obj.get("system")
-                if self.auth_type and self.auth_type not in AuthType.__members__.values():
-                    raise ValueError(f"The auth_type {self.auth_type} is invalid")
-                elif not self.system:
+                if not self.system:
                     raise ValueError("The identity.system field is mandatory for system-type identities")
                 elif not self.system.get("cert_type"):
                     raise ValueError("The cert_type field is mandatory for system-type identities")

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -77,10 +77,6 @@ class Identity:
                 raise ValueError("The account_number is mandatory.")
             if not self.identity_type or self.identity_type not in IdentityType.__members__.values():
                 raise ValueError("Identity type invalid or missing in provided Identity")
-            if not self.auth_type:
-                raise ValueError("The auth_type field is mandatory.")
-            elif self.auth_type not in AuthType.__members__.values():
-                raise ValueError(f"The auth_type {self.auth_type} is invalid")
 
             if obj["type"] == IdentityType.USER:
                 self.user = obj.get("user")
@@ -89,6 +85,10 @@ class Identity:
 
             elif obj["type"] == IdentityType.SYSTEM:
                 self.system = obj.get("system")
+                if not self.auth_type:
+                    raise ValueError("The auth_type field is mandatory.")
+                elif self.auth_type not in AuthType.__members__.values():
+                    raise ValueError(f"The auth_type {self.auth_type} is invalid")
                 if not self.system:
                     raise ValueError("The identity.system field is mandatory for system-type identities")
                 elif not self.system.get("cert_type"):

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -85,11 +85,9 @@ class Identity:
 
             elif obj["type"] == IdentityType.SYSTEM:
                 self.system = obj.get("system")
-                if not self.auth_type:
-                    raise ValueError("The auth_type field is mandatory.")
-                elif self.auth_type not in AuthType.__members__.values():
+                if self.auth_type and self.auth_type not in AuthType.__members__.values():
                     raise ValueError(f"The auth_type {self.auth_type} is invalid")
-                if not self.system:
+                elif not self.system:
                     raise ValueError("The identity.system field is mandatory for system-type identities")
                 elif not self.system.get("cert_type"):
                     raise ValueError("The cert_type field is mandatory for system-type identities")


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-13924](https://issues.redhat.com/browse/RHCLOUD-13924).
I originally opened this as a hotfix for [RHCLOUD-13572](https://issues.redhat.com/browse/RHCLOUD-13572), as I had mistakenly changed `auth_type` to be required for all Identities instead of only for system-type Identities. However, @lphiri informed us that "auth_type" shouldn't be a required field, so I'm removing that requirement from the Identity class.


## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
