### PR TITLE
Dedup: Use List instead of Set

### DIFF
--- a/tests/test_duplicate_hosts.py
+++ b/tests/test_duplicate_hosts.py
@@ -26,8 +26,6 @@ logger = get_logger(__name__)
 
 @pytest.mark.host_delete_duplicates
 def test_delete_duplicate_host(event_producer_mock, db_create_host, db_get_host, inventory_config):
-    print("reunning sdas")
-
     # make two hosts that are the same
     canonical_facts = {
         "provider_type": ProviderType.AWS,  # Doesn't matter


### PR DESCRIPTION
# Overview

This PR just changes the duplicate-delete script to use List instead of Set. While Set is faster at identifying whether it already contains a value or not, it uses much more memory when storing a large number of values. List and Deque use similar amounts of memory, but List is faster at checking whether it contains an element. I'm still investigating using Trie in Python, since the implementations I've seen don't appear to have much if any improvement over List, as far as memory/speed

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
