### PR TITLE
Identity: Disallow blank string for auth_type; re-add cert_type check

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -79,7 +79,7 @@ class Identity:
                 raise ValueError("The account_number is mandatory.")
             elif not self.identity_type or self.identity_type not in IdentityType.__members__.values():
                 raise ValueError("Identity type invalid or missing in provided Identity")
-            elif self.auth_type and self.auth_type not in AuthType.__members__.values():
+            elif self.auth_type is not None and self.auth_type not in AuthType.__members__.values():
                 raise ValueError(f"The auth_type {self.auth_type} is invalid")
 
             if self.identity_type == IdentityType.USER:
@@ -92,8 +92,7 @@ class Identity:
                 elif not self.system.get("cert_type"):
                     raise ValueError("The cert_type field is mandatory for system-type identities")
                 elif self.system.get("cert_type") not in CertType.__members__.values():
-                    # TODO: Raise ValueError once we solidify all cert_type values
-                    logger.error("The cert_type %s is invalid.", self.system.get("cert_type"))
+                    raise ValueError(f"The cert_type {self.system.get('cert_type')} is invalid.")
                 elif not self.system.get("cn"):
                     raise ValueError("The cn field is mandatory for system-type identities")
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -209,6 +209,25 @@ class AuthIdentityValidateTestCase(TestCase):
                 with self.assertRaises(ValueError):
                     Identity(test_identity)
 
+    def test_invalid_auth_types(self):
+        test_identities = [deepcopy(USER_IDENTITY), deepcopy(SYSTEM_IDENTITY)]
+        auth_types = ["", "foo"]
+        for test_identity in test_identities:
+            for auth_type in auth_types:
+                with self.subTest(auth_type=auth_type):
+                    test_identity["auth_type"] = auth_type
+                    with self.assertRaises(ValueError):
+                        Identity(test_identity)
+
+    def test_invalid_cert_types(self):
+        test_identity = deepcopy(SYSTEM_IDENTITY)
+        cert_types = [None, "", "foo"]
+        for cert_type in cert_types:
+            with self.subTest(cert_type=cert_type):
+                test_identity["system"]["cert_type"] = cert_type
+                with self.assertRaises(ValueError):
+                    Identity(test_identity)
+
 
 class TrustedIdentityTestCase(TestCase):
     shared_secret = "ImaSecret"


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-13959](https://issues.redhat.com/browse/RHCLOUD-13959).

Changes:
- Raise ValueError when Identity.auth_type is a blank string
- Raise ValueError when Identity.cert_type isn't one of the Enum values
- Add unit tests to validate these cases

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
