### PR TITLE
Add more debug statements to event-rebuilder job

### DIFF
--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -53,10 +53,12 @@ def run(config, logger, session, consumer, event_producer, shutdown_handler):
     total_messages_processed = 0
 
     logger.debug("About to start the consumer loop")
-    while num_messages > 0 and not shutdown_handler.shut_down():
+    while num_messages > 0:
+        logger.debug("Entered first loop")
         num_messages = 0
         msgs = consumer.poll(timeout_ms=1000)
         for _, messages in msgs.items():
+            logger.debug("Entered second loop")
             for message in messages:
                 logger.debug("Message received")
                 try:

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -56,8 +56,7 @@ def run(config, logger, session, consumer, event_producer, shutdown_handler):
     while num_messages > 0:
         logger.debug("Entered first loop")
         num_messages = 0
-        msgs = consumer.poll(timeout_ms=1000)
-        for _, messages in msgs.items():
+        for partition, messages in consumer.poll(timeout_ms=60000, max_records=500).items():
             logger.debug("Entered second loop")
             for message in messages:
                 logger.debug("Message received")


### PR DESCRIPTION
# Overview

This PR just adds some more debug logs to the event-rebuilder job. It also removes the shutdown handler, in case that's what's causing the entire loop to be skipped.