### PR TITLE
feat(ESSNTL-4376): Rename DELETE host-groups endpoint

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -505,7 +505,7 @@ paths:
           description: The groups were successfully deleted.
         '400':
           description: Invalid request.
-  '/groups/{group_id}/{host_id_list}':
+  '/groups/{group_id}/hosts/{host_id_list}':
     delete:
       operationId: api.group.delete_hosts_from_group
       tags:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -841,7 +841,7 @@
         }
       }
     },
-    "/groups/{group_id}/{host_id_list}": {
+    "/groups/{group_id}/hosts/{host_id_list}": {
       "delete": {
         "operationId": "api.group.delete_hosts_from_group",
         "tags": [

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -95,7 +95,7 @@ def api_remove_hosts_from_group(flask_client):
     def _api_remove_hosts_from_group(
         group_id, host_id_list, identity=USER_IDENTITY, query_parameters=None, extra_headers=None
     ):
-        url = f"{GROUP_URL}/{group_id}/{','.join([str(host_id) for host_id in host_id_list])}"
+        url = f"{GROUP_URL}/{group_id}/hosts/{','.join([str(host_id) for host_id in host_id_list])}"
         return do_request(
             flask_client.delete, url, identity, query_parameters=query_parameters, extra_headers=extra_headers
         )


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-4376](https://issues.redhat.com/browse/ESSNTL-4376).
Based on our group discussions, we've had to make some changes to the endpoints we planned. For removing host-group associations, we're going with `DELETE /groups/{group-id}/hosts/{host-id1},{host-id2}`. Notes on this decision:

- The request body is not allowed for DELETE methods. Because of this, we need to specify the host IDs in the request path.
- In the future, groups may need to contain other objects besides hosts. Because of this, we need to specify `/hosts/` in-between the group and host IDs.

The original PR implementing this endpoint is #1277.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
