### PR TITLE
Adding FLOORIST_DISABLED Parameter to clowdapp.yml

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -629,6 +629,7 @@ objects:
     - name: floorist
       schedule: ${FLOORIST_SCHEDULE}
       suspend: ${{FLOORIST_SUSPEND}}
+      disabled: ${{FLOORIST_DISABLED}}
       concurrencyPolicy: Forbid
       podSpec:
         image: ${FLOORIST_IMAGE}:${FLOORIST_IMAGE_TAG}
@@ -915,3 +916,6 @@ parameters:
 - name: FLOORIST_LOGLEVEL
   description: Floorist loglevel config
   value: 'INFO'
+- name: FLOORIST_DISABLED
+  description: Determines whether to build the Floorist Job.
+  value: 'false'


### PR DESCRIPTION
# Overview

Adding the `FLOORIST_DISABLED` parameter to the `clowdapp.yml`. This adds the ability to disable the creation of the Floorist Job within ephemeral/alternative environments.

Default: 
	`FLOORIST_DISABLED: 'False'`

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).
