### PR TITLE
essntl-1913: Re-add filtered host-deletion endpoint

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -10,7 +10,7 @@ from app.xjoin import graphql_query
 from app.xjoin import pagination_params
 from app.xjoin import params_to_order
 
-__all__ = ("get_host_list", "query_filters")
+__all__ = ("get_host_list", "get_host_ids_list", "query_filters")
 
 logger = get_logger(__name__)
 
@@ -48,6 +48,23 @@ QUERY = """query Query(
             stale_timestamp,
             reporter,
             system_profile_facts (filter: $fields),
+        }
+    }
+}"""
+HOST_IDS_QUERY = """query Query(
+    $filter: [HostFilter!],
+) {
+    hosts(
+        filter: {
+            AND: $filter,
+        }
+    ) {
+        meta {
+            total,
+        }
+        data {
+            id,
+            canonical_facts
         }
     }
 }"""
@@ -111,6 +128,41 @@ def get_host_list(
     check_pagination(offset, total)
 
     return map(deserialize_host, response["data"]), total, additional_fields
+
+
+def get_host_ids_list(
+    display_name,
+    fqdn,
+    hostname_or_id,
+    insights_id,
+    provider_id,
+    provider_type,
+    registered_with,
+    staleness,
+    tags,
+    filter,
+):
+    all_filters = query_filters(
+        fqdn,
+        display_name,
+        hostname_or_id,
+        insights_id,
+        provider_id,
+        provider_type,
+        tags,
+        staleness,
+        registered_with,
+        filter,
+    )
+
+    current_identity = get_current_identity()
+    if current_identity.identity_type == IdentityType.SYSTEM and current_identity.auth_type != AuthType.CLASSIC:
+        all_filters += owner_id_filter()
+
+    variables = {"filter": all_filters}
+    response = graphql_query(HOST_IDS_QUERY, variables, log_get_host_list_failed)["hosts"]
+
+    return [x["id"] for x in response["data"]]
 
 
 def owner_id_filter():

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -41,6 +41,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HostQueryOutput'
+    delete:
+      operationId: api.host.delete_host_list
+      tags:
+        - hosts
+      summary: Delete the entire list of hosts filtered by the given parameters
+      description: >-
+        Delete the entire list of hosts filtered by the given parameters.
+        <br /><br />
+        Required permissions: inventory:hosts:write
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/displayName'
+        - $ref: '#/components/parameters/fqdn'
+        - $ref: '#/components/parameters/hostnameOrId'
+        - $ref: '#/components/parameters/insightsId'
+        - $ref: '#/components/parameters/providerId'
+        - $ref: '#/components/parameters/providerType'
+        - $ref: '#/components/parameters/registered_with'
+        - $ref: '#/components/parameters/stalenessParam'
+        - $ref: '#/components/parameters/tagsParam'
+        - $ref: '#/components/parameters/filter_param'
+      responses:
+        '202':
+          description: Request for deletion of filtered hosts has been accepted.
+        '400':
+          description: Invalid request.
   /hosts/checkin:
     post:
       operationId: api.host.host_checkin

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -81,6 +81,59 @@
             }
           }
         }
+      },
+      "delete": {
+        "operationId": "api.host.delete_host_list",
+        "tags": [
+          "hosts"
+        ],
+        "summary": "Delete the entire list of hosts filtered by the given parameters",
+        "description": "Delete the entire list of hosts filtered by the given parameters. <br /><br /> Required permissions: inventory:hosts:write",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/displayName"
+          },
+          {
+            "$ref": "#/components/parameters/fqdn"
+          },
+          {
+            "$ref": "#/components/parameters/hostnameOrId"
+          },
+          {
+            "$ref": "#/components/parameters/insightsId"
+          },
+          {
+            "$ref": "#/components/parameters/providerId"
+          },
+          {
+            "$ref": "#/components/parameters/providerType"
+          },
+          {
+            "$ref": "#/components/parameters/registered_with"
+          },
+          {
+            "$ref": "#/components/parameters/stalenessParam"
+          },
+          {
+            "$ref": "#/components/parameters/tagsParam"
+          },
+          {
+            "$ref": "#/components/parameters/filter_param"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Request for deletion of filtered hosts has been accepted."
+          },
+          "400": {
+            "description": "Invalid request."
+          }
+        }
       }
     },
     "/hosts/checkin": {

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -57,6 +57,16 @@ def api_delete_host(flask_client):
 
 
 @pytest.fixture(scope="function")
+def api_delete_filtered_hosts(flask_client):
+    def _api_delete_filtered_hosts(query_parameters, identity=USER_IDENTITY, extra_headers=None):
+        return do_request(
+            flask_client.delete, HOST_URL, identity, query_parameters=query_parameters, extra_headers=extra_headers
+        )
+
+    return _api_delete_filtered_hosts
+
+
+@pytest.fixture(scope="function")
 def enable_rbac(inventory_config):
     inventory_config.bypass_rbac = False
 

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -11,6 +11,31 @@ SYSTEM_PROFILE_SAP_SIDS_EMPTY_RESPONSE = {
     "hostSystemProfile": {"sap_sids": {"meta": {"total": 0, "count": 0}, "data": []}}
 }
 
+XJOIN_HOSTS_RESPONSE_FOR_FILTERING = {
+    "hosts": {
+        "meta": {"total": 3},
+        "data": [
+            {
+                "id": "6e7b6317-0a2d-4552-a2f2-b7da0aece49d",
+                "canonical_facts": {
+                    "fqdn": "fqdn.test01.rhel7.jharting.local",
+                    "satellite_id": "ce87bfac-a6cb-43a0-80ce-95d9669db71f",
+                    "insights_id": "a58c53e0-8000-4384-b902-c70b69faacc5",
+                },
+            },
+            {
+                "id": "22cd8e39-13bb-4d02-8316-84b850dc5136",
+                "canonical_facts": {
+                    "fqdn": "fqdn.test02.rhel7.jharting.local",
+                    "satellite_id": "ce87bfac-a6cb-43a0-80ce-95d9669db71f",
+                    "insights_id": "17c52679-f0b9-4e9b-9bac-a3c7fae5070c",
+                },
+            },
+            {"id": "22cd8e39-13bb-4d02-8316-84b850dc5136", "canonical_facts": {"fqdn": "test03.rhel7.fqdn"}},
+        ],
+    }
+}
+
 XJOIN_HOSTS_RESPONSE = {
     "hosts": {
         "meta": {"total": 2},

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from unittest import mock
 
 import pytest
@@ -11,6 +12,7 @@ from tests.helpers.api_utils import create_mock_rbac_response
 from tests.helpers.api_utils import WRITE_ALLOWED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import WRITE_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.db_utils import db_host
+from tests.helpers.graphql_utils import XJOIN_HOSTS_RESPONSE_FOR_FILTERING
 from tests.helpers.mq_utils import assert_delete_event_is_valid
 from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import SYSTEM_IDENTITY
@@ -100,6 +102,45 @@ def test_create_then_delete_without_insights_id(
     assert_response_status(response_status, expected_status=200)
 
     assert_delete_event_is_valid(event_producer=event_producer_mock, host=host, timestamp=event_datetime_mock)
+
+
+def test_delete_hosts_using_filter(
+    event_producer_mock, db_create_multiple_hosts, db_get_hosts, api_delete_filtered_hosts, patch_xjoin_post
+):
+
+    created_hosts = db_create_multiple_hosts(how_many=len(XJOIN_HOSTS_RESPONSE_FOR_FILTERING["hosts"]["data"]))
+    host_ids = [str(host.id) for host in created_hosts]
+
+    # set the new host ids in the xjoin search reference.
+    resp = deepcopy(XJOIN_HOSTS_RESPONSE_FOR_FILTERING)
+    ind = 0
+    for id in host_ids:
+        resp["hosts"]["data"][ind]["id"] = id
+        ind += 1
+    response = {"data": resp}
+
+    # Make the new hosts available in xjoin-search to make them available
+    # for querying for deletion using filters
+    patch_xjoin_post(response, status=200)
+
+    new_hosts = db_create_multiple_hosts()
+    new_ids = [str(host.id) for host in new_hosts]
+
+    # delete hosts using the IDs supposedly returned by the query_filter
+    response_status, response_data = api_delete_filtered_hosts({"insights_id": "a58c53e0-8000-4384-b902-c70b69faacc5"})
+
+    assert '"type": "delete"' in event_producer_mock.event
+    assert_response_status(response_status, expected_status=202)
+    assert len(host_ids) == response_data["hosts_deleted"]
+
+    # check db for the deleted hosts using their IDs
+    host_id_list = [str(host.id) for host in created_hosts]
+    deleted_hosts = db_get_hosts(host_id_list)
+    assert deleted_hosts.count() == 0
+
+    # now verify that the second set of hosts still available.
+    remaining_hosts = db_get_hosts(new_ids)
+    assert len(new_hosts) == remaining_hosts.count()
 
 
 def test_create_then_delete_check_metadata(event_datetime_mock, event_producer_mock, db_create_host, api_delete_host):


### PR DESCRIPTION
Reverts RedHatInsights/insights-host-inventory#1055

It implements [ESSNTL-1913](https://issues.redhat.com/browse/ESSNTL-1913)