### PR TITLE
Fix window size limit error

### DIFF
--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -910,6 +910,7 @@
         "schema": {
           "type": "integer",
           "minimum": 1,
+          "maximum": 21474837,
           "default": 1
         },
         "description": "A page number of the items to return."

--- a/swagger/pagination.yaml
+++ b/swagger/pagination.yaml
@@ -14,6 +14,7 @@ components:
       schema:
         type: integer
         minimum: 1
+        maximum: 21474837
         default: 1
       description: A page number of the items to return.
     perPageParam:

--- a/swagger/pagination.yaml
+++ b/swagger/pagination.yaml
@@ -14,6 +14,8 @@ components:
       schema:
         type: integer
         minimum: 1
+        # page * (per_page -1) must be less than 2,147,483,647 (signed int32 max)
+        # per_page max is 100, so page max is 21474837.
         maximum: 21474837
         default: 1
       description: A page number of the items to return.

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -586,7 +586,7 @@ def test_response_pagination(page, limit, offset, mocker, graphql_query_empty_re
     )
 
 
-@pytest.mark.parametrize("page,per_page", ((0, 10), (-1, 10), (1, 0), (1, -5), (1, 101)))
+@pytest.mark.parametrize("page,per_page", ((0, 10), (-1, 10), (1, 0), (1, -5), (1, 101), (21474838, 100)))
 def test_response_invalid_pagination(page, per_page, graphql_query_empty_response, api_get):
     url = build_hosts_url(query=f"?per_page={quote(per_page)}&page={quote(page)}")
     response_status, response_data = api_get(url)
@@ -1092,7 +1092,7 @@ def test_tags_response_pagination(page, limit, offset, mocker, graphql_tag_query
     )
 
 
-@pytest.mark.parametrize("page,per_page", [(0, 10), (-1, 10), (1, 0), (1, -5), (1, 101)])
+@pytest.mark.parametrize("page,per_page", [(0, 10), (-1, 10), (1, 0), (1, -5), (1, 101), (21474838, 100)])
 def test_tags_response_invalid_pagination(page, per_page, api_get):
     url = build_tags_url(query=f"?per_page={per_page}&page={page}")
     response_status, response_data = api_get(url)


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-371](https://issues.redhat.com/browse/ESSNTL-371).
After investigating the xjoin logs for the failing requests, it became clear that the value of the "offset" variable in the query was larger than a 32-bit signed int's max value, which is what graphql is using. 

The offset for our queries is calculated as `(page - 1) * per_page`, and it cannot go higher than 2,147,483,647 (int32 max). Because we don't allow values over 100 for per_page, we can simply restrict the value of `page` to a maximum of 21,474,837.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [x] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
