### PR TITLE
Make staleness param default to all 4 values

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -643,6 +643,7 @@ components:
         default:
           - fresh
           - stale
+          - stale_warning
           - unknown
       description: "Culling states of the hosts. Default: fresh,stale,unknown"
     stalenessNoDefaultsParam:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1066,6 +1066,7 @@
           "default": [
             "fresh",
             "stale",
+            "stale_warning",
             "unknown"
           ]
         },

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -104,6 +104,7 @@ def test_query_all_hosts(mocker, graphql_query_empty_response, api_get):
                         {"stale_timestamp": mocker.ANY},
                         {"stale_timestamp": mocker.ANY},
                         {"stale_timestamp": mocker.ANY},
+                        {"stale_timestamp": mocker.ANY},
                     )
                 },
             ),
@@ -615,22 +616,6 @@ def test_query_variables_default_except_staleness(mocker, graphql_query_empty_re
     )
 
 
-def test_query_variables_default_staleness(mocker, culling_datetime_mock, graphql_query_empty_response, api_get):
-    response_status, response_data = api_get(HOST_URL)
-
-    assert response_status == 200
-
-    assert_graph_query_single_call_with_staleness(
-        mocker,
-        graphql_query_empty_response,
-        (
-            {"gt": "2019-12-16T10:10:06.754201+00:00"},  # fresh
-            {"gt": "2019-12-09T10:10:06.754201+00:00", "lte": "2019-12-16T10:10:06.754201+00:00"},  # stale
-            {"eq": None},  # unknown
-        ),
-    )
-
-
 @pytest.mark.parametrize(
     "staleness,expected",
     (
@@ -876,37 +861,6 @@ def test_tags_query_host_filters(assert_tag_query_host_filter_for_field, field, 
 def test_tags_query_host_filters_casefolding(assert_tag_query_host_filter_for_field, field, matcher, value):
     assert_tag_query_host_filter_for_field(
         build_tags_url(query=f"?{field}={quote(value.replace('*',''))}"), field, matcher, value
-    )
-
-
-def test_tags_query_variables_default_staleness(
-    mocker, culling_datetime_mock, graphql_tag_query_empty_response, api_get
-):
-    response_status, response_data = api_get(TAGS_URL)
-
-    assert response_status == 200
-
-    graphql_tag_query_empty_response.assert_called_once_with(
-        TAGS_QUERY,
-        {
-            "order_by": mocker.ANY,
-            "order_how": mocker.ANY,
-            "limit": mocker.ANY,
-            "offset": mocker.ANY,
-            "hostFilter": {
-                "OR": [
-                    {"stale_timestamp": {"gt": "2019-12-16T10:10:06.754201+00:00"}},
-                    {
-                        "stale_timestamp": {
-                            "gt": "2019-12-09T10:10:06.754201+00:00",
-                            "lte": "2019-12-16T10:10:06.754201+00:00",
-                        }
-                    },
-                    {"stale_timestamp": {"eq": None}},
-                ]
-            },
-        },
-        mocker.ANY,
     )
 
 


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-728](https://issues.redhat.com/browse/ESSNTL-728).
It defaults the staleness filter to all 4 values, since that's the direction people want to move in. It also removes tests that explicitly test that those default values are applied.
I've tried to remove the need for the defaults entirely, but that requires a fair amount of rework to all of our queries.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
