### PR TITLE
[ESSNTL-629] Throw 400 sparse field not in schema

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -18,6 +18,7 @@ from api.host_query_xjoin import get_host_list as get_host_list_xjoin
 from api.host_query_xjoin import get_host_list_by_id_list
 from api.host_query_xjoin import get_host_tags_list_by_id_list
 from api.sparse_host_list_system_profile import get_sparse_system_profile
+from api.validate_fields import validate_fields_in_schema
 from app import db
 from app import inventory_config
 from app import Permission
@@ -85,6 +86,8 @@ def get_host_list(
 
     total = 0
     host_list = ()
+
+    validate_fields_in_schema(fields)
 
     try:
         host_list, total, additional_fields = get_host_list_xjoin(
@@ -253,6 +256,7 @@ def delete_by_id(host_id_list):
 @rbac(Permission.READ)
 @metrics.api_request_time.time()
 def get_host_by_id(host_id_list, page=1, per_page=100, order_by=None, order_how=None, fields=None):
+    validate_fields_in_schema(fields)
     try:
         host_list, total, additional_fields = get_host_list_by_id_list(
             host_id_list, page, per_page, order_by, order_how, fields
@@ -271,6 +275,7 @@ def get_host_by_id(host_id_list, page=1, per_page=100, order_by=None, order_how=
 @rbac(Permission.READ)
 @metrics.api_request_time.time()
 def get_host_system_profile_by_id(host_id_list, page=1, per_page=100, order_by=None, order_how=None, fields=None):
+    validate_fields_in_schema(fields)
     try:
         total, response_list = get_sparse_system_profile(host_id_list, page, per_page, order_by, order_how, fields)
     except ValueError as e:

--- a/api/sparse_host_list_system_profile.py
+++ b/api/sparse_host_list_system_profile.py
@@ -2,7 +2,7 @@ import flask
 from flask_api import status
 
 from api.host_query_xjoin import owner_id_filter
-from app.__init__ import process_system_profile_spec
+from api.validate_fields import validate_fields_in_schema
 from app.auth import get_current_identity
 from app.auth.identity import IdentityType
 from app.instrumentation import log_get_sparse_system_profile_failed
@@ -97,11 +97,8 @@ def get_sparse_system_profile(host_id_list, page, per_page, order_by, order_how,
     }
 
     if fields.get("system_profile"):
+        validate_fields_in_schema(fields)
         variables["fields"] = list(fields.get("system_profile").keys())
-        system_profile_schema = process_system_profile_spec()
-        for field in variables["fields"]:
-            if field not in system_profile_schema.keys():
-                flask.abort(400, "Requested system_profile field is not present in the schema.")
         sp_query = SYSTEM_PROFILE_SPARSE_QUERY
 
     response = graphql_query(sp_query, variables, log_get_sparse_system_profile_failed)

--- a/api/sparse_host_list_system_profile.py
+++ b/api/sparse_host_list_system_profile.py
@@ -2,6 +2,7 @@ import flask
 from flask_api import status
 
 from api.host_query_xjoin import owner_id_filter
+from app.__init__ import process_system_profile_spec
 from app.auth import get_current_identity
 from app.auth.identity import IdentityType
 from app.instrumentation import log_get_sparse_system_profile_failed
@@ -97,6 +98,10 @@ def get_sparse_system_profile(host_id_list, page, per_page, order_by, order_how,
 
     if fields.get("system_profile"):
         variables["fields"] = list(fields.get("system_profile").keys())
+        system_profile_schema = process_system_profile_spec()
+        for field in variables["fields"]:
+            if field not in system_profile_schema.keys():
+                flask.abort(400, "Requested system_profile field is not present in the schema.")
         sp_query = SYSTEM_PROFILE_SPARSE_QUERY
 
     response = graphql_query(sp_query, variables, log_get_sparse_system_profile_failed)

--- a/api/validate_fields.py
+++ b/api/validate_fields.py
@@ -1,12 +1,12 @@
 import flask
 
-from app.__init__ import process_system_profile_spec
+from app import system_profile_spec
 
 
 def validate_fields_in_schema(fields):
     if fields.get("system_profile"):
         query_fields = list(fields.get("system_profile").keys())
-        system_profile_schema = process_system_profile_spec()
+        system_profile_schema = system_profile_spec()
         for field in query_fields:
             if field not in system_profile_schema.keys():
                 flask.abort(400, f"Requested field '{field}' is not present in the system_profile schema.")

--- a/api/validate_fields.py
+++ b/api/validate_fields.py
@@ -1,0 +1,12 @@
+import flask
+
+from app.__init__ import process_system_profile_spec
+
+
+def validate_fields_in_schema(fields):
+    if fields.get("system_profile"):
+        query_fields = list(fields.get("system_profile").keys())
+        system_profile_schema = process_system_profile_spec()
+        for field in query_fields:
+            if field not in system_profile_schema.keys():
+                flask.abort(400, f"Requested field '{field}' is not present in the system_profile schema.")

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -316,6 +316,14 @@ def build_order_query_parameters(order_by=None, order_how=None):
     return query_parameters
 
 
+def build_fields_query_parameters(fields=None):
+    query_parameters = {}
+    if fields:
+        query_parameters["fields"] = fields
+
+    return query_parameters
+
+
 def _build_url(base_url=HOST_URL, path=None, host_list_or_id=None, query=None):
     url = base_url
 

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -113,8 +113,8 @@ XJOIN_HOSTS_RESPONSE = {
                     }
                 },
                 "system_profile_facts": {
-                    "test_data": "1.2.3",
-                    "random": ["data"],
+                    "arch": "1.2.3",
+                    "operating_system": ["data"],
                     "owner_id": "1b36b20f-7fa0-4454-a6d2-008294e06378",
                 },
             },
@@ -148,7 +148,7 @@ XJOIN_HOSTS_RESPONSE = {
                         "stale_timestamp": "2020-02-10T08:07:03.354307+00:00",
                     }
                 },
-                "system_profile_facts": {"test_data": "1.2.3", "random": ["data"]},
+                "system_profile_facts": {"arch": "1.2.3", "operating_system": ["data"]},
             },
         ],
     }
@@ -161,8 +161,8 @@ XJOIN_INVALID_SYSTEM_PROFILE = {
             {
                 "id": "6e7b6317-0a2d-4552-a2f2-b7da0aece49d",
                 "system_profile_facts": {
-                    "test_data": "1.2.3",
-                    "random": ["data"],
+                    "arch": "1.2.3",
+                    "operating_system": ["data"],
                     "owner_id": "1b36b20f-7fa0-4454-a6d2-008294e06378",
                     "disk_devices": [{"options": {"": "invalid"}}],  # Invalid key (empty)
                 },

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -114,7 +114,7 @@ XJOIN_HOSTS_RESPONSE = {
                 },
                 "system_profile_facts": {
                     "arch": "1.2.3",
-                    "operating_system": ["data"],
+                    "kernel_modules": ["data"],
                     "owner_id": "1b36b20f-7fa0-4454-a6d2-008294e06378",
                 },
             },
@@ -148,7 +148,7 @@ XJOIN_HOSTS_RESPONSE = {
                         "stale_timestamp": "2020-02-10T08:07:03.354307+00:00",
                     }
                 },
-                "system_profile_facts": {"arch": "1.2.3", "operating_system": ["data"]},
+                "system_profile_facts": {"arch": "1.2.3", "kernel_modules": ["data"]},
             },
         ],
     }
@@ -162,7 +162,7 @@ XJOIN_INVALID_SYSTEM_PROFILE = {
                 "id": "6e7b6317-0a2d-4552-a2f2-b7da0aece49d",
                 "system_profile_facts": {
                     "arch": "1.2.3",
-                    "operating_system": ["data"],
+                    "kernel_modules": ["data"],
                     "owner_id": "1b36b20f-7fa0-4454-a6d2-008294e06378",
                     "disk_devices": [{"options": {"": "invalid"}}],  # Invalid key (empty)
                 },

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -7,6 +7,7 @@ from tests.helpers.api_utils import api_pagination_invalid_parameters_test
 from tests.helpers.api_utils import api_query_test
 from tests.helpers.api_utils import assert_error_response
 from tests.helpers.api_utils import assert_response_status
+from tests.helpers.api_utils import build_fields_query_parameters
 from tests.helpers.api_utils import build_hosts_url
 from tests.helpers.api_utils import build_order_query_parameters
 from tests.helpers.api_utils import build_system_profile_sap_sids_url
@@ -149,6 +150,21 @@ def test_only_order_how(mq_create_three_specific_hosts, api_get, subtests):
         with subtests.test(url=url):
             order_query_parameters = build_order_query_parameters(order_by=None, order_how="ASC")
             response_status, response_data = api_get(url, query_parameters=order_query_parameters)
+            assert response_status == 400
+
+
+def test_invalid_fields(mq_create_three_specific_hosts, api_get, subtests):
+    created_hosts = mq_create_three_specific_hosts
+
+    urls = (
+        HOST_URL,
+        build_hosts_url(host_list_or_id=created_hosts),
+        build_system_profile_url(host_list_or_id=created_hosts),
+    )
+    for url in urls:
+        with subtests.test(url=url):
+            fields_query_parameters = build_fields_query_parameters(fields="i_love_ketchup")
+            response_status, response_data = api_get(url, query_parameters=fields_query_parameters)
             assert response_status == 400
 
 
@@ -321,7 +337,7 @@ def test_sp_sparse_fields_xjoin_response_translation(patch_xjoin_post, api_get):
             ],
         ),
         (
-            "?fields[system_profile]=unknown_field",
+            "?fields[system_profile]=arch",
             [{"id": host_one_id, "system_profile_facts": {}}, {"id": host_two_id, "system_profile_facts": {}}],
         ),
         (

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -400,7 +400,7 @@ def test_validate_sp_sparse_fields_invalid_requests(api_get):
 
 def test_host_list_sp_fields_requested(patch_xjoin_post, api_get):
     patch_xjoin_post(response={"data": XJOIN_HOSTS_RESPONSE})
-    fields = ["test_data", "random", "owner_id"]
+    fields = ["arch", "operating_system", "owner_id"]
     response_status, response_data = api_get(HOST_URL + f"?fields[system_profile]={','.join(fields)}")
 
     assert response_status == 200

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -400,7 +400,7 @@ def test_validate_sp_sparse_fields_invalid_requests(api_get):
 
 def test_host_list_sp_fields_requested(patch_xjoin_post, api_get):
     patch_xjoin_post(response={"data": XJOIN_HOSTS_RESPONSE})
-    fields = ["arch", "operating_system", "owner_id"]
+    fields = ["arch", "kernel_modules", "owner_id"]
     response_status, response_data = api_get(HOST_URL + f"?fields[system_profile]={','.join(fields)}")
 
     assert response_status == 200

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -2515,10 +2515,10 @@ def test_sp_sparse_xjoin_query_translation(
     "query,fields",
     (
         ("?fields[system_profile]=arch", ["arch"]),
-        ("?fields[system_profile]=arch,operating_system,os_release", ["arch", "operating_system", "os_release"]),
+        ("?fields[system_profile]=arch,kernel_modules,os_release", ["arch", "kernel_modules", "os_release"]),
         (
-            "?fields[system_profile]=arch&fields[system_profile]=operating_system,os_release",
-            ["arch", "operating_system", "os_release"],
+            "?fields[system_profile]=arch&fields[system_profile]=kernel_modules,os_release",
+            ["arch", "kernel_modules", "os_release"],
         ),
     ),
 )

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -2396,84 +2396,85 @@ def test_query_with_owner_id_satellite_identity(mocker, subtests, graphql_query_
     (
         (
             {
-                "fields": ["field_1", "field_2", "field_3"],
+                "fields": ["arch", "operating_system", "os_release"],
                 "limit": 50,
                 "offset": 0,
                 "order_by": "modified_on",
                 "order_how": "DESC",
             },
-            "?fields[system_profile]=field_1,field_2,field_3",
+            "?fields[system_profile]=arch,operating_system,os_release",
         ),
         (
             {
-                "fields": ["field_1", "field_2"],
+                "fields": ["arch", "operating_system"],
                 "limit": 2,
                 "offset": 0,
                 "order_by": "modified_on",
                 "order_how": "DESC",
             },
-            "?fields[system_profile]=field_1,field_2&per_page=2",
+            "?fields[system_profile]=arch,operating_system&per_page=2",
         ),
         (
             {
-                "fields": ["field_1", "field_2"],
+                "fields": ["arch", "operating_system"],
                 "limit": 1,
                 "offset": 1,
                 "order_by": "modified_on",
                 "order_how": "DESC",
             },
-            "?fields[system_profile]=field_1,field_2&per_page=1&page=2",
+            "?fields[system_profile]=arch,operating_system&per_page=1&page=2",
         ),
         (
             {
-                "fields": ["field_1", "field_2"],
+                "fields": ["arch", "operating_system"],
                 "limit": 50,
                 "offset": 0,
                 "order_by": "display_name",
                 "order_how": "ASC",
             },
-            "?fields[system_profile]=field_1,field_2&order_by=display_name&order_how=ASC",
+            "?fields[system_profile]=arch,operating_system&order_by=display_name&order_how=ASC",
         ),
         (
             {
-                "fields": ["field_1", "field_2"],
+                "fields": ["arch", "operating_system"],
                 "limit": 1,
                 "offset": 1,
                 "order_by": "display_name",
                 "order_how": "ASC",
             },
-            "?fields[system_profile]=field_1,field_2&order_by=display_name&order_how=ASC&per_page=1&page=2",
+            "?fields[system_profile]=arch,operating_system&order_by=display_name&order_how=ASC&per_page=1&page=2",
         ),
         (
             {
-                "fields": ["field_1", "field_2"],
+                "fields": ["arch", "operating_system"],
                 "limit": 1,
                 "offset": 1,
                 "order_by": "modified_on",
                 "order_how": "DESC",
             },
-            "?fields[system_profile]=field_1,field_2&order_by=updated&order_how=DESC&per_page=1&page=2",
+            "?fields[system_profile]=arch,operating_system&order_by=updated&order_how=DESC&per_page=1&page=2",
         ),
         (
             {
-                "fields": ["field_1", "field_2", "field_3", "field_4"],
+                "fields": ["arch", "operating_system", "os_release", "last_boot_time"],
                 "limit": 1,
                 "offset": 1,
                 "order_by": "display_name",
                 "order_how": "ASC",
             },
-            "?fields[system_profile]=field_1,field_2&order_by=display_name&order_how=ASC&per_page=1\
-                &fields[system_profile]=field_3,field_4&page=2",
+            "?fields[system_profile]=arch,operating_system&order_by=display_name&order_how=ASC&per_page=1\
+                &fields[system_profile]=os_release,last_boot_time&page=2",
         ),
         (
             {
-                "fields": ["field_1", "field_2"],
+                "fields": ["arch", "operating_system"],
                 "limit": 50,
                 "offset": 0,
                 "order_by": "operating_system",
                 "order_how": "DESC",
             },
-            "?fields[system_profile]=field_1,field_2&order_by=operating_system&order_how=DESC&per_page=50&page=1",
+            "?fields[system_profile]=arch,operating_system&order_by=operating_system&order_how=DESC"
+            "&per_page=50&page=1",
         ),
     ),
 )

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -2514,11 +2514,11 @@ def test_sp_sparse_xjoin_query_translation(
 @pytest.mark.parametrize(
     "query,fields",
     (
-        ("?fields[system_profile]=sp_field1", ["sp_field1"]),
-        ("?fields[system_profile]=sp_field1,sp_field2,sp_field3", ["sp_field1", "sp_field2", "sp_field3"]),
+        ("?fields[system_profile]=arch", ["arch"]),
+        ("?fields[system_profile]=arch,operating_system,os_release", ["arch", "operating_system", "os_release"]),
         (
-            "?fields[system_profile]=sp_field1&fields[system_profile]=sp_field2,sp_field3",
-            ["sp_field1", "sp_field2", "sp_field3"],
+            "?fields[system_profile]=arch&fields[system_profile]=operating_system,os_release",
+            ["arch", "operating_system", "os_release"],
         ),
     ),
 )


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-629](https://issues.redhat.com/browse/ESSNTL-629).
This PR adds the ability to throw a 400 if a request for a system profile sparse field is a field that is not in our schema for the system profile.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
