### PR TITLE
ESSNTL-4070: add '[not implemented]' to group paths

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -349,9 +349,9 @@ paths:
       operationId: api.group.get_group_list
       tags:
         - groups
-      summary: Read the entire list of groups
+      summary: Read the entire list of groups [Not implemented]
       description: >-
-        Read the entire list of all groups available to the account.
+        Read the entire list of all groups available to the account. [Not implemented]
         <br /><br />
         Required permissions: inventory:groups:read
       security:
@@ -373,9 +373,9 @@ paths:
       operationId: api.group.create_group
       tags:
         - groups
-      summary: Create a new group matching the provided name and list of hosts IDs
+      summary: Create a new group matching the provided name and list of hosts IDs [Not implemented]
       description: >-
-        Creates a new group containing the hosts associated with the host IDs provided.
+        Creates a new group containing the hosts associated with the host IDs provided. [Not implemented]
         <br /><br />
         Required permissions: inventory:groups:write
       security:
@@ -400,9 +400,9 @@ paths:
       operationId: api.group.get_group
       tags:
         - groups
-      summary: Find a group by its ID
+      summary: Find a group by its ID [Not implemented]
       description: >-
-        Find a group by its ID.
+        Find a group by its ID. [Not implemented]
         <br /><br />
         Required permissions: inventory:groups:read
       security:
@@ -420,9 +420,9 @@ paths:
       operationId: api.group.patch_group_by_id
       tags:
         - groups
-      summary: Merge group information
+      summary: Merge group information [Not implemented]
       description: >-
-        Merge group information.
+        Merge group information. [Not implemented]
         <br /><br />
         Required permissions: inventory:groups:write
       security:
@@ -451,9 +451,9 @@ paths:
       operationId: api.group.update_group_details
       tags:
         - groups
-      summary: Replace group information
+      summary: Replace group information [Not implemented]
       description: >-
-        Replace information from a group.
+        Replace information from a group. [Not implemented]
         <br /><br />
         Required permissions: inventory:groups:write
       security:
@@ -482,9 +482,9 @@ paths:
       operationId: api.group.delete_group
       tags:
         - groups
-      summary: Delete a group
+      summary: Delete a group [Not implemented]
       description: >-
-        Delete a group.
+        Delete a group. [Not implemented]
         <br /><br />
         Required permissions: inventory:groups:write
       security:
@@ -501,9 +501,9 @@ paths:
       operationId: api.group.get_groups_by_id
       tags:
         - groups
-      summary: Find groups by their IDs
+      summary: Find groups by their IDs [Not implemented]
       description: >-
-        Find one or more groups by their ID.
+        Find one or more groups by their IDs. [Not implemented]
         <br /><br />
         Required permissions: inventory:groups:read
       security:
@@ -526,9 +526,9 @@ paths:
       operationId: api.group.delete_hosts_from_group
       tags:
         - groups
-      summary: Delete one or more hosts from a group
+      summary: Delete one or more hosts from a group [Not implemented]
       description: >-
-        Delete one or more hosts from a group.
+        Delete one or more hosts from a group. [Not implemented]
         <br /><br />
         Required permissions: inventory:groups:write
       security:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -349,9 +349,9 @@ paths:
       operationId: api.group.get_group_list
       tags:
         - groups
-      summary: Read the entire list of groups [Not implemented]
+      summary: Read the entire list of groups [Not Implemented]
       description: >-
-        Read the entire list of all groups available to the account. [Not implemented]
+        Read the entire list of all groups available to the account. [Not Implemented]
         <br /><br />
         Required permissions: inventory:groups:read
       security:
@@ -373,9 +373,9 @@ paths:
       operationId: api.group.create_group
       tags:
         - groups
-      summary: Create a new group matching the provided name and list of hosts IDs [Not implemented]
+      summary: Create a new group matching the provided name and list of hosts IDs [Not Implemented]
       description: >-
-        Creates a new group containing the hosts associated with the host IDs provided. [Not implemented]
+        Creates a new group containing the hosts associated with the host IDs provided. [Not Implemented]
         <br /><br />
         Required permissions: inventory:groups:write
       security:
@@ -400,9 +400,9 @@ paths:
       operationId: api.group.get_group
       tags:
         - groups
-      summary: Find a group by its ID [Not implemented]
+      summary: Find a group by its ID [Not Implemented]
       description: >-
-        Find a group by its ID. [Not implemented]
+        Find a group by its ID. [Not Implemented]
         <br /><br />
         Required permissions: inventory:groups:read
       security:
@@ -420,9 +420,9 @@ paths:
       operationId: api.group.patch_group_by_id
       tags:
         - groups
-      summary: Merge group information [Not implemented]
+      summary: Merge group information [Not Implemented]
       description: >-
-        Merge group information. [Not implemented]
+        Merge group information. [Not Implemented]
         <br /><br />
         Required permissions: inventory:groups:write
       security:
@@ -451,9 +451,9 @@ paths:
       operationId: api.group.update_group_details
       tags:
         - groups
-      summary: Replace group information [Not implemented]
+      summary: Replace group information [Not Implemented]
       description: >-
-        Replace information from a group. [Not implemented]
+        Replace information from a group. [Not Implemented]
         <br /><br />
         Required permissions: inventory:groups:write
       security:
@@ -482,9 +482,9 @@ paths:
       operationId: api.group.delete_group
       tags:
         - groups
-      summary: Delete a group [Not implemented]
+      summary: Delete a group [Not Implemented]
       description: >-
-        Delete a group. [Not implemented]
+        Delete a group. [Not Implemented]
         <br /><br />
         Required permissions: inventory:groups:write
       security:
@@ -501,9 +501,9 @@ paths:
       operationId: api.group.get_groups_by_id
       tags:
         - groups
-      summary: Find groups by their IDs [Not implemented]
+      summary: Find groups by their IDs [Not Implemented]
       description: >-
-        Find one or more groups by their IDs. [Not implemented]
+        Find one or more groups by their IDs. [Not Implemented]
         <br /><br />
         Required permissions: inventory:groups:read
       security:
@@ -526,9 +526,9 @@ paths:
       operationId: api.group.delete_hosts_from_group
       tags:
         - groups
-      summary: Delete one or more hosts from a group [Not implemented]
+      summary: Delete one or more hosts from a group [Not Implemented]
       description: >-
-        Delete one or more hosts from a group. [Not implemented]
+        Delete one or more hosts from a group. [Not Implemented]
         <br /><br />
         Required permissions: inventory:groups:write
       security:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -592,8 +592,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Read the entire list of groups",
-        "description": "Read the entire list of all groups available to the account. <br /><br /> Required permissions: inventory:groups:read",
+        "summary": "Read the entire list of groups [Not implemented]",
+        "description": "Read the entire list of all groups available to the account. [Not implemented] <br /><br /> Required permissions: inventory:groups:read",
         "security": [
           {
             "ApiKeyAuth": []
@@ -634,8 +634,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Create a new group matching the provided name and list of hosts IDs",
-        "description": "Creates a new group containing the hosts associated with the host IDs provided. <br /><br /> Required permissions: inventory:groups:write",
+        "summary": "Create a new group matching the provided name and list of hosts IDs [Not implemented]",
+        "description": "Creates a new group containing the hosts associated with the host IDs provided. [Not implemented] <br /><br /> Required permissions: inventory:groups:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -675,8 +675,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Find a group by its ID",
-        "description": "Find a group by its ID. <br /><br /> Required permissions: inventory:groups:read",
+        "summary": "Find a group by its ID [Not implemented]",
+        "description": "Find a group by its ID. [Not implemented] <br /><br /> Required permissions: inventory:groups:read",
         "security": [
           {
             "ApiKeyAuth": []
@@ -705,8 +705,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Merge group information",
-        "description": "Merge group information. <br /><br /> Required permissions: inventory:groups:write",
+        "summary": "Merge group information [Not implemented]",
+        "description": "Merge group information. [Not implemented] <br /><br /> Required permissions: inventory:groups:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -752,8 +752,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Replace group information",
-        "description": "Replace information from a group. <br /><br /> Required permissions: inventory:groups:write",
+        "summary": "Replace group information [Not implemented]",
+        "description": "Replace information from a group. [Not implemented] <br /><br /> Required permissions: inventory:groups:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -799,8 +799,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Delete a group",
-        "description": "Delete a group. <br /><br /> Required permissions: inventory:groups:write",
+        "summary": "Delete a group [Not implemented]",
+        "description": "Delete a group. [Not implemented] <br /><br /> Required permissions: inventory:groups:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -827,8 +827,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Find groups by their IDs",
-        "description": "Find one or more groups by their ID. <br /><br /> Required permissions: inventory:groups:read",
+        "summary": "Find groups by their IDs [Not implemented]",
+        "description": "Find one or more groups by their IDs. [Not implemented] <br /><br /> Required permissions: inventory:groups:read",
         "security": [
           {
             "ApiKeyAuth": []
@@ -865,8 +865,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Delete one or more hosts from a group",
-        "description": "Delete one or more hosts from a group. <br /><br /> Required permissions: inventory:groups:write",
+        "summary": "Delete one or more hosts from a group [Not implemented]",
+        "description": "Delete one or more hosts from a group. [Not implemented] <br /><br /> Required permissions: inventory:groups:write",
         "security": [
           {
             "ApiKeyAuth": []

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -592,8 +592,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Read the entire list of groups [Not implemented]",
-        "description": "Read the entire list of all groups available to the account. [Not implemented] <br /><br /> Required permissions: inventory:groups:read",
+        "summary": "Read the entire list of groups [Not Implemented]",
+        "description": "Read the entire list of all groups available to the account. [Not Implemented] <br /><br /> Required permissions: inventory:groups:read",
         "security": [
           {
             "ApiKeyAuth": []
@@ -634,8 +634,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Create a new group matching the provided name and list of hosts IDs [Not implemented]",
-        "description": "Creates a new group containing the hosts associated with the host IDs provided. [Not implemented] <br /><br /> Required permissions: inventory:groups:write",
+        "summary": "Create a new group matching the provided name and list of hosts IDs [Not Implemented]",
+        "description": "Creates a new group containing the hosts associated with the host IDs provided. [Not Implemented] <br /><br /> Required permissions: inventory:groups:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -675,8 +675,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Find a group by its ID [Not implemented]",
-        "description": "Find a group by its ID. [Not implemented] <br /><br /> Required permissions: inventory:groups:read",
+        "summary": "Find a group by its ID [Not Implemented]",
+        "description": "Find a group by its ID. [Not Implemented] <br /><br /> Required permissions: inventory:groups:read",
         "security": [
           {
             "ApiKeyAuth": []
@@ -705,8 +705,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Merge group information [Not implemented]",
-        "description": "Merge group information. [Not implemented] <br /><br /> Required permissions: inventory:groups:write",
+        "summary": "Merge group information [Not Implemented]",
+        "description": "Merge group information. [Not Implemented] <br /><br /> Required permissions: inventory:groups:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -752,8 +752,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Replace group information [Not implemented]",
-        "description": "Replace information from a group. [Not implemented] <br /><br /> Required permissions: inventory:groups:write",
+        "summary": "Replace group information [Not Implemented]",
+        "description": "Replace information from a group. [Not Implemented] <br /><br /> Required permissions: inventory:groups:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -799,8 +799,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Delete a group [Not implemented]",
-        "description": "Delete a group. [Not implemented] <br /><br /> Required permissions: inventory:groups:write",
+        "summary": "Delete a group [Not Implemented]",
+        "description": "Delete a group. [Not Implemented] <br /><br /> Required permissions: inventory:groups:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -827,8 +827,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Find groups by their IDs [Not implemented]",
-        "description": "Find one or more groups by their IDs. [Not implemented] <br /><br /> Required permissions: inventory:groups:read",
+        "summary": "Find groups by their IDs [Not Implemented]",
+        "description": "Find one or more groups by their IDs. [Not Implemented] <br /><br /> Required permissions: inventory:groups:read",
         "security": [
           {
             "ApiKeyAuth": []
@@ -865,8 +865,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Delete one or more hosts from a group [Not implemented]",
-        "description": "Delete one or more hosts from a group. [Not implemented] <br /><br /> Required permissions: inventory:groups:write",
+        "summary": "Delete one or more hosts from a group [Not Implemented]",
+        "description": "Delete one or more hosts from a group. [Not Implemented] <br /><br /> Required permissions: inventory:groups:write",
         "security": [
           {
             "ApiKeyAuth": []


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-4070](https://issues.redhat.com/browse/ESSNTL-4070).
Adds `[not implemented]` to group paths to prevent the paths being used by customers. 

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
