### PR TITLE
Add with_for_update() to queries used for deletes/updates

### DIFF
--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -30,7 +30,7 @@ def delete_hosts(select_query, event_producer, chunk_size, interrupt=lambda: Fal
 
 
 def _delete_host(session, event_producer, host):
-    delete_query = session.query(Host).filter(Host.id == host.id)
+    delete_query = session.query(Host).filter(Host.id == host.id).with_for_update()
     if kafka_available():
         delete_query.delete(synchronize_session="fetch")
         host_deleted = _deleted_by_this_query(host)

--- a/lib/host_remove_duplicates.py
+++ b/lib/host_remove_duplicates.py
@@ -82,7 +82,7 @@ def find_host_list_by_regular_canonical_facts(canonical_facts, query, logger):
 
 
 def _delete_hosts_by_id_list(session, host_id_list):
-    delete_query = session.query(Host).filter(Host.id.in_(host_id_list))
+    delete_query = session.query(Host).filter(Host.id.in_(host_id_list)).with_for_update()
     delete_query.delete(synchronize_session="fetch")
     delete_query.session.commit()
 

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -95,6 +95,7 @@ def _find_host_by_elevated_ids(identity, canonical_facts):
             existing_host = (
                 multiple_canonical_facts_host_query(identity, elevated_facts, False)
                 .order_by(Host.modified_on.desc())
+                .with_for_update()
                 .first()
             )
             if existing_host:
@@ -134,6 +135,7 @@ def find_host_by_multiple_canonical_facts(identity, canonical_facts):
     host = (
         multiple_canonical_facts_host_query(identity, canonical_facts, restrict_to_owner_id=False)
         .order_by(Host.modified_on.desc())
+        .with_for_update()
         .first()
     )
 


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-21](https://issues.redhat.com/browse/ESSNTL-21).
It adds the `with_for_update()` clause to the SELECT queries that will later be used to update/delete these hosts.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
