### PR TITLE
Don't allow "tags" field to be null

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -309,7 +309,7 @@ class Host(LimitedHost):
     def _update_tags(self, tags_dict):
         if self.tags is None:
             raise InventoryException(
-                title="Invalid request", detail="Both stale_timestamp and reporter fields must be present."
+                title="Invalid request", detail="Tags must be either an object or an array, and cannot be null."
             )
 
         for namespace, ns_tags in tags_dict.items():
@@ -479,7 +479,7 @@ class LimitedHostSchema(CanonicalFactsSchema):
         elif isinstance(tags, dict):
             return self._validate_tags_dict(tags)
         else:
-            raise MarshmallowValidationError("Tags must be either an object or an array.")
+            raise MarshmallowValidationError("Tags must be either an object or an array, and cannot be null.")
 
     @staticmethod
     def _validate_tags_list(tags):

--- a/app/models.py
+++ b/app/models.py
@@ -150,7 +150,7 @@ class LimitedHost(db.Model):
         ansible_host=None,
         account=None,
         facts=None,
-        tags=None,
+        tags={},
         system_profile_facts=None,
     ):
 
@@ -164,7 +164,7 @@ class LimitedHost(db.Model):
         self._update_ansible_host(ansible_host)
         self.account = account
         self.facts = facts or {}
-        self.tags = tags or {}
+        self.tags = tags
         self.system_profile_facts = system_profile_facts or {}
 
     def _update_ansible_host(self, ansible_host):
@@ -196,7 +196,7 @@ class Host(LimitedHost):
         ansible_host=None,
         account=None,
         facts=None,
-        tags=None,
+        tags={},
         system_profile_facts=None,
         stale_timestamp=None,
         reporter=None,
@@ -210,6 +210,9 @@ class Host(LimitedHost):
             raise InventoryException(
                 title="Invalid request", detail="Both stale_timestamp and reporter fields must be present."
             )
+
+        if tags is None:
+            raise InventoryException(title="Invalid request", detail="The tags field cannot be null.")
 
         super().__init__(canonical_facts, display_name, ansible_host, account, facts, tags, system_profile_facts)
         self.stale_timestamp = stale_timestamp
@@ -304,8 +307,10 @@ class Host(LimitedHost):
         orm.attributes.flag_modified(self, "facts")
 
     def _update_tags(self, tags_dict):
-        if not self.tags:  # fixme: Host tags should never be None, in DB neither NULL nor 'null'
-            self.tags = {}
+        if self.tags is None:
+            raise InventoryException(
+                title="Invalid request", detail="Both stale_timestamp and reporter fields must be present."
+            )
 
         for namespace, ns_tags in tags_dict.items():
             if ns_tags:
@@ -457,7 +462,7 @@ class LimitedHostSchema(CanonicalFactsSchema):
     account = fields.Str(required=True, validate=marshmallow_validate.Length(min=1, max=10))
     facts = fields.List(fields.Nested(FactsSchema))
     system_profile = fields.Dict()
-    tags = fields.Raw(allow_none=True)
+    tags = fields.Raw()
 
     def __init__(self, system_profile_schema=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -473,10 +478,8 @@ class LimitedHostSchema(CanonicalFactsSchema):
             return self._validate_tags_list(tags)
         elif isinstance(tags, dict):
             return self._validate_tags_dict(tags)
-        elif tags is None:
-            return True
         else:
-            raise MarshmallowValidationError("Tags must be either an object, an array or null.")
+            raise MarshmallowValidationError("Tags must be either an object or an array.")
 
     @staticmethod
     def _validate_tags_list(tags):

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -5,10 +5,8 @@ from datetime import timedelta
 
 import marshmallow
 import pytest
-from sqlalchemy import null
 from sqlalchemy.exc import OperationalError
 
-from app import db
 from app import UNKNOWN_REQUEST_ID_VALUE
 from app.exceptions import InventoryException
 from app.exceptions import ValidationException
@@ -598,7 +596,7 @@ def test_add_host_with_sap_system(event_datetime_mock, mq_create_or_update_host)
     assert_mq_host_data(key, event, expected_results, host_keys_to_check)
 
 
-@pytest.mark.parametrize("tags", ({}, {"tags": None}, {"tags": []}, {"tags": {}}))
+@pytest.mark.parametrize("tags", ({}, {"tags": []}, {"tags": {}}))
 def test_add_host_with_no_tags(tags, mq_create_or_update_host, db_get_host_by_insights_id):
     insights_id = generate_uuid()
     host = minimal_host(account=SYSTEM_IDENTITY["account_number"], insights_id=insights_id, **tags)
@@ -746,26 +744,6 @@ def test_add_tags_to_host_by_dict(mq_create_or_update_host, db_get_host_by_insig
             assert expected_tags == record.tags
 
 
-@pytest.mark.parametrize("empty", (None, null()))
-def test_add_tags_to_hosts_with_null_tags(empty, mq_create_or_update_host, db_get_host_by_insights_id, flask_app):
-    # FIXME: Remove this test after migration to NOT NULL.
-    insights_id = generate_uuid()
-    host = minimal_host(account=SYSTEM_IDENTITY["account_number"], insights_id=insights_id)
-    mq_create_or_update_host(host)
-
-    created_host = db_get_host_by_insights_id(insights_id)
-    created_host.tags = empty
-
-    db.session.add(created_host)
-    db.session.commit()
-
-    new_host = mq_create_or_update_host(host)
-    assert [] == new_host.tags
-
-    updated_host = db_get_host_by_insights_id(insights_id)
-    assert {} == updated_host.tags
-
-
 def test_replace_tags_of_host_by_list(mq_create_or_update_host, db_get_host_by_insights_id, subtests):
     insights_id = generate_uuid()
 
@@ -877,7 +855,6 @@ def test_keep_host_tags_by_empty(mq_create_or_update_host, db_get_host_by_insigh
     for message_tags, expected_tags in (
         ({"tags": {"namespace 1": {"key 1": ["value 1"]}}}, {"namespace 1": {"key 1": ["value 1"]}}),
         ({}, {"namespace 1": {"key 1": ["value 1"]}}),
-        ({"tags": None}, {"namespace 1": {"key 1": ["value 1"]}}),
         ({"tags": []}, {"namespace 1": {"key 1": ["value 1"]}}),
         ({"tags": {}}, {"namespace 1": {"key 1": ["value 1"]}}),
     ):
@@ -890,7 +867,7 @@ def test_keep_host_tags_by_empty(mq_create_or_update_host, db_get_host_by_insigh
             assert expected_tags == record.tags
 
 
-@pytest.mark.parametrize("tags", ({}, {"tags": None}, {"tags": []}, {"tags": {}}))
+@pytest.mark.parametrize("tags", ({}, {"tags": []}, {"tags": {}}))
 def test_add_host_default_empty_dict(tags, mq_create_or_update_host, db_get_host_by_insights_id):
     insights_id = generate_uuid()
     host = minimal_host(account=SYSTEM_IDENTITY["account_number"], insights_id=insights_id, **tags)

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -608,6 +608,13 @@ def test_add_host_with_no_tags(tags, mq_create_or_update_host, db_get_host_by_in
     assert record.tags == {}
 
 
+def test_add_host_with_null_tags(mq_create_or_update_host):
+    host = minimal_host(tags=None)
+
+    with pytest.raises(ValidationException):
+        mq_create_or_update_host(host)
+
+
 def test_add_host_with_tag_list(mq_create_or_update_host, db_get_host_by_insights_id):
     insights_id = generate_uuid()
     tags = [


### PR DESCRIPTION
## Overview

This PR is being created to address [RHCLOUD-14532](https://issues.redhat.com/browse/RHCLOUD-14532).
It changes the functionality to stop allowing the "tags" field to be set to null/None. We used to allow it to be set to null, and would just replace it with `{}` if it was. However, this was planned to be phased out, and the time has come.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
