### PR TITLE
Avoid KeyError if we do not have platform.inventory.host-ingress-p1 and app/config.py is used

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -70,6 +70,8 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
+        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
+          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -148,6 +150,8 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
+        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
+          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -217,6 +221,8 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
+        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
+          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -280,6 +286,8 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
+        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
+          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -349,6 +357,8 @@ objects:
             value: ${KAFKA_SECURITY_PROTOCOL}
           - name: KAFKA_SASL_MECHANISM
             value: ${KAFKA_SASL_MECHANISM}
+          - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
+            value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
           - name: CLOWDER_ENABLED
             value: "true"
         resources:
@@ -508,6 +518,8 @@ objects:
             value: ${KAFKA_SECURITY_PROTOCOL}
           - name: KAFKA_SASL_MECHANISM
             value: ${KAFKA_SASL_MECHANISM}
+          - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
+            value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
           - name: CLOWDER_ENABLED
             value: "true"
         resources:


### PR DESCRIPTION
# Overview

If we have configured other than default `platform.inventory.host-ingress-p1` in ClowdApp and the code runs through app/config.py, there is:

```
        self.additional_validation_topic = topic(
            os.environ.get("KAFKA_ADDITIONAL_VALIDATION_TOPIC", "platform.inventory.host-ingress-p1")
        )
```

So we need a way how to specify this variable for every app so this cod is happy even if we have this in the ClowdApp:

```
    kafkaTopics:
      - topicName: platform.inventory.system-profile
        partitions: 1
      - topicName: platform.payload-status
        partitions: 1
      - topicName: platform.inventory.events-devel
        partitions: 1
      - topicName: platform.inventory.host-ingress-devel
        partitions: 1
      - topicName: platform.inventory.host-ingress-p1-devel
        partitions: 1
```