### PR TITLE
Update registered_with to accept all reporters and add per_reporter_staleness filters

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import datetime
 from datetime import timezone
 from enum import Enum
@@ -274,14 +275,13 @@ def _generic_filter_builder(builder_function, field_name, field_value, field_fil
 
 
 def build_registered_with_filter(registered_with):
-    reg_with_no_insights = registered_with
-    regwith_filter = ()
-    if "insights" in reg_with_no_insights:
-        regwith_filter = ({"NOT": {"insights_id": {"eq": None}}},)
-        reg_with_no_insights.remove("insights")
-    if reg_with_no_insights:
-        prs_list = []
-        for item in reg_with_no_insights:
+    reg_with_copy = deepcopy(registered_with)
+    prs_list = []
+    if "insights" in reg_with_copy:
+        prs_list.append({"NOT": {"insights_id": {"eq": None}}})
+        reg_with_copy.remove("insights")
+    if reg_with_copy:
+        for item in reg_with_copy:
             prs_list.append(
                 {
                     "per_reporter_staleness": {
@@ -296,9 +296,8 @@ def build_registered_with_filter(registered_with):
                     },
                 }
             )
-        regwith_filter += ({"OR": prs_list},)
 
-    return regwith_filter
+    return ({"OR": prs_list},)
 
 
 def build_tag_query_dict_tuple(tags):

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -331,7 +331,17 @@ def query_filters(
         staleness_filters = tuple(staleness_filter(staleness))
         query_filters += ({"OR": staleness_filters},)
     if registered_with:
-        query_filters += ({"NOT": {"insights_id": {"eq": None}}},)
+        for item in registered_with:
+            if item == "insights":
+                query_filters += ({"NOT": {"insights_id": {"eq": None}}},)
+            elif item == "cloud-connector":
+                query_filters += {"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "cloud-connector"}}}}
+            elif item == "puptoo":
+                query_filters += {"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "puptoo"}}}}
+            elif item == "rhsm-conduit":
+                query_filters += {"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "rhsm-conduit"}}}}
+            else:
+                query_filters += {"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "yupana"}}}}
     if provider_type:
         query_filters += ({"provider_type": {"eq": provider_type.casefold()}},)
     if provider_id:

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -287,7 +287,11 @@ def build_registered_with_filter(registered_with):
                     "per_reporter_staleness": {
                         "reporter": {"eq": item},
                         "stale_timestamp": {
-                            "gt": str(datetime.now(timezone.utc) - inventory_config().culling_culled_offset_delta)
+                            "gt": str(
+                                (
+                                    datetime.now(timezone.utc) - inventory_config().culling_culled_offset_delta
+                                ).isoformat()
+                            )
                         },
                     },
                 }

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -274,13 +274,14 @@ def _generic_filter_builder(builder_function, field_name, field_value, field_fil
 
 
 def build_registered_with_filter(registered_with):
+    reg_with_no_insights = registered_with
     regwith_filter = ()
-    if "insights" in registered_with:
+    if "insights" in reg_with_no_insights:
         regwith_filter = ({"NOT": {"insights_id": {"eq": None}}},)
-        registered_with.remove("insights")
-    if registered_with:
+        reg_with_no_insights.remove("insights")
+    if reg_with_no_insights:
         prs_list = []
-        for item in registered_with:
+        for item in reg_with_no_insights:
             prs_list.append(
                 {
                     "per_reporter_staleness": {

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -335,13 +335,15 @@ def query_filters(
             if item == "insights":
                 query_filters += ({"NOT": {"insights_id": {"eq": None}}},)
             elif item == "cloud-connector":
-                query_filters += {"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "cloud-connector"}}}}
+                query_filters += ({"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "cloud-connector"}}}},)
             elif item == "puptoo":
-                query_filters += {"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "puptoo"}}}}
+                query_filters += ({"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "puptoo"}}}},)
             elif item == "rhsm-conduit":
-                query_filters += {"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "rhsm-conduit"}}}}
+                query_filters += ({"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "rhsm-conduit"}}}},)
+            elif item == "yupana":
+                query_filters += ({"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "yupana"}}}},)
             else:
-                query_filters += {"OR": {"per_reporter_staleness": {item.casefold(): {"eq": "yupana"}}}}
+                query_filters += ({"OR": {"per_reporter_staleness": {item.casefold(): {"eq": item}}}},)
     if provider_type:
         query_filters += ({"provider_type": {"eq": provider_type.casefold()}},)
     if provider_id:

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -6,7 +6,7 @@ from api import build_collection_response
 from api import custom_escape
 from api import flask_json_response
 from api import metrics
-from api.filtering.filtering import _build_registered_with_per_reporter_filter
+from api.filtering.filtering import build_registered_with_filter
 from api.filtering.filtering import build_system_profile_filter
 from api.filtering.filtering import build_tag_query_dict_tuple
 from api.host import get_bulk_query_source
@@ -115,7 +115,7 @@ def get_sap_system(tags=None, page=None, per_page=None, staleness=None, register
         hostfilter_and_variables = build_tag_query_dict_tuple(tags)
 
     if registered_with:
-        variables["hostFilter"] = _build_registered_with_per_reporter_filter(registered_with)
+        variables["hostFilter"] = build_registered_with_filter(registered_with)
 
     if filter:
         for key in filter:
@@ -168,7 +168,7 @@ def get_sap_sids(search=None, tags=None, page=None, per_page=None, staleness=Non
         hostfilter_and_variables = build_tag_query_dict_tuple(tags)
 
     if registered_with:
-        variables["hostFilter"] = _build_registered_with_per_reporter_filter(registered_with)
+        variables["hostFilter"] = build_registered_with_filter(registered_with)
 
     if search:
         variables["filter"] = {

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -1,6 +1,3 @@
-from datetime import datetime
-from datetime import timezone
-
 import flask
 from kafka import KafkaConsumer
 
@@ -9,6 +6,7 @@ from api import build_collection_response
 from api import custom_escape
 from api import flask_json_response
 from api import metrics
+from api.filtering.filtering import _build_registered_with_per_reporter_filter
 from api.filtering.filtering import build_system_profile_filter
 from api.filtering.filtering import build_tag_query_dict_tuple
 from api.host import get_bulk_query_source
@@ -91,20 +89,6 @@ SAP_SIDS_QUERY = """
 
 def xjoin_enabled():
     return get_bulk_query_source() == BulkQuerySource.xjoin
-
-
-def _build_registered_with_per_reporter_filter(registered_with):
-    prs_list = []
-    for item in registered_with:
-        prs_list.append(
-            {
-                "AND": {
-                    "per_reporter_staleness": {item: {"eq": item}},
-                    f"per_reporter_staleness[{item}]": {"stale_timestamp": {"gt": datetime.now(timezone.utc)}},
-                }
-            }
-        )
-    return ({"OR": prs_list},)
 
 
 @api_operation

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -673,11 +673,17 @@ components:
       in: query
       name: registered_with
       required: false
-      description: Filters out any host not registered with the specified service
+      description: Filters out any host not registered by the specified reporter
       schema:
-        type: string
-        enum:
-          - insights
+        type: array
+        items:
+          type: string
+          enum:
+            - insights
+            - yupana
+            - puptoo
+            - rhsm-conduit
+            - cloud-connector
     filter_param:
       in: query
       name: filter

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -673,7 +673,7 @@ components:
       in: query
       name: registered_with
       required: false
-      description: Filters out any host not registered by the specified reporter
+      description: Filters out any host not registered by the specified reporters
       schema:
         type: array
         items:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1086,12 +1086,19 @@
         "in": "query",
         "name": "registered_with",
         "required": false,
-        "description": "Filters out any host not registered with the specified service",
+        "description": "Filters out any host not registered by the specified reporter",
         "schema": {
-          "type": "string",
-          "enum": [
-            "insights"
-          ]
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "insights",
+              "yupana",
+              "puptoo",
+              "rhsm-conduit",
+              "cloud-connector"
+            ]
+          }
         }
       },
       "filter_param": {

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1086,7 +1086,7 @@
         "in": "query",
         "name": "registered_with",
         "required": false,
-        "description": "Filters out any host not registered by the specified reporter",
+        "description": "Filters out any host not registered by the specified reporters",
         "schema": {
           "type": "array",
           "items": {

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -85,9 +85,9 @@ XJOIN_HOSTS_RESPONSE = {
                     },
                 },
                 "stale_timestamp": "2020-01-10T08:07:03.354307Z",
-                "reporter": "puptoo",
+                "reporter": "yupana",
                 "per_reporter_staleness": {
-                    "puptoo": {
+                    "yupana": {
                         "check_in_succeeded": True,
                         "last_check_in": "2020-02-10T08:07:03.354307+00:00",
                         "stale_timestamp": "2020-02-10T08:07:03.354307+00:00",

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -153,7 +153,6 @@ def test_delete_hosts_using_filter(
 @pytest.mark.parametrize(
     "field,value",
     (
-        ("registered_with", "insights"),
         ("registered_with", "cloud-connector"),
         ("registered_with", "puptoo"),
         ("registered_with", "rhsm-conduit"),

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -117,7 +117,7 @@ def test_create_then_delete_without_insights_id(
         ("registered_with", ["puptoo", "yupana"]),
     ),
 )
-def test_delete_hosts_using_filter_and_regisered_with(
+def test_delete_hosts_using_filter_and_registered_with(
     event_producer_mock,
     db_create_multiple_hosts,
     db_get_hosts,
@@ -148,6 +148,7 @@ def test_delete_hosts_using_filter_and_regisered_with(
     assert '"type": "delete"' in event_producer_mock.event
     assert_response_status(response_status, expected_status=202)
     assert len(host_ids) == response_data["hosts_deleted"]
+    assert len(host_ids) > 0
 
     # check db for the deleted hosts using their IDs
     host_id_list = [str(host.id) for host in created_hosts]

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -150,6 +150,58 @@ def test_delete_hosts_using_filter(
     assert len(new_hosts) == remaining_hosts.count()
 
 
+@pytest.mark.parametrize(
+    "field,value",
+    (
+        ("registered_with", "insights"),
+        ("registered_with", "cloud-connector"),
+        ("registered_with", "puptoo"),
+        ("registered_with", "rhsm-conduit"),
+        ("registered_with", "yupana"),
+    ),
+)
+def test_delete_hosts_using_regisered_with(
+    event_producer_mock,
+    db_create_multiple_hosts,
+    db_get_hosts,
+    api_delete_filtered_hosts,
+    patch_xjoin_post,
+    field,
+    value,
+):
+    created_hosts = db_create_multiple_hosts(how_many=len(XJOIN_HOSTS_RESPONSE_FOR_FILTERING["hosts"]["data"]))
+    host_ids = [str(host.id) for host in created_hosts]
+
+    # set the new host ids in the xjoin search reference.
+    resp = deepcopy(XJOIN_HOSTS_RESPONSE_FOR_FILTERING)
+    for ind, id in enumerate(host_ids):
+        resp["hosts"]["data"][ind]["id"] = id
+    response = {"data": resp}
+
+    # Make the new hosts available in xjoin-search to make them available
+    # for querying for deletion using filters
+    patch_xjoin_post(response, status=200)
+
+    new_hosts = db_create_multiple_hosts()
+    new_ids = [str(host.id) for host in new_hosts]
+
+    # delete hosts using the IDs supposedly returned by the query_filter
+    response_status, response_data = api_delete_filtered_hosts({field: value})
+
+    assert '"type": "delete"' in event_producer_mock.event
+    assert_response_status(response_status, expected_status=202)
+    assert len(host_ids) == response_data["hosts_deleted"]
+
+    # check db for the deleted hosts using their IDs
+    host_id_list = [str(host.id) for host in created_hosts]
+    deleted_hosts = db_get_hosts(host_id_list)
+    assert deleted_hosts.count() == 0
+
+    # now verify that the second set of hosts still available.
+    remaining_hosts = db_get_hosts(new_ids)
+    assert len(new_hosts) == remaining_hosts.count()
+
+
 def test_delete_all_hosts(
     event_producer_mock, db_create_multiple_hosts, db_get_hosts, api_delete_all_hosts, patch_xjoin_post
 ):

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -888,8 +888,8 @@ def test_get_hosts_registered_with(mq_create_three_specific_hosts, mq_create_or_
     assert response_status == 200
     assert len(response_data["results"]) == 3
 
-    result_ids = sorted([host["id"] for host in response_data["results"]])
-    expected_ids = sorted([host.id for host in created_hosts_with_insights_id])
+    result_ids = sorted(host["id"] for host in response_data["results"])
+    expected_ids = sorted(host.id for host in created_hosts_with_insights_id)
     non_expected_id = created_host_without_insights_id.id
 
     assert expected_ids == result_ids

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -845,42 +845,17 @@ def test_only_order_how(mq_create_three_specific_hosts, api_get, subtests):
             assert response_status == 400
 
 
-def test_get_hosts_only_insights(mq_create_three_specific_hosts, mq_create_or_update_host, api_get):
-    created_hosts_with_insights_id = mq_create_three_specific_hosts
-
-    host_without_insights_id = minimal_host(subscription_manager_id=generate_uuid(), fqdn="different.fqdn.com")
-    created_host_without_insights_id = mq_create_or_update_host(host_without_insights_id)
-
-    url = build_hosts_url(query="?registered_with=insights")
-    response_status, response_data = api_get(url)
-
-    assert response_status == 200
-    assert len(response_data["results"]) == 3
-
-    result_ids = sorted(host["id"] for host in response_data["results"])
-    expected_ids = sorted(host.id for host in created_hosts_with_insights_id)
-    non_expected_id = created_host_without_insights_id.id
-
-    assert expected_ids == result_ids
-    assert non_expected_id not in expected_ids
-
-
 @pytest.mark.parametrize(
-    "field,value",
-    (
-        ("registered_with", "cloud-connector"),
-        ("registered_with", "puptoo"),
-        ("registered_with", "rhsm-conduit"),
-        ("registered_with", "yupana"),
-    ),
+    "value",
+    ("insights", "cloud-connector", "puptoo", "rhsm-conduit", "yupana"),
 )
-def test_get_hosts_registered_with(mq_create_three_specific_hosts, mq_create_or_update_host, api_get, field, value):
+def test_get_hosts_registered_with(mq_create_three_specific_hosts, mq_create_or_update_host, api_get, value):
     created_hosts_with_insights_id = mq_create_three_specific_hosts
 
     host_without_insights_id = minimal_host(subscription_manager_id=generate_uuid(), fqdn="different.fqdn.com")
     created_host_without_insights_id = mq_create_or_update_host(host_without_insights_id)
 
-    url = build_hosts_url(query=f"?{field}={value}")
+    url = build_hosts_url(query=f"?registered_with={value}")
     response_status, response_data = api_get(url)
 
     assert response_status == 200

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -865,11 +865,9 @@ def test_get_hosts_only_insights(mq_create_three_specific_hosts, mq_create_or_up
     assert non_expected_id not in expected_ids
 
 
-# TODO update tests to use per_reporter_staleness
 @pytest.mark.parametrize(
     "field,value",
     (
-        ("registered_with", "insights"),
         ("registered_with", "cloud-connector"),
         ("registered_with", "puptoo"),
         ("registered_with", "rhsm-conduit"),

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -847,7 +847,7 @@ def test_only_order_how(mq_create_three_specific_hosts, api_get, subtests):
 
 @pytest.mark.parametrize(
     "value",
-    ("insights", "cloud-connector", "puptoo", "rhsm-conduit", "yupana"),
+    ("insights", "cloud-connector", "puptoo", "rhsm-conduit", "yupana", "puptoo&registered_with=yupana"),
 )
 def test_get_hosts_registered_with(mq_create_three_specific_hosts, mq_create_or_update_host, api_get, value):
     created_hosts_with_insights_id = mq_create_three_specific_hosts
@@ -856,28 +856,6 @@ def test_get_hosts_registered_with(mq_create_three_specific_hosts, mq_create_or_
     created_host_without_insights_id = mq_create_or_update_host(host_without_insights_id)
 
     url = build_hosts_url(query=f"?registered_with={value}")
-    response_status, response_data = api_get(url)
-
-    assert response_status == 200
-    assert len(response_data["results"]) == 3
-
-    result_ids = sorted(host["id"] for host in response_data["results"])
-    expected_ids = sorted(host.id for host in created_hosts_with_insights_id)
-    non_expected_id = created_host_without_insights_id.id
-
-    assert expected_ids == result_ids
-    assert non_expected_id not in expected_ids
-
-
-def test_get_hosts_registered_with_multiple_reporters(
-    mq_create_three_specific_hosts, mq_create_or_update_host, api_get
-):
-    created_hosts_with_insights_id = mq_create_three_specific_hosts
-
-    host_without_insights_id = minimal_host(subscription_manager_id=generate_uuid(), fqdn="different.fqdn.com")
-    created_host_without_insights_id = mq_create_or_update_host(host_without_insights_id)
-
-    url = build_hosts_url(query="?registered_with=puptoo&registered_with=yupana")
     response_status, response_data = api_get(url)
 
     assert response_status == 200

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -16,7 +16,6 @@ from unittest.mock import patch
 from uuid import UUID
 from uuid import uuid4
 
-import pytest
 from kafka.errors import KafkaError
 
 from api import api_operation
@@ -462,10 +461,8 @@ class CreateAppConnexionAppInitTestCase(TestCase):
     @patch("app.SPECIFICATION_FILE", value="./swagger/api.spec.yaml")
     def test_yaml_specification(self, translating_parser, get_engine, app):
         with patch("app.create_app", side_effect=Exception("mocked error")):
-            with self.assertRaises(Exception) as e:
+            with self.assertRaises(Exception):
                 create_app(RuntimeEnvironment.TEST)
-            if e:
-                pytest.xfail("Test fails with yml")
 
 
 class HostOrderHowTestCase(TestCase):

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1287,19 +1287,6 @@ def test_system_profile_sap_system_endpoint_tags(
     )
 
 
-def test_system_profile_sap_system_endpoint_registered_with_insights(
-    mocker, query_source_xjoin, graphql_system_profile_sap_system_query_empty_response, api_get
-):
-    url = build_system_profile_sap_system_url(query="?registered_with=insights")
-
-    response_status, response_data = api_get(url)
-
-    assert response_status == 200
-    graphql_system_profile_sap_system_query_empty_response.assert_called_once_with(
-        SAP_SYSTEM_QUERY, {"hostFilter": {"NOT": {"insights_id": {"eq": None}}}, "limit": 50, "offset": 0}, mocker.ANY
-    )
-
-
 @pytest.mark.parametrize("reporter", ("cloud-connector", "puptoo", "rhsm-conduit", "yupana"))
 def test_system_profile_sap_system_endpoint_registered_with_per_reporter(
     mocker, query_source_xjoin, graphql_system_profile_sap_system_query_empty_response, api_get, reporter
@@ -1311,7 +1298,22 @@ def test_system_profile_sap_system_endpoint_registered_with_per_reporter(
     assert response_status == 200
     graphql_system_profile_sap_system_query_empty_response.assert_called_once_with(
         SAP_SYSTEM_QUERY,
-        {"hostFilter": {"OR": {"per_reporter_staleness": {reporter: {"eq": reporter}}}}, "limit": 50, "offset": 0},
+        {
+            "hostFilter": (
+                {
+                    "OR": [
+                        {
+                            "AND": {
+                                "per_reporter_staleness": {reporter: {"eq": reporter}},
+                                f"per_reporter_staleness[{reporter}]": {"stale_timestamp": {"gt": mocker.ANY}},
+                            }
+                        }
+                    ]
+                },
+            ),
+            "limit": 50,
+            "offset": 0,
+        },
         mocker.ANY,
     )
 
@@ -1388,19 +1390,6 @@ def test_system_profile_sap_sids_endpoint_tags(
     )
 
 
-def test_system_profile_sap_sids_endpoint_registered_with_insights(
-    mocker, query_source_xjoin, graphql_system_profile_sap_sids_query_empty_response, api_get
-):
-    url = build_system_profile_sap_sids_url(query="?registered_with=insights")
-
-    response_status, response_data = api_get(url)
-
-    assert response_status == 200
-    graphql_system_profile_sap_sids_query_empty_response.assert_called_once_with(
-        SAP_SIDS_QUERY, {"hostFilter": {"NOT": {"insights_id": {"eq": None}}}, "limit": 50, "offset": 0}, mocker.ANY
-    )
-
-
 @pytest.mark.parametrize("reporter", ("cloud-connector", "puptoo", "rhsm-conduit", "yupana"))
 def test_system_profile_sap_sids_endpoint_registered_with_per_reporter(
     mocker, query_source_xjoin, graphql_system_profile_sap_sids_query_empty_response, api_get, reporter
@@ -1412,7 +1401,22 @@ def test_system_profile_sap_sids_endpoint_registered_with_per_reporter(
     assert response_status == 200
     graphql_system_profile_sap_sids_query_empty_response.assert_called_once_with(
         SAP_SIDS_QUERY,
-        {"hostFilter": {"OR": {"per_reporter_staleness": {reporter: {"eq": reporter}}}}, "limit": 50, "offset": 0},
+        {
+            "hostFilter": (
+                {
+                    "OR": [
+                        {
+                            "AND": {
+                                "per_reporter_staleness": {reporter: {"eq": reporter}},
+                                f"per_reporter_staleness[{reporter}]": {"stale_timestamp": {"gt": mocker.ANY}},
+                            }
+                        }
+                    ]
+                },
+            ),
+            "limit": 50,
+            "offset": 0,
+        },
         mocker.ANY,
     )
 

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -418,6 +418,29 @@ def test_query_variables_registered_with_insights(mocker, query_source_xjoin, gr
     )
 
 
+@pytest.mark.parametrize("reporter", ("cloud-connector", "puptoo", "rhsm-conduit", "yupana"))
+def test_query_variables_registered_with_per_reporter(
+    mocker, query_source_xjoin, graphql_query_empty_response, api_get, reporter
+):
+    url = build_hosts_url(query=f"?registered_with={reporter}")
+    response_status, response_data = api_get(url)
+
+    assert response_status == 200
+
+    graphql_query_empty_response.assert_called_once_with(
+        HOST_QUERY,
+        {
+            "order_by": mocker.ANY,
+            "order_how": mocker.ANY,
+            "limit": mocker.ANY,
+            "offset": mocker.ANY,
+            "filter": (mocker.ANY, {"OR": {"per_reporter_staleness": {reporter: {"eq": reporter}}}}),
+            "fields": mocker.ANY,
+        },
+        mocker.ANY,
+    )
+
+
 @pytest.mark.parametrize("direction", ("ASC", "DESC"))
 def test_query_variables_ordering_dir(direction, mocker, query_source_xjoin, graphql_query_empty_response, api_get):
     url = build_hosts_url(query=f"?order_by=updated&order_how={quote(direction)}")
@@ -1244,8 +1267,22 @@ def test_system_profile_sap_system_endpoint_registered_with_insights(
 
     assert response_status == 200
     graphql_system_profile_sap_system_query_empty_response.assert_called_once_with(
+        SAP_SYSTEM_QUERY, {"hostFilter": {"NOT": {"insights_id": {"eq": None}}}, "limit": 50, "offset": 0}, mocker.ANY
+    )
+
+
+@pytest.mark.parametrize("reporter", ("cloud-connector", "puptoo", "rhsm-conduit", "yupana"))
+def test_system_profile_sap_system_endpoint_registered_with_per_reporter(
+    mocker, query_source_xjoin, graphql_system_profile_sap_system_query_empty_response, api_get, reporter
+):
+    url = build_system_profile_sap_system_url(query=f"?registered_with={reporter}")
+
+    response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    graphql_system_profile_sap_system_query_empty_response.assert_called_once_with(
         SAP_SYSTEM_QUERY,
-        {"hostFilter": {"OR": mocker.ANY, "NOT": {"insights_id": {"eq": None}}}, "limit": 50, "offset": 0},
+        {"hostFilter": {"OR": {"per_reporter_staleness": {reporter: {"eq": reporter}}}}, "limit": 50, "offset": 0},
         mocker.ANY,
     )
 
@@ -1331,8 +1368,22 @@ def test_system_profile_sap_sids_endpoint_registered_with_insights(
 
     assert response_status == 200
     graphql_system_profile_sap_sids_query_empty_response.assert_called_once_with(
+        SAP_SIDS_QUERY, {"hostFilter": {"NOT": {"insights_id": {"eq": None}}}, "limit": 50, "offset": 0}, mocker.ANY
+    )
+
+
+@pytest.mark.parametrize("reporter", ("cloud-connector", "puptoo", "rhsm-conduit", "yupana"))
+def test_system_profile_sap_sids_endpoint_registered_with_per_reporter(
+    mocker, query_source_xjoin, graphql_system_profile_sap_sids_query_empty_response, api_get, reporter
+):
+    url = build_system_profile_sap_sids_url(query=f"?registered_with={reporter}")
+
+    response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    graphql_system_profile_sap_sids_query_empty_response.assert_called_once_with(
         SAP_SIDS_QUERY,
-        {"hostFilter": {"OR": mocker.ANY, "NOT": {"insights_id": {"eq": None}}}, "limit": 50, "offset": 0},
+        {"hostFilter": {"OR": {"per_reporter_staleness": {reporter: {"eq": reporter}}}}, "limit": 50, "offset": 0},
         mocker.ANY,
     )
 

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -412,7 +412,7 @@ def test_query_variables_registered_with_insights(mocker, query_source_xjoin, gr
             "offset": mocker.ANY,
             "filter": (
                 mocker.ANY,
-                {"NOT": {"insights_id": {"eq": None}}},
+                {"OR": [{"NOT": {"insights_id": {"eq": None}}}]},
             ),
             "fields": mocker.ANY,
         },
@@ -1129,7 +1129,7 @@ def test_tags_query_variables_registered_with(mocker, assert_tag_query_host_filt
         build_tags_url(query="?registered_with=insights"),
         host_filter={
             "OR": mocker.ANY,
-            "AND": ({"NOT": {"insights_id": {"eq": None}}},),
+            "AND": ({"OR": [{"NOT": {"insights_id": {"eq": None}}}]},),
         },
     )
 
@@ -1235,7 +1235,7 @@ def test_tags_RBAC_allowed(
                 build_tags_url(query="?registered_with=insights"),
                 host_filter={
                     "OR": mocker.ANY,
-                    "AND": ({"NOT": {"insights_id": {"eq": None}}},),
+                    "AND": ({"OR": [{"NOT": {"insights_id": {"eq": None}}}]},),
                 },
             )
             graphql_tag_query_empty_response.reset_mock()


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2448](https://issues.redhat.com/browse/ESSNTL-2448).
The PR updates "registered_with" to accept all reporters in addition to "insights" and add filters for per_reporter_staleness.

This PR should be on hold until "per_reporter_staleness" filters are implemented in "xjoin-search".  


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
