### PR TITLE
feat(RHINENG-1436, RHINENG-1427): Add group name filter to /resource-types/inventory-groups endpoint

### DIFF
--- a/api/resource_type.py
+++ b/api/resource_type.py
@@ -49,6 +49,7 @@ def get_resource_type_list(
 @rbac(RbacResourceType.ALL, RbacPermission.ADMIN, "rbac")
 @metrics.api_request_time.time()
 def get_resource_type_groups_list(
+    name=None,
     page=1,
     per_page=100,
     order_by=None,
@@ -59,7 +60,7 @@ def get_resource_type_groups_list(
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
     try:
-        group_list, total = get_filtered_group_list_db(None, page, per_page, order_by, order_how, rbac_filter)
+        group_list, total = get_filtered_group_list_db(name, page, per_page, order_by, order_how, rbac_filter)
     except ValueError as e:
         log_get_group_list_failed(logger)
         flask.abort(400, str(e))

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -26,15 +26,15 @@ from app.logging import get_logger
 
 logger = get_logger(__name__)
 
-ROUTE = "/api/rbac/v1/access/?application="
+RBAC_ROUTE = "/api/rbac/v1/access/?application="
 CHECKED_TYPE = IdentityType.USER
 RETRY_STATUSES = [500, 502, 503, 504]
 
 outbound_http_metric = outbound_http_response_time.labels("rbac")
 
 
-def rbac_url(app: str) -> str:
-    return inventory_config().rbac_endpoint + ROUTE + app
+def get_rbac_url(app: str) -> str:
+    return inventory_config().rbac_endpoint + RBAC_ROUTE + app
 
 
 def tenant_translator_url() -> str:
@@ -49,12 +49,12 @@ def get_rbac_permissions(app):
 
     request_session = Session()
     retry_config = Retry(total=inventory_config().rbac_retries, backoff_factor=1, status_forcelist=RETRY_STATUSES)
-    request_session.mount(rbac_url(app), HTTPAdapter(max_retries=retry_config))
+    request_session.mount(get_rbac_url(app), HTTPAdapter(max_retries=retry_config))
 
     try:
         with outbound_http_metric.time():
             rbac_response = request_session.get(
-                url=rbac_url(app),
+                url=get_rbac_url(app),
                 headers=request_header,
                 timeout=inventory_config().rbac_timeout,
                 verify=LoadedConfig.tlsCAPath,

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -568,6 +568,7 @@ paths:
       security:
         - ApiKeyAuth: []
       parameters:
+        - $ref: '#/components/parameters/groupName'
         - $ref: '#/components/parameters/resourceTypesPerPageParam'
         - $ref: '#/components/parameters/pageParam'
       responses:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -942,6 +942,9 @@
         ],
         "parameters": [
           {
+            "$ref": "#/components/parameters/groupName"
+          },
+          {
             "$ref": "#/components/parameters/resourceTypesPerPageParam"
           },
           {

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -126,6 +126,23 @@ GROUP_WRITE_PROHIBITED_RBAC_RESPONSE_FILES = (
     "tests/helpers/rbac-mock-data/inv-read-only.json",
     "tests/helpers/rbac-mock-data/inv-star-read.json",
 )
+RBAC_ADMIN_PROHIBITED_RBAC_RESPONSE_FILES = (
+    "tests/helpers/rbac-mock-data/inv-read-write.json",
+    "tests/helpers/rbac-mock-data/inv-read-only.json",
+    "tests/helpers/rbac-mock-data/inv-admin.json",
+    "tests/helpers/rbac-mock-data/inv-hosts-splat.json",
+    "tests/helpers/rbac-mock-data/inv-star-read.json",
+    "tests/helpers/rbac-mock-data/inv-hosts-read-groups-write.json",
+    "tests/helpers/rbac-mock-data/inv-hosts-read-only.json",
+    "tests/helpers/rbac-mock-data/inv-none.json",
+    "tests/helpers/rbac-mock-data/inv-write-only.json",
+    "tests/helpers/rbac-mock-data/inv-star-write.json",
+    "tests/helpers/rbac-mock-data/inv-groups-read-only.json",
+    "tests/helpers/rbac-mock-data/inv-groups-write-only.json",
+    "tests/helpers/rbac-mock-data/inv-hosts-write-groups-read.json",
+    "tests/helpers/rbac-mock-data/inv-hosts-write-only.json",
+    "tests/helpers/rbac-mock-data/inv-groups-splat.json",
+)
 
 
 def do_request(func, url, identity, data=None, query_parameters=None, extra_headers=None):

--- a/tests/helpers/rbac-mock-data/rbac-admin.json
+++ b/tests/helpers/rbac-mock-data/rbac-admin.json
@@ -1,0 +1,19 @@
+{
+  "meta": {
+      "count": 1,
+      "limit": 1000,
+      "offset": 0
+  },
+  "links": {
+      "first": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0",
+      "next": null,
+      "previous": null,
+      "last": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0"
+  },
+  "data": [
+      {
+          "resourceDefinitions": [],
+          "permission": "rbac:*:*"
+      }
+  ]
+}

--- a/tests/test_api_resource_types_get.py
+++ b/tests/test_api_resource_types_get.py
@@ -4,6 +4,7 @@ from tests.helpers.api_utils import assert_resource_types_pagination
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_resource_types_groups_url
 from tests.helpers.api_utils import build_resource_types_url
+from tests.helpers.api_utils import create_mock_rbac_response
 
 
 @pytest.mark.parametrize(
@@ -61,3 +62,35 @@ def test_resource_types_groups_pagination(api_get, db_create_group, subtests):
 
                 for idx in range(per_page):
                     assert response_data["data"][idx]["name"] == f"testGroup_{((page-1)*per_page + idx):03}"
+
+
+def test_resource_types_groups_filter(api_get, db_create_group):
+    # Create a few groups, request the data using the filter, then check that the data is correct in the response
+    included_group_id_list = [str(db_create_group(f"testGroup{idx}").id) for idx in range(3)]
+    excluded_group_id_list = [str(db_create_group(f"diffGroup{idx}").id) for idx in range(5)]
+
+    response_status, response_data = api_get(build_resource_types_groups_url(query="?name=testGroup"))
+
+    assert_response_status(response_status, 200)
+
+    for group_result in response_data["data"]:
+        assert group_result["id"] in included_group_id_list
+        assert group_result["id"] not in excluded_group_id_list
+
+    assert_resource_types_pagination(response_data, 1, 10, 1, "/inventory/v1/resource-types/inventory-groups")
+
+
+@pytest.mark.parametrize(
+    "url_builder",
+    [build_resource_types_url, build_resource_types_groups_url],
+)
+def test_get_resource_types_RBAC_allowed(mocker, api_get, url_builder, enable_rbac):
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+
+    # RBAC admin should have permission to both resource-types endpoints
+    mock_rbac_response = create_mock_rbac_response("tests/helpers/rbac-mock-data/rbac-admin.json")
+
+    get_rbac_permissions_mock.return_value = mock_rbac_response
+
+    response_status, _ = api_get(url_builder())
+    assert_response_status(response_status, 200)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-1436](https://issues.redhat.com/browse/RHINENG-1436).
Adds the `name` filter to the `GET /resource-types/inventory-groups` endpoint. This supports the RBAC UI so that RBAC admins can more easily find groups to grant access to.

I also added an RBAC test to make sure RBAC admins could access the appropriate endpoints. That's more related to [RHINENG-1427](https://issues.redhat.com/browse/RHINENG-1427), but we should have the test, and I haven't yet been able to reproduce the issue described in that Jira.

Edit: I also included a fix to address [RHINENG-1427](https://issues.redhat.com/browse/RHINENG-1427), which is passing the app name through to the rbac request. It's only used when the user needs RBAC admin permission

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
