### PR TITLE
Fixed "staleness=unknown" xjoin search

### DIFF
--- a/app/xjoin.py
+++ b/app/xjoin.py
@@ -87,7 +87,10 @@ def params_to_order(param_order_by, param_order_how):
 
 def staleness_filter(staleness):
     config = inventory_config()
-    return staleness_to_conditions(config, staleness, _stale_timestamp_filter)
+    staleness_conditions = tuple(staleness_to_conditions(config, staleness, _stale_timestamp_filter))
+    if "unknown" in staleness:
+        staleness_conditions += ({"stale_timestamp": {"eq": None}},)
+    return staleness_conditions
 
 
 def string_contains(string):

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -592,6 +592,7 @@ def test_query_variables_default_staleness(
         (
             {"gt": "2019-12-16T10:10:06.754201+00:00"},  # fresh
             {"gt": "2019-12-09T10:10:06.754201+00:00", "lte": "2019-12-16T10:10:06.754201+00:00"},  # stale
+            {"eq": None},  # unknown
         ),
     )
 
@@ -868,6 +869,7 @@ def test_tags_query_variables_default_staleness(
                             "lte": "2019-12-16T10:10:06.754201+00:00",
                         }
                     },
+                    {"stale_timestamp": {"eq": None}},
                 ]
             },
         },

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -603,6 +603,7 @@ def test_query_variables_default_staleness(
         ("fresh", {"gt": "2019-12-16T10:10:06.754201+00:00"}),
         ("stale", {"gt": "2019-12-09T10:10:06.754201+00:00", "lte": "2019-12-16T10:10:06.754201+00:00"}),
         ("stale_warning", {"gt": "2019-12-02T10:10:06.754201+00:00", "lte": "2019-12-09T10:10:06.754201+00:00"}),
+        ("unknown", {"eq": None}),
     ),
 )
 def test_query_variables_staleness(
@@ -883,6 +884,7 @@ def test_tags_query_variables_default_staleness(
         ("fresh", {"gt": "2019-12-16T10:10:06.754201+00:00"}),
         ("stale", {"gt": "2019-12-09T10:10:06.754201+00:00", "lte": "2019-12-16T10:10:06.754201+00:00"}),
         ("stale_warning", {"gt": "2019-12-02T10:10:06.754201+00:00", "lte": "2019-12-09T10:10:06.754201+00:00"}),
+        ("unknown", {"eq": None}),
     ),
 )
 def test_tags_query_variables_staleness(


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2166](https://issues.redhat.com/browse/ESSNTL-2166).

Filtering on "staleness=unknown" returns all hosts, when going through xjoin. This is because the xjoin-specific section ignores the "unknown" staleness filter.
This PR implements this filter.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
