### PR TITLE
Add groups field to xjoin-search hosts query

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -50,7 +50,16 @@ QUERY = """query Query(
             reporter,
             per_reporter_staleness,
             system_profile_facts (filter: $fields),
-            groups,
+            groups {
+                data {
+                    id,
+                    name,
+                    account,
+                    org_id,
+                    created_on,
+                    modified_on
+                },
+            },
         }
     }
 }"""

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -50,6 +50,7 @@ QUERY = """query Query(
             reporter,
             per_reporter_staleness,
             system_profile_facts (filter: $fields),
+            groups,
         }
     }
 }"""

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -84,7 +84,7 @@ def deserialize_host_xjoin(data):
         stale_timestamp=_deserialize_datetime(data["stale_timestamp"]),
         reporter=data["reporter"],
         per_reporter_staleness=data.get("per_reporter_staleness", {}) or {},
-        groups=data.get("groups", []),
+        groups=data["groups"]["data"] if "groups" in data else [],
     )
     for field in ("created_on", "modified_on"):
         setattr(host, field, _deserialize_datetime(data[field]))


### PR DESCRIPTION
# Overview

This PR is being created to fix a bug we just discovered. It makes it so we retrieve the "groups" field from the xjoin host query. This was added in a previous PR, but I think it got removed by a merge conflict. 