### PR TITLE
ESSNTL-630: Replace hard coded timestamps

### DIFF
--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -2,9 +2,7 @@ import json
 import math
 import unittest.mock as mock
 from base64 import b64encode
-from datetime import datetime
 from datetime import timedelta
-from datetime import timezone
 from itertools import product
 from struct import unpack
 from urllib.parse import parse_qs
@@ -16,6 +14,7 @@ from urllib.parse import urlunsplit
 import dateutil.parser
 
 from app.auth.identity import IdentityType
+from tests.helpers.test_utils import now
 
 HOST_URL = "/api/inventory/v1/hosts"
 TAGS_URL = "/api/inventory/v1/tags"
@@ -144,7 +143,7 @@ def assert_host_was_updated(original_host, updated_host):
 def assert_host_was_created(create_host_response):
     assert create_host_response["status"] == 201
     created_time = dateutil.parser.parse(create_host_response["host"]["created"])
-    current_timestamp = datetime.now(timezone.utc)
+    current_timestamp = now()
     assert current_timestamp > created_time
     assert (current_timestamp - timedelta(minutes=15)) < created_time
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -65,6 +65,7 @@ from tests.helpers.mq_utils import expected_encoded_headers
 from tests.helpers.system_profile_utils import INVALID_SYSTEM_PROFILES
 from tests.helpers.system_profile_utils import mock_system_profile_specification
 from tests.helpers.system_profile_utils import system_profile_specification
+from tests.helpers.test_utils import now
 from tests.helpers.test_utils import set_environment
 from tests.helpers.test_utils import SYSTEM_IDENTITY
 from tests.helpers.test_utils import USER_IDENTITY
@@ -797,7 +798,7 @@ class SerializationDeserializeHostCompoundTestCase(TestCase):
             },
             "reporter": "puptoo",
         }
-        stale_timestamp = datetime.now(timezone.utc)
+        stale_timestamp = now()
         full_input = {
             **canonical_facts,
             **unchanged_input,
@@ -829,7 +830,7 @@ class SerializationDeserializeHostCompoundTestCase(TestCase):
 
     def test_with_only_required_fields(self):
         org_id = "some org_id"
-        stale_timestamp = datetime.now(timezone.utc)
+        stale_timestamp = now()
         reporter = "puptoo"
         canonical_facts = {"fqdn": "some fqdn"}
 
@@ -855,7 +856,7 @@ class SerializationDeserializeHostCompoundTestCase(TestCase):
             self.assertEqual({}, host.system_profile_facts)
 
     def test_with_invalid_input(self):
-        stale_timestamp = datetime.now(timezone.utc).isoformat()
+        stale_timestamp = now().isoformat()
         inputs = (
             {},
             {"org_id": "some org_id", "stale_timestamp": stale_timestamp},
@@ -958,7 +959,7 @@ class SerializationDeserializeHostCompoundTestCase(TestCase):
             "org_id": "some org_id",
             "reporter": "puptoo",
         }
-        stale_timestamp = datetime.now(timezone.utc)
+        stale_timestamp = now()
         full_input = {
             **canonical_facts,
             **unchanged_input,
@@ -997,7 +998,7 @@ class SerializationDeserializeHostCompoundTestCase(TestCase):
         host = deserialize_host(
             {
                 "org_id": "3340851",
-                "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+                "stale_timestamp": now().isoformat(),
                 "reporter": "puptoo",
                 "fqdn": "some fqdn",
                 "tags": tags,
@@ -1057,7 +1058,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "cores_per_socket": 3,
                 "system_memory_bytes": 4,
             },
-            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "stale_timestamp": now().isoformat(),
             "reporter": "some reporter",
         }
         host_schema = Mock(**{"return_value.load.return_value": host_input, "build_model": HostSchema.build_model})
@@ -1096,7 +1097,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "cores_per_socket": 3,
                 "system_memory_bytes": 4,
             },
-            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "stale_timestamp": now().isoformat(),
             "reporter": "some reporter",
         }
         host_schema = Mock(**{"return_value.load.return_value": host_input, "build_model": HostSchema.build_model})
@@ -1136,7 +1137,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "cores_per_socket": 3,
                 "system_memory_bytes": 4,
             },
-            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "stale_timestamp": now().isoformat(),
             "reporter": "some reporter",
         }
         host_schema = Mock(**{"return_value.load.return_value": host_input, "build_model": HostSchema.build_model})
@@ -1179,7 +1180,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "cores_per_socket": 3,
                 "system_memory_bytes": 4,
             },
-            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "stale_timestamp": now().isoformat(),
             "reporter": "some reporter",
         }
         host_schema = Mock(**{"return_value.load.return_value": host_input, "build_model": HostSchema.build_model})
@@ -1217,7 +1218,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 "some namespace": {"some key": "some value"},
                 "another namespace": {"another key": "another value"},
             },
-            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "stale_timestamp": now().isoformat(),
             "reporter": "some reporter",
         }
         host_schema = Mock(**{"return_value.load.return_value": host_input, "build_model": HostSchema.build_model})
@@ -1346,7 +1347,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
                 "some namespace": {"some key": "some value"},
                 "another namespace": {"another key": "another value"},
             },
-            "stale_timestamp": datetime.now(timezone.utc),
+            "stale_timestamp": now(),
             "tags": {
                 "some namespace": {"some key": ["some value", "another value"], "another key": ["value"]},
                 "another namespace": {"key": ["value"]},
@@ -1356,8 +1357,8 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
 
         host_attr_data = {
             "id": uuid4(),
-            "created_on": datetime.utcnow(),
-            "modified_on": datetime.utcnow(),
+            "created_on": now(),
+            "modified_on": now(),
             "per_reporter_staleness": host.per_reporter_staleness,
         }
         for k, v in host_attr_data.items():
@@ -1394,7 +1395,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
     def test_with_only_required_fields(self):
         unchanged_data = {"display_name": None, "org_id": "some org_id", "account": None, "reporter": "yupana"}
         host_init_data = {
-            "stale_timestamp": datetime.now(timezone.utc),
+            "stale_timestamp": now(),
             "canonical_facts": {"fqdn": "some fqdn"},
             **unchanged_data,
             "facts": {},
@@ -1403,8 +1404,8 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
 
         host_attr_data = {
             "id": uuid4(),
-            "created_on": datetime.utcnow(),
-            "modified_on": datetime.utcnow(),
+            "created_on": now(),
+            "modified_on": now(),
             "per_reporter_staleness": host.per_reporter_staleness,
         }
         for k, v in host_attr_data.items():
@@ -1446,10 +1447,10 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
             with self.subTest(
                 stale_warning_offset_days=stale_warning_offset_days, culled_offset_days=culled_offset_days
             ):
-                stale_timestamp = datetime.now(timezone.utc) + timedelta(days=1)
+                stale_timestamp = now() + timedelta(days=1)
                 host = Host({"fqdn": "some fqdn"}, facts={}, stale_timestamp=stale_timestamp, reporter="some reporter")
 
-                for k, v in (("id", uuid4()), ("created_on", datetime.utcnow()), ("modified_on", datetime.utcnow())):
+                for k, v in (("id", uuid4()), ("created_on", now()), ("modified_on", now())):
                     setattr(host, k, v)
 
                 config = CullingConfig(timedelta(days=stale_warning_offset_days), timedelta(days=culled_offset_days))
@@ -1482,7 +1483,7 @@ class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTes
             {"namespace": "some namespace", "key": "another key", "value": "value"},
             {"namespace": "another namespace", "key": "key", "value": "value"},
         ]
-        stale_timestamp = datetime.now(timezone.utc)
+        stale_timestamp = now()
 
         unchanged_data = {
             "display_name": "some display name",
@@ -1505,8 +1506,8 @@ class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTes
 
         host_attr_data = {
             "id": uuid4(),
-            "created_on": datetime.utcnow(),
-            "modified_on": datetime.utcnow(),
+            "created_on": now(),
+            "modified_on": now(),
             "per_reporter_staleness": host.per_reporter_staleness,
         }
         for k, v in host_attr_data.items():
@@ -1514,9 +1515,9 @@ class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTes
 
         staleness_offset = Mock(
             **{
-                "stale_timestamp.return_value": datetime.now(timezone.utc),
-                "stale_timestamp.stale_warning_timestamp": datetime.now(timezone.utc) + timedelta(hours=1),
-                "stale_timestamp.culled_timestamp": datetime.now(timezone.utc) + timedelta(hours=2),
+                "stale_timestamp.return_value": now(),
+                "stale_timestamp.stale_warning_timestamp": now() + timedelta(hours=1),
+                "stale_timestamp.culled_timestamp": now() + timedelta(hours=2),
             }
         )
         actual = serialize_host(host, staleness_offset, DEFAULT_FIELDS + ("tags",))
@@ -1552,7 +1553,7 @@ class SerializationSerializeHostSystemProfileTestCase(TestCase):
             canonical_facts={"fqdn": "some fqdn"},
             display_name="some display name",
             system_profile_facts=system_profile_facts,
-            stale_timestamp=datetime.utcnow(),
+            stale_timestamp=now(),
             reporter="yupana",
         )
         host.id = uuid4()
@@ -1565,7 +1566,7 @@ class SerializationSerializeHostSystemProfileTestCase(TestCase):
         host = Host(
             canonical_facts={"fqdn": "some fqdn"},
             display_name="some display name",
-            stale_timestamp=datetime.utcnow(),
+            stale_timestamp=now(),
             reporter="yupana",
         )
         host.id = uuid4()
@@ -1742,8 +1743,8 @@ class SerializationSerializeFactsTestCase(TestCase):
 
 class SerializationSerializeDatetime(TestCase):
     def test_utc_timezone_is_used(self):
-        now = datetime.now(timezone.utc)
-        self.assertEqual(now.isoformat(), _serialize_datetime(now))
+        _now = now()
+        self.assertEqual(_now.isoformat(), _serialize_datetime(_now))
 
     def test_iso_format_is_used(self):
         dt = datetime(2019, 7, 3, 1, 1, 4, 20647, timezone.utc)
@@ -1765,7 +1766,7 @@ class HostUpdateStaleTimestamp(TestCase):
         return Host(**{"canonical_facts": {"fqdn": "some fqdn"}, **values})
 
     def test_always_updated(self):
-        old_stale_timestamp = datetime.now(timezone.utc) + timedelta(days=2)
+        old_stale_timestamp = now() + timedelta(days=2)
         old_reporter = "old reporter"
         stale_timestamps = (old_stale_timestamp - timedelta(days=1), old_stale_timestamp - timedelta(days=2))
         reporters = (old_reporter, "new reporter")
@@ -1773,7 +1774,7 @@ class HostUpdateStaleTimestamp(TestCase):
             with self.subTest(stale_timestamps=new_stale_timestamp, reporter=new_reporter):
                 host = self._make_host(stale_timestamp=old_stale_timestamp, reporter=old_reporter)
 
-                new_stale_timestamp = datetime.now(timezone.utc) + timedelta(days=2)
+                new_stale_timestamp = now() + timedelta(days=2)
                 host._update_stale_timestamp(new_stale_timestamp, new_reporter)
 
                 self.assertEqual(new_stale_timestamp, host.stale_timestamp)
@@ -1879,7 +1880,7 @@ class EventProducerTests(TestCase):
         threadctx.request_id = str(uuid4())
         self.basic_host = {
             "id": str(uuid4()),
-            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "stale_timestamp": now().isoformat(),
             "reporter": "test_reporter",
             "account": "test",
             "org_id": "test",
@@ -2078,7 +2079,7 @@ class ModelsSystemProfileTestCase(TestCase):
             "account": "0000001",
             "org_id": "3340851",
             "system_profile": system_profile,
-            "stale_timestamp": datetime.now(timezone.utc).isoformat(),
+            "stale_timestamp": now().isoformat(),
             "reporter": "test",
         }
 


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-620](https://issues.redhat.com/browse/ESSNTL-620).
The solution for the problem of the hard coded timestamps was already in `test_utils` so I updated the tests that were not using it.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
