### PR TITLE
Allow sorting by operating_system

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -56,7 +56,7 @@ ORDER_BY_MAPPING = {
     "display_name": "display_name",
     "operating_system": "operating_system",
 }
-ORDER_HOW_MAPPING = {"modified_on": "DESC", "display_name": "ASC", "operating_system": "ASC"}
+ORDER_HOW_MAPPING = {"modified_on": "DESC", "display_name": "ASC", "operating_system": "DESC"}
 
 
 def get_host_list(

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -50,8 +50,13 @@ QUERY = """query Query(
         }
     }
 }"""
-ORDER_BY_MAPPING = {None: "modified_on", "updated": "modified_on", "display_name": "display_name"}
-ORDER_HOW_MAPPING = {"modified_on": "DESC", "display_name": "ASC"}
+ORDER_BY_MAPPING = {
+    None: "modified_on",
+    "updated": "modified_on",
+    "display_name": "display_name",
+    "operating_system": "operating_system",
+}
+ORDER_HOW_MAPPING = {"modified_on": "DESC", "display_name": "ASC", "operating_system": "ASC"}
 
 
 def get_host_list(

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -52,7 +52,6 @@ QUERY = """query Query(
 }"""
 ORDER_BY_MAPPING = {None: "modified_on", "updated": "modified_on", "display_name": "display_name"}
 ORDER_HOW_MAPPING = {"modified_on": "DESC", "display_name": "ASC"}
-SUPPORTED_RANGE_OPERATIONS = ["gt", "gte", "lt", "lte"]
 
 
 def get_host_list(

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -538,6 +538,7 @@ components:
         enum:
           - display_name
           - updated
+          - operating_system
       description: Ordering field name
     orderHowParam:
       name: order_how

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -891,7 +891,8 @@
           "type": "string",
           "enum": [
             "display_name",
-            "updated"
+            "updated",
+            "operating_system"
           ]
         },
         "description": "Ordering field name"

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -453,7 +453,7 @@ def test_query_variables_ordering_dir(direction, mocker, query_source_xjoin, gra
     (
         ("updated", "modified_on", "DESC"),
         ("display_name", "display_name", "ASC"),
-        ("operating_system", "operating_system", "ASC"),
+        ("operating_system", "operating_system", "DESC"),
     ),
 )
 def test_query_variables_ordering_by(

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -450,7 +450,11 @@ def test_query_variables_ordering_dir(direction, mocker, query_source_xjoin, gra
 
 @pytest.mark.parametrize(
     "params_order_by,xjoin_order_by,default_xjoin_order_how",
-    (("updated", "modified_on", "DESC"), ("display_name", "display_name", "ASC")),
+    (
+        ("updated", "modified_on", "DESC"),
+        ("display_name", "display_name", "ASC"),
+        ("operating_system", "operating_system", "ASC"),
+    ),
 )
 def test_query_variables_ordering_by(
     params_order_by,


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-1440](https://issues.redhat.com/browse/ESSNTL-1440).
This is the change required to support the work done in this [xjoin PR](https://github.com/RedHatInsights/xjoin-search/pull/123). Allows the user to sort by the `operating_system` field.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
