### PR TITLE
Canonical-fact-based deduplication

### DIFF
--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -2,6 +2,7 @@ from enum import Enum
 from uuid import UUID
 
 from sqlalchemy import and_
+from sqlalchemy import not_
 from sqlalchemy import or_
 
 from app import inventory_config
@@ -107,7 +108,7 @@ def multiple_canonical_facts_host_query(identity, canonical_facts, restrict_to_o
         (Host.account == identity.account_number)
         & (
             Host.canonical_facts.comparator.contains(canonical_facts)
-            | Host.canonical_facts.comparator.contained_by(canonical_facts)
+            | provided_canonical_facts_filter(canonical_facts)
         )
     )
     if restrict_to_owner_id:
@@ -135,11 +136,7 @@ def find_host_by_multiple_canonical_facts(identity, canonical_facts):
     """
     logger.debug("find_host_by_multiple_canonical_facts(%s)", canonical_facts)
 
-    host = multiple_canonical_facts_host_query(
-        identity,
-        {key: value for (key, value) in canonical_facts.items() if key not in ELEVATED_CANONICAL_FACT_FIELDS},
-        restrict_to_owner_id=False,
-    ).first()
+    host = multiple_canonical_facts_host_query(identity, canonical_facts, restrict_to_owner_id=False).first()
 
     if host:
         logger.debug("Found existing host using canonical_fact match: %s", host)
@@ -198,6 +195,19 @@ def stale_timestamp_filter(gt=None, lte=None):
         filter_ += (Host.stale_timestamp > gt,)
     if lte:
         filter_ += (Host.stale_timestamp <= lte,)
+    return and_(*filter_)
+
+
+def provided_canonical_facts_filter(canonical_facts):
+    filter_ = ()
+    for key, value in canonical_facts.items():
+        filter_ += (
+            or_(
+                not_(Host.canonical_facts.comparator.has_key(key)),  # noqa: W601
+                Host.canonical_facts.contains({key: value}),
+            ),
+        )
+
     return and_(*filter_)
 
 

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -135,7 +135,11 @@ def find_host_by_multiple_canonical_facts(identity, canonical_facts):
     """
     logger.debug("find_host_by_multiple_canonical_facts(%s)", canonical_facts)
 
-    host = multiple_canonical_facts_host_query(identity, canonical_facts, restrict_to_owner_id=False).first()
+    host = multiple_canonical_facts_host_query(
+        identity,
+        {key: value for (key, value) in canonical_facts.items() if key not in ELEVATED_CANONICAL_FACT_FIELDS},
+        restrict_to_owner_id=False,
+    ).first()
 
     if host:
         logger.debug("Found existing host using canonical_fact match: %s", host)

--- a/tests/helpers/db_utils.py
+++ b/tests/helpers/db_utils.py
@@ -105,6 +105,11 @@ def get_expected_facts_after_update(method, namespace, facts, new_facts):
     return facts
 
 
+def assert_host_missing_from_db(search_canonical_facts, identity=USER_IDENTITY):
+    identity = Identity(identity)
+    assert not find_existing_host(identity, search_canonical_facts)
+
+
 def assert_host_exists_in_db(host_id, search_canonical_facts, identity=USER_IDENTITY):
     identity = Identity(identity)
     found_host = find_existing_host(identity, search_canonical_facts)

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -862,7 +862,7 @@ def test_only_order_how(mq_create_three_specific_hosts, api_get, subtests):
 def test_get_hosts_only_insights(mq_create_three_specific_hosts, mq_create_or_update_host, api_get):
     created_hosts_with_insights_id = mq_create_three_specific_hosts
 
-    host_without_insights_id = minimal_host(subscription_manager_id=generate_uuid())
+    host_without_insights_id = minimal_host(subscription_manager_id=generate_uuid(), fqdn="different.fqdn.com")
     created_host_without_insights_id = mq_create_or_update_host(host_without_insights_id)
 
     url = build_hosts_url(query="?registered_with=insights")

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -1,6 +1,7 @@
 from pytest import mark
 
 from tests.helpers.db_utils import assert_host_exists_in_db
+from tests.helpers.db_utils import assert_host_missing_from_db
 from tests.helpers.db_utils import minimal_db_host
 from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import minimal_host
@@ -29,11 +30,25 @@ def test_find_host_using_superset_canonical_fact_match(db_create_host):
 
     host = minimal_db_host(canonical_facts=canonical_facts)
     created_host = db_create_host(host=host)
-
     assert_host_exists_in_db(created_host.id, superset_canonical_facts)
 
 
-def test_find_host_canonical_fact_match_different_elevated_ids(db_create_host):
+def test_find_host_canonical_fact_subset_match_different_elevated_ids(db_create_host):
+    base_canonical_facts = {"fqdn": "fred", "bios_uuid": generate_uuid()}
+
+    created_host_canonical_facts = base_canonical_facts.copy()
+    created_host_canonical_facts["insights_id"] = generate_uuid()
+
+    # Create the subset of canonical facts to search by
+    search_canonical_facts = {"fqdn": "fred"}
+    search_canonical_facts["subscription_manager_id"] = generate_uuid()
+
+    created_host = db_create_host(host=minimal_db_host(canonical_facts=created_host_canonical_facts))
+
+    assert_host_exists_in_db(created_host.id, search_canonical_facts)
+
+
+def test_find_host_canonical_fact_superset_match_different_elevated_ids(db_create_host):
     base_canonical_facts = {"fqdn": "fred", "bios_uuid": generate_uuid()}
 
     created_host_canonical_facts = base_canonical_facts.copy()
@@ -42,10 +57,20 @@ def test_find_host_canonical_fact_match_different_elevated_ids(db_create_host):
     # Create the superset of canonical facts to search by
     search_canonical_facts = base_canonical_facts.copy()
     search_canonical_facts["subscription_manager_id"] = generate_uuid()
+    search_canonical_facts["satellite_id"] = generate_uuid()
 
     created_host = db_create_host(host=minimal_db_host(canonical_facts=created_host_canonical_facts))
 
     assert_host_exists_in_db(created_host.id, search_canonical_facts)
+
+
+def test_no_merge_when_different_facts(db_create_host):
+    cf1 = {"fqdn": "fred", "bios_uuid": generate_uuid(), "insights_id": generate_uuid()}
+    cf2 = {"fqdn": "george", "bios_uuid": generate_uuid(), "subscription_manager_id": generate_uuid()}
+
+    db_create_host(host=minimal_db_host(canonical_facts=cf1))
+
+    assert_host_missing_from_db(cf2)
 
 
 def test_find_host_using_insights_id_match(db_create_host):

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -33,6 +33,21 @@ def test_find_host_using_superset_canonical_fact_match(db_create_host):
     assert_host_exists_in_db(created_host.id, superset_canonical_facts)
 
 
+def test_find_host_canonical_fact_match_different_elevated_ids(db_create_host):
+    base_canonical_facts = {"fqdn": "fred", "bios_uuid": generate_uuid()}
+
+    created_host_canonical_facts = base_canonical_facts.copy()
+    created_host_canonical_facts["insights_id"] = generate_uuid()
+
+    # Create the superset of canonical facts to search by
+    search_canonical_facts = base_canonical_facts.copy()
+    search_canonical_facts["subscription_manager_id"] = generate_uuid()
+
+    created_host = db_create_host(host=minimal_db_host(canonical_facts=created_host_canonical_facts))
+
+    assert_host_exists_in_db(created_host.id, search_canonical_facts)
+
+
 def test_find_host_using_insights_id_match(db_create_host):
     canonical_facts = {"fqdn": "fred", "bios_uuid": generate_uuid(), "insights_id": generate_uuid()}
 


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-773](https://issues.redhat.com/browse/ESSNTL-773).
Our contains/contained_by logic in our canonical-fact-based Host search was inadequate, and led to deduplication when the provided elevated ID wasn't the same type as what was in the DB (insights_id vs subscription_manager_id, for instance). This PR changes that logic so these types of records get merged, so long as they don't have conflicting canonical facts.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
