### PR TITLE
Loading kafka ssl creds the correct way for clowder + refactoring

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -112,7 +112,7 @@ class Config:
         self.kafka_ssl_configs = {
             "security_protocol": os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT").upper(),
             "ssl_cafile": self.kafka_ssl_cafile,
-            "sasl_mechanism": os.environ.get("KAFKA_SASL_MECHANISM", "").upper(),
+            "sasl_mechanism": os.environ.get("KAFKA_SASL_MECHANISM", "PLAIN").upper(),
             "sasl_plain_username": self.kafka_sasl_username,
             "sasl_plain_password": self.kafka_sasl_password,
         }

--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,9 @@ class Config:
         self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC", "platform.inventory.host-ingress"))
         self.event_topic = topic("platform.inventory.events")
         self.payload_tracker_kafka_topic = topic("platform.payload-status")
+        self.kafka_ssl_cafile = broker_cfg.cacert
+        self.kafka_sasl_username = broker_cfg.sasl.username
+        self.kafka_sasl_password = broker_cfg.sasl.password
 
     def non_clowder_config(self):
         self.metrics_port = 9126
@@ -69,6 +72,9 @@ class Config:
         self.event_topic = os.environ.get("KAFKA_EVENT_TOPIC", "platform.inventory.events")
         self.payload_tracker_kafka_topic = os.environ.get("PAYLOAD_TRACKER_KAFKA_TOPIC", "platform.payload-status")
         self._db_ssl_cert = os.getenv("INVENTORY_DB_SSL_CERT", "")
+        self.kafka_ssl_cafile = os.environ.get("KAFKA_SSL_CAFILE")
+        self.kafka_sasl_username = os.environ.get("KAFKA_SASL_USERNAME", "")
+        self.kafka_sasl_password = os.environ.get("KAFKA_SASL_PASSWORD", "")
 
     def __init__(self, runtime_environment):
         self.logger = get_logger(__name__)
@@ -102,6 +108,14 @@ class Config:
         self.prometheus_pushgateway = os.environ.get("PROMETHEUS_PUSHGATEWAY", "localhost:9091")
         self.kubernetes_namespace = os.environ.get("NAMESPACE")
 
+        self.kafka_ssl_configs = {
+            "security_protocol": os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT").upper(),
+            "ssl_cafile": self.kafka_ssl_cafile,
+            "sasl_mechanism": os.environ.get("KAFKA_SASL_MECHANISM", "").upper(),
+            "sasl_plain_username": self.kafka_sasl_username,
+            "sasl_plain_password": self.kafka_sasl_password,
+        }
+
         # https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html#kafka.KafkaConsumer
         self.kafka_consumer = {
             "request_timeout_ms": int(os.environ.get("KAFKA_CONSUMER_REQUEST_TIMEOUT_MS", "305000")),
@@ -114,11 +128,7 @@ class Config:
             "max_poll_interval_ms": int(os.environ.get("KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS", "300000")),
             "session_timeout_ms": int(os.environ.get("KAFKA_CONSUMER_SESSION_TIMEOUT_MS", "10000")),
             "heartbeat_interval_ms": int(os.environ.get("KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS", "3000")),
-            "security_protocol": os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT").upper(),
-            "ssl_cafile": os.environ.get("KAFKA_SSL_CAFILE"),
-            "sasl_mechanism": os.environ.get("KAFKA_SASL_MECHANISM", "").upper(),
-            "sasl_plain_username": os.environ.get("KAFKA_SASL_USERNAME", ""),
-            "sasl_plain_password": os.environ.get("KAFKA_SASL_PASSWORD", ""),
+            **self.kafka_ssl_configs,
         }
 
         self.validator_kafka_consumer = {
@@ -132,11 +142,7 @@ class Config:
             "max_poll_interval_ms": int(os.environ.get("KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS", "300000")),
             "session_timeout_ms": int(os.environ.get("KAFKA_CONSUMER_SESSION_TIMEOUT_MS", "10000")),
             "heartbeat_interval_ms": int(os.environ.get("KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS", "3000")),
-            "security_protocol": os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT").upper(),
-            "ssl_cafile": os.environ.get("KAFKA_SSL_CAFILE"),
-            "sasl_mechanism": os.environ.get("KAFKA_SASL_MECHANISM", "").upper(),
-            "sasl_plain_username": os.environ.get("KAFKA_SASL_USERNAME", ""),
-            "sasl_plain_password": os.environ.get("KAFKA_SASL_PASSWORD", ""),
+            **self.kafka_ssl_configs,
         }
 
         # https://kafka-python.readthedocs.io/en/1.4.7/apidoc/KafkaProducer.html#kafkaproducer
@@ -149,20 +155,10 @@ class Config:
             "max_in_flight_requests_per_connection": int(
                 os.environ.get("KAFKA_PRODUCER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION", "5")
             ),
-            "security_protocol": os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT").upper(),
-            "ssl_cafile": os.environ.get("KAFKA_SSL_CAFILE"),
-            "sasl_mechanism": os.environ.get("KAFKA_SASL_MECHANISM", "").upper(),
-            "sasl_plain_username": os.environ.get("KAFKA_SASL_USERNAME", ""),
-            "sasl_plain_password": os.environ.get("KAFKA_SASL_PASSWORD", ""),
+            **self.kafka_ssl_configs,
         }
 
-        self.payload_tracker_kafka_producer = {
-            "security_protocol": os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT").upper(),
-            "ssl_cafile": os.environ.get("KAFKA_SSL_CAFILE"),
-            "sasl_mechanism": os.environ.get("KAFKA_SASL_MECHANISM", "").upper(),
-            "sasl_plain_username": os.environ.get("KAFKA_SASL_USERNAME", ""),
-            "sasl_plain_password": os.environ.get("KAFKA_SASL_PASSWORD", ""),
-        }
+        self.payload_tracker_kafka_producer = {"bootstrap_servers": self.bootstrap_servers, **self.kafka_ssl_configs}
 
         self.payload_tracker_service_name = os.environ.get("PAYLOAD_TRACKER_SERVICE_NAME", "inventory")
         payload_tracker_enabled = os.environ.get("PAYLOAD_TRACKER_ENABLED", "true")

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from datetime import timedelta
 from enum import Enum
 
@@ -50,7 +51,7 @@ class Config:
         self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC", "platform.inventory.host-ingress"))
         self.event_topic = topic("platform.inventory.events")
         self.payload_tracker_kafka_topic = topic("platform.payload-status")
-        self.kafka_ssl_cafile = broker_cfg.cacert
+        self.kafka_ssl_cafile = self._kafka_ca(broker_cfg.cacert)
         self.kafka_sasl_username = broker_cfg.sasl.username
         self.kafka_sasl_password = broker_cfg.sasl.password
 
@@ -212,6 +213,14 @@ class Config:
         if value is None:
             raise ValueError(f"{os.environ.get(name)} is not a valid value for {name}")
         return value
+
+    def _kafka_ca(self, cacert_string):
+        cacert_filename = None
+        if cacert_string:
+            with tempfile.NamedTemporaryFile(delete=False) as tf:
+                cacert_filename = tf.name
+                tf.write(cacert_string.encode("utf-8"))
+        return cacert_filename
 
     def log_configuration(self):
         if not self._runtime_environment.logging_enabled:

--- a/app/payload_tracker/__init__.py
+++ b/app/payload_tracker/__init__.py
@@ -25,7 +25,7 @@ def init_payload_tracker(config, producer=None):
         _PRODUCER = producer
     else:
         logger.info("Starting KafkaProducer() for PayloadTracker")
-        _PRODUCER = KafkaProducer(bootstrap_servers=config.bootstrap_servers, **config.payload_tracker_kafka_producer)
+        _PRODUCER = KafkaProducer(**config.payload_tracker_kafka_producer)
 
 
 def get_payload_tracker(account=None, request_id=None):

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -64,8 +64,8 @@ objects:
           value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
         - name: KAFKA_SECURITY_PROTOCOL
           value: ${KAFKA_SECURITY_PROTOCOL}
-        - name: KAFKA_SSL_CAFILE
-          value: ${KAFKA_SSL_CAFILE}
+        - name: KAFKA_SASL_MECHANISM
+          value: ${KAFKA_SASL_MECHANISM}
         - name: CLOWDER_ENABLED
           value: "true"
         resources:
@@ -98,16 +98,12 @@ objects:
           name: prometheus-volume
         - mountPath: /gunicorn
           name: gunicorn-worker-dir
-        - mountPath: /opt/certs/
-          name: kafka-cacert
         volumes:
         - emptyDir: {}
           name: prometheus-volume
         - emptyDir:
             medium: Memory
           name: gunicorn-worker-dir
-        - emptyDir: {}
-          name: kafka-cacert
     - name: mq-pmin
       minReplicas: ${{REPLICAS_PMIN}}
       podSpec:
@@ -142,8 +138,8 @@ objects:
           value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
         - name: KAFKA_SECURITY_PROTOCOL
           value: ${KAFKA_SECURITY_PROTOCOL}
-        - name: KAFKA_SSL_CAFILE
-          value: ${KAFKA_SSL_CAFILE}
+        - name: KAFKA_SASL_MECHANISM
+          value: ${KAFKA_SASL_MECHANISM}
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}
@@ -167,12 +163,6 @@ objects:
           requests:
             cpu: 200m
             memory: 256Mi
-        volumeMounts:
-        - mountPath: /opt/certs/
-          name: kafka-cacert
-        volumes:
-        - emptyDir: {}
-          name: kafka-cacert
     - name: mq-p1
       minReplicas: ${{REPLICAS_P1}}
       podSpec:
@@ -213,8 +203,8 @@ objects:
           value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
         - name: KAFKA_SECURITY_PROTOCOL
           value: ${KAFKA_SECURITY_PROTOCOL}
-        - name: KAFKA_SSL_CAFILE
-          value: ${KAFKA_SSL_CAFILE}
+        - name: KAFKA_SASL_MECHANISM
+          value: ${KAFKA_SASL_MECHANISM}
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}
@@ -238,12 +228,6 @@ objects:
           requests:
             cpu: 200m
             memory: 256Mi
-        volumeMounts:
-        - mountPath: /opt/certs/
-          name: kafka-cacert
-        volumes:
-        - emptyDir: {}
-          name: kafka-cacert
     - name: mq-sp
       minReplicas: ${{REPLICAS_SP}}
       podSpec:
@@ -278,8 +262,8 @@ objects:
           value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
         - name: KAFKA_SECURITY_PROTOCOL
           value: ${KAFKA_SECURITY_PROTOCOL}
-        - name: KAFKA_SSL_CAFILE
-          value: ${KAFKA_SSL_CAFILE}
+        - name: KAFKA_SASL_MECHANISM
+          value: ${KAFKA_SASL_MECHANISM}
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}
@@ -303,12 +287,6 @@ objects:
           requests:
             cpu: 200m
             memory: 256Mi
-        volumeMounts:
-        - mountPath: /opt/certs/
-          name: kafka-cacert
-        volumes:
-        - emptyDir: {}
-          name: kafka-cacert
     jobs:
     - name: reaper
       schedule: '@hourly'
@@ -348,8 +326,8 @@ objects:
                 fieldPath: metadata.namespace
           - name: KAFKA_SECURITY_PROTOCOL
             value: ${KAFKA_SECURITY_PROTOCOL}
-          - name: KAFKA_SSL_CAFILE
-            value: ${KAFKA_SSL_CAFILE}
+          - name: KAFKA_SASL_MECHANISM
+            value: ${KAFKA_SASL_MECHANISM}
           - name: CLOWDER_ENABLED
             value: "true"
         resources:
@@ -359,12 +337,6 @@ objects:
           requests:
             cpu: 200m
             memory: 256Mi
-        volumeMounts:
-        - mountPath: /opt/certs/
-          name: kafka-cacert
-        volumes:
-        - emptyDir: {}
-          name: kafka-cacert
     - name: synchronizer
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
@@ -402,8 +374,8 @@ objects:
                 fieldPath: metadata.namespace
           - name: KAFKA_SECURITY_PROTOCOL
             value: ${KAFKA_SECURITY_PROTOCOL}
-          - name: KAFKA_SSL_CAFILE
-            value: ${KAFKA_SSL_CAFILE}
+          - name: KAFKA_SASL_MECHANISM
+            value: ${KAFKA_SASL_MECHANISM}
           - name: CLOWDER_ENABLED
             value: "true"
         resources:
@@ -413,12 +385,6 @@ objects:
           requests:
             cpu: 200m
             memory: 256Mi
-        volumeMounts:
-        - mountPath: /opt/certs/
-          name: kafka-cacert
-        volumes:
-        - emptyDir: {}
-          name: kafka-cacert
     database:
       name: host-inventory
       version: 12
@@ -517,8 +483,8 @@ parameters:
 - name: KAFKA_SECURITY_PROTOCOL
   description: The Kafka Security Protocol
   value: PLAINTEXT
-- name: KAFKA_SSL_CAFILE
-  value: /opt/certs/kafka-cacert
+- name: KAFKA_SASL_MECHANISM
+  value: ''
 # the following params values come from 'app-interface/data/products/insights/environments/<env_name>.yml'
 # if loading this file can not get the values, then `deploy-clowder.yml` from app-interface should be
 # able to.

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -484,7 +484,7 @@ parameters:
   description: The Kafka Security Protocol
   value: PLAINTEXT
 - name: KAFKA_SASL_MECHANISM
-  value: ''
+  value: 'PLAIN'
 # the following params values come from 'app-interface/data/products/insights/environments/<env_name>.yml'
 # if loading this file can not get the values, then `deploy-clowder.yml` from app-interface should be
 # able to.


### PR DESCRIPTION
# Overview

This PR allows the loading of Kafka SSL credentials the preffered way for clowderized apps and also does some refactoring around it.

For Reference:
* The `BrokerConfig` for clowderapps: [here](https://github.com/RedHatInsights/app-common-python/blob/master/schema.json#L155-L176)
* Example from `insights-ingress-go`: [here](https://github.com/RedHatInsights/insights-ingress-go/blob/master/config/config.go#L136-L153)

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
