### PR TITLE
Change reaper memory request

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -344,7 +344,7 @@ objects:
             memory: ${MEMORY_LIMIT_REAPER}
           requests:
             cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
+            memory: ${MEMORY_REQUEST_REAPER}
     - name: sp-validator
       schedule: '@hourly'
       suspend: ${{SP_VALIDATOR_SUSPEND}}
@@ -670,6 +670,9 @@ parameters:
   value: 512Mi
 - description: request limit for service
   name: MEMORY_REQUEST
+  value: 256Mi
+- description: request limit for reaper
+  name: MEMORY_REQUEST_REAPER
   value: 256Mi
 - description: Replica count for p1 consumer
   name: REPLICAS_P1


### PR DESCRIPTION
# Overview

Use separate variable for setting memory request for reaper instead of using the same request as for the service.
This is a followup to [PR1048](https://github.com/RedHatInsights/insights-host-inventory/pull/1048) and [PR1050](https://github.com/RedHatInsights/insights-host-inventory/pull/1050). Since we use a separate variable for reaper memory limit, we should also use a separate variable for reaper memory request.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
