### PR TITLE
Only allow [contains] operand on array fields [ESSNTL-2069]

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -53,9 +53,6 @@ def _wildcard_string_filter(field_name, field_value, spec=None):
 
 
 def _object_filter_builder(input_object, spec):
-    print("SPEECC!!!")
-    print(spec)
-
     object_filter = {}
 
     if not isinstance(input_object, dict):

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -53,6 +53,9 @@ def _wildcard_string_filter(field_name, field_value, spec=None):
 
 
 def _object_filter_builder(input_object, spec):
+    print("SPEECC!!!")
+    print(spec)
+
     object_filter = {}
 
     if not isinstance(input_object, dict):
@@ -62,10 +65,11 @@ def _object_filter_builder(input_object, spec):
         _check_field_in_spec(spec["children"], name)
         child_spec = spec["children"][name]
         child_filter = child_spec["filter"]
+        child_is_array = child_spec["is_array"]
         if child_filter == "object":
             object_filter[name] = _object_filter_builder(input_object[name], spec=child_spec)
         else:
-            field_value = _get_field_value(input_object[name], child_filter)
+            field_value = _get_field_value(input_object[name], child_filter, child_is_array)
             object_filter.update(
                 _generic_filter_builder(
                     BUILDER_FUNCTIONS[child_filter].value, name, field_value, child_filter, child_spec
@@ -108,11 +112,11 @@ def _get_object_base_value(field_value, field_filter):
 
 # if operation is specified, check the operation is allowed on the field
 # and find the actual value
-def _get_field_value(field_value, field_filter):
+def _get_field_value(field_value, field_filter, is_array):
     if isinstance(field_value, dict) and field_filter != "object":
         for key in field_value:
             # check if the operation is valid for the field.
-            if key not in lookup_operations(field_filter):
+            if key not in lookup_operations(field_filter, is_array):
                 raise ValidationException(f"invalid operation for {field_filter}")
 
             field_value = field_value[key]
@@ -280,6 +284,7 @@ def build_system_profile_filter(system_profile):
 
         field_input = system_profile[field_name]
         field_filter = system_profile_spec()[field_name]["filter"]
+        is_array = system_profile_spec()[field_name]["is_array"]
 
         logger.debug(f"generating filter: field: {field_name}, type: {field_filter}, field_input: {field_input}")
 
@@ -288,7 +293,7 @@ def build_system_profile_filter(system_profile):
         if field_name in custom_filter_fields:
             system_profile_filter += builder_function(field_name, field_input, field_filter)
         else:
-            field_value = _get_field_value(field_input, field_filter)
+            field_value = _get_field_value(field_input, field_filter, is_array)
             system_profile_filter += _generic_filter_builder(builder_function, field_name, field_value, field_filter)
 
     return system_profile_filter

--- a/api/filtering/filtering_common.py
+++ b/api/filtering/filtering_common.py
@@ -19,8 +19,8 @@ SPEC_OPERATIONS_LOOKUP = {
 ARRAY_SPEC_OPERATIONS_LOOKUP = {
     "string": OPERATION_SETS.eq.value,
     "wildcard": OPERATION_SETS.eq.value,  # because on our side we want eq
-    "boolean": OPERATION_SETS.eq.value,
-    "range": OPERATION_SETS.range.value,
+    "boolean": OPERATION_SETS.eq.value[0],
+    "range": OPERATION_SETS.range.value[0],
     "operating_system": OPERATION_SETS.range.value,
 }
 

--- a/api/filtering/filtering_common.py
+++ b/api/filtering/filtering_common.py
@@ -3,12 +3,20 @@ from enum import Enum
 
 class OPERATION_SETS(Enum):
     eq = ["eq", "contains"]  # add contains for when it's a list
-    matches = ["matches"]
+    matches = ["matches", "contains"]
     is_op = ["is"]  # "is" is reserved
     range = ["eq", "lt", "gt", "lte", "gte"]
 
 
 SPEC_OPERATIONS_LOOKUP = {
+    "string": OPERATION_SETS.eq.value[0],
+    "wildcard": OPERATION_SETS.eq.value[0],  # because on our side we want eq
+    "boolean": OPERATION_SETS.eq.value,
+    "range": OPERATION_SETS.range.value,
+    "operating_system": OPERATION_SETS.range.value,
+}
+
+ARRAY_SPEC_OPERATIONS_LOOKUP = {
     "string": OPERATION_SETS.eq.value,
     "wildcard": OPERATION_SETS.eq.value,  # because on our side we want eq
     "boolean": OPERATION_SETS.eq.value,
@@ -25,7 +33,9 @@ GRAPHQL_OPERATIONS_LOOKUP = {
 }
 
 
-def lookup_operations(filter_type):
+def lookup_operations(filter_type, is_array=False):
+    if is_array:
+        return ARRAY_SPEC_OPERATIONS_LOOKUP[filter_type]
     return SPEC_OPERATIONS_LOOKUP[filter_type]
 
 

--- a/api/filtering/filtering_common.py
+++ b/api/filtering/filtering_common.py
@@ -9,20 +9,21 @@ class OPERATION_SETS(Enum):
 
 
 SPEC_OPERATIONS_LOOKUP = {
-    "string": OPERATION_SETS.eq.value[0],
-    "wildcard": OPERATION_SETS.eq.value[0],  # because on our side we want eq
-    "boolean": OPERATION_SETS.eq.value[0],
+    "string": [OPERATION_SETS.eq.value[0]],
+    "wildcard": [OPERATION_SETS.eq.value[0]],  # because on our side we want eq
+    "boolean": [OPERATION_SETS.eq.value[0]],
     "range": OPERATION_SETS.range.value,
     "operating_system": OPERATION_SETS.range.value,
+    "integer": [OPERATION_SETS.eq.value[0]],
 }
 
 ARRAY_SPEC_OPERATIONS_LOOKUP = {
     "string": OPERATION_SETS.eq.value,
     "wildcard": OPERATION_SETS.eq.value,  # because on our side we want eq
-    "boolean": OPERATION_SETS.eq.value[0],
-    "range": OPERATION_SETS.range.value[0],
+    "boolean": [OPERATION_SETS.eq.value[0]],
+    "range": [OPERATION_SETS.range.value[0]],
     "operating_system": OPERATION_SETS.range.value,
-    "integer": OPERATION_SETS.eq.value[0],
+    "integer": [OPERATION_SETS.eq.value[0]],
 }
 
 GRAPHQL_OPERATIONS_LOOKUP = {

--- a/api/filtering/filtering_common.py
+++ b/api/filtering/filtering_common.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class OPERATION_SETS(Enum):
     eq = ["eq", "contains"]  # add contains for when it's a list
-    matches = ["matches", "contains"]
+    matches = ["matches"]
     is_op = ["is"]  # "is" is reserved
     range = ["eq", "lt", "gt", "lte", "gte"]
 
@@ -11,7 +11,7 @@ class OPERATION_SETS(Enum):
 SPEC_OPERATIONS_LOOKUP = {
     "string": OPERATION_SETS.eq.value[0],
     "wildcard": OPERATION_SETS.eq.value[0],  # because on our side we want eq
-    "boolean": OPERATION_SETS.eq.value,
+    "boolean": OPERATION_SETS.eq.value[0],
     "range": OPERATION_SETS.range.value,
     "operating_system": OPERATION_SETS.range.value,
 }

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -114,10 +114,6 @@ def _get_field_filter(field_name, props):
     return field_type
 
 
-def _get_field_is_array(field_name, props):
-    return "array" == props.get("type")
-
-
 def process_spec(spec, process_unindexed=False):
     system_profile_spec_processed = {}
     for field, props in spec.items():
@@ -126,7 +122,7 @@ def process_spec(spec, process_unindexed=False):
             system_profile_spec_processed[field] = {
                 "type": _spec_type_to_python_type(props["type"]),  # cast from string to type
                 "filter": field_filter,
-                "is_array": _get_field_is_array(field, props),
+                "is_array": "array" == props.get("type"),
             }
 
             if field_filter == "object":

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -114,13 +114,20 @@ def _get_field_filter(field_name, props):
     return field_type
 
 
+def _get_field_is_array(field_name, props):
+    return "array" == props.get("type")
+
+
 def process_spec(spec, process_unindexed=False):
     system_profile_spec_processed = {}
     for field, props in spec.items():
         if props.get("x-indexed", True) or process_unindexed:
-            field_type = _spec_type_to_python_type(props["type"])  # cast from string to type
             field_filter = _get_field_filter(field, props)
-            system_profile_spec_processed[field] = {"type": field_type, "filter": field_filter}
+            system_profile_spec_processed[field] = {
+                "type": _spec_type_to_python_type(props["type"]),  # cast from string to type
+                "filter": field_filter,
+                "is_array": _get_field_is_array(field, props),
+            }
 
             if field_filter == "object":
                 system_profile_spec_processed[field]["children"] = process_spec(props["properties"], True)

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -622,14 +622,6 @@ objects:
     appName: host-inventory
     jobs:
       - events-topic-rebuilder
-- apiVersion: cloud.redhat.com/v1alpha1
-  kind: ClowdJobInvocation
-  metadata:
-    name: synchronizer-${SYNCHRONIZER_CJI_RANDOM_SUFFIX}
-  spec:
-    appName: host-inventory
-    jobs:
-      - synchronizer
 # this service proxies requests for the old URL (insights-inventory:8080) to the clowderized service (host-inventory-service:8000)
 - apiVersion: v1
   kind: Service
@@ -777,9 +769,6 @@ parameters:
 - name: KAFKA_SP_VALIDATOR_MAX_MESSAGES
   value: '10000'
 - name: CJI_RANDOM_SUFFIX
-  required: true
-  value: '123456'
-- name: SYNCHRONIZER_CJI_RANDOM_SUFFIX
   required: true
   value: '123456'
 

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -32,6 +32,9 @@ from tests.helpers.api_utils import UUID_3
 from tests.helpers.db_utils import serialize_db_host
 from tests.helpers.db_utils import update_host_in_db
 from tests.helpers.graphql_utils import XJOIN_HOSTS_RESPONSE
+from tests.helpers.graphql_utils import XJOIN_SYSTEM_PROFILE_SAP_SIDS
+from tests.helpers.graphql_utils import XJOIN_SYSTEM_PROFILE_SAP_SYSTEM
+from tests.helpers.graphql_utils import XJOIN_TAGS_RESPONSE
 from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import minimal_host
 from tests.helpers.test_utils import now
@@ -1120,15 +1123,23 @@ def test_unindexed_fields_fail_gracefully(query_source_xjoin, api_get):
 
 # This test verifies that the [contains] operation is accepted for a string array field such as cpu_flags
 def test_get_hosts_contains_works_on_string_array(patch_xjoin_post, api_get, subtests, query_source_xjoin):
+
     url_builders = (
         build_hosts_url,
         build_system_profile_sap_sids_url,
         build_tags_url,
         build_system_profile_sap_system_url,
     )
-
-    for url_builder in url_builders:
-        for query in ("?filter[system_profile][cpu_flags][contains]=ex1",):
+    responses = (
+        XJOIN_HOSTS_RESPONSE,
+        XJOIN_SYSTEM_PROFILE_SAP_SIDS,
+        XJOIN_TAGS_RESPONSE,
+        XJOIN_SYSTEM_PROFILE_SAP_SYSTEM,
+    )
+    query = "?filter[system_profile][cpu_flags][contains]=ex1"
+    for url_builder, response in zip(url_builders, responses):
+        with subtests.test(url_builder=url_builder, response=response, query=query):
+            patch_xjoin_post(response={"data": response})
             response_status, _ = api_get(url_builder(query=query))
             assert response_status == 200
 
@@ -1141,8 +1152,8 @@ def test_get_hosts_contains_invalid_on_string_not_array(patch_xjoin_post, api_ge
         build_tags_url,
         build_system_profile_sap_system_url,
     )
-
+    query = "?filter[system_profile][cpu_model][contains]=Intel(R) I7(R) CPU I7-10900k 0 @ 4.90GHz"
     for url_builder in url_builders:
-        for query in ("?filter[system_profile][cpu_model][contains]=Intel(R) I7(R) CPU I7-10900k 0 @ 4.90GHz",):
+        with subtests.test(url_builder=url_builder, query=query):
             response_status, _ = api_get(url_builder(query=query))
             assert response_status == 400

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1116,3 +1116,33 @@ def test_unindexed_fields_fail_gracefully(query_source_xjoin, api_get):
         for query in ("?filter[system_profile][installed_packages_delta]=foo",):
             response_status, _ = api_get(url_builder(query=query))
             assert response_status == 400
+
+
+# This test verifies that the [contains] operation is accepted for a string array field such as cpu_flags
+def test_get_hosts_contains_works_on_string_array(patch_xjoin_post, api_get, subtests, query_source_xjoin):
+    url_builders = (
+        build_hosts_url,
+        build_system_profile_sap_sids_url,
+        build_tags_url,
+        build_system_profile_sap_system_url,
+    )
+
+    for url_builder in url_builders:
+        for query in ("?filter[system_profile][cpu_flags][contains]=ex1",):
+            response_status, _ = api_get(url_builder(query=query))
+            assert response_status == 200
+
+
+# This test verifies that the [contains] operation is denied for a non-array string field such as cpu_model
+def test_get_hosts_contains_invalid_on_string_not_array(patch_xjoin_post, api_get, subtests, query_source_xjoin):
+    url_builders = (
+        build_hosts_url,
+        build_system_profile_sap_sids_url,
+        build_tags_url,
+        build_system_profile_sap_system_url,
+    )
+
+    for url_builder in url_builders:
+        for query in ("?filter[system_profile][cpu_model][contains]=Intel(R) I7(R) CPU I7-10900k 0 @ 4.90GHz",):
+            response_status, _ = api_get(url_builder(query=query))
+            assert response_status == 400


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2069](https://issues.redhat.com/browse/ESSNTL-2069).

This PR makes it so [contains] is no longer considered a valid operand on non-array fields. This was considered misleading because the [contains] operand is intended to be used on array fields to filter on if those fields contain a specific string, so using it on a single string, object, etc, though functionally equivalent to [eq], doesn't make much sense.

Now [contains] is only a valid operand on string and wildcard-string arrays. I figure boolean arrays are unlikely to exist. Adding a contains operand to range queries probably wouldn't make a lot of sense either.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
