### PR TITLE
fix(ESSNTL-5049): Fix various resource-level RBAC issues

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -69,6 +69,11 @@ def create_group(body, rbac_filter=None):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
+    # If there is an attribute filter on the RBAC permissions,
+    # the user should not be allowed to create a group.
+    if rbac_filter is not None:
+        return Response(None, status.HTTP_403_FORBIDDEN)
+
     # Validate group input data
     try:
         validated_create_group_data = InputGroupSchema().load(body)

--- a/api/host.py
+++ b/api/host.py
@@ -288,7 +288,9 @@ def get_host_system_profile_by_id(
     host_id_list, page=1, per_page=100, order_by=None, order_how=None, fields=None, rbac_filter=None
 ):
     try:
-        total, response_list = get_sparse_system_profile(host_id_list, page, per_page, order_by, order_how, fields)
+        total, response_list = get_sparse_system_profile(
+            host_id_list, page, per_page, order_by, order_how, fields, rbac_filter
+        )
     except ValueError as e:
         log_get_host_list_failed(logger)
         flask.abort(400, str(e))

--- a/api/host.py
+++ b/api/host.py
@@ -321,7 +321,7 @@ def patch_host_by_id(host_id_list, body, rbac_filter=None):
 
     if not hosts_to_update:
         log_patch_host_failed(logger, host_id_list)
-        return flask.abort(status.HTTP_404_NOT_FOUND)
+        return flask.abort(status.HTTP_404_NOT_FOUND, "Requested host not found.")
 
     for host in hosts_to_update:
         host.patch(validated_patch_host_data)

--- a/api/sparse_host_list_system_profile.py
+++ b/api/sparse_host_list_system_profile.py
@@ -1,8 +1,6 @@
 import flask
 
-from api.filtering.filtering import owner_id_filter
-from app.auth import get_current_identity
-from app.auth.identity import IdentityType
+from api.filtering.filtering import host_id_list_query_filter
 from app.instrumentation import log_get_sparse_system_profile_failed
 from app.instrumentation import log_get_sparse_system_profile_succeeded
 from app.logging import get_logger
@@ -69,7 +67,7 @@ SYSTEM_PROFILE_FULL_QUERY = """
 """
 
 
-def get_sparse_system_profile(host_id_list, page, per_page, order_by, order_how, fields):
+def get_sparse_system_profile(host_id_list, page, per_page, order_by, order_how, fields, rbac_filter):
     limit, offset = pagination_params(page, per_page)
 
     try:
@@ -77,10 +75,7 @@ def get_sparse_system_profile(host_id_list, page, per_page, order_by, order_how,
     except ValueError as e:
         flask.abort(400, str(e))
 
-    host_filter = [{"OR": [{"id": {"eq": host_id}} for host_id in host_id_list]}]
-    current_identity = get_current_identity()
-    if current_identity.identity_type == IdentityType.SYSTEM:
-        host_filter.append(owner_id_filter()[0])
+    host_filter = host_id_list_query_filter(host_id_list, rbac_filter)
 
     sp_query = SYSTEM_PROFILE_FULL_QUERY
     variables = {

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -108,11 +108,24 @@ def rbac(resource_type, required_permission, permission_base="inventory"):
                     # Get the list of allowed Group IDs from the attribute filter.
                     groups_attribute_filter = set()
                     for resourceDefinition in rbac_permission["resourceDefinitions"]:
-                        if (
-                            "attributeFilter" in resourceDefinition
-                            and resourceDefinition["attributeFilter"].get("key") == "group.id"
-                        ):
-                            groups_attribute_filter.update(resourceDefinition["attributeFilter"]["value"])
+                        if "attributeFilter" in resourceDefinition:
+                            if resourceDefinition["attributeFilter"].get("key") != "group.id":
+                                abort(
+                                    status.HTTP_503_SERVICE_UNAVAILABLE,
+                                    "Invalid value for attributeFilter.key in RBAC response.",
+                                )
+                            elif resourceDefinition["attributeFilter"].get("operation") != "in":
+                                abort(
+                                    status.HTTP_503_SERVICE_UNAVAILABLE,
+                                    "Invalid value for attributeFilter.operation in RBAC response.",
+                                )
+                            elif not isinstance(resourceDefinition["attributeFilter"]["value"], list):
+                                abort(
+                                    status.HTTP_503_SERVICE_UNAVAILABLE,
+                                    "Did not receive a list for attributeFilter.value in RBAC response.",
+                                )
+                            else:
+                                groups_attribute_filter.update(resourceDefinition["attributeFilter"]["value"])
 
                     if groups_attribute_filter:
                         # If the RBAC permission is applicable and is limited to specific group IDs,

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,6 +1,9 @@
+import pytest
 from requests import exceptions
 
+from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_hosts_url
+from tests.helpers.api_utils import create_mock_rbac_response
 
 
 def test_rbac_retry_error_handling(mocker, db_create_host, api_get, enable_rbac):
@@ -35,3 +38,22 @@ def test_rbac_exception_handling(mocker, db_create_host, api_get, enable_rbac):
 
     mock_rbac_failure.assert_called_once()
     abort_mock.assert_called_once_with(503, "Failed to reach RBAC endpoint, request cannot be fulfilled")
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["key", "operation", "value"],
+)
+def test_RBAC_invalid_attribute_filter(mocker, api_get, field, enable_rbac):
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+
+    mock_rbac_response = create_mock_rbac_response(
+        "tests/helpers/rbac-mock-data/inv-hosts-read-resource-defs-template.json"
+    )
+    mock_rbac_response[0]["resourceDefinitions"][0]["attributeFilter"][field] = "invalidvalue"
+
+    get_rbac_permissions_mock.return_value = mock_rbac_response
+
+    response_status, response_data = api_get(build_hosts_url())
+
+    assert_response_status(response_status, 503)

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -2753,7 +2753,9 @@ def test_sp_sparse_xjoin_query_translation(
     hosts = [minimal_host(id=host_one_id), minimal_host(id=host_two_id)]
 
     # Test with user identity first
-    variables["hostFilter"] = [{"OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]}]
+    variables["hostFilter"] = (
+        {"stale_timestamp": mocker.ANY, "OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]},
+    )
 
     response_status, _ = api_get(build_system_profile_url(hosts, query=query))
 
@@ -2765,10 +2767,10 @@ def test_sp_sparse_xjoin_query_translation(
     graphql_sparse_system_profile_empty_response.reset_mock()
 
     # Now test with system identity
-    variables["hostFilter"] = [
-        {"OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]},
+    variables["hostFilter"] = (
+        {"stale_timestamp": mocker.ANY, "OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]},
         {"spf_owner_id": {"eq": SYSTEM_IDENTITY["system"]["cn"]}},
-    ]
+    )
 
     response_status, _ = api_get(build_system_profile_url(hosts, query=query), identity=SYSTEM_IDENTITY)
 


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-5049](https://issues.redhat.com/browse/ESSNTL-5049), and follows up on #1371. Fixes a number of bugs with the current resource-level RBAC implementation, including:

- Users are no longer allowed to create a group if their groups:write access is limited to specific groups
- Granular RBAC now works on GET /hosts/<host_id>/system_profile
- Added a more specific "not found" message when PATCHing a group that the user doesn't have access to
- Errors with informative hints whenever the RBAC config does not conform to requirements

It also adds tests for each of these scenarios.


## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
