### PR TITLE
fix(ESSNTL-5049): Resolve more granular RBAC issues

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -72,7 +72,10 @@ def create_group(body, rbac_filter=None):
     # If there is an attribute filter on the RBAC permissions,
     # the user should not be allowed to create a group.
     if rbac_filter is not None:
-        return Response(None, status.HTTP_403_FORBIDDEN)
+        return Response(
+            "Unfiltered inventory:groups:write RBAC permission is required in order to create new groups.",
+            status.HTTP_403_FORBIDDEN,
+        )
 
     # Validate group input data
     try:

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -288,7 +288,11 @@ def get_host_list_by_id_list_from_db(host_id_list, rbac_filter=None):
         Host.id.in_(host_id_list),
     )
     if rbac_filter and "groups" in rbac_filter:
-        filters += (HostGroupAssoc.group_id.in_(rbac_filter["groups"]),)
+        rbac_group_filters = (HostGroupAssoc.group_id.in_(rbac_filter["groups"]),)
+        if None in rbac_filter["groups"]:
+            rbac_group_filters += (HostGroupAssoc.group_id.is_(None),)
+
+        filters += (or_(*rbac_group_filters),)
 
     query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.id)
     return find_non_culled_hosts(update_query_for_owner_id(current_identity, query))

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -498,6 +498,26 @@ def test_patch_host_with_RBAC_denied_specific_groups(mocker, api_patch, db_creat
     assert response_data["detail"] == "Requested host not found."
 
 
+def test_patch_host_with_RBAC_allowed_ungrouped(mocker, api_patch, db_create_host, event_producer_mock, enable_rbac):
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+
+    # Grant write access specifically to ungrouped hosts
+    mock_rbac_response = create_mock_rbac_response(
+        "tests/helpers/rbac-mock-data/inv-hosts-write-resource-defs-template.json"
+    )
+    mock_rbac_response[0]["resourceDefinitions"][0]["attributeFilter"]["value"] = [None]
+    get_rbac_permissions_mock.return_value = mock_rbac_response
+
+    # Create an ungrouped host
+    host = db_create_host()
+    url = build_hosts_url(host_list_or_id=host.id)
+
+    new_display_name = "fred_flintstone"
+    response_status, response_data = api_patch(url, {"display_name": new_display_name})
+
+    assert_response_status(response_status, 200)
+
+
 def test_patch_host_with_RBAC_bypassed_as_system(api_patch, db_create_host, event_producer_mock, enable_rbac):
     host = db_create_host(
         SYSTEM_IDENTITY, extra_data={"system_profile_facts": {"owner_id": SYSTEM_IDENTITY["system"]["cn"]}}

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -54,6 +54,21 @@ def test_RBAC_invalid_attribute_filter(mocker, api_get, field, enable_rbac):
 
     get_rbac_permissions_mock.return_value = mock_rbac_response
 
-    response_status, response_data = api_get(build_hosts_url())
+    response_status, _ = api_get(build_hosts_url())
+
+    assert_response_status(response_status, 503)
+
+
+def test_RBAC_invalid_UUIDs(mocker, api_get, enable_rbac):
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+
+    mock_rbac_response = create_mock_rbac_response(
+        "tests/helpers/rbac-mock-data/inv-hosts-read-resource-defs-template.json"
+    )
+    mock_rbac_response[0]["resourceDefinitions"][0]["attributeFilter"]["value"] = ["not a UUID"]
+
+    get_rbac_permissions_mock.return_value = mock_rbac_response
+
+    response_status, _ = api_get(build_hosts_url())
 
     assert_response_status(response_status, 503)


### PR DESCRIPTION
# Overview

This PR is being created to address the new bugs found in the comments of [ESSNTL-5049](https://issues.redhat.com/browse/ESSNTL-5049):
- Creating groups with inventory:groups:write permission with attributeFilter now returns HTTP 403 with a more descriptive message.
- Fixed the DB-specific RBAC group ID filter so that it works when the attributeFilter contains a null (None).
- Putting a value that's neither a UUID nor None now results in error 503, because that implies the RBAC service has populated the permissions with invalid values. 

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
