### PR TITLE
Enable deleting over 100 hosts

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -256,7 +256,7 @@ def get_host_ids_list(
     while offset < total:
         variables = {"limit": 100, "offset": offset, "filter": all_filters}
         response = graphql_query(HOST_IDS_QUERY, variables, log_get_host_list_failed)["hosts"]
-        total = response["meta"]["total"]
+        total = int(response["meta"]["total"])
         id_list.extend([x["id"] for x in response["data"]])
         # Next loop, query the next 100 records.
         offset += 100

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -165,6 +165,46 @@ def test_delete_hosts_using_filter_and_registered_with(
     assert len(new_hosts) == remaining_hosts.count()
 
 
+@pytest.mark.parametrize(
+    "total_hosts,expected_times_called",
+    (
+        ("105", 2),
+        ("729", 8),
+        ("2048", 21),
+    ),
+)
+def test_delete_over_100_filtered_hosts(
+    api_delete_filtered_hosts,
+    patch_xjoin_post,
+    mocker,
+    total_hosts,
+    expected_times_called,
+):
+    hosts_per_call = len(XJOIN_HOSTS_RESPONSE_FOR_FILTERING["hosts"]["data"])
+
+    # set the new host ids in the xjoin search reference.
+    resp = deepcopy(XJOIN_HOSTS_RESPONSE_FOR_FILTERING)
+    resp["hosts"]["meta"]["total"] = total_hosts
+    response = {"data": resp}
+
+    # Make the new hosts available in xjoin-search to make them available
+    # for querying for deletion using filters
+    patched_post = patch_xjoin_post(response, status=200)
+    patched_delete = mocker.patch("api.host._delete_host_list")
+
+    # delete hosts using the IDs supposedly returned by the query_filter
+    response_status, response_data = api_delete_filtered_hosts({"staleness": "stale"})
+
+    # Just double-check that it didn't error out
+    assert_response_status(response_status, expected_status=202)
+
+    assert patched_post.call_count == expected_times_called
+
+    # The actual number of hosts deleted should be equal to this,
+    # because only hosts_per_call hosts are returned on each call
+    assert len(patched_delete.call_args[0][0]) == hosts_per_call * expected_times_called
+
+
 def test_delete_all_hosts(
     event_producer_mock, db_create_multiple_hosts, db_get_hosts, api_delete_all_hosts, patch_xjoin_post
 ):

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1713,7 +1713,7 @@ def test_xjoin_search_query_using_hostfilter(
     api_delete_filtered_hosts({field: value})
 
     graphql_query_empty_response.assert_called_once_with(
-        HOST_IDS_QUERY, {"filter": ({field: {"eq": value}},), "limit": mocker.ANY}, mocker.ANY
+        HOST_IDS_QUERY, {"filter": ({field: {"eq": value}},), "limit": mocker.ANY, "offset": 0}, mocker.ANY
     )
 
 
@@ -1726,7 +1726,11 @@ def test_xjoin_search_query_using_hostfilter_display_name(
 
     graphql_query_empty_response.assert_called_once_with(
         HOST_IDS_QUERY,
-        {"filter": ({"display_name": {"matches_lc": f"*{query_params['display_name']}*"}},), "limit": mocker.ANY},
+        {
+            "filter": ({"display_name": {"matches_lc": f"*{query_params['display_name']}*"}},),
+            "limit": mocker.ANY,
+            "offset": 0,
+        },
         mocker.ANY,
     )
 
@@ -1759,7 +1763,7 @@ def test_xjoin_search_using_hostfilters_tags(
     tag_filters = tuple({"tag": item} for item in tags)
 
     graphql_query_empty_response.assert_called_once_with(
-        HOST_IDS_QUERY, {"filter": tag_filters, "limit": mocker.ANY}, mocker.ANY
+        HOST_IDS_QUERY, {"filter": tag_filters, "limit": mocker.ANY, "offset": 0}, mocker.ANY
     )
 
 
@@ -1784,6 +1788,7 @@ def test_xjoin_search_query_using_hostfilter_provider(
         {
             "filter": ({"provider_type": {"eq": provider["type"]}}, {"provider_id": {"eq": provider["id"]}}),
             "limit": mocker.ANY,
+            "offset": 0,
         },
         mocker.ANY,
     )


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-2212](https://issues.redhat.com/browse/ESSNTL-2212).
Since xjoin can only return 100 hosts at a time, this updates the bulk deletion endpoint to loop through xjoin calls until all desired host IDs are collected, and then returns that list for deletion. The unit test I wrote for this is relatively short but potentially confusing, so I heavily commented it for clarity.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
