### PR TITLE
Suspend jobs by default (reaper/sp-validator)

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -290,6 +290,7 @@ objects:
     jobs:
     - name: reaper
       schedule: '@hourly'
+      suspend: ${REAPER_SUSPEND}
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: Never
@@ -611,6 +612,8 @@ parameters:
 - name: PENDO_SYNC_ACTIVE
   value: 'false'
 - name: SP_VALIDATOR_SUSPEND
-  value: 'false'
+  value: 'true'
+- name: REAPER_SUSPEND
+  value: 'true'
 - name: KAFKA_SP_VALIDATOR_MAX_MESSAGES
   value: '10000'


### PR DESCRIPTION
# Overview

This PR is being created to address issues brought up in CoreOS Slack ([this thread](https://coreos.slack.com/archives/C022YV4E0NA/p1626684947407900), for instance). This will suspend jobs in all envs by default, including the ephemeral cluster; I'll make an MR afterwards to set these to "true" for Stage and Prod.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
