### PR TITLE
Temporarily pin the ubi8 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-38
+FROM registry.access.redhat.com/ubi8/python-38:1-74
 
 USER root
 


### PR DESCRIPTION
# Overview

This PR is being created to address the issue discussed in [this Slack thread](https://coreos.slack.com/archives/CCRND57FW/p1637087808474000). They don't know how to fix the issue on their end yet, so they're recommending we pin our UBI8 version until they get it resolved.

After this gets merged, I'll create a follow-up PR to revert this change, which will be placed on hold until the issue is fixed.
