### PR TITLE
Allow filtering on ungrouped hosts

### DIFF
--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1965,11 +1965,33 @@ def test_query_hosts_filter_updated_error(api_get):
     assert response_status == 400
 
 
-@pytest.mark.parametrize("group_names", (["pog group"], ["group1", "group2", "group3"]))
-def test_query_variables_group_name(mocker, graphql_query_empty_response, api_get, group_names):
+@pytest.mark.parametrize(
+    "group_names,group_filter",
+    (
+        (
+            ["pog group"],
+            [{"group": {"name": {"matches_lc": "*pog group*"}}}],
+        ),
+        (
+            ["group1", "group2", "group3"],
+            [
+                {"group": {"name": {"matches_lc": "*group1*"}}},
+                {"group": {"name": {"matches_lc": "*group2*"}}},
+                {"group": {"name": {"matches_lc": "*group3*"}}},
+            ],
+        ),
+        (
+            [""],
+            [{"group": {"hasSome": {"is": False}}}],
+        ),
+        (
+            ["group A", ""],
+            [{"group": {"name": {"matches_lc": "*group A*"}}}, {"group": {"hasSome": {"is": False}}}],
+        ),
+    ),
+)
+def test_query_variables_group_name(mocker, graphql_query_empty_response, api_get, group_names, group_filter):
     group_name_params = "&".join([f"group_name={quote(name)}" for name in group_names])
-    group_filter = [{"group": {"name": {"matches_lc": f"*{name}*"}}} for name in group_names]
-
     url = build_hosts_url(query=f"?{group_name_params}")
     response_status, _ = api_get(url)
 

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1992,7 +1992,8 @@ def test_query_hosts_filter_updated_error(api_get):
 )
 def test_query_variables_group_name(mocker, graphql_query_empty_response, api_get, group_names, group_filter):
     group_name_params = "&".join([f"group_name={quote(name)}" for name in group_names])
-    url = build_hosts_url(query=f"?{group_name_params}")
+    # Verify that empty group_name values play nicely with other params (like fqdn)
+    url = build_hosts_url(query=f"?{group_name_params}&fqdn=foo.bar.com")
     response_status, _ = api_get(url)
 
     assert response_status == 200
@@ -2004,7 +2005,7 @@ def test_query_variables_group_name(mocker, graphql_query_empty_response, api_ge
             "order_how": mocker.ANY,
             "limit": mocker.ANY,
             "offset": mocker.ANY,
-            "filter": ({"OR": mocker.ANY}, {"OR": group_filter}),
+            "filter": ({"fqdn": {"eq": "foo.bar.com"}}, {"OR": mocker.ANY}, {"OR": group_filter}),
             "fields": mocker.ANY,
         },
         mocker.ANY,


### PR DESCRIPTION
# Overview

This PR is being created to allow filtering on ungrouped hosts.
By sending a blank value for the `group_name` param, you can filter on ungrouped hosts. For instance:

- `GET /hosts?group_name=` will return only ungrouped hosts
- `GET /hosts?group_name=testgroup&group_name=` will return hosts that are either ungrouped or in "testgroup"

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
