### PR TITLE
ESSNTL-4952: Add "groups" field into the API schema for hosts endpoints

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1426,6 +1426,12 @@ components:
               type: object
               additionalProperties:
                 $ref: '#/components/schemas/PerReporterStaleness'
+            groups:
+              description: >-
+                The groups that the host belongs to, if any.
+              type: array
+              items:
+                $ref: '#/components/schemas/GroupOut'
           required:
             - org_id
     HostOut:
@@ -1615,8 +1621,6 @@ components:
           $ref: "#/components/schemas/GroupId"
         name:
           $ref: "#/components/schemas/GroupName"
-        host_count:
-          $ref: "#/components/schemas/HostCount"
         account:
           $ref: "#/components/schemas/AccountNumber"
         org_id:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -2207,6 +2207,13 @@
                 "additionalProperties": {
                   "$ref": "#/components/schemas/PerReporterStaleness"
                 }
+              },
+              "groups": {
+                "description": "The groups that the host belongs to, if any.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/GroupOut"
+                }
               }
             },
             "required": [
@@ -2475,9 +2482,6 @@
           },
           "name": {
             "$ref": "#/components/schemas/GroupName"
-          },
-          "host_count": {
-            "$ref": "#/components/schemas/HostCount"
           },
           "account": {
             "$ref": "#/components/schemas/AccountNumber"


### PR DESCRIPTION
# Overview

This PR implements ESSNTL-4952, which adds "groups" to hostOut object and removes hostCount from the `GroupsOut` object in swagger schema because hostCount in a host group is not available.  Per @fstavela this fix is needed as his tests depend on it.
cc: @fstavela 

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
