### PR TITLE
Fix Cloudwatch when using clowder TLS

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -35,10 +35,6 @@ class Config:
                 self.rbac_endpoint = f"{protocol}://{endpoint.hostname}:{port}"
                 break
 
-        # ca-certs location
-        if cfg.tlsCAPath:
-            os.environ["REQUESTS_CA_BUNDLE"] = cfg.tlsCAPath
-
         broker_cfg = cfg.kafka.brokers[0]
         self.bootstrap_servers = f"{broker_cfg.hostname}:{broker_cfg.port}"
 

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -51,8 +51,10 @@ def get_rbac_permissions():
     try:
         with outbound_http_metric.time():
             rbac_response = request_session.get(
-                url=rbac_url(), headers=request_header, timeout=inventory_config().rbac_timeout,
-                verify=LoadedConfig.tlsCAPath
+                url=rbac_url(),
+                headers=request_header,
+                timeout=inventory_config().rbac_timeout,
+                verify=LoadedConfig.tlsCAPath,
             )
     except Exception as e:
         rbac_failure(logger, e)

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+from app_common_python import LoadedConfig
 from flask import abort
 from flask import g
 from flask import request
@@ -50,7 +51,8 @@ def get_rbac_permissions():
     try:
         with outbound_http_metric.time():
             rbac_response = request_session.get(
-                url=rbac_url(), headers=request_header, timeout=inventory_config().rbac_timeout
+                url=rbac_url(), headers=request_header, timeout=inventory_config().rbac_timeout,
+                verify=LoadedConfig.tlsCAPath
             )
     except Exception as e:
         rbac_failure(logger, e)


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/RHINENG-80
It turns out that setting the ca cert path globally breaks cloud watch which makes an https call.  This change narrows the scope to just the call needed.

For the time being ephemeral/stage/prod  `LoadedConfig.tlsCAPath` will be `None`

In our IT-less environments it will be `/cdapp/certs/service-ca.crt`

# Overview

This PR is being created to address [ESSNTL-xxxx](https://issues.redhat.com/browse/ESSNTL-xxxx).
(A description of your PR's changes, along with why/context to the PR, goes here.)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
