### PR TITLE
[ESSNTL-3493] account_number can be empty string

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -124,7 +124,7 @@ class IdentitySchema(IdentityBaseSchema):
     org_id = m.fields.Str(required=True, validate=m.validate.Length(min=1, max=36))
     type = m.fields.String(required=True, validate=m.validate.OneOf(IdentityType.__members__.values()))
     auth_type = IdentityLowerString(validate=m.validate.OneOf(AuthType.__members__.values()))
-    account_number = m.fields.Str(validate=m.validate.Length(min=1, max=36))
+    account_number = m.fields.Str(validate=m.validate.Length(min=0, max=36))
 
     @m.post_load
     def user_system_check(self, in_data, **kwargs):

--- a/tests/test_identity_schema.py
+++ b/tests/test_identity_schema.py
@@ -23,7 +23,7 @@ def identity_test_common(identity):
 
     if "account_number" in result:
         account_number_len = len(result.get("account_number"))
-        assert account_number_len > 0 and org_id_len <= 36
+        assert account_number_len >= 0 and org_id_len <= 36
 
     if result.get("type") == IdentityType.USER:
         assert "user" in result
@@ -79,7 +79,7 @@ def test_system_identity_missing_required(required):
 
 @pytest.mark.parametrize(
     "test_field,bad_value",
-    [("org_id", ""), ("org_id", "X" * 37), ("account_number", ""), ("account_number", "X" * 37)],
+    [("org_id", ""), ("org_id", "X" * 37), ("account_number", "X" * 37)],
 )
 def test_string_length(test_field, bad_value):
     bad_identity = USER_IDENTITY.copy()


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3493](https://issues.redhat.com/browse/ESSNTL-3493).
Hosts were being rejected when account_number was empty string, but account_number should be allowed to be zero length, as it is not required, and this is reflected in the model but our identity validation did not account for this until now with this PR.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
