### PR TITLE
Fix datasource ID for production

### DIFF
--- a/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
@@ -2541,7 +2541,7 @@ data:
         {
           "datasource": {
             "type": "cloudwatch",
-            "uid": "C_IyqZfnz"
+            "uid": "yL__iMf7z"
           },
           "description": "The available IOPS burst balance for the Prod HBI DB. When it runs out, DB performance is greatly reduced.",
           "fieldConfig": {
@@ -2616,7 +2616,7 @@ data:
             {
               "datasource": {
                 "type": "cloudwatch",
-                "uid": "C_IyqZfnz"
+                "uid": "yL__iMf7z"
               },
               "dimensions": {
                 "DBInstanceIdentifier": "host-inventory-prod"


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3603](https://issues.redhat.com/browse/ESSNTL-3603). It turns out the data source ID we were using works in Stage, but not Prod. Since Prod is more important, I've updated the data source ID to the one that works in Prod. This will result in a blank panel for Stage, but a working one for Prod.

