### PR TITLE
Allow multiple values for group_name filter param

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -452,7 +452,7 @@ def query_filters(
     if updated_start or updated_end:
         query_filters += _build_modified_on_filter(updated_start, updated_end)
     if group_name:
-        query_filters += ({"group": {"name": string_contains_lc(group_name)}},)
+        query_filters += ({"OR": [{"group": {"name": string_contains_lc(name)}} for name in group_name]},)
     if group_ids:
         query_filters += group_id_list_query_filter(group_ids)
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -26,7 +26,7 @@ paths:
         - $ref: '#/components/parameters/providerType'
         - $ref: '#/components/parameters/updatedStart'
         - $ref: '#/components/parameters/updatedEnd'
-        - $ref: '#/components/parameters/groupNameExplicit'
+        - $ref: '#/components/parameters/groupNameListParam'
         - $ref: '#/components/parameters/branchId'
         - $ref: '#/components/parameters/perPageParam'
         - $ref: '#/components/parameters/pageParam'
@@ -64,7 +64,7 @@ paths:
         - $ref: '#/components/parameters/providerType'
         - $ref: '#/components/parameters/updatedStart'
         - $ref: '#/components/parameters/updatedEnd'
-        - $ref: '#/components/parameters/groupNameExplicit'
+        - $ref: '#/components/parameters/groupNameListParam'
         - $ref: '#/components/parameters/registered_with'
         - $ref: '#/components/parameters/stalenessNoDefaultsParam'
         - $ref: '#/components/parameters/tagsParam'
@@ -604,7 +604,7 @@ paths:
         - $ref: '#/components/parameters/providerType'
         - $ref: '#/components/parameters/updatedStart'
         - $ref: '#/components/parameters/updatedEnd'
-        - $ref: '#/components/parameters/groupNameExplicit'
+        - $ref: '#/components/parameters/groupNameListParam'
         - $ref: '#/components/parameters/registered_with'
         - $ref: '#/components/parameters/filter_param'
       responses:
@@ -1048,13 +1048,15 @@ components:
         type: string
       description: Filter by group name
       required: false
-    groupNameExplicit:
+    groupNameListParam:
       in: query
       name: group_name
-      schema:
-        type: string
       description: Filter by group name
       required: false
+      schema:
+        type: array
+        items:
+          type: string
     groupId:
       in: path
       name: group_id

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -45,7 +45,7 @@
             "$ref": "#/components/parameters/updatedEnd"
           },
           {
-            "$ref": "#/components/parameters/groupNameExplicit"
+            "$ref": "#/components/parameters/groupNameListParam"
           },
           {
             "$ref": "#/components/parameters/branchId"
@@ -129,7 +129,7 @@
             "$ref": "#/components/parameters/updatedEnd"
           },
           {
-            "$ref": "#/components/parameters/groupNameExplicit"
+            "$ref": "#/components/parameters/groupNameListParam"
           },
           {
             "$ref": "#/components/parameters/registered_with"
@@ -1022,7 +1022,7 @@
             "$ref": "#/components/parameters/updatedEnd"
           },
           {
-            "$ref": "#/components/parameters/groupNameExplicit"
+            "$ref": "#/components/parameters/groupNameListParam"
           },
           {
             "$ref": "#/components/parameters/registered_with"
@@ -1679,14 +1679,17 @@
         "description": "Filter by group name",
         "required": false
       },
-      "groupNameExplicit": {
+      "groupNameListParam": {
         "in": "query",
         "name": "group_name",
-        "schema": {
-          "type": "string"
-        },
         "description": "Filter by group name",
-        "required": false
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       },
       "groupId": {
         "in": "path",


### PR DESCRIPTION
# Overview

This PR is being created to address an oversight we noticed in [this comment thread of the onboarding doc](https://docs.google.com/document/d/1O87MHvKlPEoH_DHwZw4htvwYlkGMiS-LwLQ_qKsZ5J0/edit?disco=AAAA0srgq8A). Right now, we only allow filtering on one `group_name`, but we need to allow multiple values for it to work correctly. The UI is already set up to send multiple values for this field, so there shouldn't be any compatibility risk if this is executed correctly.

Basically, if we do `GET /hosts?group_name=group1&group_name=group2`, then it should return hosts that are in either group1 or group2.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
