### PR TITLE
Fix job name

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -497,7 +497,7 @@ objects:
           requests:
             cpu: 200m
             memory: 256Mi
-    - name: duplicate_hosts_remover
+    - name: duplicate-hosts-remover
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: OnFailure

--- a/host_delete_duplicates.py
+++ b/host_delete_duplicates.py
@@ -21,8 +21,8 @@ from lib.metrics import delete_duplicate_host_count
 
 __all__ = ("main", "run")
 
-PROMETHEUS_JOB = "duplicate_hosts_remover"
-LOGGER_NAME = "duplicate_hosts_remover"
+PROMETHEUS_JOB = "duplicate-hosts-remover"
+LOGGER_NAME = "duplicate-hosts-remover"
 COLLECTED_METRICS = (delete_duplicate_host_count,)
 RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
 

--- a/utils/duplicate_remover_clowd_job_invocation.yaml
+++ b/utils/duplicate_remover_clowd_job_invocation.yaml
@@ -12,4 +12,4 @@ metadata:
 spec:
   appName: host-inventory
   jobs:
-    - duplicate_hosts_remover
+    - duplicate-hosts-remover


### PR DESCRIPTION
This PR fixes the duplicate-hosts-remover job name, which currently has underscores (which aren't allowed).