### PR TITLE
Remove duplicate Host Out definition in API schema

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -122,7 +122,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateHostOut'
+                $ref: '#/components/schemas/HostOut'
         '404':
           description: Not Found.
   '/hosts/{host_id_list}':
@@ -1354,8 +1354,8 @@ components:
               minimum: 1
               maximum: 2880
               example: 1440
-    CreateHostOut:
-      title: Create Host Out
+    HostOut:
+      title: Host Out
       description: >-
         Data of a single host belonging to an account. Represents the hosts
         without its Inventory metadata.
@@ -1434,18 +1434,6 @@ components:
                 $ref: '#/components/schemas/GroupOut'
           required:
             - org_id
-    HostOut:
-      title: A Host Inventory entry
-      description: A database entry representing a single host with its Inventory metadata.
-      allOf:
-        - $ref: '#/components/schemas/CreateHostOut'
-        - type: object
-          properties:
-            facts:
-              description: A set of facts belonging to the host.
-              type: array
-              items:
-                $ref: '#/components/schemas/FactSet'
     HostQueryOutput:
       title: A Host Inventory query result
       description: >-

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -215,7 +215,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateHostOut"
+                  "$ref": "#/components/schemas/HostOut"
                 }
               }
             }
@@ -2128,8 +2128,8 @@
           }
         ]
       },
-      "CreateHostOut": {
-        "title": "Create Host Out",
+      "HostOut": {
+        "title": "Host Out",
         "description": "Data of a single host belonging to an account. Represents the hosts without its Inventory metadata.",
         "type": "object",
         "allOf": [
@@ -2219,27 +2219,6 @@
             "required": [
               "org_id"
             ]
-          }
-        ]
-      },
-      "HostOut": {
-        "title": "A Host Inventory entry",
-        "description": "A database entry representing a single host with its Inventory metadata.",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CreateHostOut"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "facts": {
-                "description": "A set of facts belonging to the host.",
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/FactSet"
-                }
-              }
-            }
           }
         ]
       },


### PR DESCRIPTION
# Overview

This PR is being created to remove a duplicate component in our API schema. HostOut and CreateHostOut were effectively the same, but with different names; I've consolidated these into one that's named HostOut, for the sake of simplicity and accuracy.