### PR TITLE
Improve events-topic-rebuilder memory usage

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -183,6 +183,7 @@ class Config:
         self.events_kafka_consumer = {
             "group.id": "inventory-events-rebuild",
             "auto.offset.reset": "earliest",
+            "queued.max.messages.kbytes": "65536",
             "request.timeout.ms": int(os.environ.get("KAFKA_CONSUMER_REQUEST_TIMEOUT_MS", "305000")),
             "max.in.flight.requests.per.connection": int(
                 os.environ.get("KAFKA_CONSUMER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION", "5")


### PR DESCRIPTION
# Overview

This PR is being created to address some performance issues with events-topic-rebuilder. It sets the maximum messages in the background consumer queue, tells the consumer to consume based on the batch size, and routinely flushes the producer to reduce its memory usage.