### PR TITLE
Handle ID filter combinations

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -263,11 +263,12 @@ def query_filters(
     registered_with,
     filter,
 ):
+    query_filters = tuple()
     if fqdn:
-        query_filters = ({"fqdn": {"eq": fqdn.casefold()}},)
-    elif display_name:
-        query_filters = ({"display_name": string_contains_lc(display_name)},)
-    elif hostname_or_id:
+        query_filters += ({"fqdn": {"eq": fqdn.casefold()}},)
+    if display_name:
+        query_filters += ({"display_name": string_contains_lc(display_name)},)
+    if hostname_or_id:
         contains_lc = string_contains_lc(hostname_or_id)
         hostname_or_id_filters = ({"display_name": contains_lc}, {"fqdn": contains_lc})
         try:
@@ -278,11 +279,9 @@ def query_filters(
         else:
             logger.debug("Adding id (uuid) to the filter list")
             hostname_or_id_filters += ({"id": {"eq": str(id)}},)
-        query_filters = ({"OR": hostname_or_id_filters},)
-    elif insights_id:
-        query_filters = ({"insights_id": {"eq": insights_id.casefold()}},)
-    else:
-        query_filters = ()
+        query_filters += ({"OR": hostname_or_id_filters},)
+    if insights_id:
+        query_filters += ({"insights_id": {"eq": insights_id.casefold()}},)
 
     if tags:
         query_filters += build_tag_query_dict_tuple(tags)

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -314,44 +314,21 @@ def test_query_variables_none(mocker, query_source_xjoin, graphql_query_empty_re
 
 
 @pytest.mark.parametrize(
-    "filters,query",
+    "query",
     (
-        (("fqdn", "display_name"), f"fqdn={quote(generate_uuid())}&display_name={quote(generate_uuid())}"),
-        (("fqdn", "OR"), f"fqdn={quote(generate_uuid())}&hostname_or_id={quote(generate_uuid())}"),
-        (("fqdn", "insights_id"), f"fqdn={quote(generate_uuid())}&insights_id={quote(generate_uuid())}"),
-        (("display_name", "OR"), f"display_name={quote(generate_uuid())}&hostname_or_id={quote(generate_uuid())}"),
-        (
-            ("display_name", "insights_id"),
-            f"display_name={quote(generate_uuid())}&insights_id={quote(generate_uuid())}",
-        ),
-        (("OR", "insights_id"), f"hostname_or_id={quote(generate_uuid())}&insights_id={quote(generate_uuid())}"),
+        (f"fqdn={quote(generate_uuid())}&display_name={quote(generate_uuid())}"),
+        (f"fqdn={quote(generate_uuid())}&hostname_or_id={quote(generate_uuid())}"),
+        (f"fqdn={quote(generate_uuid())}&insights_id={quote(generate_uuid())}"),
+        (f"display_name={quote(generate_uuid())}&hostname_or_id={quote(generate_uuid())}"),
+        (f"display_name={quote(generate_uuid())}&insights_id={quote(generate_uuid())}"),
+        (f"hostname_or_id={quote(generate_uuid())}&insights_id={quote(generate_uuid())}"),
     ),
 )
-def test_query_variables_combination(
-    filters, query, mocker, query_source_xjoin, graphql_query_empty_response, api_get
-):
+def test_query_variables_invalid(query, mocker, query_source_xjoin, graphql_query_empty_response, api_get):
     url = build_hosts_url(query=f"?{query}")
-    mocked_filter = ()
-
-    for filter in filters:
-        mocked_filter += ({filter: mocker.ANY},)
-
-    mocked_filter += (mocker.ANY,)
     response_status, response_data = api_get(url)
-    assert response_status == 200
 
-    graphql_query_empty_response.assert_called_once_with(
-        HOST_QUERY,
-        {
-            "order_by": mocker.ANY,
-            "order_how": mocker.ANY,
-            "limit": mocker.ANY,
-            "offset": mocker.ANY,
-            "filter": mocked_filter,
-            "fields": mocker.ANY,
-        },
-        mocker.ANY,
-    )
+    assert response_status == 400
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2172](https://issues.redhat.com/browse/ESSNTL-2172).
Until now, we've had to prioritize when filtering on more than 1 of the following:

- fqdn
- display_name
- hostname_or_id
- insights_id

This was likely due to the front-end never sending one of these at a time. This PR makes it so it errors out if you provide more than 1 of these at once, and modifies one of the xjoin tests to validate the new expected output.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
