### PR TITLE
Lock 2 endpoints behind feature flag

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -103,6 +103,9 @@ def create_group(body):
 @rbac(Permission.WRITE)
 @metrics.api_request_time.time()
 def patch_group_by_id(group_id, body):
+    if not get_flag_value(FLAG_INVENTORY_GROUPS):
+        return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
+
     try:
         validated_patch_group_data = InputGroupSchema().load(body)
     except ValidationError as e:


### PR DESCRIPTION
# Overview

This PR is being created to lock 2 Inventory Group endpoints behind the feature flag. We didn't catch this in our code reviews, and we need them to be restricted.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
