### PR TITLE
fix ESSNTL-573: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,17 @@ default_language_version:
   python: python3.8
 repos:
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v1.6.0
+  rev: v3.0.1
   hooks:
   - id: reorder-python-imports
-    args: [--py37-plus]
+    args: [--py38-plus]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v1.19.0
+  rev: v2.31.1
   hooks:
   - id: pyupgrade
-    args: [--py36-plus]
-- repo: https://github.com/ambv/black
-  rev: 19.3b0
+    args: [--py38-plus]
+- repo: https://github.com/psf/black
+  rev: 22.3.0
   hooks:
   - id: black
     args: [--line-length, "119"]

--- a/Pipfile
+++ b/Pipfile
@@ -19,7 +19,7 @@ gunicorn = "~=19.9.0"
 connexion = {version = "~=2.7",extras = ["swagger-ui"]}
 markupsafe = "==2.0.1" # Using v2.1.0 breaks Jinja2
 openapi-schema-validator = "< 0.2"
-openapi-spec-validator = "*"
+openapi-spec-validator = "< 0.4.0" # those are a pain
 pyyaml = "~=5.4"
 prometheus-client = "~=0.7.1"
 logstash-formatter = "~=0.5.17"
@@ -44,12 +44,7 @@ pytest-cov = "~=2.7.1"
 pytest-mock = "~=3.1.0"
 pytest-subtests = "~=0.3.0"
 coverage = "~=4.5.3"
-flake8 = "~=3.7.7"
-pyupgrade = "~=1.21.0"
-reorder-python-imports = "~=1.6.1"
-pre-commit-hooks = "~=2.2.3"
-black = "==19.3b0"  # Pre-release, not semver
-pre-commit = "~=1.18.1"
+pre-commit = "~=2.17.0"
 ttictoc = "~=0.4.1"
 sqlalchemy-utils = "==0.36.7"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2cd606e9c4e9cbcdeb7862242c3202da47f58fee0b85a681fc76a34a1b41291e"
+            "sha256": "6281c65868f70181f7a5f9341b7b346529ff513744a8a4dd7ba14864cd37470b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -48,19 +48,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:6fa0622f308cfd1da758966fc98b52fbd74b80606d14586c8ad82c7a6c4f32d0",
-                "sha256:8fa32fcc8be38327bd667237223d71e5e4b2475f39d6882aca4dbad19fff8c29"
+                "sha256:ef210f8e85cdb6d26a38ebad1cfe9cefdef2ab269207e5987653555375a7ef6b",
+                "sha256:f0af8f4ef5fe6353c794cd3cce627d469a618b58ace7ca75a63cfd719df615ce"
             ],
             "index": "pypi",
-            "version": "==1.21.21"
+            "version": "==1.21.30"
         },
         "botocore": {
             "hashes": [
-                "sha256:7e976cfd0a61601e74624ef8f5246b40a01f2cce73a011ef29cf80a6e371d0fa",
-                "sha256:92daca8775e738a9db9b465d533019285f09d541e903233261299fd87c2f842c"
+                "sha256:af4bdc51eeecbe9fdcdadbed9ad58c5c91380ef30f3560022bbc2ee1d78f0ad6",
+                "sha256:c622751093e3d0bf61343e66d6d06190ef30bf42b1557d5070ca84e9efa06d4b"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.24.21"
+            "version": "==1.24.30"
         },
         "certifi": {
             "hashes": [
@@ -97,11 +97,11 @@
                 "swagger-ui"
             ],
             "hashes": [
-                "sha256:2d163976fbc8766038d71f4232ace07826be7dd0a8fe7a539ce5fc8a80f1ab35",
-                "sha256:c08b530418a1c448d34cd142713ddd1b245e7694f45cd80533fe8538b64aa7eb"
+                "sha256:0ba5c163d34cb3cb3bf597d5b95fc14bad5d3596bf10ec86e32cdb63f68d0c8a",
+                "sha256:26a570a0283bbe4cdaf5d90dfb3441aaf8e18cb9de10f3f96bbc128a8a3d8b47"
             ],
             "index": "pypi",
-            "version": "==2.12.0"
+            "version": "==2.13.0"
         },
         "decorator": {
             "hashes": [
@@ -200,11 +200,11 @@
         },
         "importlib-resources": {
             "hashes": [
-                "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45",
-                "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"
+                "sha256:1b93238cbf23b4cde34240dd8321d99e9bf2eb4bc91c0c99b2886283e7baad85",
+                "sha256:a9dd72f6cc106aeb50f6e66b86b69b454766dd6e39b69ac68450253058706bcc"
             ],
             "markers": "python_version < '3.9'",
-            "version": "==5.4.0"
+            "version": "==5.6.0"
         },
         "inflection": {
             "hashes": [
@@ -391,6 +391,14 @@
             "index": "pypi",
             "version": "==0.3.3"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
+        },
         "prance": {
             "hashes": [
                 "sha256:51ec41d10b317bf5d4e74782a7f7f0c0488c6042433b5b4fde2a988cd069d235",
@@ -453,6 +461,14 @@
             ],
             "index": "pypi",
             "version": "==2.8.6"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
+                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.7"
         },
         "pyrsistent": {
             "hashes": [
@@ -525,10 +541,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
-                "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"
+                "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
+                "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"
             ],
-            "version": "==2021.3"
+            "version": "==2022.1"
         },
         "pyyaml": {
             "hashes": [
@@ -628,14 +644,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.13.0"
         },
-        "setuptools": {
-            "hashes": [
-                "sha256:6599055eeb23bfef457d5605d33a4d68804266e6cb430b0fb12417c5efeae36c",
-                "sha256:782ef48d58982ddb49920c11a0c5c9c0b02e7d7d1c2ad0aa44e1a1e133051c96"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==60.10.0"
-        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -734,34 +742,11 @@
                 "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d",
                 "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.10'",
             "version": "==3.7.0"
         }
     },
     "develop": {
-        "appdirs": {
-            "hashes": [
-                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
-                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
-            ],
-            "version": "==1.4.4"
-        },
-        "aspy.refactor-imports": {
-            "hashes": [
-                "sha256:bc257946fdf5abd9c60393cfb8d0b5d45a2b87d1ee0ede46584c8be5567bc669",
-                "sha256:df497c3726ee2931b03d403e58a4590f7f4e60059b115cf5df0e07e70c7c73be"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.0.1"
-        },
-        "aspy.yaml": {
-            "hashes": [
-                "sha256:463372c043f70160a9ec950c3f1e4c3a82db5fca01d334b6bc89c7164d744bdc",
-                "sha256:e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.3.0"
-        },
         "atomicwrites": {
             "hashes": [
                 "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
@@ -778,14 +763,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.4.0"
         },
-        "black": {
-            "hashes": [
-                "sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf",
-                "sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"
-            ],
-            "index": "pypi",
-            "version": "==19.3b0"
-        },
         "cfgv": {
             "hashes": [
                 "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426",
@@ -793,14 +770,6 @@
             ],
             "markers": "python_full_version >= '3.6.1'",
             "version": "==3.3.1"
-        },
-        "click": {
-            "hashes": [
-                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
-                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==7.1.2"
         },
         "coverage": {
             "hashes": [
@@ -847,14 +816,6 @@
             ],
             "version": "==0.3.4"
         },
-        "entrypoints": {
-            "hashes": [
-                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
-                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
-            ],
-            "markers": "python_version >= '2.7'",
-            "version": "==0.3"
-        },
         "filelock": {
             "hashes": [
                 "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85",
@@ -862,14 +823,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.6.0"
-        },
-        "flake8": {
-            "hashes": [
-                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
-                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
-            ],
-            "index": "pypi",
-            "version": "==3.7.9"
         },
         "greenlet": {
             "hashes": [
@@ -948,13 +901,6 @@
             "markers": "python_version < '3.9'",
             "version": "==4.11.3"
         },
-        "mccabe": {
-            "hashes": [
-                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
-                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
-            ],
-            "version": "==0.6.1"
-        },
         "more-itertools": {
             "hashes": [
                 "sha256:43e6dd9942dffd72661a2c4ef383ad7da1e6a3e968a927ad7a6083ab410a688b",
@@ -996,19 +942,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:1d3c0587bda7c4e537a46c27f2c84aa006acc18facf9970bf947df596ce91f3f",
-                "sha256:fa78ff96e8e9ac94c748388597693f18b041a181c94a4f039ad20f45287ba44a"
+                "sha256:725fa7459782d7bec5ead072810e47351de01709be838c2ce1726b9591dad616",
+                "sha256:c1a8040ff15ad3d648c70cc3e55b93e4d2d5b687320955505587fd79bbaed06a"
             ],
             "index": "pypi",
-            "version": "==1.18.3"
-        },
-        "pre-commit-hooks": {
-            "hashes": [
-                "sha256:29349ad3894229bded388de2f9a2b4f1c95aa003f12a546d00e06ac62f5ecc5f",
-                "sha256:692c202c21b1c168749053dd44f23d40e02886c6b8e32c0469705c8ecdfb595a"
-            ],
-            "index": "pypi",
-            "version": "==2.2.3"
+            "version": "==2.17.0"
         },
         "py": {
             "hashes": [
@@ -1017,22 +955,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.11.0"
-        },
-        "pycodestyle": {
-            "hashes": [
-                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
-                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.5.0"
-        },
-        "pyflakes": {
-            "hashes": [
-                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
-                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.1.1"
         },
         "pyparsing": {
             "hashes": [
@@ -1074,14 +996,6 @@
             "index": "pypi",
             "version": "==0.3.2"
         },
-        "pyupgrade": {
-            "hashes": [
-                "sha256:868a92e8bd6ed6ef8a3ace3a7e08e9d59cbaff958e2c2d20efbe117cf1f52175",
-                "sha256:bec54923c4e2d13a73e7a70828d3c5cb1562e72b3a622959309ec93ebafb0f88"
-            ],
-            "index": "pypi",
-            "version": "==1.21.0"
-        },
         "pyyaml": {
             "hashes": [
                 "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
@@ -1116,53 +1030,6 @@
             ],
             "index": "pypi",
             "version": "==5.4.1"
-        },
-        "reorder-python-imports": {
-            "hashes": [
-                "sha256:19205da15e7bccd5a6a92fa7b97d577bc72c2e20acdcc27175fa0fd832cfed50",
-                "sha256:1c04d11c07d4c48d75b9a7f0ab5db4b61be42d294fd902c1efd2b1e0bc146d22"
-            ],
-            "index": "pypi",
-            "version": "==1.6.1"
-        },
-        "ruamel.yaml": {
-            "hashes": [
-                "sha256:742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7",
-                "sha256:8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af"
-            ],
-            "markers": "python_version >= '3'",
-            "version": "==0.17.21"
-        },
-        "ruamel.yaml.clib": {
-            "hashes": [
-                "sha256:0847201b767447fc33b9c235780d3aa90357d20dd6108b92be544427bea197dd",
-                "sha256:1070ba9dd7f9370d0513d649420c3b362ac2d687fe78c6e888f5b12bf8bc7bee",
-                "sha256:1866cf2c284a03b9524a5cc00daca56d80057c5ce3cdc86a52020f4c720856f0",
-                "sha256:221eca6f35076c6ae472a531afa1c223b9c29377e62936f61bc8e6e8bdc5f9e7",
-                "sha256:31ea73e564a7b5fbbe8188ab8b334393e06d997914a4e184975348f204790277",
-                "sha256:3fb9575a5acd13031c57a62cc7823e5d2ff8bc3835ba4d94b921b4e6ee664104",
-                "sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd",
-                "sha256:6e7be2c5bcb297f5b82fee9c665eb2eb7001d1050deaba8471842979293a80b0",
-                "sha256:72a2b8b2ff0a627496aad76f37a652bcef400fd861721744201ef1b45199ab78",
-                "sha256:77df077d32921ad46f34816a9a16e6356d8100374579bc35e15bab5d4e9377de",
-                "sha256:78988ed190206672da0f5d50c61afef8f67daa718d614377dcd5e3ed85ab4a99",
-                "sha256:7b2927e92feb51d830f531de4ccb11b320255ee95e791022555971c466af4527",
-                "sha256:7f7ecb53ae6848f959db6ae93bdff1740e651809780822270eab111500842a84",
-                "sha256:825d5fccef6da42f3c8eccd4281af399f21c02b32d98e113dbc631ea6a6ecbc7",
-                "sha256:846fc8336443106fe23f9b6d6b8c14a53d38cef9a375149d61f99d78782ea468",
-                "sha256:89221ec6d6026f8ae859c09b9718799fea22c0e8da8b766b0b2c9a9ba2db326b",
-                "sha256:9efef4aab5353387b07f6b22ace0867032b900d8e91674b5d8ea9150db5cae94",
-                "sha256:a32f8d81ea0c6173ab1b3da956869114cae53ba1e9f72374032e33ba3118c233",
-                "sha256:a49e0161897901d1ac9c4a79984b8410f450565bbad64dbfcbf76152743a0cdb",
-                "sha256:ada3f400d9923a190ea8b59c8f60680c4ef8a4b0dfae134d2f2ff68429adfab5",
-                "sha256:bf75d28fa071645c529b5474a550a44686821decebdd00e21127ef1fd566eabe",
-                "sha256:cfdb9389d888c5b74af297e51ce357b800dd844898af9d4a547ffc143fa56751",
-                "sha256:d67f273097c368265a7b81e152e07fb90ed395df6e552b9fa858c6d2c9f42502",
-                "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed",
-                "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"
-            ],
-            "markers": "python_version < '3.11' and platform_python_implementation == 'CPython'",
-            "version": "==0.2.6"
         },
         "six": {
             "hashes": [
@@ -1219,14 +1086,6 @@
             "index": "pypi",
             "version": "==0.36.7"
         },
-        "tokenize-rt": {
-            "hashes": [
-                "sha256:08a27fa032a81cf45e8858d0ac706004fcd523e8463415ddf1442be38e204ea8",
-                "sha256:0d4f69026fed520f8a1e0103aa36c406ef4661417f20ca643f913e33531b3b94"
-            ],
-            "markers": "python_full_version >= '3.6.1'",
-            "version": "==4.2.1"
-        },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
@@ -1245,11 +1104,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:dd448d1ded9f14d1a4bfa6bfc0c5b96ae3be3f2d6c6c159b23ddcfd701baa021",
-                "sha256:e9dd1a1359d70137559034c0f5433b34caf504af2dc756367be86a5a32967134"
+                "sha256:1e8588f35e8b42c6ec6841a13c5e88239de1e6e4e4cedfd3916b306dc826ec66",
+                "sha256:8e5b402037287126e81ccde9432b95a8be5b19d36584f64957060a3488c11ca8"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.13.3"
+            "version": "==20.14.0"
         },
         "wcwidth": {
             "hashes": [
@@ -1263,7 +1122,7 @@
                 "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d",
                 "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.10'",
             "version": "==3.7.0"
         }
     }

--- a/api/parsing.py
+++ b/api/parsing.py
@@ -6,8 +6,8 @@ from app.exceptions import ValidationException
 
 
 def custom_fields_parser(root_key, key_path, val):
-    """ consumes values like ("a",["foo"],["baz,hello","world"])
-        returns (a, {"foo": {"baz": True, "hello": True, "world": True}}}, is_deep_object)
+    """consumes values like ("a",["foo"],["baz,hello","world"])
+    returns (a, {"foo": {"baz": True, "hello": True, "world": True}}}, is_deep_object)
     """
     root = {key_path[0]: {}}
     for v in val:
@@ -19,8 +19,8 @@ def custom_fields_parser(root_key, key_path, val):
 class customURIParser(OpenAPIURIParser):
     @staticmethod
     def _make_deep_object(k, v):
-        """ consumes keys, value pairs like (a[foo][bar], "baz")
-            returns (a, {"foo": {"bar": "baz"}}}, is_deep_object)
+        """consumes keys, value pairs like (a[foo][bar], "baz")
+        returns (a, {"foo": {"bar": "baz"}}}, is_deep_object)
         """
 
         root_key = k.split("[", 1)[0]

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -297,9 +297,9 @@ def event_loop(consumer, flask_app, event_producer, handler, interrupt):
                         handler(message.value, event_producer)
                         metrics.ingress_message_handler_success.inc()
                     except OperationalError as oe:
-                        """ sqlalchemy.exc.OperationalError: This error occurs when an
-                            authentication failure occurs or the DB is not accessible.
-                            Exit the process to restart the pod
+                        """sqlalchemy.exc.OperationalError: This error occurs when an
+                        authentication failure occurs or the DB is not accessible.
+                        Exit the process to restart the pod
                         """
                         logger.error(f"Could not access DB {str(oe)}")
                         sys.exit(3)

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -61,8 +61,8 @@ def run(config, logger, session, consumer, event_producer, shutdown_handler):
                     # TODO: Metrics
                     # metrics.ingress_message_handler_success.inc()
                 except OperationalError as oe:
-                    """ sqlalchemy.exc.OperationalError: This error occurs when an
-                        authentication failure occurs or the DB is not accessible.
+                    """sqlalchemy.exc.OperationalError: This error occurs when an
+                    authentication failure occurs or the DB is not accessible.
                     """
                     logger.error(f"Could not access DB {str(oe)}")
                     sys.exit(3)

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -162,8 +162,8 @@ def assert_host_response_status(response, expected_status=201, host_index=None):
 
 
 def assert_host_ids_in_response(response, expected_hosts):
-    response_ids = sorted([host["id"] for host in response["results"]])
-    expected_ids = sorted([str(host.id) for host in expected_hosts])
+    response_ids = sorted(host["id"] for host in response["results"])
+    expected_ids = sorted(str(host.id) for host in expected_hosts)
     assert response_ids == expected_ids
 
 
@@ -401,7 +401,7 @@ def quote_everything(string):
 
 
 def create_mock_rbac_response(permissions_response_file):
-    with open(permissions_response_file, "r") as rbac_response:
+    with open(permissions_response_file) as rbac_response:
         resp_data = json.load(rbac_response)
         return resp_data["data"]
 

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -857,8 +857,8 @@ def test_get_hosts_only_insights(mq_create_three_specific_hosts, mq_create_or_up
     assert response_status == 200
     assert len(response_data["results"]) == 3
 
-    result_ids = sorted([host["id"] for host in response_data["results"]])
-    expected_ids = sorted([host.id for host in created_hosts_with_insights_id])
+    result_ids = sorted(host["id"] for host in response_data["results"])
+    expected_ids = sorted(host.id for host in created_hosts_with_insights_id)
     non_expected_id = created_host_without_insights_id.id
 
     assert expected_ids == result_ids

--- a/tests/test_culling.py
+++ b/tests/test_culling.py
@@ -369,10 +369,10 @@ def test_non_culled_host_is_not_removed(event_producer_mock, db_create_host, db_
         created_host = db_create_host(host=host)
         created_hosts.append(created_host)
 
-    created_host_ids = sorted([host.id for host in created_hosts])
+    created_host_ids = sorted(host.id for host in created_hosts)
     retrieved_hosts = db_get_hosts(created_host_ids)
 
-    assert created_host_ids == sorted([host.id for host in retrieved_hosts])
+    assert created_host_ids == sorted(host.id for host in retrieved_hosts)
 
     threadctx.request_id = UNKNOWN_REQUEST_ID_VALUE
     host_reaper_run(
@@ -385,7 +385,7 @@ def test_non_culled_host_is_not_removed(event_producer_mock, db_create_host, db_
 
     retrieved_hosts = db_get_hosts(created_host_ids)
 
-    assert created_host_ids == sorted([host.id for host in retrieved_hosts])
+    assert created_host_ids == sorted(host.id for host in retrieved_hosts)
     assert event_producer_mock.event is None
 
 

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -315,7 +315,7 @@ def test_add_edge_host(event_datetime_mock, mq_create_or_update_host, db_get_hos
 
 def test_add_host_with_system_profile(event_datetime_mock, mq_create_or_update_host):
     """
-     Tests adding a host with message containing system profile
+    Tests adding a host with message containing system profile
     """
     expected_insights_id = generate_uuid()
     expected_system_profile = valid_system_profile()
@@ -338,7 +338,7 @@ def test_add_host_with_system_profile(event_datetime_mock, mq_create_or_update_h
 
 def test_add_host_with_wrong_owner(event_datetime_mock, mq_create_or_update_host):
     """
-     Tests adding a host with message containing system profile
+    Tests adding a host with message containing system profile
     """
     expected_insights_id = generate_uuid()
     expected_system_profile = valid_system_profile()
@@ -394,7 +394,7 @@ def test_add_host_rhsm_conduit_owner_id(event_datetime_mock, mq_create_or_update
 
 def test_add_host_with_tags(event_datetime_mock, mq_create_or_update_host):
     """
-     Tests adding a host with message containing tags
+    Tests adding a host with message containing tags
     """
     expected_insights_id = generate_uuid()
     expected_tags = [
@@ -438,7 +438,7 @@ def test_add_host_with_tags(event_datetime_mock, mq_create_or_update_host):
 )
 def test_add_host_with_invalid_tags(tag, mq_create_or_update_host):
     """
-     Tests adding a host with message containing invalid tags
+    Tests adding a host with message containing invalid tags
     """
     insights_id = generate_uuid()
     host = minimal_host(account=SYSTEM_IDENTITY["account_number"], insights_id=insights_id, tags=[tag])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2157,7 +2157,7 @@ class CustomRegexMethodTestCase(TestCase):
 
 
 class KafkaAvailabilityTests(TestCase):
-    def setUp(self,):
+    def setUp(self):
         super().setUp()
         self.config = Config(RuntimeEnvironment.TEST)
 


### PR DESCRIPTION
# Overview

* autoupdate
* bump to python38 minimals ofr pyupgrade/reorder
* update black url to the new home