### PR TITLE
Event rebuilder fix

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -159,6 +159,7 @@ class Config:
                 os.environ.get("KAFKA_CONSUMER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION", "5")
             ),
             "enable_auto_commit": False,
+            "auto_offset_reset": "earliest",
             "max_poll_records": int(os.environ.get("KAFKA_CONSUMER_MAX_POLL_RECORDS", "10000")),
             "max_poll_interval_ms": int(os.environ.get("KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS", "300000")),
             "session_timeout_ms": int(os.environ.get("KAFKA_CONSUMER_SESSION_TIMEOUT_MS", "10000")),

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -102,7 +102,7 @@ def main(logger):
     shutdown_handler.register()
 
     with session_guard(session):
-        run(config, logger, session, event_producer, shutdown_handler)
+        run(config, logger, session, consumer, event_producer, shutdown_handler)
 
 
 if __name__ == "__main__":

--- a/tests/test_event_rebuilder.py
+++ b/tests/test_event_rebuilder.py
@@ -27,7 +27,6 @@ def test_no_delete_when_hosts_present(mocker, db_create_host, inventory_config):
     consumer_mock = create_kafka_consumer_mock(mocker, inventory_config, 1, 0, 1, event_list)
 
     rebuild_events_run(
-        inventory_config,
         mock.Mock(),
         db.session,
         consumer_mock,
@@ -65,7 +64,6 @@ def test_creates_delete_event_when_missing_from_db(
     consumer_mock = create_kafka_consumer_mock(mocker, inventory_config, 1, 0, 1, event_list)
 
     rebuild_events_run(
-        inventory_config,
         mock.Mock(),
         db.session,
         consumer_mock,


### PR DESCRIPTION
Changes the `run()` call to use the correct number of arguments, and simplifies KafkaConsumer's implementation (regarding partitions, specifically)