### PR TITLE
Update host-sync to fix null host.groups values

### DIFF
--- a/lib/host_synchronize.py
+++ b/lib/host_synchronize.py
@@ -21,12 +21,15 @@ def synchronize_hosts(select_query, event_producer, chunk_size, config, interrup
 
     while len(host_list) > 0 and not interrupt():
         for host in host_list:
+            # First, set host.groups to [] if it's null.
+            if host.groups is None:
+                host.groups = []
+
             serialized_host = serialize_host(host, Timestamps.from_config(config))
             event = build_event(EventType.updated, serialized_host)
             insights_id = host.canonical_facts.get("insights_id")
             headers = message_headers(EventType.updated, insights_id)
             # in case of a failed update event, event_producer logs the message.
-            # add back "wait=True", if needed.
             event_producer.write_event(event, str(host.id), headers, wait=True)
             synchronize_host_count.inc()
             logger.info("Synchronized host: %s", str(host.id))
@@ -39,7 +42,8 @@ def synchronize_hosts(select_query, event_producer, chunk_size, config, interrup
         except ProduceError:
             raise ProduceError(f"ProduceError: Kafka failure to flush {chunk_size} records within 300 seconds")
 
-        # load next chunk using keyset pagination
+        # flush changes, and then load next chunk using keyset pagination
+        query.session.flush()
         host_list = query.filter(Host.id > host_list[-1].id).limit(chunk_size).all()
 
     return num_synchronized


### PR DESCRIPTION
# Overview

This PR is being created to address the hosts that have `groups=NULL` instead of `groups=[]`, leftover from the original design change. With this update, the next host-synchronizer run should fix the values, allowing us to next mark that column as NOT NULL.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
