### PR TITLE
Add Rich Oliveri to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners
-* @kruai @ryandillinfelton @thearifismail
+* @kruai @ryandillinfelton @thearifismail @roliveri


### PR DESCRIPTION
This PR adds @roliveri to CODEOWNERS, so that he'll automatically get added as a PR reviewer.