### PR TITLE
Fix 500 when using system profile filter on integer fields

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -34,6 +34,18 @@ def _boolean_filter(field_name, field_value, spec=None):
     return ({field_name: {"is": (field_value.lower() == "true")}},)
 
 
+def _integer_filter(field_name, field_value, spec=None):
+    # The "spec" param is defined but unused,
+    # because this is called from the BUILDER_FUNCTIONS enum.
+    try:
+        field_value = int(field_value)
+    except Exception as e:
+        logger.debug("Exception while creating integer filter. Cannot cast field value to int. Detail: %s", e)
+        _invalid_value_error(field_name, field_value)
+
+    return ({field_name: {"eq": field_value}},)
+
+
 def _string_filter(field_name, field_value, spec=None):
     # The "spec" param is defined but unused,
     # because this is called from the BUILDER_FUNCTIONS enum.
@@ -85,6 +97,7 @@ class BUILDER_FUNCTIONS(Enum):
     wildcard = partial(_wildcard_string_filter)
     string = partial(_string_filter)
     boolean = partial(_boolean_filter)
+    integer = partial(_integer_filter)
     # integer = doesnt exist yet, no xjoin-search support yet
     # Customs under here
     operating_system = partial(build_operating_system_filter)

--- a/api/filtering/filtering_common.py
+++ b/api/filtering/filtering_common.py
@@ -14,6 +14,7 @@ SPEC_OPERATIONS_LOOKUP = {
     "boolean": OPERATION_SETS.eq.value,
     "range": OPERATION_SETS.range.value,
     "operating_system": OPERATION_SETS.range.value,
+    "integer": OPERATION_SETS.eq.value[0],
 }
 
 GRAPHQL_OPERATIONS_LOOKUP = {
@@ -22,6 +23,7 @@ GRAPHQL_OPERATIONS_LOOKUP = {
     "boolean": OPERATION_SETS.is_op.value[0],
     "range": OPERATION_SETS.eq.value[0],
     "object": OPERATION_SETS.eq.value[0],
+    "integer": OPERATION_SETS.eq.value[0],
 }
 
 

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -2983,7 +2983,7 @@ def test_generic_filtering_integer(
                         query_mock.reset_mock()
 
 
-# having both system_profile endpoints creates a moching issue right now.
+# having both system_profile endpoints creates a mocking issue right now.
 # Just going to split one off until I can refactor the whole test suite
 def test_generic_filtering_integer_sap_sids(
     mocker,


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2039](https://issues.redhat.com/browse/ESSNTL-2039).

The bug was caused by a lack of support for integer fields in system profile. According to past Ryan in a comment xjoin didn't support ints at the time.

I've simply added in a new filter constructor for integers and updated a few enums. I also added tests for integer type fields created by generic filtering in the style of the existing ones for strings, booleans, etc.

This doesn't expand the field to allow for range operations [gt, gte, lt, lte]. I've created a [follow up task](https://issues.redhat.com/browse/ESSNTL-2084) to add that in since there are no existing generic filtering types that support range operations and the implementation could be more complex than I expect. I'd rather keep this fix small and concise.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
