### PR TITLE
Don't try to create a topic if it isn't used

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -37,17 +37,13 @@ class Config:
         self.bootstrap_servers = f"{broker_cfg.hostname}:{broker_cfg.port}"
 
         def topic(t):
-            return app_common_python.KafkaTopics[t].name
+            return app_common_python.KafkaTopics[t].name if t else None
 
-        self.host_ingress_topic = topic(os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress"))
-        self.additional_validation_topic = topic(
-            os.environ.get("KAFKA_ADDITIONAL_VALIDATION_TOPIC", "platform.inventory.host-ingress-p1")
-        )
-        self.system_profile_topic = topic(
-            os.environ.get("KAFKA_SYSTEM_PROFILE_TOPIC", "platform.inventory.system-profile")
-        )
-        self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC", "platform.inventory.host-ingress"))
-        self.event_topic = topic(os.environ.get("KAFKA_EVENT_TOPIC", "platform.inventory.events"))
+        self.host_ingress_topic = topic(os.environ.get("KAFKA_HOST_INGRESS_TOPIC"))
+        self.additional_validation_topic = topic(os.environ.get("KAFKA_ADDITIONAL_VALIDATION_TOPIC"))
+        self.system_profile_topic = topic(os.environ.get("KAFKA_SYSTEM_PROFILE_TOPIC"))
+        self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC"))
+        self.event_topic = topic(os.environ.get("KAFKA_EVENT_TOPIC"))
         self.payload_tracker_kafka_topic = topic("platform.payload-status")
         # certificates are required in fedramp, but not in managed kafka
         try:

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -70,6 +70,8 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
+        - name: KAFKA_EVENT_TOPIC
+          value: ${KAFKA_EVENT_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -130,6 +132,8 @@ objects:
           value: ${KAFKA_HOST_INGRESS_TOPIC}
         - name: KAFKA_HOST_INGRESS_TOPIC
           value: ${KAFKA_HOST_INGRESS_TOPIC}
+        - name: KAFKA_EVENT_TOPIC
+          value: ${KAFKA_EVENT_TOPIC}
         - name: KAFKA_SYSTEM_PROFILE_TOPIC
           value: ${KAFKA_SYSTEM_PROFILE_TOPIC}
         - name: KAFKA_HOST_INGRESS_GROUP
@@ -199,6 +203,8 @@ objects:
           value: ${KAFKA_HOST_INGRESS_P1_TOPIC}
         - name: KAFKA_HOST_INGRESS_TOPIC
           value: ${KAFKA_HOST_INGRESS_P1_TOPIC}
+        - name: KAFKA_EVENT_TOPIC
+          value: ${KAFKA_EVENT_TOPIC}
         - name: KAFKA_SYSTEM_PROFILE_TOPIC
           value: ${KAFKA_SYSTEM_PROFILE_TOPIC}
         - name: KAFKA_HOST_INGRESS_GROUP
@@ -262,6 +268,8 @@ objects:
           value: ${KAFKA_SYSTEM_PROFILE_TOPIC}
         - name: KAFKA_HOST_INGRESS_TOPIC
           value: ${KAFKA_HOST_INGRESS_TOPIC}
+        - name: KAFKA_EVENT_TOPIC
+          value: ${KAFKA_EVENT_TOPIC}
         - name: KAFKA_SYSTEM_PROFILE_TOPIC
           value: ${KAFKA_SYSTEM_PROFILE_TOPIC}
         - name: KAFKA_HOST_INGRESS_GROUP
@@ -409,6 +417,8 @@ objects:
             value: ${KAFKA_HOST_INGRESS_TOPIC}
           - name: KAFKA_HOST_INGRESS_TOPIC
             value: ${KAFKA_HOST_INGRESS_TOPIC}
+          - name: KAFKA_EVENT_TOPIC
+            value: ${KAFKA_EVENT_TOPIC}
           - name: KAFKA_SYSTEM_PROFILE_TOPIC
             value: ${KAFKA_SYSTEM_PROFILE_TOPIC}
           - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -70,8 +70,6 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
-        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -150,8 +148,6 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
-        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -221,8 +217,6 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
-        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -286,8 +280,6 @@ objects:
           value: ${KAFKA_SECURITY_PROTOCOL}
         - name: KAFKA_SASL_MECHANISM
           value: ${KAFKA_SASL_MECHANISM}
-        - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-          value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
         - name: TENANT_TRANSLATOR_URL
           value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
         - name: BYPASS_TENANT_TRANSLATION
@@ -357,8 +349,6 @@ objects:
             value: ${KAFKA_SECURITY_PROTOCOL}
           - name: KAFKA_SASL_MECHANISM
             value: ${KAFKA_SASL_MECHANISM}
-          - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-            value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
           - name: CLOWDER_ENABLED
             value: "true"
         resources:
@@ -518,8 +508,6 @@ objects:
             value: ${KAFKA_SECURITY_PROTOCOL}
           - name: KAFKA_SASL_MECHANISM
             value: ${KAFKA_SASL_MECHANISM}
-          - name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
-            value: ${KAFKA_ADDITIONAL_VALIDATION_TOPIC}
           - name: CLOWDER_ENABLED
             value: "true"
         resources:


### PR DESCRIPTION
# Overview

This PR makes it so HBI doesn't try to create a topic it won't use. It also adds the events topic to all deployments that need it (which includes the API service).