### PR TITLE
Prevent Reaper from deleting Edge hosts

### DIFF
--- a/host_reaper.py
+++ b/host_reaper.py
@@ -24,6 +24,7 @@ from lib.db import session_guard
 from lib.handlers import register_shutdown
 from lib.handlers import ShutdownHandler
 from lib.host_delete import delete_hosts
+from lib.host_repository import exclude_edge_filter
 from lib.host_repository import stale_timestamp_filter
 from lib.metrics import delete_host_count
 from lib.metrics import delete_host_processing_time
@@ -66,8 +67,7 @@ def _excepthook(logger, type, value, traceback):
 @host_reaper_fail_count.count_exceptions()
 def run(config, logger, session, event_producer, shutdown_handler):
     conditions = Conditions.from_config(config)
-    query_filter = stale_timestamp_filter(*conditions.culled())
-
+    query_filter = exclude_edge_filter(stale_timestamp_filter(*conditions.culled()))
     query = session.query(Host).filter(query_filter)
 
     events = delete_hosts(query, event_producer, config.host_delete_chunk_size, shutdown_handler.shut_down)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -197,6 +197,18 @@ def stale_timestamp_filter(gt=None, lte=None):
     return and_(*filter_)
 
 
+def exclude_edge_filter(query):
+    return and_(
+        query,
+        (
+            or_(
+                not_(Host.system_profile_facts.has_key("host_type")),  # noqa: W601 JSONB query filter, not a dict
+                Host.system_profile_facts["host_type"].as_string() != "edge",
+            )
+        ),
+    )
+
+
 def contains_no_incorrect_facts_filter(canonical_facts):
     # Does not contain any incorrect CF values
     # Incorrect value = AND( key exists, NOT( contains key:value ) )


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-1237](https://issues.redhat.com/browse/ESSNTL-1237).
Puts an additional filter on Reaper's query so that it excludes Edge hosts. All functionality remains the same, except that hosts with `host.system_profile_facts.host_type = "edge"` are excluded from the query, meaning they don't get deleted.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
