### PR TITLE
set limit to 100 for returning filtered hosts for deletion

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -52,9 +52,11 @@ QUERY = """query Query(
     }
 }"""
 HOST_IDS_QUERY = """query Query(
+    $limit: Int!,
     $filter: [HostFilter!],
 ) {
     hosts(
+        limit: $limit,
         filter: {
             AND: $filter,
         }
@@ -159,7 +161,7 @@ def get_host_ids_list(
     if current_identity.identity_type == IdentityType.SYSTEM and current_identity.auth_type != AuthType.CLASSIC:
         all_filters += owner_id_filter()
 
-    variables = {"filter": all_filters}
+    variables = {"limit": 100, "filter": all_filters}  # maximum limit handled by xjoin.
     response = graphql_query(HOST_IDS_QUERY, variables, log_get_host_list_failed)["hosts"]
 
     return [x["id"] for x in response["data"]]

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1653,7 +1653,7 @@ def test_xjoin_search_query_using_hostfilter(
     api_delete_filtered_hosts({field: value})
 
     graphql_query_empty_response.assert_called_once_with(
-        HOST_IDS_QUERY, {"filter": ({field: {"eq": value}},)}, mocker.ANY
+        HOST_IDS_QUERY, {"filter": ({field: {"eq": value}},), "limit": mocker.ANY}, mocker.ANY
     )
 
 
@@ -1666,7 +1666,7 @@ def test_xjoin_search_query_using_hostfilter_display_name(
 
     graphql_query_empty_response.assert_called_once_with(
         HOST_IDS_QUERY,
-        {"filter": ({"display_name": {"matches_lc": f"*{query_params['display_name']}*"}},)},
+        {"filter": ({"display_name": {"matches_lc": f"*{query_params['display_name']}*"}},), "limit": mocker.ANY},
         mocker.ANY,
     )
 
@@ -1698,7 +1698,9 @@ def test_xjoin_search_using_hostfilters_tags(
 
     tag_filters = tuple({"tag": item} for item in tags)
 
-    graphql_query_empty_response.assert_called_once_with(HOST_IDS_QUERY, {"filter": tag_filters}, mocker.ANY)
+    graphql_query_empty_response.assert_called_once_with(
+        HOST_IDS_QUERY, {"filter": tag_filters, "limit": mocker.ANY}, mocker.ANY
+    )
 
 
 @pytest.mark.parametrize(
@@ -1719,7 +1721,10 @@ def test_xjoin_search_query_using_hostfilter_provider(
 
     graphql_query_empty_response.assert_called_once_with(
         HOST_IDS_QUERY,
-        {"filter": ({"provider_type": {"eq": provider["type"]}}, {"provider_id": {"eq": provider["id"]}})},
+        {
+            "filter": ({"provider_type": {"eq": provider["type"]}}, {"provider_id": {"eq": provider["id"]}}),
+            "limit": mocker.ANY,
+        },
         mocker.ANY,
     )
 


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2195](https://issues.redhat.com/browse/ESSNTL-2195).
This PR asks `xjoin-search` to return 100 hosts instead of max default of 10.  A more permanent fixed should be done on the xjoin-search side.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
