### PR TITLE
Grafana syntax fix

### DIFF
--- a/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
@@ -2312,7 +2312,7 @@ data:
               ],
               "type": "number",
               "unit": "locale"
-            },
+            }
           ],
           "targets": [
             {


### PR DESCRIPTION
This PR removes a single comma to fix the JSON syntax on the dashboard. My brain must have still been in python mode when I made this change.
