### PR TITLE
[task] Add xjoin-search dependency for clowder

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -13,6 +13,7 @@ objects:
       iqePlugin: host-inventory
     optionalDependencies:
     - rbac
+    - xjoin-search
     deployments:
     - name: service
       minReplicas: ${{REPLICAS_SVC}}


### PR DESCRIPTION
Tests involving inventory all fail if xjoin-search isn't available.
Looks to be an issue with inventory calling for xjoin by default now. if
the pod isn't there, then HBI returns a 500.

Signed-off-by: Stephen Adams <tsadams@gmail.com>

# Overview

This PR is being created to address [ESSNTL-xxxx](https://issues.redhat.com/browse/ESSNTL-xxxx).
(A description of your PR's changes, along with why/context to the PR, goes here.)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
