### PR TITLE
Rename CJI env var; trigger events topic rebuilder in Stage

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -661,7 +661,7 @@ objects:
   metadata:
     labels:
       app: host-inventory
-    name: events-topic-rebuilder-${CJI_RANDOM_SUFFIX}
+    name: events-topic-rebuilder-${EVENTS_REBUILDER_RUN_NUMBER}
   spec:
     appName: host-inventory
     jobs:
@@ -829,9 +829,6 @@ parameters:
   value: 'true'
 - name: KAFKA_SP_VALIDATOR_MAX_MESSAGES
   value: '10000'
-- name: CJI_RANDOM_SUFFIX
-  required: true
-  value: '123456'
 - name: TENANT_TRANSLATOR_HOST
   value: 'apicast.3scale-dev.svc.cluster.local'
 - name: TENANT_TRANSLATOR_PORT
@@ -845,6 +842,8 @@ parameters:
 - name: POPULATOR_RUN_NUMBER # in case the populator needs to be run more than once increment this parameter to get a new job
   value: '1'
 - name: SYNCHRONIZER_RUN_NUMBER
+  value: '1'
+- name: EVENTS_REBUILDER_RUN_NUMBER
   value: '1'
 - name: GUNICORN_WORKERS
   value: '1'


### PR DESCRIPTION
# Overview

This PR renames the env var `CJI_RANDOM_SUFFIX` to the more descriptive `EVENTS_REBUILDER_RUN_NUMBER`. This will trigger an (intended) run of the events topic rebuilder in Stage, and we can increment that var in app-interface each time we need to run it.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
