### PR TITLE
Don't try to create a topic if it isn't used

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -37,17 +37,13 @@ class Config:
         self.bootstrap_servers = f"{broker_cfg.hostname}:{broker_cfg.port}"
 
         def topic(t):
-            return app_common_python.KafkaTopics[t].name
+            return app_common_python.KafkaTopics[t].name if t else None
 
-        self.host_ingress_topic = topic(os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress"))
-        self.additional_validation_topic = topic(
-            os.environ.get("KAFKA_ADDITIONAL_VALIDATION_TOPIC", "platform.inventory.host-ingress-p1")
-        )
-        self.system_profile_topic = topic(
-            os.environ.get("KAFKA_SYSTEM_PROFILE_TOPIC", "platform.inventory.system-profile")
-        )
-        self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC", "platform.inventory.host-ingress"))
-        self.event_topic = topic(os.environ.get("KAFKA_EVENT_TOPIC", "platform.inventory.events"))
+        self.host_ingress_topic = topic(os.environ.get("KAFKA_HOST_INGRESS_TOPIC"))
+        self.additional_validation_topic = topic(os.environ.get("KAFKA_ADDITIONAL_VALIDATION_TOPIC"))
+        self.system_profile_topic = topic(os.environ.get("KAFKA_SYSTEM_PROFILE_TOPIC"))
+        self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC"))
+        self.event_topic = topic(os.environ.get("KAFKA_EVENT_TOPIC"))
         self.payload_tracker_kafka_topic = topic("platform.payload-status")
         # certificates are required in fedramp, but not in managed kafka
         try:

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -70,8 +70,6 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
-        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -150,8 +148,6 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
-        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -221,8 +217,6 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
-        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -286,8 +280,6 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
-        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -357,8 +349,6 @@ objects:
             value: ${KAFKA_SECURITY_PROTOCOL}
           - name: KAFKA_SASL_MECHANISM
             value: ${KAFKA_SASL_MECHANISM}
-          - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-            value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
           - name: CLOWDER_ENABLED
             value: "true"
         resources:
@@ -518,8 +508,6 @@ objects:
             value: ${KAFKA_SECURITY_PROTOCOL}
           - name: KAFKA_SASL_MECHANISM
             value: ${KAFKA_SASL_MECHANISM}
-          - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-            value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
           - name: CLOWDER_ENABLED
             value: "true"
         resources:


### PR DESCRIPTION
# Overview

This PR is being created to resolve the KeyError issues we're running into in the perf environment. Since we're allowing for different topic names to be defined in the `kafkaTopics` config in our deployment, it does not make sense to use default/fallback values in `config.py`. Instead, if the topic name is not provided, it simply won't create the topic.

FYI, it's still OK to use default/fallback values in `deployment.yaml`; the main thing is that the topic name in `kafkaTopics` has to be equal to the topic name that `config.py` uses to create the topic.