### PR TITLE
Fix rhsm-conduit dedup bug

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -69,7 +69,7 @@ def _get_identity(host, metadata):
     if metadata and "b64_identity" in metadata:
         identity = _decode_id(metadata["b64_identity"])
     else:
-        if host.get("reporter") == "rhsm-conduit":
+        if host.get("reporter") == "rhsm-conduit" and host.get("subscription_manager_id"):
             identity = deepcopy(SYSTEM_IDENTITY)
             identity["account_number"] = host.get("account")
             identity["system"]["cn"] = _formatted_uuid(host.get("subscription_manager_id"))

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -89,7 +89,6 @@ def _find_host_by_elevated_ids(identity, canonical_facts):
         query = Host.query.filter(
             (Host.account == identity.account_number) & (matches_at_least_one_canonical_fact_filter(canonical_facts))
         )
-        query = update_query_for_owner_id(identity, query)
         existing_host = find_non_culled_hosts(query).first()
 
         if existing_host:


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-1146](https://issues.redhat.com/browse/ESSNTL-1146).
One of my previous dedup changes introduced a bug specific to the rhsm-conduit reporter.  The PR that introduced this bug is here: https://github.com/RedHatInsights/insights-host-inventory/pull/983
This PR fixes the bug, which was caused by an incorrect call to `update_query_for_owner_id`. Because of how `owner_id` is set for rhsm-conduit hosts, HBI had not been finding matches.

I added a test for the exact scenario that was failing, because it was caused by our rhsm-specific workaround. I also made a minor change to `get_identity` to allow for better exception handling, because that threw me for a loop while debugging this. 

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
