### PR TITLE
Combine host-sync jobs & CJI

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -469,7 +469,7 @@ objects:
         command:
           - /bin/sh
           - -c
-          - python host_synchronizer.py && python rebuild_events_topic.py
+          - python rebuild_events_topic.py && python host_synchronizer.py
         env:
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -469,55 +469,7 @@ objects:
         command:
           - /bin/sh
           - -c
-          - python host_synchronizer.py
-        env:
-          - name: INVENTORY_LOG_LEVEL
-            value: ${LOG_LEVEL}
-          - name: INVENTORY_DB_SSL_MODE
-            value: ${INVENTORY_DB_SSL_MODE}
-          - name: INVENTORY_DB_SSL_CERT
-            value: ${INVENTORY_DB_SSL_CERT}
-          - name: KAFKA_BOOTSTRAP_SERVERS
-            value: ${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}
-          - name: PAYLOAD_TRACKER_KAFKA_TOPIC
-            value: platform.payload-status
-          - name: PAYLOAD_TRACKER_SERVICE_NAME
-            value: inventory-mq-service
-          - name: PAYLOAD_TRACKER_ENABLED
-            value: 'true'
-          - name: PROMETHEUS_PUSHGATEWAY
-            value: ${PROMETHEUS_PUSHGATEWAY}
-          - name: KAFKA_PRODUCER_ACKS
-            value: ${KAFKA_PRODUCER_ACKS}
-          - name: KAFKA_PRODUCER_RETRIES
-            value: ${KAFKA_PRODUCER_RETRIES}
-          - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
-            value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
-          - name: NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: KAFKA_SECURITY_PROTOCOL
-            value: ${KAFKA_SECURITY_PROTOCOL}
-          - name: KAFKA_SASL_MECHANISM
-            value: ${KAFKA_SASL_MECHANISM}
-          - name: CLOWDER_ENABLED
-            value: "true"
-        resources:
-          limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT}
-          requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
-    - name: events-topic-rebuilder
-      podSpec:
-        image: ${IMAGE}:${IMAGE_TAG}
-        restartPolicy: OnFailure
-        command:
-          - /bin/sh
-          - -c
-          - python rebuild_events_topic.py
+          - python host_synchronizer.py && python rebuild_events_topic.py
         env:
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
@@ -656,16 +608,6 @@ objects:
         partitions: 1
       - topicName: ${KAFKA_HOST_INGRESS_P1_TOPIC}
         partitions: 1
-- apiVersion: cloud.redhat.com/v1alpha1
-  kind: ClowdJobInvocation
-  metadata:
-    labels:
-      app: host-inventory
-    name: events-topic-rebuilder-${EVENTS_REBUILDER_RUN_NUMBER}
-  spec:
-    appName: host-inventory
-    jobs:
-      - events-topic-rebuilder
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
@@ -842,8 +784,6 @@ parameters:
 - name: POPULATOR_RUN_NUMBER # in case the populator needs to be run more than once increment this parameter to get a new job
   value: '1'
 - name: SYNCHRONIZER_RUN_NUMBER
-  value: '1'
-- name: EVENTS_REBUILDER_RUN_NUMBER
   value: '1'
 - name: GUNICORN_WORKERS
   value: '1'


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3066](https://issues.redhat.com/browse/ESSNTL-3066).
**rebuild-events-topic** sifts through Kafka messages in the Events topic, and produces "deleted" events when a host is not found in the DB. **host-synchronizer** goes through every host in the DB and produces "updated" events for each. In order to guarantee that the Cyndi DBs are in sync with HBI's, these both need to run.

So, I'm simply changing the `synchronizer` job to run `rebuild_events_topic.py` followed by `host_synchronizer.py`. This should make it so we can just trigger the job and expect everything to get back in sync.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
