### PR TITLE
Revert "Temporarily pin the ubi8 version"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-38:1-74
+FROM registry.access.redhat.com/ubi8/python-38
 
 USER root
 


### PR DESCRIPTION
Reverts RedHatInsights/insights-host-inventory#1036. On hold until the issue described in [this Slack thread](https://coreos.slack.com/archives/CCRND57FW/p1637087808474000) is resolved.