### PR TITLE
Set display_name to FQDN on update, if it's set to the ID

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -60,7 +60,7 @@ def _set_display_name_on_save(context):
     the id exists and can be used as the display_name if necessary.
     """
     params = context.get_current_parameters()
-    if not params["display_name"]:
+    if not params["display_name"] or params["display_name"] == str(params["id"]):
         return params["canonical_facts"].get("fqdn") or params["id"]
 
 
@@ -253,7 +253,7 @@ class Host(LimitedHost):
     def update_display_name(self, input_display_name):
         if input_display_name:
             self.display_name = input_display_name
-        elif not self.display_name:
+        elif not self.display_name or self.display_name == str(self.id):
             # This is the case where the display_name is not set on the
             # existing host record and the input host does not have it set
             if "fqdn" in self.canonical_facts:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -66,6 +66,22 @@ def test_update_existing_host_fix_display_name_using_existing_fqdn(db_create_hos
     assert existing_host.display_name == expected_fqdn
 
 
+def test_update_existing_host_update_display_name_from_id_using_existing_fqdn(db_create_host):
+    expected_fqdn = "host1.domain1.com"
+    insights_id = generate_uuid()
+
+    existing_host = db_create_host(extra_data={"canonical_facts": {"insights_id": insights_id}, "display_name": None})
+
+    db.session.commit()
+    assert existing_host.display_name == str(existing_host.id)
+
+    # Update the host
+    input_host = Host({"insights_id": insights_id, "fqdn": expected_fqdn}, reporter="puptoo", stale_timestamp=now())
+    existing_host.update(input_host)
+
+    assert existing_host.display_name == expected_fqdn
+
+
 def test_update_existing_host_fix_display_name_using_input_fqdn(db_create_host):
     # Create an "existing" host
     fqdn = "host1.domain1.com"


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-824](https://issues.redhat.com/browse/ESSNTL-824).
If we update a Host and its old display_name is set to its ID, we should set the display_name to the FQDN.
This is one of the features that was discussed after a bunch of email exchanges. Without this change, the display_name is saved to the ID upon a Host's creation, so if the FQDN isn't specified at that time, it will never default.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
