### PR TITLE
feat(ESSNTL-4375) - Create POST /groups/<group-id>/hosts endpoint

### DIFF
--- a/api/host_group.py
+++ b/api/host_group.py
@@ -1,0 +1,45 @@
+import flask
+from flask_api import status
+
+from api import api_operation
+from api import flask_json_response
+from api import metrics
+from api.group_query import build_group_response
+from app import db
+from app import Permission
+from app.instrumentation import log_host_group_add_succeeded
+from app.instrumentation import log_patch_group_failed
+from app.logging import get_logger
+from lib.group_repository import add_host_list_for_group
+from lib.group_repository import get_group_by_id_from_db
+from lib.group_repository import get_hosts_from_db
+from lib.middleware import rbac
+
+logger = get_logger(__name__)
+
+
+@api_operation
+@rbac(Permission.WRITE)
+@metrics.api_request_time.time()
+def add_hosts_to_group(group_id, body):
+    group_to_update = get_group_by_id_from_db(group_id)
+
+    if not group_to_update:
+        log_patch_group_failed(logger, group_id)
+        return flask.abort(status.HTTP_404_NOT_FOUND)
+
+    host_id_list = body
+    if not get_hosts_from_db(host_id_list):
+        return flask.abort(status.HTTP_404_NOT_FOUND)
+
+    # Next, add the host-group associations
+    assoc_list = []
+    if host_id_list is not None:
+        assoc_list = add_host_list_for_group(db.session, group_to_update, host_id_list)
+
+    if any(db.session.is_modified(assoc) for assoc in assoc_list):
+        db.session.commit()
+
+    updated_group = get_group_by_id_from_db(group_id)
+    log_host_group_add_succeeded(logger, host_id_list, group_id)
+    return flask_json_response(build_group_response(updated_group), status.HTTP_200_OK)

--- a/api/host_group.py
+++ b/api/host_group.py
@@ -12,7 +12,7 @@ from app.instrumentation import log_patch_group_failed
 from app.logging import get_logger
 from lib.group_repository import add_host_list_for_group
 from lib.group_repository import get_group_by_id_from_db
-from lib.group_repository import get_hosts_from_db
+from lib.host_repository import get_host_list_by_id_list_from_db
 from lib.middleware import rbac
 
 logger = get_logger(__name__)
@@ -29,13 +29,13 @@ def add_hosts_to_group(group_id, body):
         return flask.abort(status.HTTP_404_NOT_FOUND)
 
     host_id_list = body
-    if not get_hosts_from_db(host_id_list):
+    if not get_host_list_by_id_list_from_db(host_id_list):
         return flask.abort(status.HTTP_404_NOT_FOUND)
 
     # Next, add the host-group associations
     assoc_list = []
     if host_id_list is not None:
-        assoc_list = add_host_list_for_group(db.session, group_to_update, host_id_list)
+        assoc_list = add_host_list_for_group(group_to_update, host_id_list)
 
     if any(db.session.is_modified(assoc) for assoc in assoc_list):
         db.session.commit()

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from sqlalchemy.orm import scoped_session
+
 from api.host_query import staleness_timestamps
 from app.auth import get_current_identity
 from app.exceptions import InventoryException
@@ -24,12 +26,12 @@ from app.serialization import serialize_group
 from app.serialization import serialize_host
 from lib.db import session_guard
 from lib.host_delete import _deleted_by_this_query
+from lib.host_repository import find_existing_host_by_id
 from lib.host_repository import get_host_list_by_id_list_from_db
 from lib.metrics import delete_group_count
 from lib.metrics import delete_group_processing_time
 from lib.metrics import delete_host_group_count
 from lib.metrics import delete_host_group_processing_time
-
 
 logger = get_logger(__name__)
 
@@ -237,3 +239,49 @@ def patch_group(group: Group, patch_data: dict, event_producer: EventProducer):
 
         added_host_uuids = [str(host_id) for host_id in new_host_ids]
         _produce_host_update_events(event_producer, added_host_uuids, [group_id])
+
+
+def db_create_host_group_assoc(host_id: str, group_id: str) -> HostGroupAssoc:
+    if HostGroupAssoc.query.filter(HostGroupAssoc.host_id == host_id).one_or_none():
+        raise InventoryException(
+            title="Invalid request", detail=f"Host with ID {host_id} is already associated with another group."
+        )
+    host_group = HostGroupAssoc(host_id=host_id, group_id=group_id)
+    db.session.add(host_group)
+    return host_group
+
+
+def db_get_hosts_assoc_for_group(group_id: str) -> list:
+    return [
+        str(host_id[0])
+        for host_id in HostGroupAssoc.query.filter(HostGroupAssoc.group_id == group_id).values("host_id")
+    ]
+
+
+def add_host_list_for_group(session: scoped_session, group: Group, host_id_list: List[str]) -> List[HostGroupAssoc]:
+    assoc_list = []
+    group_hosts_associated = db_get_hosts_assoc_for_group(group.id)
+    for host_id in host_id_list:
+        if find_existing_host_by_id(get_current_identity(), host_id):
+            try:
+                assoc_list.append(db_create_host_group_assoc(host_id, group.id))
+
+                # Update modified_on timestamp on the group
+                group.update_modified_on()
+            except InventoryException:
+                # happens when host_id is already associated
+                # throw the exception *only* if host is associated to a different group
+                if host_id not in group_hosts_associated:
+                    raise InventoryException(
+                        title="Invalid request",
+                        detail=f"Host with ID {host_id} already associated to a different group ({group.id}).",
+                    )
+        else:
+            # Only raises the exception if the list contains only 1 host.
+            raise InventoryException(title="Invalid request", detail=f"Host with ID {host_id} does not exist.")
+
+    return assoc_list
+
+
+def get_hosts_from_db(host_ids: List[str]):
+    return Host.query.filter(Host.id.in_(host_ids))

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -500,6 +500,38 @@ paths:
           description: Successfully deleted hosts.
         '400':
           description: Invalid request.
+  '/groups/{group_id}/hosts':
+    post:
+      operationId: api.host_group.add_hosts_to_group
+      tags:
+        - groups
+      summary: Add host IDs to the provided group
+      description: >-
+        Adds the host list in the request body to the provided group.
+        <br /><br />
+        Required permissions: inventory:groups:write
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/groupId'
+      requestBody:
+        description: A list of hosts IDs to associate with the provided group.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HostIds'
+      responses:
+        '200':
+          description: Successfully associated hosts with group.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupOut'
+        '400':
+          description: Invalid request.
+        '404':
+          description: Group not found.
 
   /tags:
     get:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -843,6 +843,55 @@
         }
       }
     },
+    "/groups/{group_id}/hosts": {
+      "post": {
+        "operationId": "api.host_group.add_hosts_to_group",
+        "tags": [
+          "groups"
+        ],
+        "summary": "Add host IDs to the provided group",
+        "description": "Adds the host list in the request body to the provided group. <br /><br /> Required permissions: inventory:groups:write",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/groupId"
+          }
+        ],
+        "requestBody": {
+          "description": "A list of hosts IDs to associate with the provided group.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HostIds"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully associated hosts with group.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupOut"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request."
+          },
+          "404": {
+            "description": "Group not found."
+          }
+        }
+      }
+    },
     "/tags": {
       "get": {
         "tags": [

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -112,6 +112,24 @@ def api_remove_hosts_from_group(flask_client):
 
 
 @pytest.fixture(scope="function")
+def api_add_hosts_to_group(flask_client):
+    def _api_add_hosts_to_group(
+        group_id, host_id_list, identity=USER_IDENTITY, query_parameters=None, extra_headers=None
+    ):
+        url = f"{GROUP_URL}/{group_id}/hosts"
+        return do_request(
+            flask_client.post,
+            url,
+            identity,
+            host_id_list,
+            query_parameters=query_parameters,
+            extra_headers=extra_headers,
+        )
+
+    return _api_add_hosts_to_group
+
+
+@pytest.fixture(scope="function")
 def api_patch_group(flask_client):
     def _api_patch_group(group_id, group_data, identity=USER_IDENTITY, query_parameters=None, extra_headers=None):
         url = f"{GROUP_URL}/{group_id}"

--- a/tests/test_api_host_group.py
+++ b/tests/test_api_host_group.py
@@ -1,0 +1,110 @@
+import uuid
+
+
+def test_add_host_to_group(
+    db_create_group, db_create_host, db_get_hosts_for_group, db_create_host_group_assoc, api_add_hosts_to_group
+):
+    # Create a group and 3 hosts
+    group_id = db_create_group("test_group").id
+    host_id_list = [db_create_host().id for _ in range(3)]
+
+    response_status, _ = api_add_hosts_to_group(group_id, [str(host) for host in host_id_list[0:2]])
+    assert response_status == 200
+
+    # Confirm that the group now only contains  2 hosts
+    hosts_after = db_get_hosts_for_group(group_id)
+    assert len(hosts_after) == 2
+    assert hosts_after[0].id == host_id_list[0]
+    assert hosts_after[1].id == host_id_list[1]
+
+
+def test_add_associated_host_to_same_group(
+    db_create_group, db_create_host, db_get_hosts_for_group, db_create_host_group_assoc, api_add_hosts_to_group
+):
+    # Create a group and 3 hosts
+    group_id = db_create_group("test_group").id
+    host_id_list = [db_create_host().id for _ in range(3)]
+
+    # Add all 3 hosts to the group
+    for host_id in host_id_list:
+        db_create_host_group_assoc(host_id, group_id)
+
+    # Confirm that the association exists
+    hosts_before = db_get_hosts_for_group(group_id)
+    assert len(hosts_before) == 3
+
+    # Confirm that the API is  allowed to add the hosts even one is associated
+    response_status, _ = api_add_hosts_to_group(group_id, [str(host) for host in host_id_list[0:2]])
+    assert response_status == 200
+
+
+def test_add_associated_host_to_different_group(
+    db_create_group, db_create_host, db_get_hosts_for_group, db_create_host_group_assoc, api_add_hosts_to_group
+):
+    # Create a group and 3 hosts
+    group1_id = db_create_group("test_group").id
+    group2_id = db_create_group("test_group2").id
+    host_id_list = [db_create_host().id for _ in range(3)]
+
+    # Add all 3 hosts to the group
+    db_create_host_group_assoc(host_id_list[0], group1_id)
+    db_create_host_group_assoc(host_id_list[1], group1_id)
+    db_create_host_group_assoc(host_id_list[2], group2_id)
+
+    # Confirm that the association exists
+    hosts_before = db_get_hosts_for_group(group1_id)
+    assert len(hosts_before) == 2
+    hosts_before = db_get_hosts_for_group(group2_id)
+    assert len(hosts_before) == 1
+
+    # Confirm that the API is  allowed to add the hosts even one is associated
+    response_status, _ = api_add_hosts_to_group(group1_id, [str(host_id_list[2])])
+    assert response_status == 400
+
+
+def test_add_host_list_with_one_associated_host_to_group(
+    db_create_group, db_create_host, db_get_hosts_for_group, db_create_host_group_assoc, api_add_hosts_to_group
+):
+    # Create a group and 3 hosts
+    group_id = db_create_group("test_group").id
+    host_id_list = [db_create_host().id for _ in range(3)]
+
+    # Add first and last hosts to the group
+    db_create_host_group_assoc(host_id_list[0], group_id)
+    db_create_host_group_assoc(host_id_list[2], group_id)
+
+    # adding only id[1], since 0 and 2 already associated above
+    response_status, _ = api_add_hosts_to_group(group_id, [str(host) for host in host_id_list])
+    assert response_status == 200
+
+    # Confirm that the group now only contains  2 hosts
+    hosts_after = db_get_hosts_for_group(group_id)
+    assert len(hosts_after) == 3
+
+
+def test_add_host_to_missing_group(
+    db_create_group, db_create_host, db_get_hosts_for_group, db_create_host_group_assoc, api_add_hosts_to_group
+):
+    # Create a test group which not exist in database
+    missing_group_id = "454dddba-9a4d-42b3-8f16-86a8c1400000"
+    host_id_list = [db_create_host().id for _ in range(3)]
+
+    response_status, _ = api_add_hosts_to_group(missing_group_id, [str(host) for host in host_id_list])
+    assert response_status == 404
+
+
+def test_add_missing_host_to_existing_group(
+    db_create_group, db_create_host, db_get_hosts_for_group, db_create_host_group_assoc, api_add_hosts_to_group
+):
+    group_id = db_create_group("test_group").id
+    host_id_list = [str(uuid.uuid4())]
+
+    response_status, _ = api_add_hosts_to_group(group_id, host_id_list)
+    assert response_status == 400
+
+
+def test_with_empty_data(
+    db_create_group, db_create_host, db_get_hosts_for_group, db_create_host_group_assoc, api_add_hosts_to_group
+):
+    response_status, _ = api_add_hosts_to_group(None, None)
+    assert response_status == 400


### PR DESCRIPTION
This PR is being created to address ESSNTL-4375.
Adds the POST `/groups/{group_id}/hosts` endpoint. The post doc looks like the following:

```
[
  "host_id_1",
  "host_id_2",
  "host_id_3"
]
```
If the list is empty, it fails validation and returns 400. If "host_ids" is provided, the list of hosts will be associate to the group.

# Overview

This PR is being created to address [ESSNTL-xxxx](https://issues.redhat.com/browse/ESSNTL-xxxx).
(A description of your PR's changes, along with why/context to the PR, goes here.)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
