### PR TITLE
Disable delete_duplicates tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --ignore swagger
+addopts = --ignore swagger --ignore tests/test_duplicate_hosts.py
 markers =
   system_profile
   system_culling


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3380](https://issues.redhat.com/browse/ESSNTL-3380).

This PR disables unit tests for `host_delete_duplicates` script. It was just a one-time script that is no longer needed nor developed, so testing it doesn't make sense. However, we don't want to delete the tests completely, so that we can run them in case that we will need to run the script in the future.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
