### PR TITLE
Fix AttributeError when `auth_type` is None

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -78,10 +78,10 @@ class Identity:
                 raise ValueError("The account_number is mandatory.")
             elif not self.identity_type or self.identity_type not in IdentityType.__members__.values():
                 raise ValueError("Identity type invalid or missing in provided Identity")
-            elif self.auth_type is not None and self.auth_type.lower() not in AuthType.__members__.values():
-                raise ValueError(f"The auth_type {self.auth_type} is invalid")
-            else:
+            elif self.auth_type is not None:
                 self.auth_type = self.auth_type.lower()
+                if self.auth_type not in AuthType.__members__.values():
+                    raise ValueError(f"The auth_type {self.auth_type} is invalid")
 
             if self.identity_type == IdentityType.USER:
                 self.user = obj.get("user")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -244,7 +244,7 @@ class AuthIdentityValidateTestCase(TestCase):
     def test_case_insensitive_auth_types(self):
         # Validate that auth_type is case-insensitive
         test_identity = deepcopy(SYSTEM_IDENTITY)
-        auth_types = ["CLASSIC-PROXY", "Cert-Auth", "basic-auth"]
+        auth_types = ["CLASSIC-PROXY", "Cert-Auth", "basic-auth", None]
         for auth_type in auth_types:
             with self.subTest(auth_type=auth_type):
                 test_identity["auth_type"] = auth_type


### PR DESCRIPTION
## Overview

This PR fixes a bug that I introduced in #914. When an Identity has `auth_type == None`, the app hits an AttributeError.
This resolves that issue, and adds a test that verifies as much.

