### PR TITLE
Validate timestamp values for SPF filters

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -122,6 +122,7 @@ def process_spec(spec, process_unindexed=False):
             system_profile_spec_processed[field] = {
                 "type": _spec_type_to_python_type(props["type"]),  # cast from string to type
                 "filter": field_filter,
+                "format": props.get("format"),
                 "is_array": "array" == props.get("type"),
             }
 

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1157,3 +1157,7 @@ def test_get_hosts_contains_invalid_on_string_not_array(patch_xjoin_post, api_ge
         with subtests.test(url_builder=url_builder, query=query):
             response_status, _ = api_get(url_builder(query=query))
             assert response_status == 400
+
+
+def test_get_hosts_timestamp_invalid_value_graceful_rejection(patch_xjoin_post, api_get, query_source_xjoin):
+    assert 400 == api_get(build_hosts_url(query="?filter[system_profile][last_boot_time][eq]=foo"))[0]


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2136](https://issues.redhat.com/browse/ESSNTL-2136).

Added a specific handling for timestamps. Since they're ultimately a specialized form of string I've added logic dependent on the format property in the system profile schema rather than changing the filter. I think this will be more flexible down the line for other specialized strings with formats (ipv6, ipv4, UUID, etc). Same for specialized numbers like longs. 

I added a test checking that using a non-timestamp string results in a 400 error from the API. Existing happy path tests cover the valid cases.

It came to my attention while working on this that timestamps need support for range operations, but that will be a follow up.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
