### PR TITLE
Migration to add org_id column, and its associated index to hosts/

### DIFF
--- a/migrations/versions/268debe6db17_add_org_id_column_and_index.py
+++ b/migrations/versions/268debe6db17_add_org_id_column_and_index.py
@@ -5,19 +5,19 @@ Revises: 3d06b0a8828f
 Create Date: 2022-03-28 13:46:34.982026
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = '268debe6db17'
-down_revision = '3d06b0a8828f'
+revision = "268debe6db17"
+down_revision = "3d06b0a8828f"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.add_column("hosts", sa.Column("org_id", sa.String(length=255), nullable=True))
+    op.add_column("hosts", sa.Column("org_id", sa.String(length=36), nullable=True))
     op.create_index("idxorgid", "hosts", ["org_id"])
 
 

--- a/migrations/versions/268debe6db17_add_org_id_column_and_index.py
+++ b/migrations/versions/268debe6db17_add_org_id_column_and_index.py
@@ -1,0 +1,26 @@
+"""Add org_id column and index
+
+Revision ID: 268debe6db17
+Revises: 3d06b0a8828f
+Create Date: 2022-03-28 13:46:34.982026
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '268debe6db17'
+down_revision = '3d06b0a8828f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("hosts", sa.Column("org_id", sa.String(length=255), nullable=True))
+    op.create_index("idxorgid", "hosts", ["org_id"])
+
+
+def downgrade():
+    op.drop_index("idxorgid", table_name="hosts")
+    op.drop_column("hosts", "org_id")


### PR DESCRIPTION
# Overview

Add migration to add org_id column, and its associated index to the hosts table.

This PR is being created to address [ESSNTL-2522](https://issues.redhat.com/browse/ESSNTL-2522).

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
