### PR TITLE
fix(ESSNTL-4767): Make groups search use "contains" logic instead of "equals"

### DIFF
--- a/api/group_query.py
+++ b/api/group_query.py
@@ -99,7 +99,7 @@ def get_group_list_by_id_list_db(group_id_list, page, per_page, order_by, order_
 def get_filtered_group_list_db(group_name, page, per_page, order_by, order_how):
     filters = (Group.org_id == get_current_identity().org_id,)
     if group_name:
-        filters += (Group.name == group_name,)
+        filters += (Group.name.contains(group_name),)
     return get_group_list_from_db(filters, page, per_page, order_by, order_how)
 
 

--- a/tests/test_api_groups_get.py
+++ b/tests/test_api_groups_get.py
@@ -18,9 +18,10 @@ def test_basic_group_query(db_create_group, api_get):
         assert group_result["id"] in group_id_list
 
 
-def test_query_variables_group_name(db_create_group, api_get):
+@pytest.mark.parametrize("search", ["testGroup", "test", "Group", "ro"])
+def test_query_variables_group_name(db_create_group, api_get, search):
     group_id = db_create_group("testGroup").id
-    query = "?name=testGroup"
+    query = f"?name={search}"
 
     response_status, response_data = api_get(build_groups_url(query=query))
 


### PR DESCRIPTION
# Overview

This PR is being created to fix an issue with [ESSNTL-4767](https://issues.redhat.com/browse/ESSNTL-4767).
My previous PR fixed searching for hosts by filtering on the group name, but it neglected to address the issue when searching for groups. This PR addresses that.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
