### PR TITLE
ESSNTL-3986: Fix "all tests" PR check pipeline

### DIFF
--- a/iqe_tests.sh
+++ b/iqe_tests.sh
@@ -64,122 +64,12 @@ fi
 source $CICD_ROOT/deploy_ephemeral_env.sh
 bonfire namespace extend $NAMESPACE --duration 3h
 
-# source $CICD_ROOT/cji_smoke_test.sh
-set -e
+sed -i \
+'s/oc_wrapper logs -n $NAMESPACE $POD -c $CONTAINER -f &/ \
+oc_wrapper logs -n $NAMESPACE $POD -c $CONTAINER -f \&\n \
+LOGS_PID=$!\n sleep 3600\n kill $LOGS_PID\n \
+oc_wrapper logs -n $NAMESPACE $POD -c $CONTAINER -f \&/' \
+$CICD_ROOT/cji_smoke_test.sh
 
-: "${IQE_MARKER_EXPRESSION:='""'}"
-: "${IQE_FILTER_EXPRESSION:='""'}"
-: "${IQE_IMAGE_TAG:='""'}"
-: "${IQE_REQUIREMENTS:='""'}"
-: "${IQE_REQUIREMENTS_PRIORITY:='""'}"
-: "${IQE_TEST_IMPORTANCE:='""'}"
-: "${IQE_PLUGINS:='""'}"
-: "${IQE_ENV:=clowder_smoke}"
-: "${IQE_SELENIUM:=false}"
-
-
-# minio client is used to fetch test artifacts from minio in the ephemeral ns
-MC_IMAGE="quay.io/cloudservices/mc:latest"
-echo "Running: docker pull ${MC_IMAGE}"
-docker pull ${MC_IMAGE}
-
-CJI_NAME="$COMPONENT_NAME"
-
-# Invoke the CJI using the options set via env vars
-set -x
-POD=$(
-    bonfire deploy-iqe-cji $COMPONENT_NAME \
-    --marker "$IQE_MARKER_EXPRESSION" \
-    --filter "$IQE_FILTER_EXPRESSION" \
-    --image-tag "${IQE_IMAGE_TAG}" \
-    --requirements "$IQE_REQUIREMENTS" \
-    --requirements-priority "$IQE_REQUIREMENTS_PRIORITY" \
-    --test-importance "$IQE_TEST_IMPORTANCE" \
-    --plugins "$IQE_PLUGINS" \
-    --env "$IQE_ENV" \
-    --cji-name $CJI_NAME \
-    --namespace $NAMESPACE)
-set +x
-
-# Pipe logs to background to keep them rolling in jenkins
-CONTAINER=$(oc_wrapper get pod $POD -n $NAMESPACE -o jsonpath="{.status.containerStatuses[0].name}")
-oc_wrapper logs -n $NAMESPACE $POD -c $CONTAINER -f &
-LOGS_PID=$!
-sleep 3600
-kill $LOGS_PID
-oc_wrapper logs -n $NAMESPACE $POD -c $CONTAINER -f &
-
-# Wait for the job to Complete or Fail before we try to grab artifacts
-# condition=complete does trigger when the job fails
-set -x
-oc_wrapper wait --timeout=$IQE_CJI_TIMEOUT --for=condition=JobInvocationComplete -n $NAMESPACE cji/$CJI_NAME
-set +x
-
-# Set up port-forward for minio
-set -x
-LOCAL_SVC_PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
-oc_wrapper port-forward svc/env-$NAMESPACE-minio $LOCAL_SVC_PORT:9000 -n $NAMESPACE &
-set +x
-sleep 5
-PORT_FORWARD_PID=$!
-
-# Get the secret from the env
-set -x
-oc_wrapper get secret env-$NAMESPACE-minio -o json -n $NAMESPACE | jq -r '.data' > minio-creds.json
-set +x
-
-# Grab the needed creds from the secret
-export MINIO_ACCESS=$(jq -r .accessKey < minio-creds.json | base64 -d)
-export MINIO_SECRET_KEY=$(jq -r .secretKey < minio-creds.json | base64 -d)
-export MINIO_HOST=localhost
-export MINIO_PORT=$LOCAL_SVC_PORT
-
-if [ -z "$MINIO_ACCESS" ] || [ -z "$MINIO_SECRET_KEY" ] || [ -z "$MINIO_PORT" ]; then
-    echo "Failed to fetch minio connection info when running 'oc' commands"
-    exit 1
-fi
-
-# Setup the minio client to auth to the local eph minio in the ns
-echo "Fetching artifacts from minio..."
-
-CONTAINER_NAME="mc-${JOB_NAME}-${BUILD_NUMBER}"
-BUCKET_NAME="${POD}-artifacts"
-CMD="mkdir -p /artifacts &&
-mc --no-color --quiet alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} &&
-mc --no-color --quiet mirror --overwrite minio/${BUCKET_NAME} /artifacts/
-"
-
-run_mc () {
-    echo "running: docker run -t --net=host --name=$CONTAINER_NAME --entrypoint=\"/bin/sh\" $MC_IMAGE -c \"$CMD\""
-    set +e
-    docker run -t --net=host --name=$CONTAINER_NAME --entrypoint="/bin/sh" $MC_IMAGE -c "$CMD"
-    RET_CODE=$?
-    docker cp $CONTAINER_NAME:/artifacts/. $ARTIFACTS_DIR
-    docker rm $CONTAINER_NAME
-    set -e
-    return $RET_CODE
-}
-
-# Add retry logic for intermittent minio connection failures
-MINIO_SUCCESS=false
-for i in $(seq 1 5); do
-    if run_mc; then
-        MINIO_SUCCESS=true
-        break
-    else
-        if [ "$i" -lt "5" ]; then
-            echo "WARNING: minio artifact copy failed, retrying in 5sec..."
-            sleep 5
-        fi
-    fi
-done
-
-if [ "$MINIO_SUCCESS" = false ]; then
-    echo "ERROR: minio artifact copy failed"
-    exit 1
-fi
-
-echo "copied artifacts from iqe pod: "
-ls -l $ARTIFACTS_DIR
-
+source $CICD_ROOT/cji_smoke_test.sh
 source $CICD_ROOT/post_test_results.sh

--- a/iqe_tests.sh
+++ b/iqe_tests.sh
@@ -64,6 +64,8 @@ fi
 source $CICD_ROOT/deploy_ephemeral_env.sh
 bonfire namespace extend $NAMESPACE --duration 3h
 
+# Workaround for bonfire CICD script issue: https://github.com/RedHatInsights/bonfire/issues/283
+# Restart `oc logs -f` after 1 hour
 sed -i \
 's/oc_wrapper logs -n $NAMESPACE $POD -c $CONTAINER -f &/ \
 oc_wrapper logs -n $NAMESPACE $POD -c $CONTAINER -f \&\n \

--- a/iqe_tests.sh
+++ b/iqe_tests.sh
@@ -32,7 +32,7 @@ CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
 curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
 function check_image () {
-  for i in {1..30}
+  for i in {1..60}
   do
     echo "Try number $i"
     echo "Checking if image '$IMAGE:$IMAGE_TAG' already exists in quay.io..."
@@ -63,5 +63,123 @@ fi
 # Deploy ephemeral env and run IQE tests
 source $CICD_ROOT/deploy_ephemeral_env.sh
 bonfire namespace extend $NAMESPACE --duration 3h
-source $CICD_ROOT/cji_smoke_test.sh
+
+# source $CICD_ROOT/cji_smoke_test.sh
+set -e
+
+: "${IQE_MARKER_EXPRESSION:='""'}"
+: "${IQE_FILTER_EXPRESSION:='""'}"
+: "${IQE_IMAGE_TAG:='""'}"
+: "${IQE_REQUIREMENTS:='""'}"
+: "${IQE_REQUIREMENTS_PRIORITY:='""'}"
+: "${IQE_TEST_IMPORTANCE:='""'}"
+: "${IQE_PLUGINS:='""'}"
+: "${IQE_ENV:=clowder_smoke}"
+: "${IQE_SELENIUM:=false}"
+
+
+# minio client is used to fetch test artifacts from minio in the ephemeral ns
+MC_IMAGE="quay.io/cloudservices/mc:latest"
+echo "Running: docker pull ${MC_IMAGE}"
+docker pull ${MC_IMAGE}
+
+CJI_NAME="$COMPONENT_NAME"
+
+# Invoke the CJI using the options set via env vars
+set -x
+POD=$(
+    bonfire deploy-iqe-cji $COMPONENT_NAME \
+    --marker "$IQE_MARKER_EXPRESSION" \
+    --filter "$IQE_FILTER_EXPRESSION" \
+    --image-tag "${IQE_IMAGE_TAG}" \
+    --requirements "$IQE_REQUIREMENTS" \
+    --requirements-priority "$IQE_REQUIREMENTS_PRIORITY" \
+    --test-importance "$IQE_TEST_IMPORTANCE" \
+    --plugins "$IQE_PLUGINS" \
+    --env "$IQE_ENV" \
+    --cji-name $CJI_NAME \
+    --namespace $NAMESPACE)
+set +x
+
+# Pipe logs to background to keep them rolling in jenkins
+CONTAINER=$(oc_wrapper get pod $POD -n $NAMESPACE -o jsonpath="{.status.containerStatuses[0].name}")
+oc_wrapper logs -n $NAMESPACE $POD -c $CONTAINER -f &
+LOGS_PID=$!
+sleep 3600
+kill $LOGS_PID
+oc_wrapper logs -n $NAMESPACE $POD -c $CONTAINER -f &
+
+# Wait for the job to Complete or Fail before we try to grab artifacts
+# condition=complete does trigger when the job fails
+set -x
+oc_wrapper wait --timeout=$IQE_CJI_TIMEOUT --for=condition=JobInvocationComplete -n $NAMESPACE cji/$CJI_NAME
+set +x
+
+# Set up port-forward for minio
+set -x
+LOCAL_SVC_PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+oc_wrapper port-forward svc/env-$NAMESPACE-minio $LOCAL_SVC_PORT:9000 -n $NAMESPACE &
+set +x
+sleep 5
+PORT_FORWARD_PID=$!
+
+# Get the secret from the env
+set -x
+oc_wrapper get secret env-$NAMESPACE-minio -o json -n $NAMESPACE | jq -r '.data' > minio-creds.json
+set +x
+
+# Grab the needed creds from the secret
+export MINIO_ACCESS=$(jq -r .accessKey < minio-creds.json | base64 -d)
+export MINIO_SECRET_KEY=$(jq -r .secretKey < minio-creds.json | base64 -d)
+export MINIO_HOST=localhost
+export MINIO_PORT=$LOCAL_SVC_PORT
+
+if [ -z "$MINIO_ACCESS" ] || [ -z "$MINIO_SECRET_KEY" ] || [ -z "$MINIO_PORT" ]; then
+    echo "Failed to fetch minio connection info when running 'oc' commands"
+    exit 1
+fi
+
+# Setup the minio client to auth to the local eph minio in the ns
+echo "Fetching artifacts from minio..."
+
+CONTAINER_NAME="mc-${JOB_NAME}-${BUILD_NUMBER}"
+BUCKET_NAME="${POD}-artifacts"
+CMD="mkdir -p /artifacts &&
+mc --no-color --quiet alias set minio http://${MINIO_HOST}:${MINIO_PORT} ${MINIO_ACCESS} ${MINIO_SECRET_KEY} &&
+mc --no-color --quiet mirror --overwrite minio/${BUCKET_NAME} /artifacts/
+"
+
+run_mc () {
+    echo "running: docker run -t --net=host --name=$CONTAINER_NAME --entrypoint=\"/bin/sh\" $MC_IMAGE -c \"$CMD\""
+    set +e
+    docker run -t --net=host --name=$CONTAINER_NAME --entrypoint="/bin/sh" $MC_IMAGE -c "$CMD"
+    RET_CODE=$?
+    docker cp $CONTAINER_NAME:/artifacts/. $ARTIFACTS_DIR
+    docker rm $CONTAINER_NAME
+    set -e
+    return $RET_CODE
+}
+
+# Add retry logic for intermittent minio connection failures
+MINIO_SUCCESS=false
+for i in $(seq 1 5); do
+    if run_mc; then
+        MINIO_SUCCESS=true
+        break
+    else
+        if [ "$i" -lt "5" ]; then
+            echo "WARNING: minio artifact copy failed, retrying in 5sec..."
+            sleep 5
+        fi
+    fi
+done
+
+if [ "$MINIO_SUCCESS" = false ]; then
+    echo "ERROR: minio artifact copy failed"
+    exit 1
+fi
+
+echo "copied artifacts from iqe pod: "
+ls -l $ARTIFACTS_DIR
+
 source $CICD_ROOT/post_test_results.sh


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3986](https://issues.redhat.com/browse/ESSNTL-3986).

This is a temporary workaround for the bonfire CICD script issue: https://github.com/RedHatInsights/bonfire/issues/283
In short, the issue is that `oc logs -f` stops reacting after 1 hour and then after another 30 mins of inactivity the job gets aborted and fails. This PR basically just kills the `oc logs -f` after 1 hour and starts it again.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
