### PR TITLE
fix(ESSNTL-4695): Remove host_count from MQ serialization

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -39,7 +39,6 @@ from app.payload_tracker import PayloadTrackerProcessingContext
 from app.queue.events import build_event
 from app.queue.events import EventType
 from app.queue.events import message_headers
-from app.queue.queue import EGRESS_HOST_FIELDS
 from app.serialization import deserialize_canonical_facts
 from app.serialization import serialize_host
 from app.utils import Tag
@@ -319,7 +318,7 @@ def patch_host_by_id(host_id_list, body):
 
         if db.session.is_modified(host):
             db.session.commit()
-            serialized_host = serialize_host(host, staleness_timestamps(), EGRESS_HOST_FIELDS)
+            serialized_host = serialize_host(host, staleness_timestamps())
             _emit_patch_event(serialized_host, host.id, host.canonical_facts.get("insights_id"))
 
     log_patch_host_success(logger, host_id_list)
@@ -374,7 +373,7 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict):
 
         if db.session.is_modified(host):
             db.session.commit()
-            serialized_host = serialize_host(host, staleness_timestamps(), EGRESS_HOST_FIELDS)
+            serialized_host = serialize_host(host, staleness_timestamps())
             _emit_patch_event(serialized_host, host.id, host.canonical_facts.get("insights_id"))
 
     logger.debug("hosts_to_update:%s", hosts_to_update)
@@ -418,7 +417,7 @@ def host_checkin(body):
     if existing_host:
         existing_host._update_modified_date()
         db.session.commit()
-        serialized_host = serialize_host(existing_host, staleness_timestamps(), EGRESS_HOST_FIELDS)
+        serialized_host = serialize_host(existing_host, staleness_timestamps())
         _emit_patch_event(serialized_host, existing_host.id, existing_host.canonical_facts.get("insights_id"))
         return flask_json_response(serialized_host, 201)
     else:

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -1,6 +1,5 @@
 from app import inventory_config
 from app.culling import Timestamps
-from app.serialization import DEFAULT_FIELDS
 from app.serialization import serialize_host
 
 
@@ -9,7 +8,7 @@ __all__ = ("build_paginated_host_list_response", "staleness_timestamps")
 
 def build_paginated_host_list_response(total, page, per_page, host_list, additional_fields=tuple()):
     timestamps = staleness_timestamps()
-    json_host_list = [serialize_host(host, timestamps, DEFAULT_FIELDS + additional_fields) for host in host_list]
+    json_host_list = [serialize_host(host, timestamps, False, additional_fields) for host in host_list]
     return {
         "total": total,
         "count": len(json_host_list),

--- a/app/queue/event_producer.py
+++ b/app/queue/event_producer.py
@@ -32,15 +32,15 @@ class EventProducer:
     def __init__(self, config, topic):
         logger.info("Starting EventProducer()")
         self._kafka_producer = KafkaProducer({"bootstrap.servers": config.bootstrap_servers, **config.kafka_producer})
-        self.egress_topic = topic
+        self.mq_topic = topic
 
     def write_event(self, event, key, headers, *, wait=False):
-        logger.debug("Topic: %s, key: %s, event: %s, headers: %s", self.egress_topic, key, event, headers)
+        logger.debug("Topic: %s, key: %s, event: %s, headers: %s", self.mq_topic, key, event, headers)
 
         k = key.encode("utf-8") if key else None
         v = event.encode("utf-8")
         h = _encode_headers(headers)
-        topic = self.egress_topic
+        topic = self.mq_topic
 
         try:
             messageDetails = MessageDetails(topic, v, h, k)

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -38,7 +38,6 @@ from app.queue.events import operation_results_to_event_type
 from app.queue.notifications import build_notification_event
 from app.queue.notifications import notification_message_headers
 from app.queue.notifications import NotificationType
-from app.serialization import DEFAULT_FIELDS
 from app.serialization import deserialize_canonical_facts
 from app.serialization import deserialize_host
 from lib import host_repository
@@ -46,7 +45,6 @@ from lib import host_repository
 
 logger = get_logger(__name__)
 
-EGRESS_HOST_FIELDS = DEFAULT_FIELDS + ("tags", "system_profile")
 CONSUMER_POLL_TIMEOUT_SECONDS = 1
 SYSTEM_IDENTITY = {"auth_type": "cert-auth", "system": {"cert_type": "system"}, "type": "System"}
 
@@ -221,7 +219,7 @@ def update_system_profile(host_data, platform_metadata, operation_args={}):
             staleness_timestamps = Timestamps.from_config(inventory_config())
             identity = create_mock_identity_with_org_id(input_host.org_id)
             output_host, host_id, insights_id, update_result = host_repository.update_system_profile(
-                input_host, identity, staleness_timestamps, EGRESS_HOST_FIELDS
+                input_host, identity, staleness_timestamps
             )
             log_update_system_profile_success(logger, output_host)
             payload_tracker_processing_ctx.inventory_id = output_host["id"]
@@ -257,7 +255,7 @@ def add_host(host_data, platform_metadata, operation_args={}):
             staleness_timestamps = Timestamps.from_config(inventory_config())
             log_add_host_attempt(logger, input_host)
             output_host, host_id, insights_id, add_result = host_repository.add_host(
-                input_host, identity, staleness_timestamps, fields=EGRESS_HOST_FIELDS, operation_args=operation_args
+                input_host, identity, staleness_timestamps, operation_args=operation_args
             )
             log_add_update_host_succeeded(logger, add_result, host_data, output_host)
             payload_tracker_processing_ctx.inventory_id = output_host["id"]

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -19,7 +19,6 @@ from app.queue.event_producer import EventProducer
 from app.queue.events import build_event
 from app.queue.events import EventType
 from app.queue.events import message_headers
-from app.queue.queue import EGRESS_HOST_FIELDS
 from app.serialization import serialize_group
 from app.serialization import serialize_host
 from lib.db import session_guard
@@ -45,7 +44,7 @@ def _produce_host_update_events(event_producer, host_id_list, group_id_list=[]):
     # Send messages
     for host in host_list:
         host.groups = serialized_groups
-        serialized_host = serialize_host(host, staleness_timestamps(), EGRESS_HOST_FIELDS)
+        serialized_host = serialize_host(host, staleness_timestamps())
         headers = message_headers(EventType.updated, serialized_host["insights_id"])
         event = build_event(EventType.updated, serialized_host)
         event_producer.write_event(event, serialized_host["id"], headers, wait=True)

--- a/lib/host_synchronize.py
+++ b/lib/host_synchronize.py
@@ -6,7 +6,6 @@ from app.models import Host
 from app.queue.events import build_event
 from app.queue.events import EventType
 from app.queue.events import message_headers
-from app.queue.queue import EGRESS_HOST_FIELDS
 from app.serialization import serialize_host
 from lib.metrics import synchronize_host_count
 
@@ -22,7 +21,7 @@ def synchronize_hosts(select_query, event_producer, chunk_size, config, interrup
 
     while len(host_list) > 0 and not interrupt():
         for host in host_list:
-            serialized_host = serialize_host(host, Timestamps.from_config(config), EGRESS_HOST_FIELDS)
+            serialized_host = serialize_host(host, Timestamps.from_config(config))
             event = build_event(EventType.updated, serialized_host)
             insights_id = host.canonical_facts.get("insights_id")
             headers = message_headers(EventType.updated, insights_id)

--- a/tests/helpers/db_utils.py
+++ b/tests/helpers/db_utils.py
@@ -5,12 +5,9 @@ from random import randint
 from sqlalchemy.exc import InvalidRequestError
 
 from app.auth.identity import Identity
-from app.culling import Timestamps
 from app.models import db
 from app.models import Group
 from app.models import Host
-from app.serialization import serialize_host
-from app.utils import HostWrapper
 from lib.host_repository import find_existing_host
 from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import now
@@ -124,13 +121,6 @@ def create_reference_host_in_db(insights_id, reporter, system_profile, stale_tim
     db.session.add(host)
     db.session.commit()
     return host
-
-
-def serialize_db_host(host, inventory_config):
-    staleness_offset = Timestamps.from_config(inventory_config)
-    serialized_host = serialize_host(host, staleness_offset)
-
-    return HostWrapper(serialized_host)
 
 
 def get_expected_facts_after_update(method, namespace, facts, new_facts):

--- a/tests/test_api_groups_update.py
+++ b/tests/test_api_groups_update.py
@@ -86,6 +86,7 @@ def test_patch_group_happy_path(
         host = json.loads(call_arg[0][0])["host"]
         assert host["id"] in host_id_list
         assert host["groups"][0]["id"] == str(group_id)
+        assert "host_count" not in host["groups"][0]
 
 
 def test_patch_group_wrong_org_id_for_group(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -52,7 +52,6 @@ from app.serialization import _deserialize_tags_dict
 from app.serialization import _deserialize_tags_list
 from app.serialization import _serialize_datetime
 from app.serialization import _serialize_uuid
-from app.serialization import DEFAULT_FIELDS
 from app.serialization import deserialize_canonical_facts
 from app.serialization import deserialize_host
 from app.serialization import serialize_canonical_facts
@@ -1508,7 +1507,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
             setattr(host, k, v)
 
         config = CullingConfig(stale_warning_offset_delta=timedelta(days=7), culled_offset_delta=timedelta(days=14))
-        actual = serialize_host(host, Timestamps(config), DEFAULT_FIELDS + ("tags",))
+        actual = serialize_host(host, Timestamps(config), False, ("tags",))
         expected = {
             **canonical_facts,
             **unchanged_data,
@@ -1561,7 +1560,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
             setattr(host, k, v)
 
         config = CullingConfig(stale_warning_offset_delta=timedelta(days=7), culled_offset_delta=timedelta(days=14))
-        actual = serialize_host(host, Timestamps(config), DEFAULT_FIELDS + ("tags",))
+        actual = serialize_host(host, Timestamps(config), False, ("tags",))
         expected = {
             **host_init_data["canonical_facts"],
             "insights_id": None,
@@ -1603,7 +1602,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
                     setattr(host, k, v)
 
                 config = CullingConfig(timedelta(days=stale_warning_offset_days), timedelta(days=culled_offset_days))
-                serialized = serialize_host(host, Timestamps(config))
+                serialized = serialize_host(host, Timestamps(config), False)
                 self.assertEqual(
                     self._timestamp_to_str(self._add_days(stale_timestamp, stale_warning_offset_days)),
                     serialized["stale_warning_timestamp"],
@@ -1670,7 +1669,7 @@ class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTes
                 "stale_timestamp.culled_timestamp": now() + timedelta(hours=2),
             }
         )
-        actual = serialize_host(host, staleness_offset, DEFAULT_FIELDS + ("tags",))
+        actual = serialize_host(host, staleness_offset, False, ("tags",))
         expected = {
             **canonical_facts,
             **unchanged_data,


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-4695](https://issues.redhat.com/browse/ESSNTL-4695).
This PR does the following:

- Removes host.groups[].host_count from produced MQ messages. We're doing this because if we want to keep that value in sync, we'd have to send a message for each host on the group every time a host is added or removed from the group (huge overhead)
- Simplifies serialization calls. You no longer need to specify the list of fields to send, since it was always either `DEFAULT_FIELDS` or `EGRESS_HOST_FIELDS`. Now you just optionally specify if you're not serializing it for MQ, or if there are any additional fields you'd like to include. 
- Removes the last references to the egress topic (we don't use that anymore)
- Removes an unused DB util function

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
