### PR TITLE
Remove ryandillinfelton from CODEOWNERS :(

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners
-* @kruai @ryandillinfelton @thearifismail @roliveri
+* @kruai @thearifismail @roliveri


### PR DESCRIPTION
Removes Ryan from CODEOWNERS so he won't keep getting assigned to HBI PRs by default.
