### PR TITLE
Unleash integration; hide edge hosts by default if feature flag enabled

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -37,6 +37,7 @@ honcho = "*"
 sqlalchemy = "<1.4.0"
 urllib3 = ">=1.26.5"
 python-snappy = "*"
+flask-unleash = "*"
 
 [dev-packages]
 pytest = "~=5.0.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2cd606e9c4e9cbcdeb7862242c3202da47f58fee0b85a681fc76a34a1b41291e"
+            "sha256": "41d8207c8b8adee56ee0a6ece18067837549942cf9e1b8dc09f7a4059ced32a9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -38,6 +38,21 @@
             "index": "pypi",
             "version": "==0.1.10"
         },
+        "appdirs": {
+            "hashes": [
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            ],
+            "version": "==1.4.4"
+        },
+        "apscheduler": {
+            "hashes": [
+                "sha256:65e6574b6395498d371d045f2a8a7e4f7d50c6ad21ef7313d15b1c7cf20df1e3",
+                "sha256:ddc25a0ddd899de44d7f451f4375fb971887e65af51e41e5dcf681f59b8b2c9a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==3.9.1"
+        },
         "attrs": {
             "hashes": [
                 "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
@@ -46,21 +61,43 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.4.0"
         },
+        "backports.zoneinfo": {
+            "hashes": [
+                "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf",
+                "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328",
+                "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546",
+                "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6",
+                "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570",
+                "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9",
+                "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7",
+                "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987",
+                "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722",
+                "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582",
+                "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc",
+                "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b",
+                "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1",
+                "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08",
+                "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac",
+                "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==0.2.1"
+        },
         "boto3": {
             "hashes": [
-                "sha256:6fa0622f308cfd1da758966fc98b52fbd74b80606d14586c8ad82c7a6c4f32d0",
-                "sha256:8fa32fcc8be38327bd667237223d71e5e4b2475f39d6882aca4dbad19fff8c29"
+                "sha256:8c7c296edac2a76d3fdc9e9664d2adac37ac0205b18ffda22e3f1e3c078038ba",
+                "sha256:c971850fa4466ed7ebcd9bbef58d03cd81c9dd3cf4e45cc1a916fc44cf2dcaf8"
             ],
             "index": "pypi",
-            "version": "==1.21.21"
+            "version": "==1.21.24"
         },
         "botocore": {
             "hashes": [
-                "sha256:7e976cfd0a61601e74624ef8f5246b40a01f2cce73a011ef29cf80a6e371d0fa",
-                "sha256:92daca8775e738a9db9b465d533019285f09d541e903233261299fd87c2f842c"
+                "sha256:6f8c79a784f04f074319cfbc4de7f858639049ac73065b26fd97b66839ab3b30",
+                "sha256:e6b5fe8bf1d3515256ebeea67b9e89d2f0cacf19131c1c86d744e5037f627d6e"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.24.21"
+            "version": "==1.24.24"
         },
         "certifi": {
             "hashes": [
@@ -97,11 +134,11 @@
                 "swagger-ui"
             ],
             "hashes": [
-                "sha256:2d163976fbc8766038d71f4232ace07826be7dd0a8fe7a539ce5fc8a80f1ab35",
-                "sha256:c08b530418a1c448d34cd142713ddd1b245e7694f45cd80533fe8538b64aa7eb"
+                "sha256:0ba5c163d34cb3cb3bf597d5b95fc14bad5d3596bf10ec86e32cdb63f68d0c8a",
+                "sha256:26a570a0283bbe4cdaf5d90dfb3441aaf8e18cb9de10f3f96bbc128a8a3d8b47"
             ],
             "index": "pypi",
-            "version": "==2.12.0"
+            "version": "==2.13.0"
         },
         "decorator": {
             "hashes": [
@@ -110,6 +147,13 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==5.1.1"
+        },
+        "fcache": {
+            "hashes": [
+                "sha256:36c2aab0ee6e0eccd69ff2b8da4f508f0464d94856c9469c22ba386a0c5e2ba4",
+                "sha256:a7d14a72e9b5dbf232184a70caf9ff39820583b7a42bc64424cd7d9487c63d86"
+            ],
+            "version": "==0.4.7"
         },
         "flask": {
             "hashes": [
@@ -165,6 +209,14 @@
             ],
             "index": "pypi",
             "version": "==2.4.4"
+        },
+        "flask-unleash": {
+            "hashes": [
+                "sha256:6838f0ae25a05ff73365c6f2f67c8a6b524fe4897dd7b5f5b2e387204c341db1",
+                "sha256:8ca151adf17627379c9129494ad96a717d811e53507a6def12d3746895542e17"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
         },
         "gunicorn": {
             "hashes": [
@@ -374,6 +426,37 @@
             "index": "pypi",
             "version": "==3.8.0"
         },
+        "mmh3": {
+            "hashes": [
+                "sha256:01e456edf9cc381298a590923aadd1c0bf9934d93433099a5001d656112437c2",
+                "sha256:07f1308a410dc406d6a3c282a685728d00a87f3ed684f012671b96d6cc6a41c3",
+                "sha256:0fd09c4b61fcddbcf0a87d5463b4e6d2919896736a67efc5248d5c74c1c9c742",
+                "sha256:12484ac80373db77d8a6beb7615e7dac8b6c3fb118905311a51450b4fc4a24d1",
+                "sha256:150439b906b4deaf6d796b2c2d11fb6159f08d02330d97723071ab3bf43b51df",
+                "sha256:167cbc2b5ae27f3bccd797a2e8a9e7561791bee4cc2885f2c140eedc5df000ef",
+                "sha256:19874e12acb4119ef1ef83062ef4ac953c3343dd07a67ede8fa096d0393f34be",
+                "sha256:23912dde2ad4f701926948dd8e79a0e42b000f73962806f153931f52985e1e07",
+                "sha256:2b6c79fc314b34b911245b460a79b601fff39bb807521fb7ed7c15cacf0394ac",
+                "sha256:3566d1455fa4a09f8fb1aa5b37f68914949674f9aa2bd630e9fdf344207f55b5",
+                "sha256:3e52b869572c09db0c1a483f6e9cedbccfae8a282d95e552d3d4bd0712ab3196",
+                "sha256:4589adcb609d1547aac7c1ac1064eb27cdd44b65b7e8a114e2971cd3b7110306",
+                "sha256:6d0b3e9def1fdfe4eadd35ee26bf72bd715ba97711f7101302d54c9d2e70ba27",
+                "sha256:7a311efd4ecf122f21392ec6bf447c620cc783d20bdb9aec60bb469a54318419",
+                "sha256:8803d28c17cf898f5f00c0433e8b13d51fa3bb4ebecf59872ba1eaa20d94128a",
+                "sha256:8fb833c2942917eff54f984b067d93e5a3c54dbb00720323460cdfed9292835f",
+                "sha256:9097be65aa95460bc68b6108601da8894757532450daf74034e4eaecd536acca",
+                "sha256:92fdffd63edb67c30dbaba18a7448d762209c0e678b0c9d577d17b30362b59a3",
+                "sha256:93c96e657e9bf9e9ef12ddaeae9f109c0b3134146e2eff2cbddde5a34190920e",
+                "sha256:b7d26d0243ed9a5b8bf7aa8c53697cb79dff1e1d207f42396b7a7cb2a62298b7",
+                "sha256:bd870aedd9189eff1cf4e1687869b56c7e9461ee869789139c3e704009e5c227",
+                "sha256:c17fe2e276edd37ad8a6aff3b1663d3479c2c5c5993539c1050422a1dae33033",
+                "sha256:d1ec578c09a07d3518ec9be540b87546397fa3455de73c166fcce51eaa5c41c5",
+                "sha256:e08a5d81a2ff53625953290187bed4ae96a6972e2b5cd5984a6ebc5a9aab256c",
+                "sha256:f1cce018cc82a8a6287e6aeb139e441129837b810f2ddf372e3ff7f0fefb0947",
+                "sha256:ff69ddc2d46e3e42720840b6b4f7bfb032fd1e677fac347fdfff6e4d9fd01212"
+            ],
+            "version": "==3.0.0"
+        },
         "openapi-schema-validator": {
             "hashes": [
                 "sha256:230db361c71a5b08b25ec926797ac8b59a8f499bbd7316bd15b6cd0fc9aea5df",
@@ -390,6 +473,14 @@
             ],
             "index": "pypi",
             "version": "==0.3.3"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
         },
         "prance": {
             "hashes": [
@@ -453,6 +544,14 @@
             ],
             "index": "pypi",
             "version": "==2.8.6"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
+                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.7"
         },
         "pyrsistent": {
             "hashes": [
@@ -525,10 +624,18 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
-                "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"
+                "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
+                "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"
             ],
-            "version": "==2021.3"
+            "version": "==2022.1"
+        },
+        "pytz-deprecation-shim": {
+            "hashes": [
+                "sha256:8314c9692a636c8eb3bda879b9f119e350e93223ae83e70e80c31675a0fdc1a6",
+                "sha256:af097bae1b616dde5c5744441e2ddc69e74dfdcb0c263129610d85b87445a59d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==0.1.0.post0"
         },
         "pyyaml": {
             "hashes": [
@@ -691,12 +798,36 @@
             ],
             "version": "==0.0.9"
         },
+        "tzdata": {
+            "hashes": [
+                "sha256:238e70234214138ed7b4e8a0fab0e5e13872edab3be586ab8198c407620e2ab9",
+                "sha256:8b536a8ec63dc0751342b3984193a3118f8fca2afe25752bb9b7fffd398552d3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.1"
+        },
+        "tzlocal": {
+            "hashes": [
+                "sha256:0f28015ac68a5c067210400a9197fc5d36ba9bc3f8eaf1da3cbd59acdfed9e09",
+                "sha256:28ba8d9fcb6c9a782d6e0078b4f6627af1ea26aeaa32b4eab5324abc7df4149f"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.1"
+        },
         "ujson": {
             "hashes": [
                 "sha256:f66073e5506e91d204ab0c614a148d5aa938bdbf104751be66f8ad7a222f5f86"
             ],
             "index": "pypi",
             "version": "==1.35"
+        },
+        "unleashclient": {
+            "hashes": [
+                "sha256:77e5b5ace9dad88e4cc62b7a8824222f10d973f9c6af4b108b82ddf0297d4c80",
+                "sha256:8f92cc504a9d0f61f4efbed3a653e0c9fb975d8a3e1297d6c7cf3003c15dff45",
+                "sha256:b4c468868637cafe0f4f593380e0af55e4af8c0f6df331880d99d816bd49a337"
+            ],
+            "version": "==5.1.1"
         },
         "urllib3": {
             "hashes": [
@@ -1245,11 +1376,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:dd448d1ded9f14d1a4bfa6bfc0c5b96ae3be3f2d6c6c159b23ddcfd701baa021",
-                "sha256:e9dd1a1359d70137559034c0f5433b34caf504af2dc756367be86a5a32967134"
+                "sha256:c3e01300fb8495bc00ed70741f5271fc95fed067eb7106297be73d30879af60c",
+                "sha256:ce8901d3bbf3b90393498187f2d56797a8a452fb2d0d7efc6fd837554d6f679c"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.13.3"
+            "version": "==20.13.4"
         },
         "wcwidth": {
             "hashes": [

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -341,10 +341,11 @@ def query_filters(
         query_filters += ({"provider_id": {"eq": provider_id.casefold()}},)
 
     # FEATURE FLAG: Edge hosts should be hidden by default.
-    # If the feature flag "hbi.api-hide-edge-default" is enabled, filter here on the API side.
+    # If the feature flag is enabled, filter here on the API side.
     sp_filter = deepcopy(filter)
     if UNLEASH.client.is_enabled(FLAG_HIDE_EDGE_BY_DEFAULT):
-        sp_filter.setdefault("system_profile", []).append({"host_type": "edge"})
+        if sp_filter.get("system_profile", {}).get("host_type") is None:
+            sp_filter.setdefault("system_profile", {}).update({"host_type": "nil"})
 
     for key in sp_filter:
         if key == "system_profile":

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -181,11 +181,9 @@ def create_app(runtime_environment):
     flask_app.config["SYSTEM_PROFILE_SPEC"] = process_system_profile_spec()
 
     # Configure Unleash (feature flags)
-    flask_app.config[
-        "UNLEASH_URL"
-    ] = f"{app_config.unleash_prefix}://{app_config.unleash_host}:{app_config.unleash_port}/api"
+    flask_app.config["UNLEASH_URL"] = app_config.unleash_url
     flask_app.config["UNLEASH_APP_NAME"] = "Host Inventory"
-    flask_app.config["UNLEASH_ENVIRONMENT"] = app_config.unleash_environment
+    flask_app.config["UNLEASH_ENVIRONMENT"] = None
     if app_config.unleash_token:
         flask_app.config["UNLEASH_CUSTOM_HEADERS"] = f"Bearer {app_config.unleash_token}"
 

--- a/app/config.py
+++ b/app/config.py
@@ -213,11 +213,8 @@ class Config:
         if self._runtime_environment == RuntimeEnvironment.TEST:
             self.bypass_rbac = "true"
 
-        self.unleash_host = os.environ.get("UNLEASH_HOST", "unleash")
-        self.unleash_port = os.environ.get("UNLEASH_PORT", "4242")
-        self.unleash_prefix = "https" if str(self.unleash_port) == "443" else "http"
+        self.unleash_url = os.environ.get("UNLEASH_URL", "http://unleash:4242/api")
         self.unleash_token = os.environ.get("UNLEASH_TOKEN", "")
-        self.unleash_environment = os.environ.get("ENV_NAME")
 
     def _build_base_url_path(self):
         app_name = os.getenv("APP_NAME", "inventory")

--- a/app/config.py
+++ b/app/config.py
@@ -213,6 +213,12 @@ class Config:
         if self._runtime_environment == RuntimeEnvironment.TEST:
             self.bypass_rbac = "true"
 
+        self.unleash_host = os.environ.get("UNLEASH_HOST", "unleash")
+        self.unleash_port = os.environ.get("UNLEASH_PORT", "4242")
+        self.unleash_prefix = "https" if str(self.unleash_port) == "443" else "http"
+        self.unleash_token = os.environ.get("UNLEASH_TOKEN", "")
+        self.unleash_environment = os.environ.get("ENV_NAME")
+
     def _build_base_url_path(self):
         app_name = os.getenv("APP_NAME", "inventory")
         path_prefix = os.getenv("PATH_PREFIX", "api")

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -75,6 +75,13 @@ objects:
           value: ${KAFKA_SASL_MECHANISM}
         - name: CLOWDER_ENABLED
           value: "true"
+        - name: UNLEASH_URL
+          value: ${UNLEASH_URL}
+        - name: UNLEASH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ${UNLEASH_SECRET_NAME}
+              key: CLIENT_ACCESS_TOKEN
         resources:
           limits:
             cpu: ${CPU_LIMIT}
@@ -149,6 +156,13 @@ objects:
           value: ${KAFKA_SASL_MECHANISM}
         - name: CLOWDER_ENABLED
           value: "true"
+        - name: UNLEASH_URL
+          value: ${UNLEASH_URL}
+        - name: UNLEASH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ${UNLEASH_SECRET_NAME}
+              key: CLIENT_ACCESS_TOKEN
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3
@@ -214,6 +228,13 @@ objects:
           value: ${KAFKA_SASL_MECHANISM}
         - name: CLOWDER_ENABLED
           value: "true"
+        - name: UNLEASH_URL
+          value: ${UNLEASH_URL}
+        - name: UNLEASH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ${UNLEASH_SECRET_NAME}
+              key: CLIENT_ACCESS_TOKEN
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3
@@ -273,6 +294,13 @@ objects:
           value: ${KAFKA_SASL_MECHANISM}
         - name: CLOWDER_ENABLED
           value: "true"
+        - name: UNLEASH_URL
+          value: ${UNLEASH_URL}
+        - name: UNLEASH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ${UNLEASH_SECRET_NAME}
+              key: CLIENT_ACCESS_TOKEN
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3
@@ -338,6 +366,13 @@ objects:
             value: ${KAFKA_SASL_MECHANISM}
           - name: CLOWDER_ENABLED
             value: "true"
+          - name: UNLEASH_URL
+            value: ${UNLEASH_URL}
+          - name: UNLEASH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: ${UNLEASH_SECRET_NAME}
+                key: CLIENT_ACCESS_TOKEN
         resources:
           limits:
             cpu: ${CPU_LIMIT}
@@ -408,6 +443,13 @@ objects:
             value: ${KAFKA_SASL_MECHANISM}
           - name: CLOWDER_ENABLED
             value: "true"
+          - name: UNLEASH_URL
+            value: ${UNLEASH_URL}
+          - name: UNLEASH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: ${UNLEASH_SECRET_NAME}
+                key: CLIENT_ACCESS_TOKEN
         resources:
           limits:
             cpu: ${CPU_LIMIT}
@@ -773,6 +815,14 @@ parameters:
 - name: CJI_RANDOM_SUFFIX
   required: true
   value: '123456'
+
+# Feature flags
+- description: Unleash secret name
+  name: UNLEASH_SECRET_NAME
+  value: unleash-ephemeral
+- description: Unleash API url
+  name: UNLEASH_URL
+  value: ''
 
 #floorist
 - name: MEMORY_LIMIT_FLOO

--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -1,0 +1,11 @@
+from flask_unleash import Unleash
+
+UNLEASH = Unleash()
+
+
+def init_unleash_app(app):
+    UNLEASH.init_app(app)
+
+
+def unleash_default_value(feature_name: str, context: dict) -> bool:
+    return f"Unable to retrieve value for {feature_name} from Unleash; using default value"

--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -1,7 +1,7 @@
 from flask_unleash import Unleash
 
 UNLEASH = Unleash()
-FLAG_HIDE_EDGE_BY_DEFAULT = "hbi.api-hide-edge-default"
+FLAG_HIDE_EDGE_BY_DEFAULT = "hbi.api.hide-edge-by-default"
 
 
 def init_unleash_app(app):

--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -1,11 +1,8 @@
 from flask_unleash import Unleash
 
 UNLEASH = Unleash()
+FLAG_HIDE_EDGE_BY_DEFAULT = "hbi.api-hide-edge-default"
 
 
 def init_unleash_app(app):
     UNLEASH.init_app(app)
-
-
-def unleash_default_value(feature_name: str, context: dict) -> bool:
-    return f"Unable to retrieve value for {feature_name} from Unleash; using default value"

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -416,9 +416,10 @@ class ConfigTestCase(TestCase):
 
 
 @patch("app.db.get_engine")
+@patch("app.init_unleash_app")
 @patch("app.Config", **{"return_value.mgmt_url_path_prefix": "/"})
 class CreateAppConfigTestCase(TestCase):
-    def test_config_is_assigned(self, config, get_engine):
+    def test_config_is_assigned(self, config, get_engine, init_unleash_app):
         app = create_app(RuntimeEnvironment.TEST)
         self.assertIn("INVENTORY_CONFIG", app.config)
         self.assertEqual(config.return_value, app.config["INVENTORY_CONFIG"])
@@ -426,9 +427,10 @@ class CreateAppConfigTestCase(TestCase):
 
 @patch("app.connexion.App")
 @patch("app.db.get_engine")
+@patch("app.init_unleash_app")
 class CreateAppConnexionAppInitTestCase(TestCase):
     @patch("app.TranslatingParser")
-    def test_specification_is_provided(self, translating_parser, get_engine, app):
+    def test_specification_is_provided(self, translating_parser, get_engine, init_unleash_app, app):
         create_app(RuntimeEnvironment.TEST)
 
         translating_parser.assert_called_once_with(SPECIFICATION_FILE)
@@ -439,7 +441,7 @@ class CreateAppConnexionAppInitTestCase(TestCase):
         assert len(args) == 1
         assert args[0] is translating_parser.return_value.specification
 
-    def test_specification_is_parsed(self, get_engine, app):
+    def test_specification_is_parsed(self, get_engine, init_unleash_app, app):
         create_app(RuntimeEnvironment.TEST)
         app.return_value.add_api.assert_called_once()
         args = app.return_value.add_api.mock_calls[0].args
@@ -448,7 +450,7 @@ class CreateAppConnexionAppInitTestCase(TestCase):
 
     # Test here the parsing is working with the referenced schemas from system_profile.spec.yaml
     # and the check parser.specification["components"]["schemas"] - this is more a library test
-    def test_translatingparser(self, get_engine, app):
+    def test_translatingparser(self, get_engine, init_unleash_app, app):
         create_app(RuntimeEnvironment.TEST)
         # Check whether SystemProfileNetworkInterface is inside the schemas section
         # add_api uses the specification as firts argument
@@ -460,7 +462,7 @@ class CreateAppConnexionAppInitTestCase(TestCase):
 
     # Create an app with bad defs assert that it wont create and will raise and exception
     @patch("app.SPECIFICATION_FILE", value="./swagger/api.spec.yaml")
-    def test_yaml_specification(self, translating_parser, get_engine, app):
+    def test_yaml_specification(self, translating_parser, get_engine, init_unleash_app, app):
         with patch("app.create_app", side_effect=Exception("mocked error")):
             with self.assertRaises(Exception) as e:
                 create_app(RuntimeEnvironment.TEST)


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2469](https://issues.redhat.com/browse/ESSNTL-2469) and [ESSNTL-2425](https://issues.redhat.com/browse/ESSNTL-2425).
This connects HBI to our Unleash feature flag service, and implements filtering out Edge hosts by default when the feature flag is enabled. The feature flag's name is `hbi.api.hide-edge-by-default`, and is located [here in Stage Unleash](https://insights-stage.unleash.devshift.net/#/features/strategies/hbi.api.hide-edge-by-default).

I also added and modified some xjoin tests to validate the functionality with and without the flag enabled. With the flag disabled, the current functionality should not change; with it enabled, Edge hosts get filtered out unless the request is specifically filtering on `system_profile.host_type`.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [x] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
