### PR TITLE
Dedup: Fix Elevated ID matching

### DIFF
--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -79,28 +79,26 @@ def find_existing_host(identity, canonical_facts):
 def find_existing_host_by_id(identity, host_id):
     query = Host.query.filter((Host.account == identity.account_number) & (Host.id == UUID(host_id)))
     query = update_query_for_owner_id(identity, query)
-    return find_non_culled_hosts(query).first()
+    return find_non_culled_hosts(query).order_by(Host.modified_on).first()
 
 
 @metrics.find_host_using_elevated_ids.time()
 def _find_host_by_elevated_ids(identity, canonical_facts):
-    elevated_facts = {key: value for (key, value) in canonical_facts.items() if key in ELEVATED_CANONICAL_FACT_FIELDS}
+    elevated_facts = {
+        key: canonical_facts[key] for key in ELEVATED_CANONICAL_FACT_FIELDS if key in canonical_facts.keys()
+    }
     if elevated_facts:
-        query = Host.query.filter(
-            (Host.account == identity.account_number) & (matches_at_least_one_canonical_fact_filter(canonical_facts))
-        )
-        existing_host = find_non_culled_hosts(query).first()
+        elevated_keys = [key for key in ELEVATED_CANONICAL_FACT_FIELDS if key in canonical_facts.keys()]
+        elevated_keys.reverse()
 
-        if existing_host:
-            # If the highest-priority CF value exists and differs on the host, it's not actually a match
-            first_elevated_field = list(
-                {key: canonical_facts[key] for key in ELEVATED_CANONICAL_FACT_FIELDS if key in canonical_facts.keys()}
-            )[0]
+        for del_key in elevated_keys:
+            existing_host = (
+                multiple_canonical_facts_host_query(identity, elevated_facts, False).order_by(Host.modified_on).first()
+            )
+            if existing_host:
+                return existing_host
 
-            if existing_host.canonical_facts.get(first_elevated_field) != canonical_facts.get(first_elevated_field):
-                return None
-
-            return existing_host
+            del elevated_facts[del_key]
 
     return None
 
@@ -131,7 +129,11 @@ def find_host_by_multiple_canonical_facts(identity, canonical_facts):
     """
     logger.debug("find_host_by_multiple_canonical_facts(%s)", canonical_facts)
 
-    host = multiple_canonical_facts_host_query(identity, canonical_facts, restrict_to_owner_id=False).first()
+    host = (
+        multiple_canonical_facts_host_query(identity, canonical_facts, restrict_to_owner_id=False)
+        .order_by(Host.modified_on)
+        .first()
+    )
 
     if host:
         logger.debug("Found existing host using canonical_fact match: %s", host)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -79,7 +79,7 @@ def find_existing_host(identity, canonical_facts):
 def find_existing_host_by_id(identity, host_id):
     query = Host.query.filter((Host.account == identity.account_number) & (Host.id == UUID(host_id)))
     query = update_query_for_owner_id(identity, query)
-    return find_non_culled_hosts(query).order_by(Host.modified_on).first()
+    return find_non_culled_hosts(query).order_by(Host.modified_on.desc()).first()
 
 
 @metrics.find_host_using_elevated_ids.time()
@@ -93,7 +93,9 @@ def _find_host_by_elevated_ids(identity, canonical_facts):
 
         for del_key in elevated_keys:
             existing_host = (
-                multiple_canonical_facts_host_query(identity, elevated_facts, False).order_by(Host.modified_on).first()
+                multiple_canonical_facts_host_query(identity, elevated_facts, False)
+                .order_by(Host.modified_on.desc())
+                .first()
             )
             if existing_host:
                 return existing_host
@@ -131,7 +133,7 @@ def find_host_by_multiple_canonical_facts(identity, canonical_facts):
 
     host = (
         multiple_canonical_facts_host_query(identity, canonical_facts, restrict_to_owner_id=False)
-        .order_by(Host.modified_on)
+        .order_by(Host.modified_on.desc())
         .first()
     )
 

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -65,6 +65,17 @@ def test_find_host_canonical_fact_superset_match_different_elevated_ids(db_creat
     assert_host_exists_in_db(created_host.id, search_canonical_facts)
 
 
+def test_find_correct_host_when_similar_canonical_facts(db_create_host):
+    cf1 = {"fqdn": "fred", "bios_uuid": generate_uuid(), "insights_id": generate_uuid()}
+    cf2 = {"fqdn": "george", "bios_uuid": generate_uuid(), "insights_id": generate_uuid()}
+    cf3 = {"fqdn": cf1["fqdn"], "bios_uuid": cf1["bios_uuid"], "insights_id": cf2["insights_id"]}
+
+    db_create_host(host=minimal_db_host(canonical_facts=cf1))
+    created_host_2 = db_create_host(host=minimal_db_host(canonical_facts=cf2))
+
+    assert_host_exists_in_db(created_host_2.id, cf3)
+
+
 def test_no_merge_when_no_match(mq_create_or_update_host):
     wrapper = minimal_host(fqdn="test_fqdn", insights_id=generate_uuid())
     del wrapper.ip_addresses


### PR DESCRIPTION
# Overview

This PR is being created to fix the issue created by our latest Prod deploy. The PRs that led to this issue are #978 and #983.
This changes the elevated ID search so that it explicitly looks for the best possible match. It first searches for a record that matches all 3 of its elevated IDs, if applicable, and then searches with 2, then just 1. It also adds ordering to these searches, so it always gets the most recent record.

Finally, I added a test which reproduces what we saw in Prod. The issue was that it was finding a basic canonical fact match with a different host, but then rejecting that record because the highest-prio elevated IDs didn't match. 

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
