### PR TITLE
feat(ESSNTL-3097): Make tags search case-insensitive

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -373,7 +373,7 @@ class Tag:
         filtered_tags = []
 
         for tag in tags:
-            if any(filter(lambda x: x is not None and searchTerm in x, list(tag.values()))):
+            if any(filter(lambda x: x is not None and searchTerm.lower() in x.lower(), list(tag.values()))):
                 filtered_tags.append(tag)
 
         return filtered_tags

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -679,10 +679,10 @@ class TagFilterTagsTestCase(TestCase):
         self._base_structured_to_filtered_test(structured_tags, expected_filtered_tags, "key1")
 
     def test_complex_filter(self):
-        structured_tags = [Tag("NS1", "key1", "val"), Tag(None), Tag("NS2", "key2"), Tag("NS3", "key3", "value3")]
-        expected_filtered_tags = [Tag("NS1", "key1", "val"), Tag("NS3", "key3", "value3")]
+        structured_tags = [Tag("NS1", "key1", "val"), Tag(None), Tag("NS2", "key2"), Tag("NS3", "key3", "Value3")]
+        expected_filtered_tags = [Tag("NS1", "key1", "val"), Tag("NS3", "key3", "Value3")]
 
-        self._base_structured_to_filtered_test(structured_tags, expected_filtered_tags, "val")
+        self._base_structured_to_filtered_test(structured_tags, expected_filtered_tags, "vA")
 
     def test_empty_filter(self):
         structured_tags = [Tag("NS1", "key1", "val"), Tag(None), Tag("NS2", "key2"), Tag("NS3", "key3", "value3")]
@@ -705,7 +705,7 @@ class TagFilterTagsTestCase(TestCase):
 
         # key
         structured_tags = [Tag("NS1", "key1", "val"), Tag(None), Tag("NS2", "Key2"), Tag("NS3", "key3", "value3")]
-        expected_filtered_tags = [Tag("NS2", "Key2")]
+        expected_filtered_tags = [Tag("NS1", "key1", "val"), Tag("NS2", "Key2"), Tag("NS3", "key3", "value3")]
 
         self._base_structured_to_filtered_test(structured_tags, expected_filtered_tags, "K")
 


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3097](https://issues.redhat.com/browse/ESSNTL-3097).
This makes the `search` param on the `GET /hosts/<host_id>/tags` endpoint case-insensitive.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
