### PR TITLE
Handle broker_config attributes in a pythonic way

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -51,11 +51,11 @@ class Config:
         self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC", "platform.inventory.host-ingress"))
         self.event_topic = topic("platform.inventory.events")
         self.payload_tracker_kafka_topic = topic("platform.payload-status")
-        if broker_cfg.sasl:
+        try:
             self.kafka_ssl_cafile = self._kafka_ca(broker_cfg.cacert)
             self.kafka_sasl_username = broker_cfg.sasl.username
             self.kafka_sasl_password = broker_cfg.sasl.password
-        else:
+        except AttributeError:
             self.kafka_ssl_cafile = None
             self.kafka_sasl_username = ""
             self.kafka_sasl_password = ""


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-949](https://issues.redhat.com/browse/ESSNTL-949).
This changes how we access our kafka broker_config attributes to be more pythonic. In turn, this should fix the error we're seeing every time Reaper runs in the Stage environment.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
