### PR TITLE
remove left over external id from api.spec

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -802,13 +802,6 @@ components:
         type: string
       example:
       - 'c2:00:d0:c8:61:01'
-    ExternalId:
-      description: >-
-        Host’s reference in the external source e.g. AWS EC2, Azure,
-        OpenStack, etc. This field is considered to be a canonical fact.
-      type: string
-      nullable: true
-      example: i-05d2313e6b9a42b16
     ProviderId:
       description: >-
         Host’s reference in the external source e.g. Alibaba, AWS EC2, Azure,


### PR DESCRIPTION
# Overview

This PR removes the "ExternalId" spec from the api.spec which didn't get cleaned.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
