### PR TITLE
Adding host_type filter

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -327,6 +327,8 @@ def _build_system_profile_filter(system_profile):
         system_profile_filter += build_filter_string_multiple("spf_owner_id", system_profile["owner_id"], "eq")
     if system_profile.get("operating_system"):
         system_profile_filter += _build_operating_system_filter(system_profile["operating_system"])
+    if system_profile.get("host_type"):
+        system_profile_filter += build_filter_string_multiple("spf_host_type", system_profile["host_type"], "eq")
 
     return system_profile_filter
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -776,6 +776,7 @@ Not every field in system profile may be used in filters. The following is a lis
 | is_marketplace | Boolean | true |
 | operating_system | String | 7.5 |
 | owner_id | UUID | 0892cd6b-c564-4f53-a0cb-0784d79ee323 |
+| host_type | String | edge |
 
 For example, to query for hosts with insights client version
 7 and any minor version, the query parameter should be defined as:


### PR DESCRIPTION
## Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/RHCLOUD-13856).
This PR enables filtering of `system_profile.host_type` filter. There isn't much difference between this filter and the ones we have for `rhc_client_id` and `owner_id`.

This functionality won't work until the [xjoin-search PR](https://github.com/RedHatInsights/xjoin-search/pull/97) is merged.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [x] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Input Validation
- [x] Output Encoding
- [x] General Coding Practices
