### PR TITLE
feat(ESSNTL-4766, ESSNTL-4767): Make group-name filter case-insensitive and inclusive

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -437,7 +437,7 @@ def query_filters(
     if updated_start or updated_end:
         query_filters += _build_modified_on_filter(updated_start, updated_end)
     if group_name:
-        query_filters += ({"group": {"name": {"eq_lc": group_name}}},)
+        query_filters += ({"group": {"name": string_contains_lc(group_name)}},)
     if group_ids:
         query_filters += group_id_list_query_filter(group_ids)
 

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -872,7 +872,7 @@ def test_tags_query_host_filters_casefolding(assert_tag_query_host_filter_for_fi
 def test_tags_query_group_name_filter(assert_tag_query_host_filter_single_call, mocker):
     assert_tag_query_host_filter_single_call(
         build_tags_url(query="?group_name=coolgroup"),
-        host_filter={"OR": mocker.ANY, "AND": ({"group": {"name": {"eq_lc": "coolgroup"}}},)},
+        host_filter={"OR": mocker.ANY, "AND": ({"group": {"name": {"matches_lc": "*coolgroup*"}}},)},
     )
 
 
@@ -1816,7 +1816,7 @@ def test_query_variables_group_name(mocker, graphql_query_empty_response, api_ge
             "order_how": mocker.ANY,
             "limit": mocker.ANY,
             "offset": mocker.ANY,
-            "filter": ({"OR": mocker.ANY}, {"group": {"name": {"eq_lc": f"{group_name}"}}}),
+            "filter": ({"OR": mocker.ANY}, {"group": {"name": {"matches_lc": f"*{group_name}*"}}}),
             "fields": mocker.ANY,
         },
         mocker.ANY,


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-4766](https://issues.redhat.com/browse/ESSNTL-4766) and [ESSNTL-4767](https://issues.redhat.com/browse/ESSNTL-4767).
It changes the group-name filter to use "matches_lc" instead of "eq". This makes it so that the filter is case-insensitive, and also matches inclusively (instead of a strict equals). In other words, if you search for "ROUP", it will now find "Group1".

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
