### PR TITLE
Update event rebuilder to also write "updated" events

### DIFF
--- a/app/queue/events.py
+++ b/app/queue/events.py
@@ -72,7 +72,7 @@ class HostDeleteEvent(Schema):
     metadata = fields.Nested(HostEventMetadataSchema())
 
 
-def message_headers(event_type, insights_id):
+def message_headers(event_type: EventType, insights_id: str):
     return {
         "event_type": event_type.name,
         "request_id": threadctx.request_id,

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -166,7 +166,7 @@ def parse_operation_message(message):
     return parsed_operation
 
 
-def sync_deleted_event_message(message, session, event_producer):
+def sync_event_message(message, session, event_producer):
     if message["type"] != EventType.delete.name:
         query = session.query(Host).filter(
             (Host.account == message["host"]["account"]) & (Host.id == UUID(message["host"]["id"]))

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -16,7 +16,7 @@ from app.logging import get_logger
 from app.logging import threadctx
 from app.queue.event_producer import EventProducer
 from app.queue.queue import send_update_messages_for_existing_hosts
-from app.queue.queue import sync_deleted_event_message
+from app.queue.queue import sync_event_message
 from lib.db import session_guard
 from lib.handlers import register_shutdown
 from lib.handlers import ShutdownHandler
@@ -58,7 +58,7 @@ def run(config, logger, session, consumer, event_producer, shutdown_handler):
             for message in messages:
                 logger.debug("Message received")
                 try:
-                    sync_deleted_event_message(json.loads(message.value), session, event_producer)
+                    sync_event_message(json.loads(message.value), session, event_producer)
                     # TODO: Metrics
                     # metrics.ingress_message_handler_success.inc()
                 except OperationalError as oe:

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -15,7 +15,8 @@ from app.logging import configure_logging
 from app.logging import get_logger
 from app.logging import threadctx
 from app.queue.event_producer import EventProducer
-from app.queue.queue import sync_event_message
+from app.queue.queue import send_update_messages_for_existing_hosts
+from app.queue.queue import sync_deleted_event_message
 from lib.db import session_guard
 from lib.handlers import register_shutdown
 from lib.handlers import ShutdownHandler
@@ -57,7 +58,7 @@ def run(config, logger, session, consumer, event_producer, shutdown_handler):
             for message in messages:
                 logger.debug("Message received")
                 try:
-                    sync_event_message(json.loads(message.value), session, event_producer)
+                    sync_deleted_event_message(json.loads(message.value), session, event_producer)
                     # TODO: Metrics
                     # metrics.ingress_message_handler_success.inc()
                 except OperationalError as oe:
@@ -75,7 +76,11 @@ def run(config, logger, session, consumer, event_producer, shutdown_handler):
 
         total_messages_processed += num_messages
 
-    logger.info(f"Event topic rebuild complete. Processed {total_messages_processed} messages.")
+    logger.info(f"Event topic rebuild: Wrote {total_messages_processed} 'delete' messages.")
+
+    total_updates_produced = send_update_messages_for_existing_hosts(session, event_producer)
+
+    logger.info(f"Event topic rebuild: Wrote {total_updates_produced} 'updated' messages.")
 
 
 def main(logger):

--- a/tests/test_event_rebuilder.py
+++ b/tests/test_event_rebuilder.py
@@ -45,9 +45,7 @@ def test_no_delete_when_hosts_present(mocker, db_create_host, inventory_config):
 
 @pytest.mark.parametrize("num_existing", (0, 3, 4))
 @pytest.mark.parametrize("num_missing", (1, 3, 5))
-def test_creates_delete_event_when_missing_from_db(
-    mocker, db_create_host, inventory_config, num_existing, num_missing
-):
+def test_creates_delete_and_update_events(mocker, db_create_host, inventory_config, num_existing, num_missing):
     event_producer_mock = mock.Mock()
     threadctx.request_id = UNKNOWN_REQUEST_ID_VALUE
     event_list = []


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-1292](https://issues.redhat.com/browse/ESSNTL-1292).
Changes `rebuild_events_topic.py` so that it not only sends "delete" messages for hosts that are missing from the DB, but also sends "updated" messages for those that exist in the DB. This job will need to be run after we run the org_id DB column populator.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
