### PR TITLE
ESSNTL-1915: Tests raise an error after running

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -185,8 +185,8 @@ def create_app(runtime_environment):
     flask_app.config["SQLALCHEMY_ECHO"] = False
     flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = app_config.db_uri
-    flask_app.config["SQLALCHEMY_POOL_SIZE"] = app_config.db_pool_size
-    flask_app.config["SQLALCHEMY_POOL_TIMEOUT"] = app_config.db_pool_timeout
+    flask_app.config["SQLALCHEMY_ENGINE_OPTIONS['pool_size']"] = app_config.db_pool_size
+    flask_app.config["SQLALCHEMY_ENGINE_OPTIONS['pool_timeout']"] = app_config.db_pool_timeout
 
     flask_app.config["INVENTORY_CONFIG"] = app_config
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,7 @@
 addopts = --ignore swagger
 markers =
   system_profile
+  system_culling
+  host_synchronizer
+  host_delete_duplicates
+  host_reaper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,3 +24,15 @@ def pytest_assertrepr_compare(config, op, left, right):
     if isinstance(left, HostWrapper) and isinstance(right, HostWrapper) and op == "==":
         res = config.hook.pytest_assertrepr_compare(config=config, op=op, left=repr(left), right=repr(right))
         return res[0]
+
+
+def pytest_sessionfinish():
+    """Remove handlers from all loggers"""
+    import logging
+
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        if not hasattr(logger, "handlers"):
+            continue
+        for handler in logger.handlers[:]:
+            logger.removeHandler(handler)


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-1915](https://issues.redhat.com/browse/ESSNTL-1915).
Removes the handlers for the loggers when a pytest session is finished to prevent log messages after all the tests pass.
Upon running all the tests, `test_duplicate_hosts.py` still prints a log message. As discussed, it is not to be run regularly since it tests a temporary script.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
