### PR TITLE
Adds canonical_facts and request_id to the payload

### DIFF
--- a/app/queue/notifications.py
+++ b/app/queue/notifications.py
@@ -7,7 +7,6 @@ from marshmallow import Schema as MarshmallowSchema
 from marshmallow import validate as marshmallow_validate
 
 from app.logging import threadctx
-from app.models import CanonicalFactsSchema
 from app.queue.events import hostname
 from app.queue.metrics import notification_event_serialization_time
 
@@ -27,8 +26,7 @@ class PayloadSchema(MarshmallowSchema):
     request_id = fields.Str(required=True)
     host_id = fields.UUID(required=True)
     display_name = fields.Str()
-    insights_id = fields.Str()
-    canonical_facts = CanonicalFactsSchema()
+    canonical_facts = fields.Dict()
     error = fields.Nested(HostValidationErrorSchema())
 
 
@@ -77,7 +75,6 @@ def host_validation_error_event(notification_type, message_id, host, detail, sta
                     "request_id": threadctx.request_id,
                     "host_id": host.get("id"),
                     "display_name": host.get("display_name"),
-                    "insights_id": host.get("insights_id"),
                     "canonical_facts": host.get("canonical_facts"),
                     "error": {
                         "code": "VE001",

--- a/app/queue/notifications.py
+++ b/app/queue/notifications.py
@@ -7,6 +7,7 @@ from marshmallow import Schema as MarshmallowSchema
 from marshmallow import validate as marshmallow_validate
 
 from app.logging import threadctx
+from app.models import CanonicalFactsSchema
 from app.queue.events import hostname
 from app.queue.metrics import notification_event_serialization_time
 
@@ -23,8 +24,11 @@ class HostValidationErrorSchema(MarshmallowSchema):
 
 
 class PayloadSchema(MarshmallowSchema):
+    request_id = fields.Str(required=True)
     host_id = fields.UUID(required=True)
     display_name = fields.Str()
+    insights_id = fields.Str()
+    canonical_facts = CanonicalFactsSchema()
     error = fields.Nested(HostValidationErrorSchema())
 
 
@@ -70,9 +74,11 @@ def host_validation_error_event(notification_type, message_id, host, detail, sta
             {
                 "metadata": {},
                 "payload": {
+                    "request_id": threadctx.request_id,
                     "host_id": host.get("id"),
                     "display_name": host.get("display_name"),
                     "insights_id": host.get("insights_id"),
+                    "canonical_facts": host.get("canonical_facts"),
                     "error": {
                         "code": "VE001",
                         "message": detail,

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -39,6 +39,7 @@ from app.queue.notifications import build_notification_event
 from app.queue.notifications import notification_message_headers
 from app.queue.notifications import NotificationType
 from app.serialization import DEFAULT_FIELDS
+from app.serialization import deserialize_canonical_facts
 from app.serialization import deserialize_host
 from lib import host_repository
 
@@ -136,6 +137,7 @@ def _build_minimal_host_info(host_data):
         "insights_id": host_data.get("insights_id"),
         "display_name": host_data.get("display_name"),
         "id": host_data.get("id"),
+        "canonical_facts": deserialize_canonical_facts(host_data, all=True),
     }
 
 

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -55,11 +55,14 @@ def deserialize_host(raw_data, schema=HostSchema, system_profile_spec=None):
     return schema.build_model(validated_data, canonical_facts, facts, tags)
 
 
-def deserialize_canonical_facts(raw_data):
+def deserialize_canonical_facts(raw_data, all=False):
     try:
         validated_data = CanonicalFactsSchema().load(raw_data)
     except ValidationError as e:
         raise ValidationException(str(e.messages)) from None
+
+    if all:
+        return _deserialize_all_canonical_facts(validated_data)
     return _deserialize_canonical_facts(validated_data)
 
 
@@ -150,6 +153,10 @@ def _recursive_casefold(field_data):
 
 def _deserialize_canonical_facts(data):
     return {field: _recursive_casefold(data[field]) for field in _CANONICAL_FACTS_FIELDS if data.get(field)}
+
+
+def _deserialize_all_canonical_facts(data):
+    return {field: _recursive_casefold(data[field]) if data.get(field) else None for field in _CANONICAL_FACTS_FIELDS}
 
 
 def serialize_canonical_facts(canonical_facts):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -45,7 +45,6 @@ from app.queue.event_producer import logger as event_producer_logger
 from app.queue.events import build_event
 from app.queue.events import EventType
 from app.queue.events import message_headers
-from app.serialization import _deserialize_all_canonical_facts
 from app.serialization import _deserialize_canonical_facts
 from app.serialization import _deserialize_facts
 from app.serialization import _deserialize_tags
@@ -54,6 +53,7 @@ from app.serialization import _deserialize_tags_list
 from app.serialization import _serialize_datetime
 from app.serialization import _serialize_uuid
 from app.serialization import DEFAULT_FIELDS
+from app.serialization import deserialize_canonical_facts
 from app.serialization import deserialize_host
 from app.serialization import serialize_canonical_facts
 from app.serialization import serialize_facts
@@ -1625,11 +1625,9 @@ class SerializationDeserializeCanonicalFactsTestCase(TestCase):
         self.assertEqual(result, canonical_facts)
 
     def test_empty_fields_are_not_rejected_when_all_is_passed(self):
-        canonical_facts = {"fqdn": "some fqdn"}
-        input = {**canonical_facts, "insights_id": "", "ip_addresses": [], "mac_addresses": tuple()}
+        canonical_facts = {"fqdn": "some fqdn", "insights_id": str(uuid4())}
         expected = {
             **canonical_facts,
-            "insights_id": None,
             "ip_addresses": None,
             "mac_addresses": None,
             "bios_uuid": None,
@@ -1638,7 +1636,7 @@ class SerializationDeserializeCanonicalFactsTestCase(TestCase):
             "satellite_id": None,
             "subscription_manager_id": None,
         }
-        result = _deserialize_all_canonical_facts(input)
+        result = deserialize_canonical_facts(canonical_facts, all=True)
         self.assertEqual(result, expected)
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -45,6 +45,7 @@ from app.queue.event_producer import logger as event_producer_logger
 from app.queue.events import build_event
 from app.queue.events import EventType
 from app.queue.events import message_headers
+from app.serialization import _deserialize_all_canonical_facts
 from app.serialization import _deserialize_canonical_facts
 from app.serialization import _deserialize_facts
 from app.serialization import _deserialize_tags
@@ -1622,6 +1623,23 @@ class SerializationDeserializeCanonicalFactsTestCase(TestCase):
         input = {**canonical_facts, "insights_id": "", "ip_addresses": [], "mac_addresses": tuple()}
         result = _deserialize_canonical_facts(input)
         self.assertEqual(result, canonical_facts)
+
+    def test_empty_fields_are_not_rejected_when_all_is_passed(self):
+        canonical_facts = {"fqdn": "some fqdn"}
+        input = {**canonical_facts, "insights_id": "", "ip_addresses": [], "mac_addresses": tuple()}
+        expected = {
+            **canonical_facts,
+            "insights_id": None,
+            "ip_addresses": None,
+            "mac_addresses": None,
+            "bios_uuid": None,
+            "provider_id": None,
+            "provider_type": None,
+            "satellite_id": None,
+            "subscription_manager_id": None,
+        }
+        result = _deserialize_all_canonical_facts(input)
+        self.assertEqual(result, expected)
 
 
 class SerializationSerializeCanonicalFactsTestCase(TestCase):


### PR DESCRIPTION
# Overview

This PR is being created to further address [ESSNTL-2739](https://issues.redhat.com/browse/ESSNTL-2739).
Adds all the canonical facts and request id to the payload sent for the notifications.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
