### PR TITLE
Make cert_type and auth_type case-insensitive

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -93,8 +93,8 @@ class Identity:
                         raise ValueError("The identity.system field is mandatory for system-type identities")
                     elif not self.system.get("cert_type"):
                         raise ValueError("The cert_type field is mandatory for system-type identities")
-                    elif self.system.get("cert_type").lower() not in CertType.__members__.values():
-                        raise ValueError(f"The cert_type {self.system.get('cert_type')} is invalid.")
+                    elif self.system["cert_type"].lower() not in CertType.__members__.values():
+                        raise ValueError(f"The cert_type {self.system['cert_type']} is invalid.")
                     elif not self.system.get("cn"):
                         raise ValueError("The cn field is mandatory for system-type identities")
                     else:

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -78,8 +78,10 @@ class Identity:
                 raise ValueError("The account_number is mandatory.")
             elif not self.identity_type or self.identity_type not in IdentityType.__members__.values():
                 raise ValueError("Identity type invalid or missing in provided Identity")
-            elif self.auth_type is not None and self.auth_type not in AuthType.__members__.values():
+            elif self.auth_type is not None and self.auth_type.lower() not in AuthType.__members__.values():
                 raise ValueError(f"The auth_type {self.auth_type} is invalid")
+            else:
+                self.auth_type = self.auth_type.lower()
 
             if self.identity_type == IdentityType.USER:
                 self.user = obj.get("user")
@@ -91,10 +93,12 @@ class Identity:
                         raise ValueError("The identity.system field is mandatory for system-type identities")
                     elif not self.system.get("cert_type"):
                         raise ValueError("The cert_type field is mandatory for system-type identities")
-                    elif self.system.get("cert_type") not in CertType.__members__.values():
+                    elif self.system.get("cert_type").lower() not in CertType.__members__.values():
                         raise ValueError(f"The cert_type {self.system.get('cert_type')} is invalid.")
                     elif not self.system.get("cn"):
                         raise ValueError("The cn field is mandatory for system-type identities")
+                    else:
+                        self.system["cert_type"] = self.system["cert_type"].lower()
 
             threadctx.account_number = obj["account_number"]
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -231,7 +231,7 @@ class AuthIdentityValidateTestCase(TestCase):
     def test_case_insensitive_cert_types(self):
         # Validate that cert_type is case-insensitive
         test_identity = deepcopy(SYSTEM_IDENTITY)
-        cert_types = ["RHUI", "Satellite", "SYSTEM", "hypervisor"]
+        cert_types = ["RHUI", "Satellite", "system"]
         for cert_type in cert_types:
             with self.subTest(cert_type=cert_type):
                 test_identity["system"]["cert_type"] = cert_type
@@ -244,7 +244,7 @@ class AuthIdentityValidateTestCase(TestCase):
     def test_case_insensitive_auth_types(self):
         # Validate that auth_type is case-insensitive
         test_identity = deepcopy(SYSTEM_IDENTITY)
-        auth_types = []
+        auth_types = ["CLASSIC-PROXY", "Cert-Auth", "basic-auth"]
         for auth_type in auth_types:
             with self.subTest(auth_type=auth_type):
                 test_identity["auth_type"] = auth_type

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -229,7 +229,7 @@ class AuthIdentityValidateTestCase(TestCase):
                     Identity(test_identity)
 
     def test_case_insensitive_cert_types(self):
-        # Validate that auth_type and cert_type are case-insensitive
+        # Validate that cert_type is case-insensitive
         test_identity = deepcopy(SYSTEM_IDENTITY)
         cert_types = ["RHUI", "Satellite", "SYSTEM", "hypervisor"]
         for cert_type in cert_types:
@@ -242,7 +242,7 @@ class AuthIdentityValidateTestCase(TestCase):
                     self.fail()
 
     def test_case_insensitive_auth_types(self):
-        # Validate that auth_type and cert_type are case-insensitive
+        # Validate that auth_type is case-insensitive
         test_identity = deepcopy(SYSTEM_IDENTITY)
         auth_types = []
         for auth_type in auth_types:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -228,6 +228,32 @@ class AuthIdentityValidateTestCase(TestCase):
                 with self.assertRaises(ValueError):
                     Identity(test_identity)
 
+    def test_case_insensitive_cert_types(self):
+        # Validate that auth_type and cert_type are case-insensitive
+        test_identity = deepcopy(SYSTEM_IDENTITY)
+        cert_types = ["RHUI", "Satellite", "SYSTEM", "hypervisor"]
+        for cert_type in cert_types:
+            with self.subTest(cert_type=cert_type):
+                test_identity["system"]["cert_type"] = cert_type
+                try:
+                    Identity(test_identity)
+                    self.assertTrue(True)
+                except Exception:
+                    self.fail()
+
+    def test_case_insensitive_auth_types(self):
+        # Validate that auth_type and cert_type are case-insensitive
+        test_identity = deepcopy(SYSTEM_IDENTITY)
+        auth_types = []
+        for auth_type in auth_types:
+            with self.subTest(auth_type=auth_type):
+                test_identity["auth_type"] = auth_type
+                try:
+                    Identity(test_identity)
+                    self.assertTrue(True)
+                except Exception:
+                    self.fail()
+
 
 class TrustedIdentityTestCase(TestCase):
     shared_secret = "ImaSecret"


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-14391](https://issues.redhat.com/browse/RHCLOUD-14391).
Some host-ingress messages are failing because the `cert_type` is set to "RHUI", while Identity allows only lowercase values. This PR changes `cert_type` and `auth_type` to be case-insensitive.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
