### PR TITLE
Update cloudwatch handler

### DIFF
--- a/app/logging.py
+++ b/app/logging.py
@@ -67,16 +67,17 @@ def cloudwatch_handler():
 
     if all((aws_access_key_id, aws_secret_access_key, aws_region_name)):
         aws_log_stream = os.getenv("AWS_LOG_STREAM", _get_hostname())
-        print(f"Configuring watchtower logging (log_group={aws_log_group}, stream_name={aws_log_stream})")
+        print(f"Configuring watchtower logging (log_group_name={aws_log_group}, log_stream_name={aws_log_stream})")
         boto3_session = Session(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             region_name=aws_region_name,
         )
+        boto3_client = boto3_session.client("logs")
         return watchtower.CloudWatchLogHandler(
-            boto3_session=boto3_session,
-            log_group=aws_log_group,
-            stream_name=aws_log_stream,
+            boto3_client=boto3_client,
+            log_group_name=aws_log_group,
+            log_stream_name=aws_log_stream,
             create_log_group=create_log_group,
         )
     else:


### PR DESCRIPTION
# Overview

This PR is being created to address pods missing in stage after dependabot updating watchtower dependencies.

Alerts informed us pods were down. Logs show that the issue was an unexpected keyword argument "boto3_session". Changelog for watchtower indicate as of v2.0.0 `boto3_session` support has been removed and replaced with `boto3_client`.

This PR updates the cloudwatch handler to use the `boto3_client` and also updates `log_group` to `log_group_name` and `stream_name` to `log_stream_name`.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
