### PR TITLE
Make wildcard strings use eq/matches conditionally

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -49,7 +49,10 @@ def _wildcard_string_filter(field_name, field_value, spec=None):
     if not isinstance(field_value, str):
         _invalid_value_error(field_name, field_value)
 
-    return ({field_name: {"matches": (field_value)}},)
+    if "*" in field_value:
+        return ({field_name: {"matches": (field_value)}},)
+    else:
+        return ({field_name: {"eq": (field_value)}},)
 
 
 def _object_filter_builder(input_object, spec):

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1945,7 +1945,7 @@ def test_query_hosts_filter_spf_insights_client_version(
     filter_paths = ("[system_profile][insights_client_version]", "[system_profile][insights_client_version][eq]")
     values = ("3.0.6-2.el7_6", "3.*", "nil", "not_nil")
     queries = (
-        {"spf_insights_client_version": {"matches": "3.0.6-2.el7_6"}},
+        {"spf_insights_client_version": {"eq": "3.0.6-2.el7_6"}},
         {"spf_insights_client_version": {"matches": "3.*"}},
         {"spf_insights_client_version": {"eq": None}},
         {"NOT": {"spf_insights_client_version": {"eq": None}}},
@@ -2151,22 +2151,22 @@ def test_query_hosts_filter_spf_ansible(mocker, subtests, query_source_xjoin, gr
     )
 
     graphql_queries = (
-        {"AND": [{"spf_ansible": {"controller_version": {"matches": "7.1"}}}]},
+        {"AND": [{"spf_ansible": {"controller_version": {"eq": "7.1"}}}]},
         {"AND": [{"spf_ansible": {"hub_version": {"matches": "8.0.*"}}}]},
         {"AND": [{"spf_ansible": {"catalog_worker_version": {"eq": None}}}]},
-        {"AND": [{"spf_ansible": {"sso_version": {"matches": "0.44.963"}}}]},
+        {"AND": [{"spf_ansible": {"sso_version": {"eq": "0.44.963"}}}]},
         {
             "AND": [
                 {"NOT": {"spf_ansible": {"hub_version": {"eq": None}}}},
-                {"spf_ansible": {"controller_version": {"matches": "7.1"}}},
+                {"spf_ansible": {"controller_version": {"eq": "7.1"}}},
             ]
         },
         {
             "AND": [
                 {
                     "OR": [
-                        {"spf_ansible": {"catalog_worker_version": {"matches": "8.0"}}},
-                        {"spf_ansible": {"catalog_worker_version": {"matches": "9.0"}}},
+                        {"spf_ansible": {"catalog_worker_version": {"eq": "8.0"}}},
+                        {"spf_ansible": {"catalog_worker_version": {"eq": "9.0"}}},
                     ]
                 }
             ]
@@ -2175,8 +2175,8 @@ def test_query_hosts_filter_spf_ansible(mocker, subtests, query_source_xjoin, gr
             "AND": [
                 {
                     "OR": [
-                        {"spf_ansible": {"catalog_worker_version": {"matches": "8.0"}}},
-                        {"spf_ansible": {"catalog_worker_version": {"matches": "9.0"}}},
+                        {"spf_ansible": {"catalog_worker_version": {"eq": "8.0"}}},
+                        {"spf_ansible": {"catalog_worker_version": {"eq": "9.0"}}},
                     ]
                 },
                 {"NOT": {"spf_ansible": {"hub_version": {"eq": None}}}},
@@ -2218,8 +2218,8 @@ def test_query_hosts_filter_deep_objects(
     )
 
     graphql_queries = (
-        {"AND": [{"spf_ansible": {"d0n1": {"d1n2": {"name": {"matches": "foo"}}}}}]},
-        {"AND": [{"spf_ansible": {"d0n1": {"d1n1": {"d2n1": {"name": {"matches": "bar"}}}}}}]},
+        {"AND": [{"spf_ansible": {"d0n1": {"d1n2": {"name": {"eq": "foo"}}}}}]},
+        {"AND": [{"spf_ansible": {"d0n1": {"d1n1": {"d2n1": {"name": {"eq": "bar"}}}}}}]},
         {"AND": [{"spf_ansible": {"d0n1": {"d1n1": {"d2n2": {"name": {"eq": None}}}}}}]},
     )
 
@@ -2937,7 +2937,7 @@ def test_generic_filtering_wildcard(
     values = ("8.*", "7.3", "nil", "not_nil")
     insights_client_version_queries = (
         {"spf_insights_client_version": {"matches": "8.*"}},
-        {"spf_insights_client_version": {"matches": "7.3"}},
+        {"spf_insights_client_version": {"eq": "7.3"}},
         {"spf_insights_client_version": {"eq": None}},
         {"NOT": {"spf_insights_client_version": {"eq": None}}},
     )
@@ -2982,7 +2982,7 @@ def test_generic_filtering_wildcard_sap_sids(
     values = ("8.*", "7.3", "nil", "not_nil")
     insights_client_version_queries = (
         {"spf_insights_client_version": {"matches": "8.*"}},
-        {"spf_insights_client_version": {"matches": "7.3"}},
+        {"spf_insights_client_version": {"eq": "7.3"}},
         {"spf_insights_client_version": {"eq": None}},
         {"NOT": {"spf_insights_client_version": {"eq": None}}},
     )


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2042](https://issues.redhat.com/browse/ESSNTL-2042).

The bug was that `insights_client_version` doesn't return hosts with empy `insights_client_version` fields when queried with an empty string. The behavior was a byproduct of wildcard enabled string fields always using the `matches` when querying xjoin.
We really only need to use `matches` when a `*` is present in the filter value, so this PR conditionally switches between the two operations depending on if a `*` is present in the field value.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
