### PR TITLE
ESSNTL-2863: Inventory doesn't send update event messages after updating facts

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -365,10 +365,10 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
         else:
             host.merge_facts_in_namespace(namespace, fact_dict)
 
-    if db.session.is_modified(host):
-        db.session.commit()
-        serialized_host = serialize_host(host, staleness_timestamps(), EGRESS_HOST_FIELDS)
-        _emit_patch_event(serialized_host, host.id, host.canonical_facts.get("insights_id"))
+        if db.session.is_modified(host):
+            db.session.commit()
+            serialized_host = serialize_host(host, staleness_timestamps(), EGRESS_HOST_FIELDS)
+            _emit_patch_event(serialized_host, host.id, host.canonical_facts.get("insights_id"))
 
     logger.debug("hosts_to_update:%s", hosts_to_update)
 

--- a/api/host.py
+++ b/api/host.py
@@ -366,7 +366,7 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
         else:
             host.merge_facts_in_namespace(namespace, fact_dict)
 
-        db.session.commit()
+    db.session.commit()
 
     logger.debug("hosts_to_update:%s", hosts_to_update)
 

--- a/api/host.py
+++ b/api/host.py
@@ -366,7 +366,10 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
         else:
             host.merge_facts_in_namespace(namespace, fact_dict)
 
-    db.session.commit()
+        if db.session.is_modified(host):
+            db.session.commit()
+            serialized_host = serialize_host(host, staleness_timestamps(), EGRESS_HOST_FIELDS)
+            _emit_patch_event(serialized_host, host.id, host.canonical_facts.get("insights_id"))
 
     logger.debug("hosts_to_update:%s", hosts_to_update)
 

--- a/api/host.py
+++ b/api/host.py
@@ -366,10 +366,7 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
         else:
             host.merge_facts_in_namespace(namespace, fact_dict)
 
-        if db.session.is_modified(host):
-            db.session.commit()
-            serialized_host = serialize_host(host, staleness_timestamps(), EGRESS_HOST_FIELDS)
-            _emit_patch_event(serialized_host, host.id, host.canonical_facts.get("insights_id"))
+        db.session.commit()
 
     logger.debug("hosts_to_update:%s", hosts_to_update)
 

--- a/api/host.py
+++ b/api/host.py
@@ -366,7 +366,10 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
         else:
             host.merge_facts_in_namespace(namespace, fact_dict)
 
-    db.session.commit()
+    if db.session.is_modified(host):
+        db.session.commit()
+        serialized_host = serialize_host(host, staleness_timestamps(), EGRESS_HOST_FIELDS)
+        _emit_patch_event(serialized_host, host.id, host.canonical_facts.get("insights_id"))
 
     logger.debug("hosts_to_update:%s", hosts_to_update)
 

--- a/tests/test_api_facts.py
+++ b/tests/test_api_facts.py
@@ -17,7 +17,9 @@ from tests.helpers.test_utils import get_staleness_timestamps
 from tests.helpers.test_utils import SYSTEM_IDENTITY
 
 
-def test_replace_facts_to_multiple_hosts_with_branch_id(db_create_multiple_hosts, db_get_hosts, api_put):
+def test_replace_facts_to_multiple_hosts_with_branch_id(
+    db_create_multiple_hosts, db_get_hosts, api_put, event_producer_mock
+):
     created_hosts = db_create_multiple_hosts(how_many=2, extra_data={"facts": DB_FACTS})
 
     host_id_list = get_id_list_from_hosts(created_hosts)
@@ -43,7 +45,9 @@ def test_replace_facts_to_multiple_hosts_including_nonexistent_host(db_create_mu
     assert_response_status(response_status, expected_status=400)
 
 
-def test_replace_facts_to_multiple_hosts_with_empty_key_value_pair(db_create_multiple_hosts, db_get_hosts, api_put):
+def test_replace_facts_to_multiple_hosts_with_empty_key_value_pair(
+    db_create_multiple_hosts, db_get_hosts, api_put, event_producer_mock
+):
     new_facts = {}
 
     created_hosts = db_create_multiple_hosts(how_many=2, extra_data={"facts": DB_FACTS})
@@ -78,7 +82,7 @@ def test_replace_facts_without_fact_dict(api_put):
     assert_error_response(response_data, expected_status=400, expected_detail="Request body is not valid JSON")
 
 
-def test_replace_facts_on_multiple_hosts(db_create_multiple_hosts, db_get_hosts, api_put):
+def test_replace_facts_on_multiple_hosts(db_create_multiple_hosts, db_get_hosts, api_put, event_producer_mock):
     created_hosts = db_create_multiple_hosts(how_many=2, extra_data={"facts": DB_FACTS})
 
     host_id_list = get_id_list_from_hosts(created_hosts)
@@ -92,7 +96,7 @@ def test_replace_facts_on_multiple_hosts(db_create_multiple_hosts, db_get_hosts,
     assert all(host.facts == expected_facts for host in db_get_hosts(host_id_list))
 
 
-def test_replace_empty_facts_on_multiple_hosts(db_create_multiple_hosts, db_get_hosts, api_put):
+def test_replace_empty_facts_on_multiple_hosts(db_create_multiple_hosts, db_get_hosts, api_put, event_producer_mock):
     new_facts = {}
 
     created_hosts = db_create_multiple_hosts(how_many=2, extra_data={"facts": DB_FACTS})
@@ -131,7 +135,7 @@ def test_replace_facts_on_multiple_culled_hosts(db_create_multiple_hosts, db_get
     assert_response_status(response_status, expected_status=400)
 
 
-def test_put_facts_with_RBAC_allowed(subtests, mocker, api_put, db_create_host, enable_rbac):
+def test_put_facts_with_RBAC_allowed(subtests, mocker, api_put, db_create_host, enable_rbac, event_producer_mock):
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
 
     for response_file in WRITE_ALLOWED_RBAC_RESPONSE_FILES:
@@ -147,7 +151,9 @@ def test_put_facts_with_RBAC_allowed(subtests, mocker, api_put, db_create_host, 
             assert_response_status(response_status, 200)
 
 
-def test_put_facts_with_RBAC_denied(subtests, mocker, api_put, db_create_host, db_get_host, enable_rbac):
+def test_put_facts_with_RBAC_denied(
+    subtests, mocker, api_put, db_create_host, db_get_host, enable_rbac, event_producer_mock
+):
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
 
     updated_facts = {"updatedfact1": "updatedvalue1", "updatedfact2": "updatedvalue2"}
@@ -167,7 +173,7 @@ def test_put_facts_with_RBAC_denied(subtests, mocker, api_put, db_create_host, d
             assert db_get_host(host.id).facts[DB_FACTS_NAMESPACE] != updated_facts
 
 
-def test_put_facts_with_RBAC_bypassed_as_system(api_put, db_create_host, enable_rbac):
+def test_put_facts_with_RBAC_bypassed_as_system(api_put, db_create_host, enable_rbac, event_producer_mock):
     host = db_create_host(
         SYSTEM_IDENTITY,
         extra_data={"facts": DB_FACTS, "system_profile_facts": {"owner_id": SYSTEM_IDENTITY["system"].get("cn")}},

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -303,7 +303,7 @@ def test_add_facts_without_fact_dict(api_patch, db_create_host):
     assert_error_response(response_data, expected_status=400, expected_detail="Request body is not valid JSON")
 
 
-def test_add_facts_to_multiple_hosts(db_create_multiple_hosts, db_get_hosts, api_patch):
+def test_add_facts_to_multiple_hosts(event_producer_mock, db_create_multiple_hosts, db_get_hosts, api_patch):
     created_hosts = db_create_multiple_hosts(how_many=2, extra_data={"facts": DB_FACTS})
 
     host_id_list = get_id_list_from_hosts(created_hosts)
@@ -318,7 +318,9 @@ def test_add_facts_to_multiple_hosts(db_create_multiple_hosts, db_get_hosts, api
     assert all(host.facts == expected_facts for host in db_get_hosts(host_id_list))
 
 
-def test_add_facts_to_multiple_hosts_with_branch_id(db_create_multiple_hosts, db_get_hosts, api_patch):
+def test_add_facts_to_multiple_hosts_with_branch_id(
+    event_producer_mock, db_create_multiple_hosts, db_get_hosts, api_patch
+):
     created_hosts = db_create_multiple_hosts(how_many=2, extra_data={"facts": DB_FACTS})
 
     host_id_list = get_id_list_from_hosts(created_hosts)
@@ -343,7 +345,9 @@ def test_add_facts_to_multiple_hosts_including_nonexistent_host(db_create_multip
     assert_response_status(response_status, expected_status=400)
 
 
-def test_add_facts_to_multiple_hosts_overwrite_empty_key_value_pair(db_create_multiple_hosts, db_get_hosts, api_patch):
+def test_add_facts_to_multiple_hosts_overwrite_empty_key_value_pair(
+    event_producer_mock, db_create_multiple_hosts, db_get_hosts, api_patch
+):
     facts = {DB_FACTS_NAMESPACE: {}}
 
     created_hosts = db_create_multiple_hosts(how_many=2, extra_data={"facts": facts})

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -271,6 +271,25 @@ def test_patch_produces_update_event_no_insights_id(
     )
 
 
+def test_patch_by_namespace_produces_update_event(
+    event_producer_mock, event_datetime_mock, db_create_host, db_get_host, api_patch
+):
+    host = db_host()
+    created_host = db_create_host(host=host, extra_data={"facts": DB_FACTS})
+
+    facts_url = build_facts_url(host_list_or_id=created_host.id, namespace=DB_FACTS_NAMESPACE)
+    response_status, response_data = api_patch(facts_url, DB_NEW_FACTS)
+    assert_response_status(response_status, expected_status=200)
+
+    assert_patch_event_is_valid(
+        host=created_host,
+        event_producer=event_producer_mock,
+        expected_request_id="-1",
+        expected_timestamp=event_datetime_mock,
+        display_name="test-display-name",
+    )
+
+
 def test_event_producer_instrumentation(mocker, event_producer, future_mock, db_create_host, api_patch):
     created_host = db_create_host()
     patch_doc = {"display_name": "patch_event_test"}

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -271,14 +271,11 @@ def test_patch_produces_update_event_no_insights_id(
     )
 
 
-def test_patch_by_namespace_produces_update_event(
-    event_producer_mock, event_datetime_mock, db_create_host, db_get_host, api_patch
-):
-    host = db_host()
-    created_host = db_create_host(host=host, extra_data={"facts": DB_FACTS})
+def test_patch_by_namespace_produces_update_event(event_producer_mock, event_datetime_mock, db_create_host, api_patch):
+    created_host = db_create_host(host=db_host(), extra_data={"facts": DB_FACTS})
 
     facts_url = build_facts_url(host_list_or_id=created_host.id, namespace=DB_FACTS_NAMESPACE)
-    response_status, response_data = api_patch(facts_url, DB_NEW_FACTS)
+    response_status, _ = api_patch(facts_url, DB_NEW_FACTS)
     assert_response_status(response_status, expected_status=200)
 
     assert_patch_event_is_valid(


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2863](https://issues.redhat.com/browse/ESSNTL-2863).

Adds a event emitter when host facts are updated by namespace.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
