### PR TITLE
fix(ESSNTL-4991): Increase gunicorn's limit-request-line from 4094 to 8190

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -30,6 +30,7 @@ objects:
         - --workers=${GUNICORN_WORKERS}
         - --threads=${GUNICORN_THREADS}
         - --limit-request-field_size=${GUNICORN_REQUEST_FIELD_LIMIT}
+        - --limit-request-line=${GUNICORN_REQUEST_LINE_LIMIT}
         - --worker-tmp-dir=/gunicorn
         - -c
         - gunicorn.conf.py
@@ -872,6 +873,8 @@ parameters:
   value: '8'
 - name: GUNICORN_REQUEST_FIELD_LIMIT
   value: '16380'
+- name: GUNICORN_REQUEST_LINE_LIMIT
+  value: '8190'
 - name: SCRIPT_CHUNK_SIZE
   value: '500'
 


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-4991](https://issues.redhat.com/browse/ESSNTL-4991).
The original issue this is addressing is located [here](https://github.com/RedHatInsights/ansible-collections-insights/issues/48). Sometimes a request comes in that has a lot of filters, and gunicorn blocks it because the line is too long. In order to mitigate this in the medium-term, I'm increasing that limit to its max value (without setting it to unlimited, which could be a security risk without additional measures).

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
