### PR TITLE
Decrease script chunk size, add env var

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -207,7 +207,7 @@ class Config:
         self.xjoin_graphql_url = os.environ.get("XJOIN_GRAPHQL_URL", "http://localhost:4000/graphql")
 
         self.host_delete_chunk_size = int(os.getenv("HOST_DELETE_CHUNK_SIZE", "1000"))
-        self.script_chunk_size = int(os.getenv("SCRIPT_CHUNK_SIZE", "1000"))
+        self.script_chunk_size = int(os.getenv("SCRIPT_CHUNK_SIZE", "500"))
         self.sp_authorized_users = os.getenv("SP_AUTHORIZED_USERS", "tuser@redhat.com").split()
 
         if self._runtime_environment == RuntimeEnvironment.PENDO_JOB:

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -536,6 +536,8 @@ objects:
             value: ${KAFKA_SASL_MECHANISM}
           - name: CLOWDER_ENABLED
             value: "true"
+          - name: SCRIPT_CHUNK_SIZE
+            value: ${SCRIPT_CHUNK_SIZE}
         resources:
           limits:
             cpu: ${CPU_LIMIT}
@@ -785,6 +787,8 @@ parameters:
   value: '2'
 - name: GUNICORN_REQUEST_FIELD_LIMIT
   value: '16380'
+- name: SCRIPT_CHUNK_SIZE
+  value: '500'
 
 #floorist
 - name: MEMORY_LIMIT_FLOO


### PR DESCRIPTION
# Overview

This PR is being created to address the OOMKill failures that the host-sync job is running into. I'm hoping that decreasing the number of hosts that get loaded into memory at once will make it take up less memory. I think there may still be a memory leak hiding in the code somewhere, but I haven't found it yet.