### PR TITLE
Remove unused REST_POST_ENABLED env var

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -90,7 +90,6 @@ class Config:
         self.mgmt_url_path_prefix = os.getenv("INVENTORY_MANAGEMENT_URL_PATH_PREFIX", "/")
 
         self.api_urls = [self.api_url_path_prefix, self.legacy_api_url_path_prefix]
-        self.rest_post_enabled = os.environ.get("REST_POST_ENABLED", "true").lower() == "true"
 
         self.rbac_enforced = os.environ.get("RBAC_ENFORCED", "false").lower() == "true"
         self.rbac_retries = os.environ.get("RBAC_RETRIES", 2)

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -59,8 +59,6 @@ objects:
           value: ${BULK_QUERY_SOURCE}
         - name: BULK_QUERY_SOURCE_BETA
           value: ${BULK_QUERY_SOURCE_BETA}
-        - name: REST_POST_ENABLED
-          value: ${REST_POST_ENABLED}
         - name: RBAC_ENFORCED
           value: ${RBAC_ENFORCED}
         - name: KAFKA_PRODUCER_ACKS
@@ -329,9 +327,6 @@ parameters:
 - description: SSL validation mode for the DB
   name: INVENTORY_DB_SSL_MODE
   value: prefer
-- description: If creating/updating hosts through the REST API is enabled
-  name: REST_POST_ENABLED
-  value: 'true'
 - description: activate RBAC middleware
   name: RBAC_ENFORCED
   value: 'false'

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -57,11 +57,6 @@ def api_delete_host(flask_client):
 
 
 @pytest.fixture(scope="function")
-def disable_rest_api_post(inventory_config):
-    inventory_config.rest_post_enabled = False
-
-
-@pytest.fixture(scope="function")
 def enable_rbac(inventory_config):
     inventory_config.rbac_enforced = True
 


### PR DESCRIPTION
## Overview

This PR is just for cleanup, so no Jira this time. I'm just removing the `REST_POST_ENABLED` environment variable, since we don't use it anymore.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
