### PR TITLE
Fix null account issue

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -77,7 +77,8 @@ def _get_identity(host, metadata):
     else:
         if host.get("reporter") == "rhsm-conduit" and host.get("subscription_manager_id"):
             identity = deepcopy(SYSTEM_IDENTITY)
-            identity["account_number"] = host.get("account")
+            if "account" in host:
+                identity["account_number"] = host["account"]
             identity["org_id"] = host.get("org_id")
             identity["system"]["cn"] = _formatted_uuid(host.get("subscription_manager_id"))
         elif metadata:

--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -16,7 +16,6 @@ from tests.helpers.test_utils import get_platform_metadata
 from tests.helpers.test_utils import get_staleness_timestamps
 from tests.helpers.test_utils import minimal_host
 from tests.helpers.test_utils import now
-from tests.helpers.test_utils import SYSTEM_IDENTITY
 
 
 @pytest.fixture(scope="function")
@@ -31,7 +30,7 @@ def mq_create_or_update_host(flask_app, event_producer_mock, notification_event_
     ):
         if not platform_metadata:
             platform_metadata = get_platform_metadata()
-        host_data.data()["account"] = SYSTEM_IDENTITY.get("account_number")
+
         message = wrap_message(host_data.data(), platform_metadata=platform_metadata)
         handle_message(json.dumps(message), event_producer, notification_event_producer, message_operation)
         event = json.loads(event_producer.event)

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -6,6 +6,7 @@ from tests.helpers.db_utils import assert_host_missing_from_db
 from tests.helpers.db_utils import minimal_db_host
 from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import minimal_host
+from tests.helpers.test_utils import SYSTEM_IDENTITY
 
 
 def test_find_host_using_subset_canonical_fact_match(db_create_host):
@@ -167,6 +168,7 @@ def test_find_host_using_subscription_manager_id_match(db_create_host):
 @mark.parametrize("changing_id", ("insights_id", "subscription_manager_id"))
 def test_rhsm_conduit_elevated_id_priority_no_identity(mq_create_or_update_host, changing_id):
     base_canonical_facts = {
+        "account": SYSTEM_IDENTITY["account_number"],
         "provider_type": ProviderType.AWS,  # Doesn't matter
         "provider_id": generate_uuid(),
         "insights_id": generate_uuid(),

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -385,7 +385,14 @@ def test_add_host_with_wrong_owner(event_datetime_mock, mq_create_or_update_host
     assert str(ve.value) == "The owner in host does not match the owner in identity"
 
 
-def test_add_host_rhsm_conduit_without_cn(event_datetime_mock, mq_create_or_update_host):
+@pytest.mark.parametrize(
+    "with_account",
+    (
+        True,
+        False,
+    ),
+)
+def test_add_host_rhsm_conduit_without_cn(event_datetime_mock, mq_create_or_update_host, with_account):
     """
     Tests adding a host with reporter rhsm-conduit and no cn
     """
@@ -394,9 +401,14 @@ def test_add_host_rhsm_conduit_without_cn(event_datetime_mock, mq_create_or_upda
     metadata_without_b64 = get_platform_metadata(identity=SYSTEM_IDENTITY)
     del metadata_without_b64["b64_identity"]
 
-    host = minimal_host(
-        account=SYSTEM_IDENTITY["account_number"], reporter="rhsm-conduit", subscription_manager_id=sub_mangager_id
-    )
+    if with_account:
+        host = minimal_host(
+            account=SYSTEM_IDENTITY.get("account_number"),
+            reporter="rhsm-conduit",
+            subscription_manager_id=sub_mangager_id,
+        )
+    else:
+        host = minimal_host(reporter="rhsm-conduit", subscription_manager_id=sub_mangager_id)
 
     key, event, headers = mq_create_or_update_host(host, platform_metadata=metadata_without_b64, return_all_data=True)
 


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3492](https://issues.redhat.com/browse/ESSNTL-3492).
It fixes the final bullet point on the Jira, which is the null account issue when the account is not set on either the host or the identity for rhsm-conduit payloads.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
