### PR TITLE
Hotfix: Prepend "Bearer " to Unleash authorization

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -205,7 +205,7 @@ def create_app(runtime_environment):
         flask_app.config["UNLEASH_APP_NAME"] = "host-inventory-api"
         flask_app.config["UNLEASH_ENVIRONMENT"] = "default"
         flask_app.config["UNLEASH_URL"] = app_config.unleash_url
-        flask_app.config["UNLEASH_CUSTOM_HEADERS"] = {"Authorization": app_config.unleash_token}
+        flask_app.config["UNLEASH_CUSTOM_HEADERS"] = {"Authorization": f"Bearer {app_config.unleash_token}"}
         if hasattr(app_config, "unleash_cache_directory"):
             flask_app.config["UNLEASH_CACHE_DIRECTORY"] = app_config.unleash_cache_directory
         init_unleash_app(flask_app)


### PR DESCRIPTION
# Overview

This PR is a quick hotfix to address the authorization issue we're running into with Unleash. It looks like I forgot to prepend "Bearer " to the Unleash token in the authorization header. The Slack conversation is [here](https://redhat-internal.slack.com/archives/C022YV4E0NA/p1675782353563019), for context.