### PR TITLE
Fix clowder-based service/deployment naming

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -100,7 +100,7 @@ objects:
         - emptyDir:
             medium: Memory
           name: gunicorn-worker-dir
-    - name: inventory-mq-pmin
+    - name: mq-pmin
       minReplicas: ${{REPLICAS_PMIN}}
       podSpec:
         command:
@@ -155,7 +155,7 @@ objects:
           requests:
             cpu: 200m
             memory: 256Mi
-    - name: inventory-mq-p1
+    - name: mq-p1
       minReplicas: ${{REPLICAS_P1}}
       podSpec:
         initContainers:
@@ -216,7 +216,7 @@ objects:
           requests:
             cpu: 200m
             memory: 256Mi
-    - name: inventory-mq-sp
+    - name: mq-sp
       minReplicas: ${{REPLICAS_SP}}
       podSpec:
         command:


### PR DESCRIPTION
## Overview

This PR is being created to address [ESSNTL-790](https://issues.redhat.com/browse/ESSNTL-790).
Our Clowder-based deployments and services have "inventory" in them twice, e.g. "host-inventory-inventory-mq-p1". This PR fixes that.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Checklist GitHub Link

- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
