### PR TITLE
Remove user requirement from Identity

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -82,12 +82,10 @@ class Identity:
             elif self.auth_type and self.auth_type not in AuthType.__members__.values():
                 raise ValueError(f"The auth_type {self.auth_type} is invalid")
 
-            if obj["type"] == IdentityType.USER:
+            if self.identity_type == IdentityType.USER:
                 self.user = obj.get("user")
-                if not self.user:
-                    raise ValueError("The identity.user field is mandatory for user-type identities")
 
-            elif obj["type"] == IdentityType.SYSTEM:
+            elif self.identity_type == IdentityType.SYSTEM:
                 self.system = obj.get("system")
                 if not self.system:
                     raise ValueError("The identity.system field is mandatory for system-type identities")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -200,15 +200,6 @@ class AuthIdentityValidateTestCase(TestCase):
                 with self.assertRaises(ValueError):
                     Identity(test_identity)
 
-    def test_invalid_user_obj(self):
-        test_identity = deepcopy(USER_IDENTITY)
-        user_objects = [None, ""]
-        for user_object in user_objects:
-            with self.subTest(user_object=user_object):
-                test_identity["user"] = user_object
-                with self.assertRaises(ValueError):
-                    Identity(test_identity)
-
     def test_invalid_system_obj(self):
         test_identity = deepcopy(SYSTEM_IDENTITY)
         system_objects = [None, ""]


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-13951](https://issues.redhat.com/browse/RHCLOUD-13951).
Insights Classic sends a number of identities that don't adhere to the agreed-upon structure. This change makes it so HBI doesn't complain if it receives a user-type Identity that doesn't provide a "user" object in the Identity.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
