### PR TITLE
fix(ESSNTL-4769): Ordering groups by host_ids is random if groups have same amount of hosts

### DIFF
--- a/api/group_query.py
+++ b/api/group_query.py
@@ -72,6 +72,7 @@ def get_group_list_from_db(filters, page, per_page, param_order_by, param_order_
         .filter(*filters)
         .group_by(Group.id)
         .order_by(order_how_func(order_by))
+        .order_by(Group.id)
         .offset((page - 1) * per_page)
         .limit(per_page)
         .all()


### PR DESCRIPTION

# Overview

This PR is being created to address the bug reported at [ESSNTL-4769](https://issues.redhat.com/browse/ESSNTL-4769) .
It adds another `.order_by` to the group's query.

With this, the data that is being returned is fixed and correctly ordered.
Data is preserved when using `per_page` and `page` query parameters.

Related: ESSNTL-4769

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
