### PR TITLE
Re-add "group_id" to events-topic consumer config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -162,6 +162,7 @@ class Config:
         }
 
         self.events_kafka_consumer = {
+            "group_id": "inventory-events-rebuild",
             "auto_offset_reset": "earliest",
             "request_timeout_ms": int(os.environ.get("KAFKA_CONSUMER_REQUEST_TIMEOUT_MS", "305000")),
             "max_in_flight_requests_per_connection": int(


### PR DESCRIPTION
This just re-adds `"group_id": "inventory-events-rebuild"` to the events-topic consumer config. I was hoping that removing it would fix the issue in Stage, but it didn't. It's safer to have a discrete group ID when doing things like `seek_to_beginning()` and setting auto-offset config.