### PR TITLE
feat(ESSNTL-4615): Add "groups" column to hosts table

### DIFF
--- a/app/serialization.py
+++ b/app/serialization.py
@@ -82,6 +82,7 @@ def deserialize_host_xjoin(data):
         stale_timestamp=_deserialize_datetime(data["stale_timestamp"]),
         reporter=data["reporter"],
         per_reporter_staleness=data.get("per_reporter_staleness", {}) or {},
+        groups=data.get("groups", {}) or {},
     )
     for field in ("created_on", "modified_on"):
         setattr(host, field, _deserialize_datetime(data[field]))
@@ -133,6 +134,8 @@ def serialize_host(host, staleness_timestamps, fields=DEFAULT_FIELDS):
         serialized_host["tags"] = _serialize_tags(host.tags)
     if "system_profile" in fields:
         serialized_host["system_profile"] = host.system_profile_facts or {}
+    if "groups" in fields:
+        serialized_host["groups"] = host.groups or {}
 
     return serialized_host
 

--- a/migrations/versions/b48ad9e4c8c5_add_groups_jsonb_to_hosts_table.py
+++ b/migrations/versions/b48ad9e4c8c5_add_groups_jsonb_to_hosts_table.py
@@ -1,0 +1,25 @@
+"""Add groups JSONB to hosts table
+
+Revision ID: b48ad9e4c8c5
+Revises: 0f2fb89499ce
+Create Date: 2023-04-06 09:42:51.222003
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "b48ad9e4c8c5"
+down_revision = "0f2fb89499ce"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("hosts", sa.Column("groups", postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+
+
+def downgrade():
+    op.drop_column("hosts", "groups")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1060,6 +1060,24 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             },
             "stale_timestamp": now().isoformat(),
             "reporter": "some reporter",
+            "groups": [
+                {
+                    "id": str(uuid4()),
+                    "org_id": "3340851",
+                    "account": "some acct",
+                    "name": "group 1",
+                    "created_on": now().isoformat(),
+                    "modified_on": now().isoformat(),
+                },
+                {
+                    "id": str(uuid4()),
+                    "org_id": "3340851",
+                    "account": "some acct",
+                    "name": "group 2",
+                    "created_on": now().isoformat(),
+                    "modified_on": now().isoformat(),
+                },
+            ],
         }
         host_schema = Mock(**{"return_value.load.return_value": host_input, "build_model": HostSchema.build_model})
         result = deserialize_host({}, host_schema)
@@ -1079,6 +1097,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             host_input["system_profile"],
             host_input["stale_timestamp"],
             host_input["reporter"],
+            host_input["groups"],
         )
 
     def test_without_facts(self, deserialize_canonical_facts, deserialize_facts, deserialize_tags, host):
@@ -1099,6 +1118,24 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             },
             "stale_timestamp": now().isoformat(),
             "reporter": "some reporter",
+            "groups": [
+                {
+                    "id": str(uuid4()),
+                    "org_id": "3340851",
+                    "account": "some acct",
+                    "name": "group 1",
+                    "created_on": now().isoformat(),
+                    "modified_on": now().isoformat(),
+                },
+                {
+                    "id": str(uuid4()),
+                    "org_id": "3340851",
+                    "account": "some acct",
+                    "name": "group 2",
+                    "created_on": now().isoformat(),
+                    "modified_on": now().isoformat(),
+                },
+            ],
         }
         host_schema = Mock(**{"return_value.load.return_value": host_input, "build_model": HostSchema.build_model})
 
@@ -1119,6 +1156,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             host_input["system_profile"],
             host_input["stale_timestamp"],
             host_input["reporter"],
+            host_input["groups"],
         )
 
     def test_without_tags(self, deserialize_canonical_facts, deserialize_facts, deserialize_tags, host):
@@ -1139,6 +1177,24 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             },
             "stale_timestamp": now().isoformat(),
             "reporter": "some reporter",
+            "groups": [
+                {
+                    "id": str(uuid4()),
+                    "org_id": "3340851",
+                    "account": "some acct",
+                    "name": "group 1",
+                    "created_on": now().isoformat(),
+                    "modified_on": now().isoformat(),
+                },
+                {
+                    "id": str(uuid4()),
+                    "org_id": "3340851",
+                    "account": "some acct",
+                    "name": "group 2",
+                    "created_on": now().isoformat(),
+                    "modified_on": now().isoformat(),
+                },
+            ],
         }
         host_schema = Mock(**{"return_value.load.return_value": host_input, "build_model": HostSchema.build_model})
 
@@ -1159,6 +1215,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             host_input["system_profile"],
             host_input["stale_timestamp"],
             host_input["reporter"],
+            host_input["groups"],
         )
 
     def test_without_display_name(self, deserialize_canonical_facts, deserialize_facts, deserialize_tags, host):
@@ -1182,6 +1239,24 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             },
             "stale_timestamp": now().isoformat(),
             "reporter": "some reporter",
+            "groups": [
+                {
+                    "id": str(uuid4()),
+                    "org_id": "3340851",
+                    "account": "some acct",
+                    "name": "group 1",
+                    "created_on": now().isoformat(),
+                    "modified_on": now().isoformat(),
+                },
+                {
+                    "id": str(uuid4()),
+                    "org_id": "3340851",
+                    "account": "some acct",
+                    "name": "group 2",
+                    "created_on": now().isoformat(),
+                    "modified_on": now().isoformat(),
+                },
+            ],
         }
         host_schema = Mock(**{"return_value.load.return_value": host_input, "build_model": HostSchema.build_model})
 
@@ -1202,6 +1277,7 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             host_input["system_profile"],
             host_input["stale_timestamp"],
             host_input["reporter"],
+            host_input["groups"],
         )
 
     def test_without_system_profile(self, deserialize_canonical_facts, deserialize_facts, deserialize_tags, host):
@@ -1214,6 +1290,69 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
                 {"namespace": "NS1", "key": "key1", "value": "value1"},
                 {"namespace": "NS2", "key": "key2", "value": "value2"},
             ],
+            "facts": {
+                "some namespace": {"some key": "some value"},
+                "another namespace": {"another key": "another value"},
+            },
+            "stale_timestamp": now().isoformat(),
+            "reporter": "some reporter",
+            "groups": [
+                {
+                    "id": str(uuid4()),
+                    "org_id": "3340851",
+                    "account": "some acct",
+                    "name": "group 1",
+                    "created_on": now().isoformat(),
+                    "modified_on": now().isoformat(),
+                },
+                {
+                    "id": str(uuid4()),
+                    "org_id": "3340851",
+                    "account": "some acct",
+                    "name": "group 2",
+                    "created_on": now().isoformat(),
+                    "modified_on": now().isoformat(),
+                },
+            ],
+        }
+        host_schema = Mock(**{"return_value.load.return_value": host_input, "build_model": HostSchema.build_model})
+
+        result = deserialize_host({}, host_schema)
+        self.assertEqual(host.return_value, result)
+
+        deserialize_canonical_facts.assert_called_once_with(host_input)
+        deserialize_facts.assert_called_once_with(host_input["facts"])
+        deserialize_tags.assert_called_once_with(host_input["tags"])
+        host.assert_called_once_with(
+            deserialize_canonical_facts.return_value,
+            host_input["display_name"],
+            host_input["ansible_host"],
+            host_input["account"],
+            host_input["org_id"],
+            deserialize_facts.return_value,
+            deserialize_tags.return_value,
+            {},
+            host_input["stale_timestamp"],
+            host_input["reporter"],
+            host_input["groups"],
+        )
+
+    def test_without_groups(self, deserialize_canonical_facts, deserialize_facts, deserialize_tags, host):
+        host_input = {
+            "display_name": "some display name",
+            "ansible_host": "some ansible host",
+            "account": "some account",
+            "org_id": "3340851",
+            "tags": [
+                {"namespace": "NS1", "key": "key1", "value": "value1"},
+                {"namespace": "NS2", "key": "key2", "value": "value2"},
+            ],
+            "system_profile": {
+                "number_of_cpus": 1,
+                "number_of_sockets": 2,
+                "cores_per_socket": 3,
+                "system_memory_bytes": 4,
+            },
             "facts": {
                 "some namespace": {"some key": "some value"},
                 "another namespace": {"another key": "another value"},
@@ -1237,9 +1376,10 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             host_input["org_id"],
             deserialize_facts.return_value,
             deserialize_tags.return_value,
-            {},
+            host_input["system_profile"],
             host_input["stale_timestamp"],
             host_input["reporter"],
+            {},
         )
 
     def test_without_culling_fields(self, deserialize_canonical_facts, deserialize_facts, deserialize_tags, host):


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-4615](https://issues.redhat.com/browse/ESSNTL-4615).
It adds the "groups" JSONB column to the hosts table, implementation for the models & schemas, and serialization/deserialization. This will be populated with the data of the host's associated group(s) in a follow-up PR.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
