### PR TITLE
Fix CJIs in template

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -80,8 +80,8 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 200m
-            memory: 256Mi
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -168,8 +168,8 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 200m
-            memory: 256Mi
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
     - name: mq-p1
       minReplicas: ${{REPLICAS_P1}}
       podSpec:
@@ -233,8 +233,8 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 200m
-            memory: 256Mi
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
     - name: mq-sp
       minReplicas: ${{REPLICAS_SP}}
       podSpec:
@@ -292,8 +292,8 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 200m
-            memory: 256Mi
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
     jobs:
     - name: reaper
       schedule: '@hourly'
@@ -343,8 +343,8 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 200m
-            memory: 256Mi
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
     - name: sp-validator
       schedule: '@hourly'
       suspend: ${{SP_VALIDATOR_SUSPEND}}
@@ -413,8 +413,8 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 200m
-            memory: 256Mi
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
     - name: pendo-syncher
       schedule: ${PENDO_CRON_SCHEDULE}
       suspend: ${{PENDO_SYNCHER_SUSPEND}}
@@ -452,8 +452,8 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 200m
-            memory: 256Mi
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
     - name: synchronizer
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
@@ -500,8 +500,8 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 200m
-            memory: 256Mi
+            cpu: ${CPU_REQUEST}
+            memory: ${MEMORY_REQUEST}
     - name: events-topic-rebuilder
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
@@ -548,7 +548,7 @@ objects:
             cpu: ${CPU_LIMIT}
             memory: ${MEMORY_LIMIT}
           requests:
-            cpu: 200m
+            cpu: ${CPU_REQUEST}
             memory: ${MEMORY_REQUEST}
     - name: floorist
       schedule: ${FLOORIST_SCHEDULE}
@@ -664,6 +664,8 @@ objects:
 parameters:
 - name: LOG_LEVEL
   value: INFO
+- descrpition: Cpu request of service
+  value: 200m
 - description: Cpu limit of service
   name: CPU_LIMIT
   value: 500m

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -617,14 +617,6 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    name: duplicate-hosts-remover-${CJI_RANDOM_SUFFIX}
-  spec:
-    appName: host-inventory
-    jobs:
-      - duplicate-hosts-remover
-- apiVersion: cloud.redhat.com/v1alpha1
-  kind: ClowdJobInvocation
-  metadata:
     name: events-topic-rebuilder-${CJI_RANDOM_SUFFIX}
   spec:
     appName: host-inventory
@@ -675,9 +667,6 @@ parameters:
 - description: request limit for service
   name: MEMORY_REQUEST
   value: 256Mi
-- description: memory limit for dedup job
-  name: DEDUP_MEMORY_LIMIT
-  value: 1Gi
 - description: Replica count for p1 consumer
   name: REPLICAS_P1
   value: "5"

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -657,6 +657,7 @@ parameters:
 - name: LOG_LEVEL
   value: INFO
 - descrpition: Cpu request of service
+  name: CPU_REQUEST
   value: 200m
 - description: Cpu limit of service
   name: CPU_LIMIT


### PR DESCRIPTION
There are two CJIs which fail to run correctly when this template is deployed

One fails due to a bad cpu request/limit ratio:
```
  Warning  FailedCreate  9m1s   job-controller  Error creating: pods "host-inventory-events-topic-rebuilder-3n4ep5b--1-7pmj8" is forbidden: memory max limit to request ratio per Pod is 2, but provided ratio is 8.000000
```
so I am changing the template to use the CPU_REQUEST/MEMORY_REQUEST parameter everywhere. The values seemed to be set to `200m` and `256Mi` everywhere, which should still be the case since that will match the default values of the parameters.


The other fails because no 'job' exists on the ClowdApp anymore:
```
  Conditions:
    Last Transition Time:  2021-12-14T18:22:50Z
    Message:               Some Jobs are still incomplete
    Reason:                No such job duplicate-hosts-remover
    Status:                False
    Type:                  JobInvocationComplete
```
so I've removed this CJI from the template
