### PR TITLE
Remove org-id-populator job

### DIFF
--- a/deploy/cji.yml
+++ b/deploy/cji.yml
@@ -13,16 +13,6 @@ objects:
     appName: host-inventory
     jobs:
       - synchronizer
-- apiVersion: cloud.redhat.com/v1alpha1
-  kind: ClowdJobInvocation
-  metadata:
-    name: populate-org-id-column-${POPULATOR_RUN_NUMBER}
-  spec:
-    appName: host-inventory
-    jobs:
-      - org-id-populator
 parameters:
-- name: POPULATOR_RUN_NUMBER # in case the populator needs to be run more than once increment this parameter to get a new job
-  value: '1'
 - name: SYNCHRONIZER_RUN_NUMBER
   value: '1'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -545,40 +545,6 @@ objects:
           requests:
             cpu: ${CPU_REQUEST}
             memory: ${MEMORY_REQUEST}
-
-    # This job populates the org_id field on all hosts that are missing a value for it.
-    # After executing this job, the host-synchronizer should be run to sync Cyndi DBs.
-    # After all hosts have been updated in Stage and Prod, we can remove this job.
-    # Documentation for this job can be found here:
-    # https://github.com/RedHatInsights/tenant-utils/blob/main/cmd/org-id-column-populator/README.md
-    - name: org-id-populator
-      podSpec:
-        image: ${POPULATOR_IMAGE}:${POPULATOR_IMAGE_TAG}
-        command:
-          - ./org-id-column-populator
-          - -C
-          - -a
-          - account
-          - -o
-          - org_id
-          - -t
-          - hosts
-          - --ean-translator-addr
-          - http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
-          - --prometheus-push-addr
-          - ${PROMETHEUS_PUSHGATEWAY}
-        env:
-          - name: LOG_FORMAT
-            value: ${POPULATOR_LOG_FORMAT}
-          - name: LOG_BATCH_FREQUENCY
-            value: '1s'
-        resources:
-          limits:
-            cpu: 300m
-            memory: 1Gi
-          requests:
-            cpu: 50m
-            memory: 512Mi
     - name: floorist
       schedule: ${FLOORIST_SCHEDULE}
       suspend: ${{FLOORIST_SUSPEND}}
@@ -809,12 +775,6 @@ parameters:
   value: 'apicast.3scale-dev.svc.cluster.local'
 - name: TENANT_TRANSLATOR_PORT
   value: '8892'
-- name: POPULATOR_LOG_FORMAT
-  value: cloudwatch
-- name: POPULATOR_IMAGE
-  value: quay.io/cloudservices/tenant-utils
-- name: POPULATOR_IMAGE_TAG
-  value: latest
 - name: GUNICORN_WORKERS
   value: '1'
 - name: GUNICORN_THREADS


### PR DESCRIPTION
# Overview

This PR is being created to remove the org_id populator job, which was only needed in the Org ID transition period. It removes the job definition from the clowdapp, and the CJI, and the relevant parameters.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
