### PR TITLE
Host dedup logic fix

### DIFF
--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -73,8 +73,8 @@ def test_no_merge_when_no_match(mq_create_or_update_host):
         minimal_host(
             bios_uuid=generate_uuid(),
             satellite_id=generate_uuid(),
-            ansible_host="rhiqe.laptop-57.perez.org",
-            display_name="rhiqe.61ceb1ad-a4f9-4f97-9d60-6df238559676.lt-24.spencer.info",
+            ansible_host="testhost",
+            display_name="testdisplayname",
         )
     )
 

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -64,6 +64,23 @@ def test_find_host_canonical_fact_superset_match_different_elevated_ids(db_creat
     assert_host_exists_in_db(created_host.id, search_canonical_facts)
 
 
+def test_no_merge_when_no_match(mq_create_or_update_host):
+    wrapper = minimal_host(fqdn="test_fqdn", insights_id=generate_uuid())
+    del wrapper.ip_addresses
+    first_host = mq_create_or_update_host(wrapper)
+
+    second_host = mq_create_or_update_host(
+        minimal_host(
+            bios_uuid=generate_uuid(),
+            satellite_id=generate_uuid(),
+            ansible_host="rhiqe.laptop-57.perez.org",
+            display_name="rhiqe.61ceb1ad-a4f9-4f97-9d60-6df238559676.lt-24.spencer.info",
+        )
+    )
+
+    assert first_host.id != second_host.id
+
+
 def test_no_merge_when_different_facts(db_create_host):
     cf1 = {"fqdn": "fred", "bios_uuid": generate_uuid(), "insights_id": generate_uuid()}
     cf2 = {"fqdn": "george", "bios_uuid": generate_uuid(), "subscription_manager_id": generate_uuid()}


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-1059](https://issues.redhat.com/browse/ESSNTL-1059).
It further tweaks the dedup logic to be more precise. Once it's determined that it can't find the host by elevated ID, the basic logic will now match INPUT_HOST to EXISTING_HOST if:
- EXISTING_HOST is in the user's account, AND
- none of INPUT_HOST's canonical facts have different values than EXISTING_HOST's
- at least one of INPUT_HOST's canonical facts is the same on EXISTING_HOST

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
