### PR TITLE
chore: Use the same pattern for host and group id

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -728,6 +728,13 @@ components:
       $ref: 'pagination.yaml#/components/parameters/pageParam'
     perPageParam:
       $ref: 'pagination.yaml#/components/parameters/perPageParam'
+    hostId:
+      in: path
+      name: host_id
+      description: Host (system) ID.
+      required: true
+      schema:
+        $ref: '#/components/schemas/HostId'
     hostIdList:
       in: path
       name: host_id_list
@@ -736,9 +743,7 @@ components:
       schema:
         type: array
         items:
-          type: string
-          pattern: ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$
-          format: uuid
+          $ref: '#/components/schemas/HostId'
     branchId:
       in: query
       name: branch_id
@@ -955,9 +960,7 @@ components:
       description: Group ID.
       required: true
       schema:
-        type: string
-        pattern: ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$
-        format: uuid
+        $ref: '#/components/schemas/HostId'
     groupIdList:
       in: path
       name: group_id_list
@@ -966,9 +969,7 @@ components:
       schema:
         type: array
         items:
-          type: string
-          pattern: ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$
-          format: uuid
+          $ref: '#/components/schemas/HostId'
 
   schemas:
     SystemProfileOperatingSystemOut:
@@ -1319,7 +1320,7 @@ components:
                 Reporting source of the last checkin status, stale_timestamp, and last_check_in.
               type: object
               additionalProperties:
-                $ref: '#components/schemas/PerReporterStaleness'
+                $ref: '#/components/schemas/PerReporterStaleness'
           required:
             - org_id
     HostOut:
@@ -1453,6 +1454,8 @@ components:
         A durable and reliable platform-wide group identifier. Applications
         should use this identifier to reference groups.
       type: string
+      pattern: ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$
+      format: uuid
       example: 3f01b55457674041b75e41829bcee1dc
     GroupName:
       description: >-
@@ -1460,12 +1463,20 @@ components:
       type: string
       nullable: true
       example: sre-group
+    HostId:
+      description: >-
+        A durable and reliable platform-wide group identifier. Applications
+        should use this identifier to reference hosts.
+      type: string
+      pattern: ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$
+      format: uuid
+      example: bA6deCFc19564430AB814bf8F70E8cEf
     HostIds:
       description: A comma separated list of host IDs that belong to the group.
       type: array
       nullable: true
       items:
-        type: string
+        $ref: '#/components/schemas/HostId'
     GroupIn:
       title: Group In
       description: >-

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1231,6 +1231,15 @@
         },
         "description": "A number of items to return per page."
       },
+      "hostId": {
+        "in": "path",
+        "name": "host_id",
+        "description": "Host (system) ID.",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/HostId"
+        }
+      },
       "hostIdList": {
         "in": "path",
         "name": "host_id_list",
@@ -1239,9 +1248,7 @@
         "schema": {
           "type": "array",
           "items": {
-            "type": "string",
-            "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$",
-            "format": "uuid"
+            "$ref": "#/components/schemas/HostId"
           }
         }
       },
@@ -1514,9 +1521,7 @@
         "description": "Group ID.",
         "required": true,
         "schema": {
-          "type": "string",
-          "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$",
-          "format": "uuid"
+          "$ref": "#/components/schemas/HostId"
         }
       },
       "groupIdList": {
@@ -1527,9 +1532,7 @@
         "schema": {
           "type": "array",
           "items": {
-            "type": "string",
-            "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$",
-            "format": "uuid"
+            "$ref": "#/components/schemas/HostId"
           }
         }
       }
@@ -2023,7 +2026,7 @@
                 "description": "Reporting source of the last checkin status, stale_timestamp, and last_check_in.",
                 "type": "object",
                 "additionalProperties": {
-                  "$ref": "#components/schemas/PerReporterStaleness"
+                  "$ref": "#/components/schemas/PerReporterStaleness"
                 }
               }
             },
@@ -2223,6 +2226,8 @@
       "GroupId": {
         "description": "A durable and reliable platform-wide group identifier. Applications should use this identifier to reference groups.",
         "type": "string",
+        "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$",
+        "format": "uuid",
         "example": "3f01b55457674041b75e41829bcee1dc"
       },
       "GroupName": {
@@ -2231,12 +2236,19 @@
         "nullable": true,
         "example": "sre-group"
       },
+      "HostId": {
+        "description": "A durable and reliable platform-wide group identifier. Applications should use this identifier to reference hosts.",
+        "type": "string",
+        "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$",
+        "format": "uuid",
+        "example": "bA6deCFc19564430AB814bf8F70E8cEf"
+      },
       "HostIds": {
         "description": "A comma separated list of host IDs that belong to the group.",
         "type": "array",
         "nullable": true,
         "items": {
-          "type": "string"
+          "$ref": "#/components/schemas/HostId"
         }
       },
       "GroupIn": {


### PR DESCRIPTION
This commit edits the OpenAPI schema for HBI: 1) use the same UUID pattern for host and group IDs, 2) fix incorrect reference to PerReporterStaleness.

# Overview

This is a quick patch and it is not linked to any Jiras.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
