### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners
-* @kruai @thearifismail @roliveri
+* @RedHatInsights/host-based-inventory-committers


### PR DESCRIPTION
# Overview

This PR updates CODEOWNERS to use @RedHatInsights/host-based-inventory-committers. As the name implies, it's a GitHub team that contains all the users that should be committing code to HBI repos. This should make Fabricia a default reviewer, and we shouldn't have to update this file from now on.