### PR TITLE
fix(ESSNTL-4077): Fix the group.id field in Kafka consumer configs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -147,7 +147,7 @@ class Config:
         }
 
         self.validator_kafka_consumer = {
-            "group_id": "inventory-sp-validator",
+            "group.id": "inventory-sp-validator",
             "request.timeout.ms": int(os.environ.get("KAFKA_CONSUMER_REQUEST_TIMEOUT_MS", "305000")),
             "max.in.flight.requests.per.connection": int(
                 os.environ.get("KAFKA_CONSUMER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION", "5")
@@ -160,7 +160,7 @@ class Config:
         }
 
         self.events_kafka_consumer = {
-            "group_id": "inventory-events-rebuild",
+            "group.id": "inventory-events-rebuild",
             "auto.offset.reset": "earliest",
             "request.timeout.ms": int(os.environ.get("KAFKA_CONSUMER_REQUEST_TIMEOUT_MS", "305000")),
             "max.in.flight.requests.per.connection": int(


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-4077](https://issues.redhat.com/browse/ESSNTL-4077).
In the [migration to confluent-kafka](https://github.com/RedHatInsights/insights-host-inventory/pull/1193), the `group-id` field wasn't changed to `group.id`, and the host-synchronizer and sp-validator jobs are failing as a result. This PR fixes those configs, which should allow the jobs to run again.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
