### PR TITLE
Update per-reporter staleness schema to be more precise

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -982,6 +982,17 @@ components:
               description: >-
                 Reporting source of the last checkin status, stale_timestamp, and last_check_in.
               type: object
+              additionalProperties:
+                type: object
+                properties:
+                  last_check_in:
+                    type: string
+                    format: date-time
+                  stale_timestamp:
+                    type: string
+                    format: date-time
+                  check_in_succeeded:
+                    type: boolean
           required:
             - account
     HostOut:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1068,9 +1068,11 @@ components:
         last_check_in:
           type: string
           format: date-time
+          example: '2020-02-10T08:07:03.354307+00:00'
         stale_timestamp:
           type: string
           format: date-time
+          example: '2020-02-17T08:07:03.354307+00:00'
         check_in_succeeded:
           type: boolean
     ActiveTags:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -983,16 +983,7 @@ components:
                 Reporting source of the last checkin status, stale_timestamp, and last_check_in.
               type: object
               additionalProperties:
-                type: object
-                properties:
-                  last_check_in:
-                    type: string
-                    format: date-time
-                  stale_timestamp:
-                    type: string
-                    format: date-time
-                  check_in_succeeded:
-                    type: boolean
+                $ref: '#components/schemas/PerReporterStaleness'
           required:
             - account
     HostOut:
@@ -1091,7 +1082,17 @@ components:
             name.
           type: string
           example: host1.mydomain.com
-
+    PerReporterStaleness:
+      type: object
+      properties:
+        last_check_in:
+          type: string
+          format: date-time
+        stale_timestamp:
+          type: string
+          format: date-time
+        check_in_succeeded:
+          type: boolean
     ActiveTags:
       title: Host data
       type: object


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-1032](https://issues.redhat.com/browse/ESSNTL-1032).
It updates the API schema for the per-reporter staleness field to be more precise. Instead of just defining a general object, it specifies the dictionary structure along with the 3 fields in the "value" part of the key-value pair.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
