### PR TITLE
Add regex escapes to sap_version field

### DIFF
--- a/swagger/system_profile.spec.yaml
+++ b/swagger/system_profile.spec.yaml
@@ -330,7 +330,7 @@ $defs:
         description: The version of the SAP HANA lifecycle management program
         example:  '1.00.122.04.1478575636'
         maxLength: 22
-        pattern: '^[0-9].[0-9]{2}.[0-9]{3}.[0-9]{2}.[0-9]{10}$'
+        pattern: '^[0-9]\.[0-9]{2}\.[0-9]{3}\.[0-9]{2}\.[0-9]{10}$'
       tuned_profile:
         type: string
         maxLength: 256


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-14537](https://issues.redhat.com/browse/RHCLOUD-14537).
Adds regex escapes to the `sap_version` field, which currently allows any 22-number string.
inventory-schemas PR here: https://github.com/RedHatInsights/inventory-schemas/pull/68

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
