### PR TITLE
[fix] check for the kafka_ssl_file independently

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -49,12 +49,15 @@ class Config:
         self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC", "platform.inventory.host-ingress"))
         self.event_topic = topic("platform.inventory.events")
         self.payload_tracker_kafka_topic = topic("platform.payload-status")
+        # certificates are required in fedramp, but not in managed kafka
         try:
             self.kafka_ssl_cafile = self._kafka_ca(broker_cfg.cacert)
+        except AttributeError:
+            self.kafka_ssl_cafile = None
+        try:
             self.kafka_sasl_username = broker_cfg.sasl.username
             self.kafka_sasl_password = broker_cfg.sasl.password
         except AttributeError:
-            self.kafka_ssl_cafile = None
             self.kafka_sasl_username = ""
             self.kafka_sasl_password = ""
 


### PR DESCRIPTION
The managed kafka environment does not use a CAFile, but fedramp does.
We need this to be more forgivable so we can still connect without it
if we don't have it.

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>

# Overview
Working the managed kafka switch and we noticed that this zeroes out the username and password if the cert doesn't exist. This is just a first pass and more might be needed but this seems like it could be part of the problem.

Thanks!

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
