### PR TITLE
essntl-2795: Remove searchParam from "system_profile/operating_system" and fixed its descripiton

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -453,7 +453,6 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
-        - $ref: '#/components/parameters/searchParam'
         - $ref: '#/components/parameters/tagsParam'
         - $ref: '#/components/parameters/perPageParam'
         - $ref: '#/components/parameters/pageParam'
@@ -697,7 +696,7 @@ components:
       in: query
       name: search
       required: false
-      description: Only include tags that match the given search string. The value is matched against namespace, key and value.
+      description: Used for searching tags and sap_sids that match the given search string. For searching tags, a tag's namespace, key, and/or value is used for matching.
       schema:
         type: string
     registered_with:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -790,9 +790,6 @@
         ],
         "parameters": [
           {
-            "$ref": "#/components/parameters/searchParam"
-          },
-          {
             "$ref": "#/components/parameters/tagsParam"
           },
           {
@@ -1136,7 +1133,7 @@
         "in": "query",
         "name": "search",
         "required": false,
-        "description": "Only include tags that match the given search string. The value is matched against namespace, key and value.",
+        "description": "Used for searching tags and sap_sids that match the given search string. For searching tags, a tag's namespace, key, and/or value is used for matching.",
         "schema": {
           "type": "string"
         }


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2795](https://issues.redhat.com/browse/ESSNTL-2795).

Removed the searhParam from "system_profile/operating_system" endpoint following this comment from @kruai 
```
Hmm... yeah, looking at how it's implemented in the SAP_SIDs query, I see what you mean. OK, with that info, I'm cool with removing "search" for this endpoint. If additional functionality gets requested, we can address it at that time. Sorry for the confusion [Muhammad Arif](https://issues.redhat.com/secure/ViewProfile.jspa?name=theaarif)
```

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
