### PR TITLE
List the rbac ClowdApp as a dependency

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -9,7 +9,7 @@ objects:
     name: host-inventory
   spec:
     envName: ${ENV_NAME}
-    dependencies:
+    optionalDependencies:
     - rbac
     deployments:
     - name: service

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -9,6 +9,8 @@ objects:
     name: host-inventory
   spec:
     envName: ${ENV_NAME}
+    dependencies:
+    - rbac
     deployments:
     - name: service
       minReplicas: ${{REPLICAS_SVC}}


### PR DESCRIPTION
For testing in ephemeral envs, rbac needs to be present to do anything useful with the inventory API.

Listing rbac as an optional dependency will cause bonfire to deploy it unless `--no-get-dependencies` is specified.

