### PR TITLE
Replace empty-string host.groups values with empty arrays instead

### DIFF
--- a/migrations/versions/8277117fa057_correct_empty_string_groups_value_on_.py
+++ b/migrations/versions/8277117fa057_correct_empty_string_groups_value_on_.py
@@ -6,6 +6,7 @@ Create Date: 2023-06-06 11:26:53.810997
 
 """
 from alembic import op
+from sqlalchemy import or_
 from sqlalchemy.dialects.postgresql import JSONB
 
 from app.models import Host
@@ -22,11 +23,11 @@ def upgrade():
     with session() as s:
         # For all hosts that have an empty string in their `groups` field,
         # set the `groups` field to an empty array instead.
-        s.query(Host).filter(Host.groups == JSONB.NULL).update({Host.groups: []})
-        s.query(Host).filter(Host.groups == {}).update({Host.groups: []})
+        s.query(Host).filter(or_(Host.groups == JSONB.NULL, Host.groups == {})).update({Host.groups: []})
         op.alter_column("hosts", "groups", nullable=False)
 
 
 def downgrade():
     # Nothing to do; we don't want to un-correct the data
+    op.alter_column("hosts", "groups", nullable=True)
     pass

--- a/migrations/versions/8277117fa057_correct_empty_string_groups_value_on_.py
+++ b/migrations/versions/8277117fa057_correct_empty_string_groups_value_on_.py
@@ -1,0 +1,27 @@
+"""correct empty string groups value on some hosts
+
+Revision ID: 8277117fa057
+Revises: b48ad9e4c8c5
+Create Date: 2023-06-06 11:26:53.810997
+
+"""
+from app.models import Host
+from migrations.helpers import session
+
+# revision identifiers, used by Alembic.
+revision = "8277117fa057"
+down_revision = "b48ad9e4c8c5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with session() as s:
+        # For all hosts that have an empty string in their `groups` field,
+        # set the `groups` field to an empty array instead.
+        s.query(Host).filter(Host.groups == "").update({Host.groups: []})
+
+
+def downgrade():
+    # Nothing to do; we don't want to un-correct the data
+    pass

--- a/migrations/versions/8277117fa057_correct_empty_string_groups_value_on_.py
+++ b/migrations/versions/8277117fa057_correct_empty_string_groups_value_on_.py
@@ -5,6 +5,9 @@ Revises: b48ad9e4c8c5
 Create Date: 2023-06-06 11:26:53.810997
 
 """
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
 from app.models import Host
 from migrations.helpers import session
 
@@ -19,7 +22,9 @@ def upgrade():
     with session() as s:
         # For all hosts that have an empty string in their `groups` field,
         # set the `groups` field to an empty array instead.
-        s.query(Host).filter(Host.groups == "").update({Host.groups: []})
+        s.query(Host).filter(Host.groups == JSONB.NULL).update({Host.groups: []})
+        s.query(Host).filter(Host.groups == {}).update({Host.groups: []})
+        op.alter_column("hosts", "groups", nullable=False)
 
 
 def downgrade():


### PR DESCRIPTION
# Overview

This PR is being created to address an issue where some hosts created in the early stages of Inventory Groups have host.groups set to `""`. If a host isn't associated with a group, its default value should be `[]`.
This just creates a new alembic migration to update the existing errant data.