### PR TITLE
Add negative values to registered_with; update tests

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -282,20 +282,22 @@ def build_registered_with_filter(registered_with):
         reg_with_copy.remove("insights")
     if reg_with_copy:
         for item in reg_with_copy:
-            prs_list.append(
-                {
-                    "per_reporter_staleness": {
-                        "reporter": {"eq": item},
-                        "stale_timestamp": {
-                            "gt": str(
-                                (
-                                    datetime.now(timezone.utc) - inventory_config().culling_culled_offset_delta
-                                ).isoformat()
-                            )
-                        },
+            prs_item = {
+                "per_reporter_staleness": {
+                    "reporter": {"eq": item.replace("!", "")},
+                    "stale_timestamp": {
+                        "gt": str(
+                            (datetime.now(timezone.utc) - inventory_config().culling_culled_offset_delta).isoformat()
+                        )
                     },
-                }
-            )
+                },
+            }
+
+            # If registered_with starts with "!", we want to invert the condition.
+            if item.startswith("!"):
+                prs_item = {"NOT": prs_item}
+
+            prs_list.append(prs_item)
 
     return ({"OR": prs_list},)
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -714,6 +714,10 @@ components:
             - puptoo
             - rhsm-conduit
             - cloud-connector
+            - "!yupana"
+            - "!puptoo"
+            - "!rhsm-conduit"
+            - "!cloud-connector"
     filter_param:
       in: query
       name: filter

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1152,7 +1152,11 @@
               "yupana",
               "puptoo",
               "rhsm-conduit",
-              "cloud-connector"
+              "cloud-connector",
+              "!yupana",
+              "!puptoo",
+              "!rhsm-conduit",
+              "!cloud-connector"
             ]
           }
         }

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -870,7 +870,7 @@ def test_get_hosts_registered_with(mq_create_three_specific_hosts, mq_create_or_
 
 
 def test_query_variables_registered_with_using_unknown_reporter(api_get):
-    MSG = "'unknown' is not one of ['insights', 'yupana', 'puptoo', 'rhsm-conduit', 'cloud-connector']"
+    MSG = "'unknown' is not one of ["
     url = build_hosts_url(query="?registered_with=unknown")
 
     response_status, response_data = api_get(url)

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -424,6 +424,7 @@ def _build_prs_array(mocker, reporters):
         ["cloud-connector", "puptoo", "rhsm-conduit"],
         ["!puptoo"],
         ["!yupana", "puptoo"],
+        ["!yupana", "!puptoo", "rhsm-conduit"],
     ),
 )
 def test_query_variables_registered_with_per_reporter(
@@ -1099,6 +1100,7 @@ def test_tags_query_variables_registered_with(mocker, assert_tag_query_host_filt
         ["cloud-connector", "puptoo", "rhsm-conduit"],
         ["!puptoo"],
         ["!yupana", "puptoo"],
+        ["!yupana", "!puptoo", "rhsm-conduit"],
     ),
 )
 def test_tags_query_variables_registered_with_per_reporter(
@@ -1316,6 +1318,7 @@ def test_system_profile_sap_system_endpoint_tags(
         ["cloud-connector", "puptoo", "rhsm-conduit"],
         ["!puptoo"],
         ["!yupana", "puptoo"],
+        ["!yupana", "!puptoo", "rhsm-conduit"],
     ),
 )
 def test_system_profile_sap_system_endpoint_registered_with_per_reporter(
@@ -1422,6 +1425,7 @@ def test_system_profile_sap_sids_endpoint_tags(
         ["cloud-connector", "puptoo", "rhsm-conduit", "yupana"],
         ["!puptoo"],
         ["!yupana", "puptoo"],
+        ["!yupana", "!puptoo", "rhsm-conduit"],
     ),
 )
 def test_system_profile_sap_sids_endpoint_registered_with_per_reporter(

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -401,21 +401,30 @@ def test_query_variables_tags_with_search(field, mocker, query_source_xjoin, gra
 def _build_prs_array(mocker, reporters):
     prs_array = []
     for reporter in reporters:
-        prs_array.append(
-            {
-                "per_reporter_staleness": {
-                    "reporter": {"eq": reporter},
-                    "stale_timestamp": {"gt": mocker.ANY},
-                }
+        prs_item = {
+            "per_reporter_staleness": {
+                "reporter": {"eq": reporter.replace("!", "")},
+                "stale_timestamp": {"gt": mocker.ANY},
             }
-        )
+        }
+
+        if reporter.startswith("!"):
+            prs_item = {"NOT": prs_item}
+
+        prs_array.append(prs_item)
 
     return prs_array
 
 
 @pytest.mark.parametrize(
     "reporters",
-    (["cloud-connector"], ["puptoo"], ["rhsm-conduit"], ["yupana"], ["cloud-connector", "puptoo", "rhsm-conduit"]),
+    (
+        ["cloud-connector"],
+        ["puptoo", "yupana"],
+        ["cloud-connector", "puptoo", "rhsm-conduit"],
+        ["!puptoo"],
+        ["!yupana", "puptoo"],
+    ),
 )
 def test_query_variables_registered_with_per_reporter(
     mocker, query_source_xjoin, graphql_query_empty_response, api_get, reporters
@@ -1084,7 +1093,13 @@ def test_tags_query_variables_registered_with(mocker, assert_tag_query_host_filt
 
 @pytest.mark.parametrize(
     "reporters",
-    (["cloud-connector"], ["puptoo"], ["rhsm-conduit"], ["yupana"], ["cloud-connector", "puptoo", "rhsm-conduit"]),
+    (
+        ["cloud-connector"],
+        ["puptoo", "yupana"],
+        ["cloud-connector", "puptoo", "rhsm-conduit"],
+        ["!puptoo"],
+        ["!yupana", "puptoo"],
+    ),
 )
 def test_tags_query_variables_registered_with_per_reporter(
     mocker, assert_tag_query_host_filter_single_call, reporters
@@ -1295,7 +1310,13 @@ def test_system_profile_sap_system_endpoint_tags(
 
 @pytest.mark.parametrize(
     "reporters",
-    (["cloud-connector"], ["puptoo"], ["rhsm-conduit"], ["yupana"], ["cloud-connector", "puptoo", "rhsm-conduit"]),
+    (
+        ["cloud-connector"],
+        ["puptoo", "yupana"],
+        ["cloud-connector", "puptoo", "rhsm-conduit"],
+        ["!puptoo"],
+        ["!yupana", "puptoo"],
+    ),
 )
 def test_system_profile_sap_system_endpoint_registered_with_per_reporter(
     mocker, query_source_xjoin, graphql_system_profile_sap_system_query_empty_response, api_get, reporters
@@ -1397,10 +1418,10 @@ def test_system_profile_sap_sids_endpoint_tags(
     "reporters",
     (
         ["cloud-connector"],
-        ["puptoo"],
-        ["rhsm-conduit"],
-        ["yupana"],
+        ["puptoo", "yupana"],
         ["cloud-connector", "puptoo", "rhsm-conduit", "yupana"],
+        ["!puptoo"],
+        ["!yupana", "puptoo"],
     ),
 )
 def test_system_profile_sap_sids_endpoint_registered_with_per_reporter(


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2797](https://issues.redhat.com/browse/ESSNTL-2797).
Adds the ability to filter on inverse registered_with values. For instance, `?registered_with=!puptoo` would mean "only show me hosts that are not actively being reported by puptoo. `?registered_with=puptoo&registered_with=!puptoo` would mean "show me hosts that are either being reported to by puptoo or _not_ being reported by puptoo, which should be all hosts.

I also verified that the graphql queries this generates work as expected in xjoin-search.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
