### PR TITLE
Fix data types for SUSPEND vars

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -290,7 +290,7 @@ objects:
     jobs:
     - name: reaper
       schedule: '@hourly'
-      suspend: ${REAPER_SUSPEND}
+      suspend: ${{REAPER_SUSPEND}}
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: Never
@@ -340,7 +340,7 @@ objects:
             memory: 256Mi
     - name: sp-validator
       schedule: '@hourly'
-      suspend: ${SP_VALIDATOR_SUSPEND}
+      suspend: ${{SP_VALIDATOR_SUSPEND}}
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: Never
@@ -410,7 +410,7 @@ objects:
             memory: 256Mi
     - name: pendo-syncher
       schedule: ${PENDO_CRON_SCHEDULE}
-      suspend: ${PENDO_SYNCHER_SUSPEND}
+      suspend: ${{PENDO_SYNCHER_SUSPEND}}
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: Never


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-959](https://issues.redhat.com/browse/ESSNTL-959).
It changes our SUSPEND variables to use `${{}}` instead of `${}`, which should coerce the data into the appropriate type (instead of leaving it as a string). This should fix the clowder deployment issue we're running into.

For reference, the latest build failure is [here](https://console-openshift-console.apps.app-sre-prod-01.i7w5.p1.openshiftapps.com/k8s/ns/crc-pipelines/tekton.dev~v1beta1~PipelineRun/host-inventory-clowder-insights-stage-202107222003).

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
