### PR TITLE
Add greenboot fallback detected bool to system profile.

### DIFF
--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -362,6 +362,9 @@ $defs:
         maxLength: 5
         description: Indicates the greenboot status of an edge device.
         example: 'red'
+      greenboot_fallback_detected:
+        type: boolean
+        description: Indicates whether greenboot detected a rolled back update on an edge device.
       rhsm:
         description: Object for subscription-manager details
         type: object


### PR DESCRIPTION
Signed-off-by: Christopher Sams <csams@redhat.com>

## Overview

This PR is being created to address [RHELPLAN-80227](https://issues.redhat.com/browse/RHELPLAN-80227).
Adding a boolean that indicates whether greenboot detected an OS update that was rolled back.

See also:
- [Schema update](https://github.com/RedHatInsights/inventory-schemas/pull/66)
- [puptoo update](https://github.com/RedHatInsights/insights-puptoo/pull/161)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [X] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
