### PR TITLE
Set min/max for System Profile integers

### DIFF
--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -108,6 +108,8 @@ $defs:
       mtu:
         description: MTU (Maximum transmission unit)
         type: integer
+        minimum: 0
+        maximum: 18446744073709551615
       mac_address:
         description: MAC address (with or without colons)
         example: "00:00:00:00:00:00"
@@ -158,13 +160,21 @@ $defs:
         example: 'Intel(R) Xeon(R) CPU E5-2690 0 @ 2.90GHz'
       number_of_cpus:
         type: integer
+        minimum: 0
+        maximum: 4294967295
       number_of_sockets:
         type: integer
+        minimum: 0
+        maximum: 4294967295
       cores_per_socket:
         type: integer
+        minimum: 0
+        maximum: 4294967295
       system_memory_bytes:
         type: integer
         format: int64
+        minimum: 0
+        maximum: 18446744073709551615
       infrastructure_type:
         type: string
         maxLength: 100


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-14535](https://issues.redhat.com/browse/RHCLOUD-14535).
It adds min/max values to System Profile int fields, since exceeding these values can lead to 5xx on our end.
inventory-schemas PR here: https://github.com/RedHatInsights/inventory-schemas/pull/67

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
