### PR TITLE
[ESSNTL-4398] Update schema to reference list of hosts

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -180,9 +180,9 @@ paths:
     patch:
       tags:
         - hosts
-      summary: Update a host
+      summary: Update hosts
       description: >-
-        Update a host
+        Update hosts
         <br /><br />
         Required permissions: inventory:hosts:write
       operationId: api.host.patch_host_by_id
@@ -192,7 +192,7 @@ paths:
         - $ref: '#/components/parameters/hostIdList'
         - $ref: '#/components/parameters/branchId'
       requestBody:
-        description: A group of fields to be updated on the host
+        description: A group of fields to be updated on the hosts
         required: true
         content:
           application/json:
@@ -200,7 +200,7 @@ paths:
               $ref: '#/components/schemas/PatchHostIn'
       responses:
         '200':
-          description: Successfully updated the host.
+          description: Successfully updated the hosts.
         '400':
           description: Invalid request.
         '404':
@@ -327,9 +327,9 @@ paths:
     get:
       tags:
         - hosts
-      summary: Get the number of tags on a host
+      summary: Get the number of tags on a host or hosts
       description: >-
-        Get the number of tags on a host
+        Get the number of tags on a host or hosts
         <br /><br />
         Required permissions: inventory:hosts:read
       operationId: api.host.get_host_tag_count

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -317,8 +317,8 @@
         "tags": [
           "hosts"
         ],
-        "summary": "Update a host",
-        "description": "Update a host <br /><br /> Required permissions: inventory:hosts:write",
+        "summary": "Update hosts",
+        "description": "Update hosts <br /><br /> Required permissions: inventory:hosts:write",
         "operationId": "api.host.patch_host_by_id",
         "security": [
           {
@@ -334,7 +334,7 @@
           }
         ],
         "requestBody": {
-          "description": "A group of fields to be updated on the host",
+          "description": "A group of fields to be updated on the hosts",
           "required": true,
           "content": {
             "application/json": {
@@ -346,7 +346,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successfully updated the host."
+            "description": "Successfully updated the hosts."
           },
           "400": {
             "description": "Invalid request."
@@ -562,8 +562,8 @@
         "tags": [
           "hosts"
         ],
-        "summary": "Get the number of tags on a host",
-        "description": "Get the number of tags on a host <br /><br /> Required permissions: inventory:hosts:read",
+        "summary": "Get the number of tags on a host or hosts",
+        "description": "Get the number of tags on a host or hosts <br /><br /> Required permissions: inventory:hosts:read",
         "operationId": "api.host.get_host_tag_count",
         "security": [
           {

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -39,16 +39,19 @@ from tests.helpers.test_utils import SYSTEM_IDENTITY
 )
 def test_update_fields(patch_doc, event_producer_mock, db_create_host, db_get_host, api_patch):
     host = db_create_host()
+    host2 = db_create_host()
 
-    url = build_hosts_url(host_list_or_id=host.id)
+    url = build_hosts_url(host_list_or_id=[host, host2])
     response_status, response_data = api_patch(url, patch_doc)
 
     assert_response_status(response_status, expected_status=200)
 
     record = db_get_host(host.id)
+    record2 = db_get_host(host2.id)
 
     for key in patch_doc:
         assert getattr(record, key) == patch_doc[key]
+        assert getattr(record2, key) == patch_doc[key]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-4398](https://issues.redhat.com/browse/ESSNTL-4398).
Some of the schema descriptions for host update endpoints incorrectly used the singular "host" when a list of "hosts" is what is actually provided as a parameter.  In future, we may revisit this as the primary user (the UI) only ever uses a single host at a time, and if we update the code to no longer use a list, we will update the API schema version to v2, but for now, we are only updating the language used in the descriptions to accurately reflect the code and updating the unit test to check for updating multiple hosts instead of a single host.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
