### PR TITLE
Debug Kafka SASL errors

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -59,11 +59,15 @@ class Config:
             self.kafka_sasl_password = broker_cfg.sasl.password
             self.kafka_sasl_mechanism = broker_cfg.sasl.saslMechanism
             self.kafka_security_protocol = broker_cfg.sasl.securityProtocol
+            self.logger.info("There wasn't Attribute error")
         except AttributeError:
             self.kafka_sasl_username = ""
             self.kafka_sasl_password = ""
             self.kafka_sasl_mechanism = "PLAIN"
             self.kafka_security_protocol = "PLAINTEXT"
+            self.logger.info("There was Attribute error")
+        self.logger.info(f"kafka_sasl_mechanism: {self.kafka_sasl_mechanism}")
+        self.logger.info(f"kafka_security_protocol: {self.kafka_security_protocol}")
 
         # Feature flags
         unleash = cfg.featureFlags
@@ -150,6 +154,8 @@ class Config:
             "sasl.username": self.kafka_sasl_username,
             "sasl.password": self.kafka_sasl_password,
         }
+        self.logger.info(f"sasl.mechanism: {self.kafka_ssl_configs['sasl.mechanism']}")
+        self.logger.info(f"security.protocol: {self.kafka_ssl_configs['security.protocol']}")
 
         # https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
         self.kafka_consumer = {


### PR DESCRIPTION
# Overview

There is quite a lot of warnings similar to this in ephemeral envs:
```
%4|1684317028.691|CONFWARN|rdkafka#producer-1| [thrd:app]: Configuration property `sasl.mechanism` set to `PLAIN` but `security.protocol` is not configured for SASL: recommend setting `security.protocol` to SASL_SSL or SASL_PLAINTEXT
```

This PR is being created to debug and get rid of these warnings.

DON'T MERGE THIS PR FOR NOW.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
