### PR TITLE
fix(ESSNTL-3698): Add "groups" field to Host responses in the API spec

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1426,6 +1426,12 @@ components:
               type: object
               additionalProperties:
                 $ref: '#/components/schemas/PerReporterStaleness'
+            groups:
+              description: >-
+                The groups that the host belongs to, if any.
+              type: array
+              items:
+                $ref: '#/components/schemas/GroupOut'
           required:
             - org_id
     HostOut:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -2201,6 +2201,13 @@
                 "additionalProperties": {
                   "$ref": "#/components/schemas/PerReporterStaleness"
                 }
+              },
+              "groups": {
+                "description": "The groups that the host belongs to, if any.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/GroupOut"
+                }
               }
             },
             "required": [


### PR DESCRIPTION
# Overview

This PR is being created to fix an issue with [ESSNTL-3698](https://issues.redhat.com/browse/ESSNTL-3698).
The "groups" field is returned in the host data, but it's not defined in the API spec. This PR fixes that by adding it to all Host responses. This is a follow-up to #1302.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
