### PR TITLE
fix(ESSNTL-4519): PATCH /groups/<group-id> fixes

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -57,8 +57,8 @@ def patch_group_by_id(group_id, body):
         return flask.abort(status.HTTP_404_NOT_FOUND)
 
     # Separate out the host IDs because they're not stored on the Group
-    host_id_list = validated_patch_group_data.pop("host_ids", None)
     group_to_update.patch(validated_patch_group_data)
+    host_id_list = validated_patch_group_data.get("host_ids")
 
     # Next, replace the host-group associations
     assoc_list = []

--- a/api/group.py
+++ b/api/group.py
@@ -1,6 +1,7 @@
 import flask
 from flask_api import status
 from marshmallow import ValidationError
+from sqlalchemy.exc import IntegrityError
 
 from api import api_operation
 from api import flask_json_response
@@ -9,6 +10,7 @@ from api.group_query import build_group_response
 from app import db
 from app import inventory_config
 from app import Permission
+from app.exceptions import InventoryException
 from app.instrumentation import log_patch_group_failed
 from app.instrumentation import log_patch_group_success
 from app.logging import get_logger
@@ -54,7 +56,7 @@ def patch_group_by_id(group_id, body):
 
     if not group_to_update:
         log_patch_group_failed(logger, group_id)
-        return flask.abort(status.HTTP_404_NOT_FOUND)
+        flask.abort(status.HTTP_404_NOT_FOUND)
 
     # Separate out the host IDs because they're not stored on the Group
     group_to_update.patch(validated_patch_group_data)
@@ -63,12 +65,23 @@ def patch_group_by_id(group_id, body):
     # Next, replace the host-group associations
     assoc_list = []
     if host_id_list is not None:
-        assoc_list = replace_host_list_for_group(db.session, group_to_update, host_id_list)
+        try:
+            assoc_list = replace_host_list_for_group(db.session, group_to_update, host_id_list)
+        except InventoryException as ie:
+            log_patch_group_failed(logger, group_id)
+            flask.abort(status.HTTP_400_BAD_REQUEST, str(ie.detail))
 
     if db.session.is_modified(group_to_update) or any(db.session.is_modified(assoc) for assoc in assoc_list):
-        db.session.commit()
-        # TODO: Emit patch event for group, and one per assoc
+        try:
+            db.session.commit()
+        except IntegrityError:
+            log_patch_group_failed(logger, group_id)
+            flask.abort(
+                status.HTTP_400_BAD_REQUEST,
+                f"Group with name '{validated_patch_group_data.get('name')}' already exists.",
+            )
 
+    # TODO: Emit patch event for group, and one per assoc
     updated_group = get_group_by_id_from_db(group_id)
     log_patch_group_success(logger, group_id)
     return flask_json_response(build_group_response(updated_group), status.HTTP_200_OK)

--- a/app/models.py
+++ b/app/models.py
@@ -420,7 +420,8 @@ class Group(db.Model):
         if not patch_data:
             raise InventoryException(title="Bad Request", detail="Patch json document cannot be empty.")
 
-        self.name = patch_data.get("name")
+        if "name" in patch_data:
+            self.name = patch_data["name"]
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     account = db.Column(db.String(10))

--- a/app/models.py
+++ b/app/models.py
@@ -390,8 +390,8 @@ class Host(LimitedHost):
 class Group(db.Model):
     __tablename__ = "groups"
     __table_args__ = (
-        UniqueConstraint("name", "org_id"),
         Index("idxgrouporgid", "org_id"),
+        Index("idx_groups_org_id_name_nocase", "org_id", text("lower(name)"), unique=True),
     )
 
     def __init__(
@@ -437,6 +437,7 @@ class HostGroupAssoc(db.Model):
     __table_args__ = (
         Index("idxhostsgroups", "host_id", "group_id"),
         Index("idxgroups_hosts", "group_id", "host_id"),
+        UniqueConstraint("host_id", name="hosts_groups_unique_host_id"),
     )
 
     def __init__(

--- a/migrations/versions/0f2fb89499ce_make_group_name_constraint_case_.py
+++ b/migrations/versions/0f2fb89499ce_make_group_name_constraint_case_.py
@@ -1,0 +1,43 @@
+"""Make Group name constraint case-insensitive
+
+Revision ID: 0f2fb89499ce
+Revises: ada40da60e4e
+Create Date: 2023-03-21 10:53:36.544420
+
+"""
+from alembic import op
+from sqlalchemy import text
+
+
+# revision identifiers, used by Alembic.
+revision = "0f2fb89499ce"
+down_revision = "ada40da60e4e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Replace the old Unique Constraint with a case-insensitive functional index
+    op.drop_constraint("groups_org_id_name_key", "groups")
+    op.create_index(
+        index_name="idx_groups_org_id_name_nocase",
+        table_name="groups",
+        columns=["org_id", text("lower(name)")],
+        unique=True,
+    )
+
+    # For now, each host can only be associated with one group at a time
+    op.create_unique_constraint(
+        constraint_name="hosts_groups_unique_host_id", table_name="hosts_groups", columns=["host_id"]
+    )
+    pass
+
+
+def downgrade():
+    op.drop_constraint("hosts_groups_unique_host_id", "hosts_groups")
+
+    op.drop_index("idx_groups_org_id_name_nocase", "groups")
+    op.create_unique_constraint(
+        constraint_name="groups_org_id_name_key", table_name="groups", columns=["org_id", "name"]
+    )
+    pass


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-4519](https://issues.redhat.com/browse/ESSNTL-4519).
Implements these fixes:
- PATCHing a group without providing a name is now allowed
- Updating a group's name with the name of a different group now returns HTTP 400 with additional data in the message
- This also applies to case-insensitive naming; if a group named "test-group" already exists, renaming a different group to "Test-Group" is no longer allowed
- If the user attempts to add a host to their group but the host already exists in a different group, it returns 400 with a message explaining as much (including the offending Host ID)

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
