### PR TITLE
Remove redundant spec parsing

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -146,7 +146,6 @@ def create_app(runtime_environment):
     connexion_app = connexion.App("inventory", specification_dir="./swagger/", options=connexion_options)
 
     parser = TranslatingParser(SPECIFICATION_FILE)
-    parser.parse()
     for api_url in app_config.api_urls:
         if api_url:
             connexion_app.add_api(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -24,6 +24,7 @@ from api.host_query_db import _order_how
 from api.host_query_db import params_to_order_by
 from api.parsing import custom_fields_parser
 from app import create_app
+from app import SPECIFICATION_FILE
 from app.auth.identity import from_auth_header
 from app.auth.identity import from_bearer_token
 from app.auth.identity import Identity
@@ -418,6 +419,29 @@ class CreateAppConfigTestCase(TestCase):
         app = create_app(RuntimeEnvironment.TEST)
         self.assertIn("INVENTORY_CONFIG", app.config)
         self.assertEqual(config.return_value, app.config["INVENTORY_CONFIG"])
+
+
+@patch("app.connexion.App")
+@patch("app.db.get_engine")
+class CreateAppConnexionAppInitTestCase(TestCase):
+    @patch("app.TranslatingParser")
+    def test_specification_is_provided(self, translating_parser, get_engine, app):
+        create_app(RuntimeEnvironment.TEST)
+
+        translating_parser.assert_called_once_with(SPECIFICATION_FILE)
+        assert "lazy" not in translating_parser.mock_calls[0].kwargs
+
+        app.return_value.add_api.assert_called_once()
+        args = app.return_value.add_api.mock_calls[0].args
+        assert len(args) == 1
+        assert args[0] is translating_parser.return_value.specification
+
+    def test_specification_is_parsed(self, get_engine, app):
+        create_app(RuntimeEnvironment.TEST)
+        app.return_value.add_api.assert_called_once()
+        args = app.return_value.add_api.mock_calls[0].args
+        assert len(args) == 1
+        assert args[0] is not None
 
 
 class HostOrderHowTestCase(TestCase):


### PR DESCRIPTION
# Overview

_TranslatingParser_ does parsing automatically on initialization. Calling it again manually is not only unnecessary, but also inefficient. Removed the call from the _create_app_ function.

Loading, parsing and validating the specification is one of the heavier steps in the app initialization process. Doing it once instead of twice should measurably improve its boot time.

Does not relate to any JIRA ticket. This is a part of my Hackathon work on the Prance library.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
