### PR TITLE
Log exception when org_id translator gives unexpected response

### DIFF
--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -1,3 +1,4 @@
+import json
 from functools import wraps
 
 from flask import abort
@@ -125,6 +126,16 @@ def translate_account_to_org_id(account: str) -> str:
     finally:
         request_session.close()
 
-    resp_data = translator_response.json()
+    try:
+        resp_data = translator_response.json()
+    except json.decoder.JSONDecodeError as e:
+        tenant_translator_failure(logger, e)
+        raise InventoryException(
+            title="Network Error",
+            detail=(
+                "Could not decode response body received from tenant translator endpoint "
+                f"with status {translator_response.status_code}: {translator_response.content}"
+            ),
+        )
 
     return resp_data.get(account)

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -1586,3 +1586,30 @@ def test_add_host_missing_org_id_error(mocker, mq_create_or_update_host, enable_
 
     with pytest.raises(InventoryException):
         mq_create_or_update_host(host, return_all_data=True)
+
+
+def test_translate_org_id_unexpected_response(mocker, mq_create_or_update_host, enable_org_id_translation):
+    """
+    Tests the error handling for org_id translation when the 3scale response is invalid.
+    """
+    account_number = SYSTEM_IDENTITY["account_number"]
+
+    # Mock the post() so it generates an error
+    session_post_mock = mocker.patch("lib.middleware.Session.post")
+    mock_response = MockResponseObject()
+    mock_response.status_code = 403
+    mock_response.content = "asdf"
+    session_post_mock.side_effect = mock_response
+
+    host = minimal_host(
+        account=account_number,
+        system_profile={"owner_id": OWNER_ID},
+    )
+
+    with pytest.raises(InventoryException) as exception:
+        mq_create_or_update_host(host, return_all_data=True)
+
+    assert (
+        str(exception.value.detail)
+        == "Could not decode response body received from tenant translator endpoint with status 403: asdf"
+    )


### PR DESCRIPTION
# Overview

This PR is being created to help with investigation into Prod behavior for [ESSNTL-2775](https://issues.redhat.com/browse/ESSNTL-2775).
Whenever the tenant translator endpoint response has an unexpected format, it logs the response's status code and content.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
