### PR TITLE
essntl-2447: Update xjoin queries to return per_reporter_staleness data

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -47,6 +47,7 @@ QUERY = """query Query(
             facts,
             stale_timestamp,
             reporter,
+            per_reporter_staleness,
             system_profile_facts (filter: $fields),
         }
     }

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -155,6 +155,24 @@ def xjoin_host_response(timestamp):
     }
 
 
+def xjoin_response_with_per_reporter_staleness(timestamp, newprs):
+    return {
+        "hosts": {
+            **XJOIN_HOSTS_RESPONSE["hosts"],
+            "meta": {"total": 1},
+            "data": [
+                {
+                    **XJOIN_HOSTS_RESPONSE["hosts"]["data"][0],
+                    "created_on": timestamp,
+                    "modified_on": timestamp,
+                    "stale_timestamp": timestamp,
+                    "per_reporter_staleness": newprs,
+                }
+            ],
+        }
+    }
+
+
 def assert_graph_query_single_call_with_staleness(mocker, graphql_query, staleness_conditions):
     conditions = tuple({"stale_timestamp": staleness_condition} for staleness_condition in staleness_conditions)
     graphql_query.assert_called_once_with(


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-xxxx](https://issues.redhat.com/browse/ESSNTL-2447).
This PR updates xjoin-search query to include `per_reporter_staleness` for the data to fetch from xjoin.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
