### PR TITLE
De-duplication bugfix

### DIFF
--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -86,12 +86,22 @@ def find_existing_host_by_id(identity, host_id):
 def _find_host_by_elevated_ids(identity, canonical_facts):
     elevated_facts = {key: value for (key, value) in canonical_facts.items() if key in ELEVATED_CANONICAL_FACT_FIELDS}
     if elevated_facts:
-        existing_host = find_host_by_multiple_canonical_facts(identity, elevated_facts)
+        query = Host.query.filter(
+            (Host.account == identity.account_number) & (matches_at_least_one_canonical_fact_filter(canonical_facts))
+        )
+        query = update_query_for_owner_id(identity, query)
+        existing_host = find_non_culled_hosts(query).first()
+
         if existing_host:
-            for elevated_field in (key for key in elevated_facts if key in existing_host.canonical_facts):
+            for elevated_field in (
+                key for key in ELEVATED_CANONICAL_FACT_FIELDS if key in existing_host.canonical_facts
+            ):
+                # MUST be in the order defined in ELEVATED_CANONICAL_FACT_FIELDS
                 # If this value exists and differs on the host, it's not actually a match
-                if existing_host.canonical_facts.get(elevated_field) != canonical_facts[elevated_field]:
+                if existing_host.canonical_facts.get(elevated_field) != canonical_facts.get(elevated_field):
                     return None
+                else:
+                    break
 
             return existing_host
 

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -93,15 +93,13 @@ def _find_host_by_elevated_ids(identity, canonical_facts):
         existing_host = find_non_culled_hosts(query).first()
 
         if existing_host:
-            for elevated_field in (
-                key for key in ELEVATED_CANONICAL_FACT_FIELDS if key in existing_host.canonical_facts
-            ):
-                # MUST be in the order defined in ELEVATED_CANONICAL_FACT_FIELDS
-                # If this value exists and differs on the host, it's not actually a match
-                if existing_host.canonical_facts.get(elevated_field) != canonical_facts.get(elevated_field):
-                    return None
-                else:
-                    break
+            # If the highest-priority CF value exists and differs on the host, it's not actually a match
+            first_elevated_field = list(
+                {key: canonical_facts[key] for key in ELEVATED_CANONICAL_FACT_FIELDS if key in canonical_facts.keys()}
+            )[0]
+
+            if existing_host.canonical_facts.get(first_elevated_field) != canonical_facts.get(first_elevated_field):
+                return None
 
             return existing_host
 

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -105,13 +105,12 @@ def test_elevated_id_priority_order_match(db_create_host, changing_id):
         "subscription_manager_id": generate_uuid(),
     }
 
-    matching_host = db_create_host(host=minimal_db_host(canonical_facts=base_canonical_facts))
+    created_host = db_create_host(host=minimal_db_host(canonical_facts=base_canonical_facts))
 
-    nomatch_host_canonical_facts = base_canonical_facts.copy()
-    nomatch_host_canonical_facts[changing_id] = generate_uuid()
+    match_host_canonical_facts = base_canonical_facts.copy()
+    match_host_canonical_facts[changing_id] = generate_uuid()
 
-    assert_host_exists_in_db(matching_host.id, base_canonical_facts)
-    assert_host_missing_from_db(nomatch_host_canonical_facts)
+    assert_host_exists_in_db(created_host.id, match_host_canonical_facts)
 
 
 def test_no_merge_when_different_facts(db_create_host):


### PR DESCRIPTION
# Overview

This PR is being created to address a bug introduced by [ESSNTL-555](https://issues.redhat.com/browse/ESSNTL-555).
I messed up my original `test_elevated_id_priority_order_match` test, so I didn't realize the dedup logic was faulty. This PR fixes the test and the elevated-id dedup logic.

Here's the original PR that this one's trying to fix: https://github.com/RedHatInsights/insights-host-inventory/pull/978

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
