### PR TITLE
Translate & populate org_id when missing from host payloads

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -109,6 +109,8 @@ class Config:
         self.rbac_retries = os.environ.get("RBAC_RETRIES", 2)
         self.rbac_timeout = os.environ.get("RBAC_TIMEOUT", 10)
 
+        self.tenant_translator_url = os.environ.get("TENANT_TRANSLATOR_URL")
+
         self.host_ingress_consumer_group = os.environ.get("KAFKA_HOST_INGRESS_GROUP", "inventory-mq")
         self.sp_validator_max_messages = int(os.environ.get("KAFKA_SP_VALIDATOR_MAX_MESSAGES", "10000"))
 

--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -7,6 +7,7 @@ from app.queue.metrics import event_producer_failure
 from app.queue.metrics import event_producer_success
 from app.queue.metrics import rbac_access_denied
 from app.queue.metrics import rbac_fetching_failure
+from app.queue.metrics import tenant_translator_fetching_failure
 from lib.metrics import pendo_fetching_failure
 
 
@@ -183,6 +184,11 @@ def rbac_permission_denied(logger, required_permission, user_permissions):
         extra={"required_permission": required_permission, "user_permissions": user_permissions},
     )
     rbac_access_denied.labels(required_permission=required_permission).inc()
+
+
+def tenant_translator_failure(logger, error_message=None):
+    logger.error("Failed to access 3scale tenant translator service: %s", error_message)
+    tenant_translator_fetching_failure.inc()
 
 
 def log_db_access_failure(logger, message, host_data):

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -47,6 +47,9 @@ rbac_fetching_failure = Counter("inventory_rbac_fetching_failures", "Total amoun
 rbac_access_denied = Counter(
     "inventory_rbac_access_denied", "Total amount of failures authorizing with RBAC", ["required_permission"]
 )
+tenant_translator_fetching_failure = Counter(
+    "inventory_tenant_translator_fetching_failures", "Total amount of failures fetching 3scale tenant translator data"
+)
 db_communication_error = Counter(
     "inventory_mq_db_communication_error",
     "Total number of connection errors between inventory-mq and the DB",

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -147,6 +147,8 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
+        - name: TENANT_TRANSLATOR_URL
+          value: ${TENANT_TRANSLATOR_PROTOCOL}://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}
@@ -212,6 +214,8 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
+        - name: TENANT_TRANSLATOR_URL
+          value: ${TENANT_TRANSLATOR_PROTOCOL}://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}
@@ -271,6 +275,8 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
+        - name: TENANT_TRANSLATOR_URL
+          value: ${TENANT_TRANSLATOR_PROTOCOL}://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}
@@ -773,6 +779,12 @@ parameters:
 - name: CJI_RANDOM_SUFFIX
   required: true
   value: '123456'
+- name: TENANT_TRANSLATOR_HOST
+  value: 'apicast.3scale-dev.svc.cluster.local'
+- name: TENANT_TRANSLATOR_PORT
+  value: '8892'
+- name: TENANT_TRANSLATOR_PROTOCOL
+  value: 'http'
 
 #floorist
 - name: MEMORY_LIMIT_FLOO

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -148,7 +148,7 @@ objects:
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
         - name: TENANT_TRANSLATOR_URL
-          value: ${TENANT_TRANSLATOR_PROTOCOL}://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+          value: ${TENANT_TRANSLATOR_PROTOCOL}://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}
@@ -215,7 +215,7 @@ objects:
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
         - name: TENANT_TRANSLATOR_URL
-          value: ${TENANT_TRANSLATOR_PROTOCOL}://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+          value: ${TENANT_TRANSLATOR_PROTOCOL}://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}
@@ -276,7 +276,7 @@ objects:
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
         - name: TENANT_TRANSLATOR_URL
-          value: ${TENANT_TRANSLATOR_PROTOCOL}://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+          value: ${TENANT_TRANSLATOR_PROTOCOL}://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: CLOWDER_ENABLED
           value: "true"
         image: ${IMAGE}:${IMAGE_TAG}

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -16,6 +16,7 @@ from app.serialization import DEFAULT_FIELDS
 from app.serialization import serialize_host
 from lib import metrics
 from lib.db import session_guard
+from lib.middleware import translate_account_to_org_id
 
 
 __all__ = (
@@ -54,6 +55,10 @@ def add_host(input_host, identity, staleness_offset, update_system_profile=True,
      - at least one of the canonical facts fields is required
      - account number
     """
+
+    # If there's no org_id, populate it using the 3scale endpoint
+    if not input_host.org_id:
+        input_host.org_id = translate_account_to_org_id(input_host.account)
 
     with session_guard(db.session):
         existing_host = find_existing_host(identity, input_host.canonical_facts)


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2775](https://issues.redhat.com/browse/ESSNTL-2775).
Makes it so that if an incoming host is missing `org_id`, it attempts to fetch it from the tenant-translation 3scale endpoint. It uses the same retry & timeout config that the RBAC requests use. If the org_id is missing from the host and it's unable to fetch the value from the tenant translator, the payload is rejected.

On hold until #1125 is merged.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
