### PR TITLE
⬆️ Bump reorder-python-imports pre-commit hook to use --py37-plus

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   rev: v1.6.0
   hooks:
   - id: reorder-python-imports
-    args: [--py3-plus]
+    args: [--py37-plus]
 - repo: https://github.com/asottile/pyupgrade
   rev: v1.19.0
   hooks:


### PR DESCRIPTION
Since we are now using Python 3.8.

_reorder-python-imports_ supports _--py37-plus_ as its maximum.
```
  --py37-plus           Remove obsolete future imports (generator_stop). implies: --py22-plus, --py23-plus, --py26-plus, --py3-plus
```

_pyupgrade_’s most recent support is still _--py36-plus_, so no change there.
```
  --py36-plus
```