### PR TITLE
perf(cyndi): keep only the id and name fields in hosts.groups

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -165,7 +165,7 @@ class LimitedHost(db.Model):
         facts=None,
         tags={},
         system_profile_facts=None,
-        groups=None,
+        groups=[],
     ):
         self.canonical_facts = canonical_facts
 
@@ -180,7 +180,7 @@ class LimitedHost(db.Model):
         self.facts = facts or {}
         self.tags = tags
         self.system_profile_facts = system_profile_facts or {}
-        self.groups = groups or []
+        self.groups = [{key: group[key] for key in group if key in ["id", "name"]} for group in groups]
 
     def _update_ansible_host(self, ansible_host):
         if ansible_host is not None:
@@ -219,7 +219,7 @@ class Host(LimitedHost):
         stale_timestamp=None,
         reporter=None,
         per_reporter_staleness=None,
-        groups=None,
+        groups=[],
     ):
         if not canonical_facts:
             raise ValidationException("At least one of the canonical fact fields must be present.")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1179,19 +1179,11 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             "groups": [
                 {
                     "id": str(uuid4()),
-                    "org_id": "3340851",
-                    "account": "some acct",
                     "name": "group 1",
-                    "created": now().isoformat(),
-                    "updated": now().isoformat(),
                 },
                 {
                     "id": str(uuid4()),
-                    "org_id": "3340851",
-                    "account": "some acct",
                     "name": "group 2",
-                    "created": now().isoformat(),
-                    "updated": now().isoformat(),
                 },
             ],
         }
@@ -1241,19 +1233,11 @@ class SerializationDeserializeHostMockedTestCase(TestCase):
             "groups": [
                 {
                     "id": str(uuid4()),
-                    "org_id": "3340851",
-                    "account": "some acct",
                     "name": "group 1",
-                    "created": now().isoformat(),
-                    "updated": now().isoformat(),
                 },
                 {
                     "id": str(uuid4()),
-                    "org_id": "3340851",
-                    "account": "some acct",
                     "name": "group 2",
-                    "created": now().isoformat(),
-                    "updated": now().isoformat(),
                 },
             ],
         }


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-xxxx](https://issues.redhat.com/browse/ESSNTL-xxxx).
(A description of your PR's changes, along with why/context to the PR, goes here.)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
