### PR TITLE
Add translator env vars to API service

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -69,6 +69,10 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
+        - name: TENANT_TRANSLATOR_URL
+          value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
+        - name: BYPASS_TENANT_TRANSLATION
+          value: ${BYPASS_TENANT_TRANSLATION}
         - name: CLOWDER_ENABLED
           value: "true"
         resources:


### PR DESCRIPTION
# Overview

This PR adds the translator-related env vars to the API service deployment. This is to support my previous PR: https://github.com/RedHatInsights/insights-host-inventory/pull/1149