### PR TITLE
Check response for None before indexing

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -1,3 +1,5 @@
+import flask
+
 from api.filtering.filtering import host_id_list_query_filter
 from api.filtering.filtering import query_filters
 from app.auth import get_current_identity
@@ -94,8 +96,10 @@ def get_host_list_using_filters(all_filters, page, per_page, param_order_by, par
         "fields": system_profile_fields,
     }
     response = graphql_query(QUERY, variables, log_get_host_list_failed)
-    if response is None:
-        return iter([]), 0, additional_fields
+    if response is None or "hosts" not in response:
+        # Log an error implicating xjoin, then abort with status 503
+        logger.error("xjoin-search responded with invalid format")
+        flask.abort(503)
 
     response = response["hosts"]
 

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -93,7 +93,11 @@ def get_host_list_using_filters(all_filters, page, per_page, param_order_by, par
         "filter": all_filters,
         "fields": system_profile_fields,
     }
-    response = graphql_query(QUERY, variables, log_get_host_list_failed)["hosts"]
+    response = graphql_query(QUERY, variables, log_get_host_list_failed)
+    if response is None:
+        return iter([]), 0, additional_fields
+
+    response = response["hosts"]
 
     total = response["meta"]["total"]
     check_pagination(offset, total)

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -62,6 +62,28 @@ def test_host_request_xjoin_status_403(patch_xjoin_post, api_get):
     assert response_status == 500
 
 
+def test_host_request_xjoin_invalid_response_none(patch_xjoin_post, api_get):
+    patch_xjoin_post(response={"data": None}, status=200)
+    request_id = generate_uuid()
+
+    response_status, response_data = api_get(
+        HOST_URL, extra_headers={"x-rh-insights-request-id": request_id, "foo": "bar"}
+    )
+
+    assert response_status == 503
+
+
+def test_host_request_xjoin_invalid_response_empty(patch_xjoin_post, api_get):
+    patch_xjoin_post(response={"data": {}}, status=200)
+    request_id = generate_uuid()
+
+    response_status, response_data = api_get(
+        HOST_URL, extra_headers={"x-rh-insights-request-id": request_id, "foo": "bar"}
+    )
+
+    assert response_status == 503
+
+
 def test_host_request_xjoin_status_200(patch_xjoin_post, api_get):
     patch_xjoin_post(response={"data": EMPTY_HOSTS_RESPONSE}, status=200)
     request_id = generate_uuid()

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -62,19 +62,9 @@ def test_host_request_xjoin_status_403(patch_xjoin_post, api_get):
     assert response_status == 500
 
 
-def test_host_request_xjoin_invalid_response_none(patch_xjoin_post, api_get):
-    patch_xjoin_post(response={"data": None}, status=200)
-    request_id = generate_uuid()
-
-    response_status, response_data = api_get(
-        HOST_URL, extra_headers={"x-rh-insights-request-id": request_id, "foo": "bar"}
-    )
-
-    assert response_status == 503
-
-
-def test_host_request_xjoin_invalid_response_empty(patch_xjoin_post, api_get):
-    patch_xjoin_post(response={"data": {}}, status=200)
+@pytest.mark.parametrize("response_data", (None, {}))
+def test_host_request_xjoin_invalid_response(patch_xjoin_post, api_get, response_data):
+    patch_xjoin_post(response={"data": response_data}, status=200)
     request_id = generate_uuid()
 
     response_status, response_data = api_get(


### PR DESCRIPTION
HBI returns 500 on /hosts request, through xjoin, if there are no hosts in the database. This is because xjoin returns None in this situation and we try to index that return value.

# Overview

This PR is being created to address [ESSNTL-1158](https://issues.redhat.com/browse/ESSNTL-1158).
In get_host_list_using_filters(), check response for None before indexing.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
