### PR TITLE
Unpin version and disable beta RPMs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM registry.access.redhat.com/ubi8/python-38:1-74
+FROM registry.access.redhat.com/ubi8/python-38
 
 USER root
 
+RUN dnf config-manager --disable rhel-8-for-x86_64-baseos-beta-rpms rhel-8-for-x86_64-appstream-beta-rpms
 RUN dnf module install -y postgresql:13
 
 # remove packages not used by host-inventory to avoid security vulnerabilityes


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-1961](https://issues.redhat.com/browse/ESSNTL-1961), which progresses work on the issue discussed in this [Slack thread](https://coreos.slack.com/archives/CCRND57FW/p1637087808474000). It unpins the UBI8 version, and disables a couple of beta RPM repos. 

The issues we saw were caused by newer versions of the UBI8 image using Beta RPM repos, which subscription-manager did not like.
