### PR TITLE
Rename delete_host_list and _delete_filtered_hosts

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -137,7 +137,7 @@ def get_host_list(
 @api_operation
 @rbac(Permission.WRITE)
 @metrics.api_request_time.time()
-def delete_host_list(
+def delete_hosts_by_filter(
     display_name=None,
     fqdn=None,
     hostname_or_id=None,
@@ -191,7 +191,7 @@ def delete_host_list(
         flask.abort(status.HTTP_404_NOT_FOUND, "No hosts found for deletion.")
 
     try:
-        delete_count = _delete_filtered_hosts(ids_list)
+        delete_count = _delete_host_list(ids_list)
     except KafkaError:
         logger.error("Kafka server not available")
         flask.abort(503)
@@ -201,7 +201,7 @@ def delete_host_list(
     return flask_json_response(json_data, status.HTTP_202_ACCEPTED)
 
 
-def _delete_filtered_hosts(host_id_list):
+def _delete_host_list(host_id_list):
     current_identity = get_current_identity()
     payload_tracker = get_payload_tracker(account=current_identity.account_number, request_id=threadctx.request_id)
 
@@ -255,7 +255,7 @@ def delete_all_hosts(confirm_delete_all=None):
         flask.abort(status.HTTP_404_NOT_FOUND, "No hosts found for deletion.")
 
     try:
-        delete_count = _delete_filtered_hosts(ids_list)
+        delete_count = _delete_host_list(ids_list)
     except KafkaError:
         logger.error("Kafka server not available")
         flask.abort(503)
@@ -269,7 +269,7 @@ def delete_all_hosts(confirm_delete_all=None):
 @rbac(Permission.WRITE)
 @metrics.api_request_time.time()
 def delete_by_id(host_id_list):
-    _delete_filtered_hosts(host_id_list)
+    _delete_host_list(host_id_list)
     return flask.Response(None, status.HTTP_200_OK)
 
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -42,7 +42,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/HostQueryOutput'
     delete:
-      operationId: api.host.delete_host_list
+      operationId: api.host.delete_hosts_by_filter
       tags:
         - hosts
       summary: Delete the entire list of hosts filtered by the given parameters

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -83,7 +83,7 @@
         }
       },
       "delete": {
-        "operationId": "api.host.delete_host_list",
+        "operationId": "api.host.delete_hosts_by_filter",
         "tags": [
           "hosts"
         ],


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-1969](https://issues.redhat.com/browse/ESSNTL-1969).

- Renames `delete_host_list` to `delete_hosts_by_filter`, since the params are filters rather than a list of host IDs
- Renames `_delete_filtered_hosts` to `_delete_host_list`, since the param is a list of host IDs

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
