### PR TITLE
Get Kafka security protocol from Clowder when using it

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -45,6 +45,7 @@ class Config:
         self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC"))
         self.event_topic = topic(os.environ.get("KAFKA_EVENT_TOPIC"))
         self.payload_tracker_kafka_topic = topic("platform.payload-status")
+        self.kafka_security_protocol = "PLAINTEXT"
 
         # certificates are required in fedramp, but not in managed kafka
         try:
@@ -54,13 +55,10 @@ class Config:
         try:
             self.kafka_sasl_username = broker_cfg.sasl.username
             self.kafka_sasl_password = broker_cfg.sasl.password
+            self.kafka_security_protocol = "SASL_SSL"
         except AttributeError:
             self.kafka_sasl_username = ""
             self.kafka_sasl_password = ""
-        try:
-            self.kafka_security_protocol = broker_cfg.authtype
-        except AttributeError:
-            self.kafka_security_protocol = "PLAINTEXT"
 
     def non_clowder_config(self):
         self.metrics_port = 9126

--- a/app/config.py
+++ b/app/config.py
@@ -45,16 +45,13 @@ class Config:
         self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC"))
         self.event_topic = topic(os.environ.get("KAFKA_EVENT_TOPIC"))
         self.payload_tracker_kafka_topic = topic("platform.payload-status")
+        self.kafka_security_protocol = "SASL_SSL"
 
         # certificates are required in fedramp, but not in managed kafka
         try:
             self.kafka_ssl_cafile = self._kafka_ca(broker_cfg.cacert)
-            self.kafka_security_protocol = "SASL_SSL"
-            self.kafka_sasl_mechanism = "SCRAM_SHA_512"
         except AttributeError:
             self.kafka_ssl_cafile = None
-            self.kafka_security_protocol = "PLAINTEXT"
-            self.kafka_sasl_mechanism = "PLAIN"
         try:
             self.kafka_sasl_username = broker_cfg.sasl.username
             self.kafka_sasl_password = broker_cfg.sasl.password
@@ -85,7 +82,6 @@ class Config:
         self.kafka_sasl_username = os.environ.get("KAFKA_SASL_USERNAME", "")
         self.kafka_sasl_password = os.environ.get("KAFKA_SASL_PASSWORD", "")
         self.kafka_security_protocol = os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT").upper()
-        self.kafka_sasl_mechanism = os.environ.get("KAFKA_SASL_MECHANISM", "PLAIN").upper()
 
     def __init__(self, runtime_environment):
         self.logger = get_logger(__name__)
@@ -125,7 +121,7 @@ class Config:
         self.kafka_ssl_configs = {
             "security_protocol": self.kafka_security_protocol,
             "ssl_cafile": self.kafka_ssl_cafile,
-            "sasl_mechanism": self.kafka_sasl_mechanism,
+            "sasl_mechanism": os.environ.get("KAFKA_SASL_MECHANISM", "PLAIN").upper(),
             "sasl_plain_username": self.kafka_sasl_username,
             "sasl_plain_password": self.kafka_sasl_password,
         }

--- a/app/config.py
+++ b/app/config.py
@@ -45,6 +45,8 @@ class Config:
         self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC"))
         self.event_topic = topic(os.environ.get("KAFKA_EVENT_TOPIC"))
         self.payload_tracker_kafka_topic = topic("platform.payload-status")
+        self.kafka_security_protocol = broker_cfg.authtype
+
         # certificates are required in fedramp, but not in managed kafka
         try:
             self.kafka_ssl_cafile = self._kafka_ca(broker_cfg.cacert)
@@ -79,6 +81,7 @@ class Config:
         self.kafka_ssl_cafile = os.environ.get("KAFKA_SSL_CAFILE")
         self.kafka_sasl_username = os.environ.get("KAFKA_SASL_USERNAME", "")
         self.kafka_sasl_password = os.environ.get("KAFKA_SASL_PASSWORD", "")
+        self.kafka_security_protocol = os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT").upper()
 
     def __init__(self, runtime_environment):
         self.logger = get_logger(__name__)
@@ -116,7 +119,7 @@ class Config:
         self.kubernetes_namespace = os.environ.get("NAMESPACE")
 
         self.kafka_ssl_configs = {
-            "security_protocol": os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT").upper(),
+            "security_protocol": self.kafka_security_protocol,
             "ssl_cafile": self.kafka_ssl_cafile,
             "sasl_mechanism": os.environ.get("KAFKA_SASL_MECHANISM", "PLAIN").upper(),
             "sasl_plain_username": self.kafka_sasl_username,

--- a/app/config.py
+++ b/app/config.py
@@ -45,13 +45,16 @@ class Config:
         self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC"))
         self.event_topic = topic(os.environ.get("KAFKA_EVENT_TOPIC"))
         self.payload_tracker_kafka_topic = topic("platform.payload-status")
-        self.kafka_security_protocol = broker_cfg.authtype
 
         # certificates are required in fedramp, but not in managed kafka
         try:
             self.kafka_ssl_cafile = self._kafka_ca(broker_cfg.cacert)
+            self.kafka_security_protocol = "SASL_SSL"
+            self.kafka_sasl_mechanism = "SCRAM_SHA_512"
         except AttributeError:
             self.kafka_ssl_cafile = None
+            self.kafka_security_protocol = "PLAINTEXT"
+            self.kafka_sasl_mechanism = "PLAIN"
         try:
             self.kafka_sasl_username = broker_cfg.sasl.username
             self.kafka_sasl_password = broker_cfg.sasl.password
@@ -82,6 +85,7 @@ class Config:
         self.kafka_sasl_username = os.environ.get("KAFKA_SASL_USERNAME", "")
         self.kafka_sasl_password = os.environ.get("KAFKA_SASL_PASSWORD", "")
         self.kafka_security_protocol = os.environ.get("KAFKA_SECURITY_PROTOCOL", "PLAINTEXT").upper()
+        self.kafka_sasl_mechanism = os.environ.get("KAFKA_SASL_MECHANISM", "PLAIN").upper()
 
     def __init__(self, runtime_environment):
         self.logger = get_logger(__name__)
@@ -121,7 +125,7 @@ class Config:
         self.kafka_ssl_configs = {
             "security_protocol": self.kafka_security_protocol,
             "ssl_cafile": self.kafka_ssl_cafile,
-            "sasl_mechanism": os.environ.get("KAFKA_SASL_MECHANISM", "PLAIN").upper(),
+            "sasl_mechanism": self.kafka_sasl_mechanism,
             "sasl_plain_username": self.kafka_sasl_username,
             "sasl_plain_password": self.kafka_sasl_password,
         }

--- a/app/config.py
+++ b/app/config.py
@@ -45,7 +45,6 @@ class Config:
         self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC"))
         self.event_topic = topic(os.environ.get("KAFKA_EVENT_TOPIC"))
         self.payload_tracker_kafka_topic = topic("platform.payload-status")
-        self.kafka_security_protocol = "SASL_SSL"
 
         # certificates are required in fedramp, but not in managed kafka
         try:
@@ -58,6 +57,10 @@ class Config:
         except AttributeError:
             self.kafka_sasl_username = ""
             self.kafka_sasl_password = ""
+        try:
+            self.kafka_security_protocol = broker_cfg.authtype
+        except AttributeError:
+            self.kafka_security_protocol = "PLAINTEXT"
 
     def non_clowder_config(self):
         self.metrics_port = 9126


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3199](https://issues.redhat.com/browse/ESSNTL-3199).
This changes our config class so that, when using Clowder, it will get the security protocol from `broker_cfg.authtype`. When not using Clowder, it will continue to get the value from the `KAFKA_SECURITY_PROTOCOL` environment variable.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
