### PR TITLE
Remove DB session from events-topic-rebuilder

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -189,10 +189,10 @@ def parse_operation_message(message):
     return parsed_operation
 
 
-def sync_event_message(message, session, event_producer):
+def sync_event_message(message, event_producer):
     if message["type"] != EventType.delete.name:
         host_id = message["host"]["id"]
-        query = session.query(Host).filter((Host.org_id == message["host"]["org_id"]) & (Host.id == UUID(host_id)))
+        query = Host.query.filter((Host.org_id == message["host"]["org_id"]) & (Host.id == UUID(host_id)))
         # If the host doesn't exist in the DB, produce a Delete event.
         if not query.count():
             host = deserialize_host({k: v for k, v in message["host"].items() if v}, schema=LimitedHostSchema)

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -15,7 +15,6 @@ from app.logging import get_logger
 from app.logging import threadctx
 from app.queue.event_producer import EventProducer
 from app.queue.queue import sync_event_message
-from lib.db import session_guard
 from lib.handlers import register_shutdown
 from lib.handlers import ShutdownHandler
 
@@ -36,7 +35,7 @@ def _init_db(config):
     return sessionmaker(bind=engine)
 
 
-def run(config, logger, session, consumer, event_producer, shutdown_handler):
+def run(config, logger, consumer, event_producer, shutdown_handler):
     num_messages = 1
     partitions = []
 
@@ -59,7 +58,7 @@ def run(config, logger, session, consumer, event_producer, shutdown_handler):
         new_messages = consumer.consume(timeout=10)
         for message in new_messages:
             try:
-                sync_event_message(json.loads(message.value()), session, event_producer)
+                sync_event_message(json.loads(message.value()), event_producer)
                 # TODO: Metrics
                 # metrics.ingress_message_handler_success.inc()
             except OperationalError as oe:
@@ -82,10 +81,6 @@ def run(config, logger, session, consumer, event_producer, shutdown_handler):
 def main(logger):
     application = create_app(RuntimeEnvironment.JOB)
     config = application.config["INVENTORY_CONFIG"]
-    Session = _init_db(config)
-    session = Session()
-    # TODO: Metrics
-    # start_http_server(config.metrics_port)
 
     consumer = KafkaConsumer(
         {
@@ -94,7 +89,6 @@ def main(logger):
         }
     )
 
-    register_shutdown(session.get_bind().dispose, "Closing database")
     consumer_shutdown = partial(consumer.close, autocommit=True)
     register_shutdown(consumer_shutdown, "Closing consumer")
     event_producer = EventProducer(config, config.event_topic)
@@ -102,8 +96,7 @@ def main(logger):
     shutdown_handler = ShutdownHandler()
     shutdown_handler.register()
 
-    with session_guard(session):
-        run(config, logger, session, consumer, event_producer, shutdown_handler)
+    run(config, logger, consumer, event_producer, shutdown_handler)
 
 
 if __name__ == "__main__":

--- a/tests/test_event_rebuilder.py
+++ b/tests/test_event_rebuilder.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import pytest
 
-from app import db
 from app import threadctx
 from app.queue.events import build_event
 from app.queue.events import EventType
@@ -28,7 +27,6 @@ def test_no_delete_when_hosts_present(mocker, db_create_host, inventory_config):
     rebuild_events_run(
         inventory_config,
         mock.Mock(),
-        db.session,
         consumer_mock,
         event_producer_mock,
         shutdown_handler=mock.Mock(**{"shut_down.return_value": False}),
@@ -66,7 +64,6 @@ def test_creates_delete_event_when_missing_from_db(
     rebuild_events_run(
         inventory_config,
         mock.Mock(),
-        db.session,
         consumer_mock,
         event_producer_mock,
         shutdown_handler=mock.Mock(**{"shut_down.return_value": False}),


### PR DESCRIPTION
# Overview

This PR is being created to reduce the memory usage of the events-topic-rebuilder part of the host synchronizer.
The rebuilder does not make any DB changes, so having a Session is unnecessary. In fact, having a session_guard around the entire process may have been eating up way more memory than it needed. I'm removing all of that in favor of simple SQLAlchemy ORM queries.