### PR TITLE
Fix host serialization when host.groups is undefined; add tests

### DIFF
--- a/app/serialization.py
+++ b/app/serialization.py
@@ -159,7 +159,7 @@ def serialize_host(host, staleness_timestamps, for_mq=True, additional_fields=tu
         serialized_host["system_profile"] = host.system_profile_facts or {}
     if "groups" in fields:
         # For MQ messages, we don't include the host_count field.
-        if for_mq:
+        if for_mq and host.groups:
             serialized_host["groups"] = [
                 {key: group[key] for key in group if key != "host_count"} for group in host.groups
             ]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1535,60 +1535,68 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
         self.assertEqual(expected, actual)
 
     def test_with_only_required_fields(self):
-        unchanged_data = {
-            "display_name": None,
-            "org_id": "some org_id",
-            "account": None,
-            "reporter": "yupana",
-            "groups": [],
-        }
-        host_init_data = {
-            "stale_timestamp": now(),
-            "canonical_facts": {"fqdn": "some fqdn"},
-            **unchanged_data,
-            "facts": {},
-        }
-        host = Host(**host_init_data)
+        self.maxDiff = None
 
-        host_attr_data = {
-            "id": uuid4(),
-            "created_on": now(),
-            "modified_on": now(),
-            "per_reporter_staleness": host.per_reporter_staleness,
-        }
-        for k, v in host_attr_data.items():
-            setattr(host, k, v)
+        for group_data in ({"groups": None}, {"groups": ""}, {"groups": {}}, {"groups": []}, {}):
+            with self.subTest(group_data=group_data):
+                unchanged_data = {
+                    "display_name": None,
+                    "org_id": "some org_id",
+                    "account": None,
+                    "reporter": "yupana",
+                }
+                host_init_data = {
+                    "stale_timestamp": now(),
+                    "canonical_facts": {"fqdn": "some fqdn"},
+                    **unchanged_data,
+                    "facts": {},
+                }
+                host = Host(**host_init_data)
 
-        config = CullingConfig(stale_warning_offset_delta=timedelta(days=7), culled_offset_delta=timedelta(days=14))
-        actual = serialize_host(host, Timestamps(config), False, ("tags",))
-        expected = {
-            **host_init_data["canonical_facts"],
-            "insights_id": None,
-            "subscription_manager_id": None,
-            "satellite_id": None,
-            "bios_uuid": None,
-            "ip_addresses": None,
-            "mac_addresses": None,
-            "ansible_host": None,
-            "provider_id": None,
-            "provider_type": None,
-            **unchanged_data,
-            "facts": [],
-            "tags": [],
-            "id": str(host_attr_data["id"]),
-            "created": self._timestamp_to_str(host_attr_data["created_on"]),
-            "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
-            "stale_timestamp": self._timestamp_to_str(host_init_data["stale_timestamp"]),
-            "stale_warning_timestamp": self._timestamp_to_str(
-                self._add_days(host_init_data["stale_timestamp"], config.stale_warning_offset_delta.days)
-            ),
-            "culled_timestamp": self._timestamp_to_str(
-                self._add_days(host_init_data["stale_timestamp"], config.culled_offset_delta.days)
-            ),
-            "per_reporter_staleness": host_attr_data["per_reporter_staleness"],
-        }
+                host_attr_data = {
+                    "id": uuid4(),
+                    "created_on": now(),
+                    "modified_on": now(),
+                    "per_reporter_staleness": host.per_reporter_staleness,
+                    **group_data,
+                }
+                for k, v in host_attr_data.items():
+                    setattr(host, k, v)
 
-        self.assertEqual(expected, actual)
+                config = CullingConfig(
+                    stale_warning_offset_delta=timedelta(days=7), culled_offset_delta=timedelta(days=14)
+                )
+                actual = serialize_host(host, Timestamps(config), True, ("tags",))
+                expected = {
+                    **host_init_data["canonical_facts"],
+                    "insights_id": None,
+                    "subscription_manager_id": None,
+                    "system_profile": {},
+                    "satellite_id": None,
+                    "bios_uuid": None,
+                    "ip_addresses": None,
+                    "mac_addresses": None,
+                    "ansible_host": None,
+                    "provider_id": None,
+                    "provider_type": None,
+                    **unchanged_data,
+                    "facts": [],
+                    "groups": [],
+                    "tags": [],
+                    "id": str(host_attr_data["id"]),
+                    "created": self._timestamp_to_str(host_attr_data["created_on"]),
+                    "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
+                    "stale_timestamp": self._timestamp_to_str(host_init_data["stale_timestamp"]),
+                    "stale_warning_timestamp": self._timestamp_to_str(
+                        self._add_days(host_init_data["stale_timestamp"], config.stale_warning_offset_delta.days)
+                    ),
+                    "culled_timestamp": self._timestamp_to_str(
+                        self._add_days(host_init_data["stale_timestamp"], config.culled_offset_delta.days)
+                    ),
+                    "per_reporter_staleness": host_attr_data["per_reporter_staleness"],
+                }
+
+                self.assertEqual(expected, actual)
 
     def test_stale_timestamp_config(self):
         for stale_warning_offset_days, culled_offset_days in ((1, 2), (7, 14), (100, 1000)):


### PR DESCRIPTION
# Overview

This PR is being created to address the issue we saw in Prod yesterday. If the service attempts to serialize a host for MQ when host.groups does not exist, it raises [an exception](https://kibana.apps.crcp01ue1.o9m8.p1.openshiftapps.com/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2023-06-08T17:01:01.175Z',to:'2023-06-08T18:50:36.349Z'))&_a=(columns:!(exc_text),filters:!(),index:'43c5fed0-d5ce-11ea-b58c-a7c95afd7a5d',interval:auto,query:(language:lucene,query:'@log_stream:%20%22host-inventory-mq%22%20AND%20levelname:%20ERROR%20AND%20msg:%20%22Unable%20to%20process%20message%22'),sort:!(!('@timestamp',desc)))); this PR fixes that, and adds some thorough testing to make sure it doesn't happen again.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
