### PR TITLE
Remove restrictions from classic-proxy requests; remove unused type

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -43,7 +43,6 @@ class CertType(str, Enum):
 class IdentityType(str, Enum):
     SYSTEM = "System"
     USER = "User"
-    CLASSIC = "Insights_Classic_System"
 
 
 class Identity:
@@ -87,14 +86,15 @@ class Identity:
 
             elif self.identity_type == IdentityType.SYSTEM:
                 self.system = obj.get("system")
-                if not self.system:
-                    raise ValueError("The identity.system field is mandatory for system-type identities")
-                elif not self.system.get("cert_type"):
-                    raise ValueError("The cert_type field is mandatory for system-type identities")
-                elif self.system.get("cert_type") not in CertType.__members__.values():
-                    raise ValueError(f"The cert_type {self.system.get('cert_type')} is invalid.")
-                elif not self.system.get("cn"):
-                    raise ValueError("The cn field is mandatory for system-type identities")
+                if self.auth_type != AuthType.CLASSIC:
+                    if not self.system:
+                        raise ValueError("The identity.system field is mandatory for system-type identities")
+                    elif not self.system.get("cert_type"):
+                        raise ValueError("The cert_type field is mandatory for system-type identities")
+                    elif self.system.get("cert_type") not in CertType.__members__.values():
+                        raise ValueError(f"The cert_type {self.system.get('cert_type')} is invalid.")
+                    elif not self.system.get("cn"):
+                        raise ValueError("The cn field is mandatory for system-type identities")
 
             threadctx.account_number = obj["account_number"]
 


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-14158](https://issues.redhat.com/browse/RHCLOUD-14158).
Removes Identity restrictions for classic-proxy API requests. Now, if auth_type is provided and set to "classic-proxy", the Identity only needs to have an account number, Identity type, and auth_type (obviously). 
This also removes the "Insights_Classic_System" value from possible IdentityTypes.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
