### PR TITLE
Use /bin/sh -c on container startup commands

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -19,10 +19,9 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         initContainers:
         - command:
-          - /opt/app-root/bin/python
-          - manage.py
-          - db
-          - upgrade
+          - /bin/sh
+          - -c
+          - python manage.py db upgrade
           inheritEnv: true
         command:
         - gunicorn
@@ -111,8 +110,9 @@ objects:
       minReplicas: ${{REPLICAS_PMIN}}
       podSpec:
         command:
-        - python
-        - inv_mq_service.py
+        - /bin/sh
+        - -c
+        - python inv_mq_service.py
         env:
         - name: INVENTORY_LOG_LEVEL
           value: ${LOG_LEVEL}
@@ -165,8 +165,9 @@ objects:
       minReplicas: ${{REPLICAS_P1}}
       podSpec:
         command:
-        - python
-        - inv_mq_service.py
+        - /bin/sh 
+        - -c
+        - python inv_mq_service.py
         env:
         - name: INVENTORY_LOG_LEVEL
           value: ${LOG_LEVEL}
@@ -219,8 +220,9 @@ objects:
       minReplicas: ${{REPLICAS_SP}}
       podSpec:
         command:
-        - python
-        - inv_mq_service.py
+        - /bin/sh 
+        - -c
+        - python inv_mq_service.py
         env:
         - name: INVENTORY_LOG_LEVEL
           value: ${LOG_LEVEL}

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -165,7 +165,7 @@ objects:
       minReplicas: ${{REPLICAS_P1}}
       podSpec:
         command:
-        - /bin/sh 
+        - /bin/sh
         - -c
         - python inv_mq_service.py
         env:
@@ -220,7 +220,7 @@ objects:
       minReplicas: ${{REPLICAS_SP}}
       podSpec:
         command:
-        - /bin/sh 
+        - /bin/sh
         - -c
         - python inv_mq_service.py
         env:


### PR DESCRIPTION
This seems to fix the certifi import issues when running in kubernetes. I'm not sure why but I suspect there's an issue with the virtual environment when `python` is called directly.