### PR TITLE
Add temporary OrgID translator endpoint

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -48,6 +48,7 @@ from lib.host_repository import find_existing_host
 from lib.host_repository import find_non_culled_hosts
 from lib.host_repository import update_query_for_owner_id
 from lib.middleware import rbac
+from lib.middleware import translate_account_to_org_id
 
 
 FactOperations = Enum("FactOperations", ("merge", "replace"))
@@ -470,3 +471,11 @@ def host_checkin(body):
         return flask_json_response(serialized_host, 201)
     else:
         flask.abort(404, "No hosts match the provided canonical facts.")
+
+
+@api_operation
+@rbac(Permission.READ)
+@metrics.api_request_time.time()
+def translate_to_org_id(account):
+    org_id = translate_account_to_org_id(account)
+    return flask.Response(f"{account} translates to {org_id}", status.HTTP_200_OK)

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -344,7 +344,28 @@ paths:
                 $ref: '#/components/schemas/TagCountOut'
         '400':
           description: Invalid request.
-
+  '/orgid/{account}':
+    get:
+      tags:
+        - orgid
+      summary: Translate account to Org ID
+      description: >-
+        Translates an account number to its Org ID
+        <br /><br />
+        Required permissions: inventory:hosts:read
+      operationId: api.host.translate_to_org_id
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - in: path
+          name: account
+          required: true
+          schema:
+            type: string
+          description: The account number to translate
+      responses:
+        '200':
+          description: Successfully translated.
   /tags:
     get:
       tags:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -586,6 +586,37 @@
         }
       }
     },
+    "/orgid/{account}": {
+      "get": {
+        "tags": [
+          "orgid"
+        ],
+        "summary": "Translate account to Org ID",
+        "description": "Translates an account number to its Org ID <br /><br /> Required permissions: inventory:hosts:read",
+        "operationId": "api.host.translate_to_org_id",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The account number to translate"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully translated."
+          }
+        }
+      }
+    },
     "/tags": {
       "get": {
         "tags": [


### PR DESCRIPTION
# Overview

This PR adds the temporary endpoint `/orgid/{account}`. It takes the account number in the path and translates it to the Org ID. This is needed to help debug the translator issue in Prod.