### PR TITLE
fix(RHINENG-1426): Update API spec to show correct permission requirements

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -542,7 +542,7 @@ paths:
       description: >-
         Returns the list of available RBAC resource types.
         <br /><br />
-        Required permissions: inventory:*:*
+        Required permissions: rbac:*:*
       security:
         - ApiKeyAuth: []
       parameters:
@@ -564,7 +564,7 @@ paths:
       description: >-
         Returns the list of groups in the current account.
         <br /><br />
-        Required permissions: inventory:*:*
+        Required permissions: rbac:*:*
       security:
         - ApiKeyAuth: []
       parameters:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -899,7 +899,7 @@
           "resource-types"
         ],
         "summary": "Get the list of resource types",
-        "description": "Returns the list of available RBAC resource types. <br /><br /> Required permissions: inventory:*:*",
+        "description": "Returns the list of available RBAC resource types. <br /><br /> Required permissions: rbac:*:*",
         "security": [
           {
             "ApiKeyAuth": []
@@ -934,7 +934,7 @@
           "resource-types"
         ],
         "summary": "Get the list of inventory groups in resource-types format",
-        "description": "Returns the list of groups in the current account. <br /><br /> Required permissions: inventory:*:*",
+        "description": "Returns the list of groups in the current account. <br /><br /> Required permissions: rbac:*:*",
         "security": [
           {
             "ApiKeyAuth": []


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-1426](https://issues.redhat.com/browse/RHINENG-1426).
It updates descriptions for the resource-types endpoints in the API spec to correctly reflect the required permissions. The user actually needs rbac:*:* permission, not inventory:*:* permission.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
