### PR TITLE
Add separate metrics server for API

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -207,7 +207,6 @@ def create_app(runtime_environment):
             flask_app,
             defaults_prefix="inventory",
             group_by="url_rule",
-            path=None,
             excluded_paths=["^/metrics$", "^/health$", "^/version$", r"^/favicon\.ico$"],
         )
         metrics.start_http_server(app_config.metrics_port, endpoint=app_config.metrics_path)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -203,13 +203,14 @@ def create_app(runtime_environment):
 
     # HTTP request metrics
     if runtime_environment.metrics_endpoint_enabled:
-        PrometheusMetrics(
+        metrics = PrometheusMetrics(
             flask_app,
             defaults_prefix="inventory",
             group_by="url_rule",
             path=None,
             excluded_paths=["^/metrics$", "^/health$", "^/version$", r"^/favicon\.ico$"],
         )
+        metrics.start_http_server(app_config.metrics_port, endpoint=app_config.metrics_path)
 
     # initialize metrics to zero
     initialize_metrics(app_config)

--- a/app/config.py
+++ b/app/config.py
@@ -53,6 +53,7 @@ class Config:
 
     def non_clowder_config(self):
         self.metrics_port = 9126
+        self.metrics_path = "/metrics"
         self._db_user = os.getenv("INVENTORY_DB_USER", "insights")
         self._db_password = os.getenv("INVENTORY_DB_PASS", "insights")
         self._db_host = os.getenv("INVENTORY_DB_HOST", "localhost")

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -20,7 +20,7 @@ logger = get_logger("mq_service")
 def main():
     application = create_app(RuntimeEnvironment.SERVICE)
     config = application.config["INVENTORY_CONFIG"]
-    start_http_server(config.metrics_port)
+    start_http_server(config.metrics_port, endpoint=config.metrics_path)
 
     topic_to_handler = {config.host_ingress_topic: add_host, config.system_profile_topic: update_system_profile}
 


### PR DESCRIPTION
# Overview

This PR is being created as part of [ESSNTL-761](https://issues.redhat.com/browse/ESSNTL-761).
It makes it so the metrics endpoint is separate from the other API traffic, and is configurable via Clowder.
I also added a small update to the MQ service's config to make its metrics path configurable as well (only the port was configured before).

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
