### PR TITLE
Add timecheck to old kafka-python for comparing against confuent-kafka

### DIFF
--- a/app/queue/event_producer.py
+++ b/app/queue/event_producer.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from kafka import KafkaProducer
 from kafka.errors import KafkaError
 
@@ -21,6 +23,9 @@ class EventProducer:
         self.egress_topic = topic
 
     def write_event(self, event, key, headers, *, wait=False):
+        enterTime = datetime.now()
+        logger.info(f"TIMECHECK: app.queue.event_producer.EventProducer.write_event() enter time: {enterTime}")
+
         logger.debug("Topic: %s, key: %s, event: %s, headers: %s", self.egress_topic, key, event, headers)
 
         k = key.encode("utf-8") if key else None
@@ -38,6 +43,11 @@ class EventProducer:
 
             if wait:
                 send_future.get()
+
+        execTime = (datetime.now() - enterTime).microseconds
+        logger.info(
+            f"TIMECHECK: app.queue.event_producer.EventProducer.write_event() execution time: {execTime} microseconds"
+        )
 
     def close(self):
         self._kafka_producer.flush()

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum
 from uuid import UUID
 
@@ -65,11 +66,18 @@ def add_host(input_host, identity, staleness_offset, update_system_profile=True,
 
 @metrics.host_dedup_processing_time.time()
 def find_existing_host(identity, canonical_facts):
+
+    enterTime = datetime.now()
+    logger.info(f"TIMECHECK: lib.host_repository.find_existing_host() enter time: {enterTime}")
+
     logger.debug("find_existing_host(%s, %s)", identity, canonical_facts)
     existing_host = _find_host_by_elevated_ids(identity, canonical_facts)
 
     if not existing_host:
         existing_host = find_host_by_multiple_canonical_facts(identity, canonical_facts)
+
+    execTime = (datetime.now() - enterTime).microseconds
+    logger.info(f"TIMECHECK: lib.host_repository.find_existing_host() execution time: {execTime} microseconds")
 
     return existing_host
 
@@ -159,6 +167,9 @@ def find_non_culled_hosts(query):
 def create_new_host(input_host, staleness_offset, fields):
     logger.debug("Creating a new host")
 
+    enterTime = datetime.now()
+    logger.info(f"TIMECHECK: lib.host_repository.create_new_host() enter time: {enterTime}")
+
     input_host.save()
     db.session.commit()
 
@@ -167,6 +178,10 @@ def create_new_host(input_host, staleness_offset, fields):
 
     output_host = serialize_host(input_host, staleness_offset, fields)
     insights_id = input_host.canonical_facts.get("insights_id")
+
+    execTime = (datetime.now() - enterTime).microseconds
+    logger.info(f"TIMECHECK: lib.host_repository.create_new_host() execution time: {execTime} microseconds")
+
     return output_host, input_host.id, insights_id, AddHostResult.created
 
 
@@ -174,6 +189,9 @@ def create_new_host(input_host, staleness_offset, fields):
 def update_existing_host(existing_host, input_host, staleness_offset, update_system_profile, fields):
     logger.debug("Updating an existing host")
     logger.debug(f"existing host = {existing_host}")
+
+    enterTime = datetime.now()
+    logger.info(f"TIMECHECK: lib.host_repository.update_existing_host() enter time: {enterTime}")
 
     existing_host.update(input_host, update_system_profile)
     db.session.commit()
@@ -183,6 +201,10 @@ def update_existing_host(existing_host, input_host, staleness_offset, update_sys
 
     output_host = serialize_host(existing_host, staleness_offset, fields)
     insights_id = existing_host.canonical_facts.get("insights_id")
+
+    execTime = (datetime.now() - enterTime).microseconds
+    logger.info(f"TIMECHECK: lib.host_repository.update_existing_host() exeuction time: {execTime} microseconds")
+
     return output_host, existing_host.id, insights_id, AddHostResult.updated
 
 


### PR DESCRIPTION
# Overview

## DO NOT MERGE
**This PR is being created for @fstavela to compare "kafka python" against "confluent-kafka"**

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
