### PR TITLE
Build image forcing --no-cache use to pickup latest security fixes

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -18,7 +18,7 @@ export REGISTRY_AUTH_FILE="$AUTH_CONF_DIR/auth.json"
 
 podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-podman build -f Dockerfile -t "${IMAGE}:${IMAGE_TAG}" .
+podman build --no-cache -f Dockerfile -t "${IMAGE}:${IMAGE_TAG}" .
 podman push "${IMAGE}:${IMAGE_TAG}"
 
 # To enable backwards compatibility with ci, qa, and smoke, always push latest and qa tags


### PR DESCRIPTION
# Overview

This PR is being created to address [this Jira](https://issues.redhat.com/browse/ESSNTL-569).
Using `--no-cache` switch forces building image from scratch and picks all the new security patches applied to `registry.access.redhat.com/ubi8/python-38`

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
