### PR TITLE
Update docs links

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -3,6 +3,6 @@ date: 2021-06-09 0:30:00.997996
 title: Host-Inventory
 ---
 
-The Host-Inventory documentation has been moved to clouddot.pages.redhat.com.
-You can view the new documentation [on the new site](https://clouddot.pages.redhat.com/docs/dev/services/inventory.html),
-or contribute [to the repo](https://gitlab.cee.redhat.com/clouddot/clouddot.pages.redhat.com/-/blob/main/modules/services/pages/inventory.adoc).
+The Host-Inventory documentation has been moved to consoledot.pages.redhat.com.
+You can view the new documentation [on the new site](https://consoledot.pages.redhat.com/docs/dev/services/inventory.html),
+or contribute [to the repo](https://gitlab.cee.redhat.com/consoledot/consoledot.pages.redhat.com/-/blob/main/modules/services/pages/inventory.adoc).


### PR DESCRIPTION
# Overview

This PR simply updates the links in our docs folder to point to the updated docs repo (consoledot.pages.redhat.com).