### PR TITLE
ESSNTL-3785: missing canonical facts raise different error

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -214,11 +214,6 @@ class Host(LimitedHost):
         reporter=None,
         per_reporter_staleness=None,
     ):
-        if not canonical_facts:
-            raise InventoryException(
-                title="Invalid request", detail="At least one of the canonical fact fields must be present."
-            )
-
         if not stale_timestamp or not reporter:
             raise InventoryException(
                 title="Invalid request", detail="Both stale_timestamp and reporter fields must be present."
@@ -483,6 +478,11 @@ class CanonicalFactsSchema(MarshmallowSchema):
         # check for white spaces, tabs, and newline characters only
         if provider_id and provider_id.isspace():
             raise MarshmallowValidationError("Provider id can not be just blank, whitespaces or tabs")
+
+    @validates_schema
+    def validate_fields(self, data, **kwargs):
+        if not any(data.keys()):
+            raise MarshmallowValidationError("At least one of the canonical fact fields must be present.")
 
 
 class LimitedHostSchema(CanonicalFactsSchema):

--- a/app/models.py
+++ b/app/models.py
@@ -51,6 +51,18 @@ SYSTEM_PROFILE_SPECIFICATION_FILE = "system_profile.spec.yaml"
 # set edge host stale_timestamp way out in future to Year 2260
 EDGE_HOST_STALE_TIMESTAMP = datetime(2260, 1, 1, tzinfo=timezone.utc)
 
+CANONICAL_FACTS_FIELDS = (
+    "insights_id",
+    "subscription_manager_id",
+    "satellite_id",
+    "bios_uuid",
+    "ip_addresses",
+    "fqdn",
+    "mac_addresses",
+    "provider_id",
+    "provider_type",
+)
+
 
 class ProviderType(str, Enum):
     ALIBABA = "alibaba"
@@ -481,7 +493,7 @@ class CanonicalFactsSchema(MarshmallowSchema):
 
     @validates_schema
     def validate_fields(self, data, **kwargs):
-        if not any(data.keys()):
+        if not any(CANONICAL_FACTS_FIELDS in data.keys()):
             raise MarshmallowValidationError("At least one of the canonical fact fields must be present.")
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -51,18 +51,6 @@ SYSTEM_PROFILE_SPECIFICATION_FILE = "system_profile.spec.yaml"
 # set edge host stale_timestamp way out in future to Year 2260
 EDGE_HOST_STALE_TIMESTAMP = datetime(2260, 1, 1, tzinfo=timezone.utc)
 
-CANONICAL_FACTS_FIELDS = (
-    "insights_id",
-    "subscription_manager_id",
-    "satellite_id",
-    "bios_uuid",
-    "ip_addresses",
-    "fqdn",
-    "mac_addresses",
-    "provider_id",
-    "provider_type",
-)
-
 
 class ProviderType(str, Enum):
     ALIBABA = "alibaba"
@@ -233,6 +221,9 @@ class Host(LimitedHost):
 
         if tags is None:
             raise InventoryException(title="Invalid request", detail="The tags field cannot be null.")
+
+        if not canonical_facts:
+            raise MarshmallowValidationError("At least one of the canonical fact fields must be present.")
 
         super().__init__(
             canonical_facts, display_name, ansible_host, account, org_id, facts, tags, system_profile_facts
@@ -491,10 +482,10 @@ class CanonicalFactsSchema(MarshmallowSchema):
         if provider_id and provider_id.isspace():
             raise MarshmallowValidationError("Provider id can not be just blank, whitespaces or tabs")
 
-    @validates_schema
-    def validate_fields(self, data, **kwargs):
-        if not any(x in CANONICAL_FACTS_FIELDS for x in data.keys()):
-            raise MarshmallowValidationError("At least one of the canonical fact fields must be present.")
+    # @validates_schema
+    # def validate_fields(self, data, **kwargs):
+    #     if not any(CANONICAL_FACTS_FIELDS in data.keys()):
+    #         raise MarshmallowValidationError("At least one of the canonical fact fields must be present.")
 
 
 class LimitedHostSchema(CanonicalFactsSchema):

--- a/app/models.py
+++ b/app/models.py
@@ -493,7 +493,7 @@ class CanonicalFactsSchema(MarshmallowSchema):
 
     @validates_schema
     def validate_fields(self, data, **kwargs):
-        if not any(CANONICAL_FACTS_FIELDS in data.keys()):
+        if not any(x in CANONICAL_FACTS_FIELDS for x in data.keys()):
             raise MarshmallowValidationError("At least one of the canonical fact fields must be present.")
 
 

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -5,7 +5,6 @@ from marshmallow import ValidationError
 
 from app.exceptions import InputFormatException
 from app.exceptions import ValidationException
-from app.models import CANONICAL_FACTS_FIELDS
 from app.models import CanonicalFactsSchema
 from app.models import Host as Host
 from app.models import HostSchema
@@ -13,6 +12,19 @@ from app.utils import Tag
 
 
 __all__ = ("deserialize_host", "serialize_host", "serialize_host_system_profile", "serialize_canonical_facts")
+
+
+_CANONICAL_FACTS_FIELDS = (
+    "insights_id",
+    "subscription_manager_id",
+    "satellite_id",
+    "bios_uuid",
+    "ip_addresses",
+    "fqdn",
+    "mac_addresses",
+    "provider_id",
+    "provider_type",
+)
 
 DEFAULT_FIELDS = (
     "id",
@@ -141,15 +153,15 @@ def _recursive_casefold(field_data):
 
 
 def _deserialize_canonical_facts(data):
-    return {field: _recursive_casefold(data[field]) for field in CANONICAL_FACTS_FIELDS if data.get(field)}
+    return {field: _recursive_casefold(data[field]) for field in _CANONICAL_FACTS_FIELDS if data.get(field)}
 
 
 def _deserialize_all_canonical_facts(data):
-    return {field: _recursive_casefold(data[field]) if data.get(field) else None for field in CANONICAL_FACTS_FIELDS}
+    return {field: _recursive_casefold(data[field]) if data.get(field) else None for field in _CANONICAL_FACTS_FIELDS}
 
 
 def serialize_canonical_facts(canonical_facts):
-    return {field: canonical_facts.get(field) for field in CANONICAL_FACTS_FIELDS}
+    return {field: canonical_facts.get(field) for field in _CANONICAL_FACTS_FIELDS}
 
 
 def _deserialize_facts(data):

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -5,6 +5,7 @@ from marshmallow import ValidationError
 
 from app.exceptions import InputFormatException
 from app.exceptions import ValidationException
+from app.models import CANONICAL_FACTS_FIELDS
 from app.models import CanonicalFactsSchema
 from app.models import Host as Host
 from app.models import HostSchema
@@ -12,19 +13,6 @@ from app.utils import Tag
 
 
 __all__ = ("deserialize_host", "serialize_host", "serialize_host_system_profile", "serialize_canonical_facts")
-
-
-_CANONICAL_FACTS_FIELDS = (
-    "insights_id",
-    "subscription_manager_id",
-    "satellite_id",
-    "bios_uuid",
-    "ip_addresses",
-    "fqdn",
-    "mac_addresses",
-    "provider_id",
-    "provider_type",
-)
 
 DEFAULT_FIELDS = (
     "id",
@@ -153,15 +141,15 @@ def _recursive_casefold(field_data):
 
 
 def _deserialize_canonical_facts(data):
-    return {field: _recursive_casefold(data[field]) for field in _CANONICAL_FACTS_FIELDS if data.get(field)}
+    return {field: _recursive_casefold(data[field]) for field in CANONICAL_FACTS_FIELDS if data.get(field)}
 
 
 def _deserialize_all_canonical_facts(data):
-    return {field: _recursive_casefold(data[field]) if data.get(field) else None for field in _CANONICAL_FACTS_FIELDS}
+    return {field: _recursive_casefold(data[field]) if data.get(field) else None for field in CANONICAL_FACTS_FIELDS}
 
 
 def serialize_canonical_facts(canonical_facts):
-    return {field: canonical_facts.get(field) for field in _CANONICAL_FACTS_FIELDS}
+    return {field: canonical_facts.get(field) for field in CANONICAL_FACTS_FIELDS}
 
 
 def _deserialize_facts(data):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -228,6 +228,27 @@ def test_host_models_missing_fields(missing_field):
         Host(**values)
 
 
+def test_host_models_missing_canonical_facts():
+    limited_values = {
+        "account": USER_IDENTITY["account_number"],
+        "canonical_facts": {"fqdn": "foo.qoo.doo.noo"},
+        "system_profile_facts": {"number_of_cpus": 1},
+    }
+    if "canonical_facts" in limited_values:
+        limited_values["canonical_facts"] = None
+
+    # LimitedHost should be fine with these missing values
+    LimitedHost(**limited_values)
+
+    values = {**limited_values, "stale_timestamp": now(), "reporter": "reporter"}
+    if "canonical_facts" in values:
+        values["canonical_facts"] = None
+
+    # Host should complain about the missing values
+    with pytest.raises(MarshmallowValidationError):
+        Host(**values)
+
+
 def test_host_schema_timezone_enforced():
     host = {
         "fqdn": "scooby.doo.com",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,7 @@ from marshmallow import ValidationError as MarshmallowValidationError
 from sqlalchemy.exc import DataError
 
 from app import db
-from app.exceptions import InventoryException
+from app.exceptions import ValidationException
 from app.models import CanonicalFactsSchema
 from app.models import Host
 from app.models import HostSchema
@@ -206,7 +206,7 @@ def test_host_schema_invalid_tags(tags):
     assert error_messages["tags"] == {0: {"key": ["Missing data for required field."]}}
 
 
-@pytest.mark.parametrize("missing_field", ["stale_timestamp", "reporter"])
+@pytest.mark.parametrize("missing_field", ["canonical_facts", "stale_timestamp", "reporter"])
 def test_host_models_missing_fields(missing_field):
     limited_values = {
         "account": USER_IDENTITY["account_number"],
@@ -224,28 +224,7 @@ def test_host_models_missing_fields(missing_field):
         values[missing_field] = None
 
     # Host should complain about the missing values
-    with pytest.raises(InventoryException):
-        Host(**values)
-
-
-def test_host_models_missing_canonical_facts():
-    limited_values = {
-        "account": USER_IDENTITY["account_number"],
-        "canonical_facts": {"fqdn": "foo.qoo.doo.noo"},
-        "system_profile_facts": {"number_of_cpus": 1},
-    }
-    if "canonical_facts" in limited_values:
-        limited_values["canonical_facts"] = None
-
-    # LimitedHost should be fine with these missing values
-    LimitedHost(**limited_values)
-
-    values = {**limited_values, "stale_timestamp": now(), "reporter": "reporter"}
-    if "canonical_facts" in values:
-        values["canonical_facts"] = None
-
-    # Host should complain about the missing values
-    with pytest.raises(MarshmallowValidationError):
+    with pytest.raises(ValidationException):
         Host(**values)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -206,7 +206,7 @@ def test_host_schema_invalid_tags(tags):
     assert error_messages["tags"] == {0: {"key": ["Missing data for required field."]}}
 
 
-@pytest.mark.parametrize("missing_field", ["canonical_facts", "stale_timestamp", "reporter"])
+@pytest.mark.parametrize("missing_field", ["stale_timestamp", "reporter"])
 def test_host_models_missing_fields(missing_field):
     limited_values = {
         "account": USER_IDENTITY["account_number"],
@@ -513,6 +513,11 @@ def test_valid_providers(provider):
 def test_invalid_providers(canonical_facts):
     with pytest.raises(MarshmallowValidationError):
         CanonicalFactsSchema().load(canonical_facts)
+
+
+def test_empty_canonical_facts():
+    with pytest.raises(MarshmallowValidationError):
+        CanonicalFactsSchema().load({})
 
 
 @pytest.mark.parametrize(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -515,11 +515,6 @@ def test_invalid_providers(canonical_facts):
         CanonicalFactsSchema().load(canonical_facts)
 
 
-def test_empty_canonical_facts():
-    with pytest.raises(MarshmallowValidationError):
-        CanonicalFactsSchema().load({})
-
-
 @pytest.mark.parametrize(
     "ip_addresses", (["127.0.0.1"], ["1.2.3.4"], ["2001:db8:3333:4444:5555:6666:7777:8888"], ["::"], ["2001:db8::"])
 )


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3785](https://issues.redhat.com/browse/ESSNTL-3785).
Throughout the code, our own `ValidationException` has been used to refer to incorrect values received from the customers or reporters, so this PR changes the exception raised by the missing canonical facts and related fields in the same block of code to a `ValidationException`.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
