### PR TITLE
Add ingress as an optional dependency

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -14,6 +14,7 @@ objects:
     optionalDependencies:
     - rbac
     - xjoin-search
+    - ingress
     deployments:
     - name: service
       minReplicas: ${{REPLICAS_SVC}}


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-1617](https://issues.redhat.com/browse/ESSNTL-1617).

This PR adds ingress as an optional dependency to HBI clowder deployment.
This is needed by the IQE smoke tests to be able to do better end-to-end testing.
The [PR-1026](https://github.com/RedHatInsights/insights-host-inventory/pull/1026) is blocked on this, because the PR check is failing there because of this.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
