### PR TITLE
ESSNTL-3503: Notification messages bugs

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -310,6 +310,7 @@ def handle_message(message, event_producer, notification_event_producer, message
             raise
         except InventoryException as ie:
             send_kafka_error_message(notification_event_producer, host, str(ie.detail))
+            raise
 
 
 def event_loop(consumer, flask_app, event_producer, notification_event_producer, handler, interrupt):

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -89,7 +89,9 @@ def _get_identity(host, metadata):
         else:
             raise ValidationException("platform_metadata is mandatory")
 
-    if host.get("org_id") != identity["org_id"]:
+    if not host.get("org_id"):
+        raise ValidationException("org_id must be provided")
+    elif host.get("org_id") != identity["org_id"]:
         raise ValidationException("The org_id in the identity does not match the org_id in the host.")
     try:
         identity = Identity(identity)
@@ -310,6 +312,7 @@ def handle_message(message, event_producer, notification_event_producer, message
             raise
         except InventoryException as ie:
             send_kafka_error_message(notification_event_producer, host, str(ie.detail))
+            raise
 
 
 def event_loop(consumer, flask_app, event_producer, notification_event_producer, handler, interrupt):

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -356,5 +356,7 @@ def send_kafka_error_message(notification_event_producer, host, detail):
         NotificationType.validation_error,
         rh_message_id=rh_message_id,
     )
-    key = minimal_host.get("canonical_facts" or {}).get("insights_id")
+    insights_id = minimal_host.get("canonical_facts" or {}).get("insights_id")
+    key = insights_id if type(insights_id) is str else None
+
     notification_event_producer.write_event(event, key, headers, wait=True)

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -310,7 +310,6 @@ def handle_message(message, event_producer, notification_event_producer, message
             raise
         except InventoryException as ie:
             send_kafka_error_message(notification_event_producer, host, str(ie.detail))
-            raise
 
 
 def event_loop(consumer, flask_app, event_producer, notification_event_producer, handler, interrupt):


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3503](https://issues.redhat.com/browse/ESSNTL-3503).
This PR fixes the last cases in which a notification should be produced but isn't.
- Checks if `insights_id` is a string before sending it as key for the message
- Raises a ValidationException if `org_id` is not provided

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
