### PR TITLE
Add workloads to floorplan

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -649,7 +649,10 @@ objects:
             "system_profile_facts"->'insights_client_version' AS "insights_client_version",
             "system_profile_facts"->'insights_egg_version' AS "insights_egg_version",
             "system_profile_facts"->'satellite_managed' AS "is_satellite_managed",
-            "system_profile_facts"->'subscription_status' AS "subscription_status"
+            "system_profile_facts"->'subscription_status' AS "subscription_status",
+            "system_profile_facts"->'ansible' AS "ansible_workload",
+            "system_profile_facts"->'mssql' AS "mssql_workload",
+            "system_profile_facts"->'sap' AS "sap_workload"
           FROM "hosts"
 parameters:
 - name: LOG_LEVEL


### PR DESCRIPTION
# Overview

PMs were requesting the ability to access our three system_profile fields used to determine workload (ansible, mssql, sap) in AWS S3 buckets.  Floorist is not currently adding these three fields; this PR addresses that.
