### PR TITLE
Hotfix: Set PRS to {} if None or key doesn't exist

### DIFF
--- a/app/serialization.py
+++ b/app/serialization.py
@@ -75,7 +75,7 @@ def deserialize_host_xjoin(data):
         system_profile_facts=data["system_profile_facts"] or {},
         stale_timestamp=_deserialize_datetime(data["stale_timestamp"]),
         reporter=data["reporter"],
-        per_reporter_staleness=data["per_reporter_staleness"] or {},
+        per_reporter_staleness=data.get("per_reporter_staleness", {}) or {},
     )
     for field in ("created_on", "modified_on"):
         setattr(host, field, _deserialize_datetime(data[field]))


### PR DESCRIPTION
Should fix the error caused by xjoin not returning `per_reporter_staleness` data.