### PR TITLE
fix(ESSNTL-5049): Minor RBAC follow-ups

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -73,9 +73,9 @@ def create_group(body, rbac_filter=None):
     # If there is an attribute filter on the RBAC permissions,
     # the user should not be allowed to create a group.
     if rbac_filter is not None:
-        return Response(
-            "Unfiltered inventory:groups:write RBAC permission is required in order to create new groups.",
+        abort(
             status.HTTP_403_FORBIDDEN,
+            "Unfiltered inventory:groups:write RBAC permission is required in order to create new groups.",
         )
 
     # Validate group input data

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -135,7 +135,7 @@ def rbac(resource_type, required_permission, permission_base="inventory"):
                                 except ValueError:
                                     abort(
                                         status.HTTP_503_SERVICE_UNAVAILABLE,
-                                        "Received invalid UUIDs for attributeFilter value in RBAC response.",
+                                        "Received invalid UUIDs for attributeFilter.value in RBAC response.",
                                     )
 
                     if groups_attribute_filter:


### PR DESCRIPTION
# Overview

This PR is being created to address the last couple of issues in the comments of [ESSNTL-5049](https://issues.redhat.com/browse/ESSNTL-5049).
It puts a `.` in one of the error strings, and switches out a `Response()` in favor of `abort()` for one of the RBAC errors.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
