### PR TITLE
Hotfix: Remove endopint param from MQ metrics server command

### DIFF
--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -20,7 +20,7 @@ logger = get_logger("mq_service")
 def main():
     application = create_app(RuntimeEnvironment.SERVICE)
     config = application.config["INVENTORY_CONFIG"]
-    start_http_server(config.metrics_port, endpoint=config.metrics_path)
+    start_http_server(config.metrics_port)
 
     topic_to_handler = {config.host_ingress_topic: add_host, config.system_profile_topic: update_system_profile}
 


### PR DESCRIPTION
The MQ config was busted by my last PR: https://github.com/RedHatInsights/insights-host-inventory/pull/945
I incorrectly assumed that both `start_http_server()` calls would take the same params. I'm reverting that change here.