### PR TITLE
remove cji for non-existent duplicate-hosts-remover job

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -617,14 +617,6 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    name: duplicate-hosts-remover-${CJI_RANDOM_SUFFIX}
-  spec:
-    appName: host-inventory
-    jobs:
-      - duplicate-hosts-remover
-- apiVersion: cloud.redhat.com/v1alpha1
-  kind: ClowdJobInvocation
-  metadata:
     name: events-topic-rebuilder-${CJI_RANDOM_SUFFIX}
   spec:
     appName: host-inventory


### PR DESCRIPTION
# Overview

This PR removes a ClowdJobInvocation for duplicate-hosts-inventory job which does not existent.  This should stop rolling out of pod to run it as a manual job.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
