### PR TITLE
Don't require Identity for messages from system-profile topic

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -121,5 +121,7 @@ class Identity:
         return self.account_number == other.account_number
 
 
+# Messages from the system_profile topic don't need to provide a real Identity,
+# So this helper function creates a basic User-type identity from the host data.
 def create_mock_identity_from_host(host):
     return Identity({"account_number": host.account, "type": IdentityType.USER, "auth_type": AuthType.BASIC})

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -119,3 +119,7 @@ class Identity:
 
     def __eq__(self, other):
         return self.account_number == other.account_number
+
+
+def create_mock_identity_from_host(host):
+    return Identity({"account_number": host.account, "type": IdentityType.USER, "auth_type": AuthType.BASIC})

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -87,6 +87,18 @@ def _get_identity(host, metadata):
     return identity
 
 
+# Messages from the system_profile topic don't need to provide a real Identity.
+def _create_mock_identity_from_host(host):
+    return Identity(
+        {
+            "account_number": host.account,
+            "type": "User",
+            "auth_type": "basic-auth",
+            "user": {"email": "mock-account@redhat.com", "first_name": "mock"},
+        }
+    )
+
+
 # When identity_type is System, set owner_id if missing from the host system_profile
 def _set_owner(host, identity):
     cn = identity.system.get("cn")
@@ -161,7 +173,7 @@ def parse_operation_message(message):
     return parsed_operation
 
 
-def update_system_profile(host_data, identity):
+def update_system_profile(host_data, platform_metadata):
     payload_tracker = get_payload_tracker(request_id=threadctx.request_id)
 
     with PayloadTrackerProcessingContext(
@@ -174,6 +186,7 @@ def update_system_profile(host_data, identity):
             input_host = deserialize_host(host_data, schema=LimitedHostSchema)
             input_host.id = host_data.get("id")
             staleness_timestamps = Timestamps.from_config(inventory_config())
+            identity = _create_mock_identity_from_host(input_host)
             output_host, host_id, insights_id, update_result = host_repository.update_system_profile(
                 input_host, identity, staleness_timestamps, EGRESS_HOST_FIELDS
             )
@@ -195,7 +208,7 @@ def update_system_profile(host_data, identity):
             raise
 
 
-def add_host(host_data, identity):
+def add_host(host_data, platform_metadata):
     payload_tracker = get_payload_tracker(request_id=threadctx.request_id)
 
     with PayloadTrackerProcessingContext(
@@ -203,6 +216,7 @@ def add_host(host_data, identity):
     ) as payload_tracker_processing_ctx:
 
         try:
+            identity = _get_identity(host_data, platform_metadata)
             # basic-auth does not need owner_id
             if identity.identity_type == IdentityType.SYSTEM:
                 host_data = _set_owner(host_data, identity)
@@ -247,8 +261,7 @@ def handle_message(message, event_producer, message_operation=add_host):
         try:
             host = validated_operation_msg["data"]
 
-            identity = _get_identity(host, platform_metadata)
-            output_host, host_id, insights_id, operation_result = message_operation(host, identity)
+            output_host, host_id, insights_id, operation_result = message_operation(host, platform_metadata)
             event_type = operation_results_to_event_type(operation_result)
             event = build_event(event_type, output_host, platform_metadata=platform_metadata)
 

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -1172,6 +1172,27 @@ def test_handle_message_side_effect(mocker, flask_app):
         handle_message(message, mocker.MagicMock())
 
 
+@pytest.mark.parametrize("platform_metadata", (None, {}, {"request_id": "12345"}))
+def test_update_system_profile_no_identity(mocker, event_datetime_mock, flask_app, platform_metadata):
+    message = wrap_message(
+        minimal_host(account="foobar", system_profile={"number_of_cpus": 4}).data(), "add_host", platform_metadata
+    )
+
+    # We don't care about the values here
+    mocker.patch(
+        "lib.host_repository.update_system_profile",
+        return_value=(
+            {"id": generate_uuid(), "insights_id": generate_uuid()},
+            generate_uuid(),
+            generate_uuid(),
+            AddHostResult.updated,
+        ),
+    )
+
+    # Just make sure it doesn't complain about missing Identity/metadata
+    handle_message(json.dumps(message), mocker.Mock(), update_system_profile)
+
+
 # Adding a host requires identity or rhsm-conduit reporter, which does not have identity
 def test_no_identity_and_no_rhsm_reporter(mocker, event_datetime_mock, flask_app):
     expected_insights_id = generate_uuid()

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -10,7 +10,6 @@ from sqlalchemy.exc import OperationalError
 
 from app import db
 from app import UNKNOWN_REQUEST_ID_VALUE
-from app.auth.identity import Identity
 from app.exceptions import InventoryException
 from app.exceptions import ValidationException
 from app.logging import threadctx
@@ -136,9 +135,7 @@ def test_request_id_is_reset(mocker, flask_app):
         assert threadctx.request_id == get_platform_metadata().get("request_id")
 
         message = wrap_message(minimal_host().data(), "add_host", {})
-
-        with pytest.raises(ValidationException):
-            handle_message(json.dumps(message), mock_event_producer, add_host_mock)
+        handle_message(json.dumps(message), mock_event_producer, add_host_mock)
 
         assert threadctx.request_id == UNKNOWN_REQUEST_ID_VALUE
 
@@ -212,7 +209,7 @@ def test_handle_message_unicode_not_damaged(mocker, flask_app, subtests, db_get_
             add_host.reset_mock()
             add_host.return_value = ({"id": host_id}, host_id, None, AddHostResult.updated)
             handle_message(message, mocker.Mock(), add_host)
-            add_host.assert_called_once_with(json.loads(message)["data"], Identity(SYSTEM_IDENTITY))
+            add_host.assert_called_once_with(json.loads(message)["data"], mocker.ANY)
 
 
 def test_handle_message_verify_metadata_pass_through(mq_create_or_update_host):
@@ -1178,17 +1175,6 @@ def test_handle_message_side_effect(mocker, flask_app):
 # Adding a host requires identity or rhsm-conduit reporter, which does not have identity
 def test_no_identity_and_no_rhsm_reporter(mocker, event_datetime_mock, flask_app):
     expected_insights_id = generate_uuid()
-    host_id = generate_uuid()
-
-    mock_add_host = mocker.patch(
-        "app.queue.queue.add_host",
-        return_value=(
-            {"id": host_id, "insights_id": expected_insights_id},
-            host_id,
-            expected_insights_id,
-            AddHostResult.created,
-        ),
-    )
     mock_event_producer = mocker.Mock()
 
     host = minimal_host(account=SYSTEM_IDENTITY["account_number"], insights_id=expected_insights_id)
@@ -1199,7 +1185,7 @@ def test_no_identity_and_no_rhsm_reporter(mocker, event_datetime_mock, flask_app
     message = wrap_message(host.data(), "add_host", platform_metadata)
 
     with pytest.raises(ValueError):
-        handle_message(json.dumps(message), mock_event_producer, mock_add_host)
+        handle_message(json.dumps(message), mock_event_producer)
 
 
 # Adding a host requires identity or rhsm-conduit reporter, which does not have identity
@@ -1259,17 +1245,6 @@ def test_rhsm_reporter_and_no_identity(mocker, event_datetime_mock, flask_app):
 
 def test_non_rhsm_reporter_and_no_identity(mocker, event_datetime_mock, flask_app):
     expected_insights_id = generate_uuid()
-    host_id = generate_uuid()
-
-    mock_add_host = mocker.patch(
-        "app.queue.queue.add_host",
-        return_value=(
-            {"id": host_id, "insights_id": expected_insights_id},
-            host_id,
-            expected_insights_id,
-            AddHostResult.created,
-        ),
-    )
     mock_event_producer = mocker.Mock()
 
     host = minimal_host(
@@ -1283,7 +1258,7 @@ def test_non_rhsm_reporter_and_no_identity(mocker, event_datetime_mock, flask_ap
     platform_metadata.pop("b64_identity")
     message = wrap_message(host.data(), "add_host", platform_metadata)
     with pytest.raises(ValueError):
-        handle_message(json.dumps(message), mock_event_producer, mock_add_host)
+        handle_message(json.dumps(message), mock_event_producer)
 
 
 def test_owner_id_different_from_cn(mocker):


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-13840](https://issues.redhat.com/browse/RHCLOUD-13840).

Changes:
- Verify Identity within `add_host` rather than `handle_message`
- Update `update_system_profile` to generate a mock Identity based on the host data
- Remove unnecessary mocks from some MQ tests

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
