### PR TITLE
fix(ESSNTL-4518) Remove host from its group before deletion

### DIFF
--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -498,7 +498,6 @@ def test_delete_host_that_belongs_to_group_fail(
     assert len(hosts_before) == 3
 
     # Patch it so the DB deletion fails
-    mocker.patch("lib.host_delete.delete_hosts", return_value=False)
     deleted_by_this_query_mock = mocker.patch("lib.host_delete._deleted_by_this_query")
     deleted_by_this_query_mock.side_effect = False
 


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-4518](https://issues.redhat.com/browse/ESSNTL-4518).
Currently, if you try to delete a host that's associated with a group, it will hit an exception and return HTTP 500.
This PR fixes that issue, and removes the host from the group before deleting it. It also adds a test to validate this, and a test that verifies that the entire thing rolls back if something goes wrong with the deletion.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [x] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
