### PR TITLE
fix(ESSNTL-4458): Fix too old date on filter

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -306,19 +306,19 @@ def build_registered_with_filter(registered_with):
     return ({"OR": prs_list},)
 
 
-def _build_modified_on_filter(updated_start: str = None, updated_end: str = None) -> Tuple:
+def _build_modified_on_filter(updated_start: str, updated_end: str) -> Tuple:
     updated_start_date = parser.isoparse(updated_start) if updated_start else None
     updated_end_date = parser.isoparse(updated_end) if updated_end else None
 
     if updated_start_date and updated_end_date and updated_start_date > updated_end_date:
         raise ValueError("updated_start cannot be after updated_end.")
     modified_on_filter = {}
-    if updated_start_date:
+    if updated_start_date and updated_start_date.year > 1970:
         modified_on_filter["gte"] = updated_start_date.isoformat()
-    if updated_end_date:
+    if updated_end_date and updated_end_date.year > 1970:
         modified_on_filter["lte"] = updated_end_date.isoformat()
 
-    return ({"modified_on": modified_on_filter},)
+    return ({"modified_on": modified_on_filter},) if modified_on_filter else ()
 
 
 def build_tag_query_dict_tuple(tags):
@@ -450,13 +450,7 @@ def query_filters(
     if provider_id:
         query_filters += ({"provider_id": {"eq": provider_id.casefold()}},)
     if updated_start or updated_end:
-        # Need to check if date is less then 1970, since ElasticSearch doesn't
-        # allow timestamps before above this year. See ticket #ESSNTL-4458
-        if parser.isoparse(updated_start).year > 1970 or parser.isoparse(updated_end).year > 1970:
-            query_filters += _build_modified_on_filter(
-                updated_start=updated_start if parser.isoparse(updated_start).year > 1970 else None,
-                updated_end=updated_end if parser.isoparse(updated_end).year > 1970 else None,
-            )
+        query_filters += _build_modified_on_filter(updated_start, updated_end)
     if group_name:
         query_filters += ({"group": {"name": string_contains_lc(group_name)}},)
     if group_ids:

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -451,9 +451,12 @@ def query_filters(
         query_filters += ({"provider_id": {"eq": provider_id.casefold()}},)
     if updated_start or updated_end:
         # Need to check if date is less then 1970, since ElasticSearch doesn't
-        # allow query above this year. See ticket #ESSNTL-4458
-        if parser.isoparse(updated_start).year > 1970 and parser.isoparse(updated_end).year > 1970:
-            query_filters += _build_modified_on_filter(updated_start, updated_end)
+        # allow timestamps before above this year. See ticket #ESSNTL-4458
+        if parser.isoparse(updated_start).year > 1970 or parser.isoparse(updated_end).year > 1970:
+            query_filters += _build_modified_on_filter(
+                updated_start=updated_start if parser.isoparse(updated_start).year > 1970 else None,
+                updated_end=updated_end if parser.isoparse(updated_end).year > 1970 else None,
+            )
     if group_name:
         query_filters += ({"group": {"name": string_contains_lc(group_name)}},)
     if group_ids:

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -450,7 +450,10 @@ def query_filters(
     if provider_id:
         query_filters += ({"provider_id": {"eq": provider_id.casefold()}},)
     if updated_start or updated_end:
-        query_filters += _build_modified_on_filter(updated_start, updated_end)
+        # Need to check if date is less then 1970, since ElasticSearch doesn't
+        # allow query above this year. See ticket #ESSNTL-4458
+        if parser.isoparse(updated_start).year > 1970 and parser.isoparse(updated_end).year > 1970:
+            query_filters += _build_modified_on_filter(updated_start, updated_end)
     if group_name:
         query_filters += ({"group": {"name": string_contains_lc(group_name)}},)
     if group_ids:

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -474,3 +474,14 @@ def test_get_hosts_contains_invalid_on_string_not_array(patch_xjoin_post, api_ge
 
 def test_get_hosts_timestamp_invalid_value_graceful_rejection(patch_xjoin_post, api_get):
     assert 400 == api_get(build_hosts_url(query="?filter[system_profile][last_boot_time][eq]=foo"))[0]
+
+
+@pytest.mark.parametrize(
+    "query_params",
+    ("?updated_start=0199-03-04T04:56:02.000Z&updated_end=0199-03-04T04:56:02.000Z"),
+)
+def test_get_hosts_too_old_date_params(query_params, api_get):
+    url = build_hosts_url(query=query_params)
+
+    response_code, _ = api_get(url)
+    assert_response_status(response_code, 200)

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -474,14 +474,3 @@ def test_get_hosts_contains_invalid_on_string_not_array(patch_xjoin_post, api_ge
 
 def test_get_hosts_timestamp_invalid_value_graceful_rejection(patch_xjoin_post, api_get):
     assert 400 == api_get(build_hosts_url(query="?filter[system_profile][last_boot_time][eq]=foo"))[0]
-
-
-@pytest.mark.parametrize(
-    "query_params",
-    ("?updated_start=0199-03-04T04:56:02.000Z&updated_end=0199-03-04T04:56:02.000Z"),
-)
-def test_get_hosts_too_old_date_params(query_params, api_get):
-    url = build_hosts_url(query=query_params)
-
-    response_code, _ = api_get(url)
-    assert_response_status(response_code, 200)

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -293,7 +293,7 @@ def test_query_variables_updated_too_old_timestamp(mocker, graphql_query_empty_r
 
     assert response_status == 200
 
-    graphql_query_empty_response.graphql_query_with_response(
+    graphql_query_empty_response.assert_called_once_with(
         HOST_QUERY,
         {
             "order_by": mocker.ANY,
@@ -310,20 +310,9 @@ def test_query_variables_updated_too_old_timestamp(mocker, graphql_query_empty_r
     url = build_hosts_url(query="?updated_start=2001-03-04T04:56:02.000Z&updated_end=0199-03-04T04:56:02.000Z")
     response_status, response_data = api_get(url)
 
-    assert response_status == 200
+    assert response_status == 400
 
-    graphql_query_empty_response.graphql_query_with_response(
-        HOST_QUERY,
-        {
-            "order_by": mocker.ANY,
-            "order_how": mocker.ANY,
-            "limit": mocker.ANY,
-            "offset": mocker.ANY,
-            "filter": (mocker.ANY, {"modified_on": {"gte": "2001-03-04T04:56:02+00:00"}}),
-            "fields": mocker.ANY,
-        },
-        mocker.ANY,
-    )
+    graphql_query_empty_response.reset_mock()
 
     # testing updated_start with too old.
     url = build_hosts_url(query="?updated_start=0199-03-04T04:56:02.000Z&updated_end=2010-03-04T04:56:02.000Z")
@@ -331,7 +320,7 @@ def test_query_variables_updated_too_old_timestamp(mocker, graphql_query_empty_r
 
     assert response_status == 200
 
-    graphql_query_empty_response.graphql_query_with_response(
+    graphql_query_empty_response.assert_called_once_with(
         HOST_QUERY,
         {
             "order_by": mocker.ANY,

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -286,6 +286,65 @@ def test_query_variables_provider_id(mocker, graphql_query_empty_response, api_g
     )
 
 
+def test_query_variables_updated_too_old_timestamp(mocker, graphql_query_empty_response, api_get):
+    # testing both timestamp with too old.
+    url = build_hosts_url(query="?updated_start=0199-03-04T04:56:02.000Z&updated_end=0199-03-04T04:56:02.000Z")
+    response_status, response_data = api_get(url)
+
+    assert response_status == 200
+
+    graphql_query_empty_response.graphql_query_with_response(
+        HOST_QUERY,
+        {
+            "order_by": mocker.ANY,
+            "order_how": mocker.ANY,
+            "limit": mocker.ANY,
+            "offset": mocker.ANY,
+            "filter": (mocker.ANY,),
+            "fields": mocker.ANY,
+        },
+        mocker.ANY,
+    )
+
+    # testing updated_end with too old.
+    url = build_hosts_url(query="?updated_start=2001-03-04T04:56:02.000Z&updated_end=0199-03-04T04:56:02.000Z")
+    response_status, response_data = api_get(url)
+
+    assert response_status == 200
+
+    graphql_query_empty_response.graphql_query_with_response(
+        HOST_QUERY,
+        {
+            "order_by": mocker.ANY,
+            "order_how": mocker.ANY,
+            "limit": mocker.ANY,
+            "offset": mocker.ANY,
+            "filter": (mocker.ANY, {"modified_on": {"gte": "2001-03-04T04:56:02+00:00"}}),
+            "fields": mocker.ANY,
+        },
+        mocker.ANY,
+    )
+
+    # testing updated_start with too old.
+    url = build_hosts_url(query="?updated_start=0199-03-04T04:56:02.000Z&updated_end=2010-03-04T04:56:02.000Z")
+    response_status, response_data = api_get(url)
+
+    assert response_status == 200
+
+    graphql_query_empty_response.graphql_query_with_response(
+        HOST_QUERY,
+        {
+            "order_by": mocker.ANY,
+            "order_how": mocker.ANY,
+            "limit": mocker.ANY,
+            "offset": mocker.ANY,
+            "filter": (mocker.ANY, {"modified_on": {"lte": "2010-03-04T04:56:02+00:00"}}),
+            "fields": mocker.ANY,
+        },
+        mocker.ANY,
+    )
+
+
 @pytest.mark.parametrize(
     "provider",
     (


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-4458](https://issues.redhat.com/browse/ESSNTL-4458).

Elastic Search doesn't allow date before 1970, returned message from ES:
```
date[0199-03-04T04:56:02Z] is before the epoch in 1970 and cannot be stored in nanosecond resolution
```
so,  If the date args is before 1970, remove from filters query.


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
