### PR TITLE
Use the correct ID path for Delete events

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -180,8 +180,8 @@ def parse_operation_message(message):
 
 
 def sync_event_message(message, session, event_producer):
-    host_id = message["host"]["id"]
     if message["type"] != EventType.delete.name:
+        host_id = message["host"]["id"]
         query = session.query(Host).filter((Host.org_id == message["host"]["org_id"]) & (Host.id == UUID(host_id)))
         # If the host doesn't exist in the DB, produce a Delete event.
         if not query.count():
@@ -195,7 +195,7 @@ def sync_event_message(message, session, event_producer):
         else:
             logger.info(f"{host_id}: Latest event is not a delete, but host found in DB.")
     else:
-        logger.info(f"{host_id}: Latest event is a delete.")
+        logger.info(f"{message['id']}: Latest event is a delete.")
 
     return
 


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3589](https://issues.redhat.com/browse/ESSNTL-3589).
This fixes the path for the host ID on Delete messages in the events-topic rebuilder. The job works right now, but it outputs stack traces instead of the logging I expected; this PR fixes it so we get cleaner output.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
