### PR TITLE
Adding optional kafka ssl config vars

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -62,6 +62,10 @@ objects:
           value: ${KAFKA_PRODUCER_RETRIES}
         - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
           value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
+        - name: KAFKA_SECURITY_PROTOCOL
+          value: ${KAFKA_SECURITY_PROTOCOL}
+        - name: KAFKA_SSL_CAFILE
+          value: ${KAFKA_SSL_CAFILE}
         - name: CLOWDER_ENABLED
           value: "true"
         resources:
@@ -94,12 +98,16 @@ objects:
           name: prometheus-volume
         - mountPath: /gunicorn
           name: gunicorn-worker-dir
+        - mountPath: /opt/certs/
+          name: kafka-cacert
         volumes:
         - emptyDir: {}
           name: prometheus-volume
         - emptyDir:
             medium: Memory
           name: gunicorn-worker-dir
+        - emptyDir: {}
+          name: kafka-cacert
     - name: mq-pmin
       minReplicas: ${{REPLICAS_PMIN}}
       podSpec:
@@ -132,6 +140,10 @@ objects:
           value: ${KAFKA_PRODUCER_RETRIES}
         - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
           value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
+        - name: KAFKA_SECURITY_PROTOCOL
+          value: ${KAFKA_SECURITY_PROTOCOL}
+        - name: KAFKA_SSL_CAFILE
+          value: ${KAFKA_SSL_CAFILE}
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}
@@ -155,6 +167,12 @@ objects:
           requests:
             cpu: 200m
             memory: 256Mi
+        volumeMounts:
+        - mountPath: /opt/certs/
+          name: kafka-cacert
+        volumes:
+        - emptyDir: {}
+          name: kafka-cacert
     - name: mq-p1
       minReplicas: ${{REPLICAS_P1}}
       podSpec:
@@ -193,6 +211,10 @@ objects:
           value: ${KAFKA_PRODUCER_RETRIES}
         - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
           value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
+        - name: KAFKA_SECURITY_PROTOCOL
+          value: ${KAFKA_SECURITY_PROTOCOL}
+        - name: KAFKA_SSL_CAFILE
+          value: ${KAFKA_SSL_CAFILE}
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}
@@ -216,6 +238,12 @@ objects:
           requests:
             cpu: 200m
             memory: 256Mi
+        volumeMounts:
+        - mountPath: /opt/certs/
+          name: kafka-cacert
+        volumes:
+        - emptyDir: {}
+          name: kafka-cacert
     - name: mq-sp
       minReplicas: ${{REPLICAS_SP}}
       podSpec:
@@ -248,6 +276,10 @@ objects:
           value: ${KAFKA_PRODUCER_RETRIES}
         - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
           value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
+        - name: KAFKA_SECURITY_PROTOCOL
+          value: ${KAFKA_SECURITY_PROTOCOL}
+        - name: KAFKA_SSL_CAFILE
+          value: ${KAFKA_SSL_CAFILE}
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}
@@ -271,6 +303,12 @@ objects:
           requests:
             cpu: 200m
             memory: 256Mi
+        volumeMounts:
+        - mountPath: /opt/certs/
+          name: kafka-cacert
+        volumes:
+        - emptyDir: {}
+          name: kafka-cacert
     database:
       name: host-inventory
       version: 12
@@ -366,3 +404,8 @@ parameters:
 - name: KAFKA_SYSTEM_PROFILE_TOPIC
   description: The topic containing Host data for System Profile updates
   value: platform.inventory.system-profile
+- name: KAFKA_SECURITY_PROTOCOL
+  description: The Kafka Security Protocol
+  value: PLAINTEXT
+- name: KAFKA_SSL_CAFILE
+  value: /opt/certs/kafka-cacert


### PR DESCRIPTION
# Overview

These won't probably resolve the ongoing partial outage in stage. I am adding these for safety, atm. There are other kafka ssl configs, but those won't get checked unless we use the `sasl_ssl` kafka security protocol.

N.B. just adding an empty directory for the `kafka-cacert`. If the `KAFKA_SECURITY_PROTOCOL` environment variable is set to `PLAINTEXT`, it shouldn't try to read it.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
