### PR TITLE
feat(RHINENG-1427): Add workaround for RBAC admins

### DIFF
--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,9 +1,13 @@
+from copy import deepcopy
+
 import pytest
 from requests import exceptions
 
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_hosts_url
+from tests.helpers.api_utils import build_resource_types_url
 from tests.helpers.api_utils import create_mock_rbac_response
+from tests.helpers.test_utils import USER_IDENTITY
 
 
 def test_rbac_retry_error_handling(mocker, db_create_host, api_get, enable_rbac):
@@ -72,3 +76,20 @@ def test_RBAC_invalid_UUIDs(mocker, api_get, enable_rbac):
     response_status, _ = api_get(build_hosts_url())
 
     assert_response_status(response_status, 503)
+
+
+def test_RBAC_admin_workaround(mocker, api_get, enable_rbac):
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+
+    # Grant permissions that are irrelevant to the endpoint we want to access
+    mock_rbac_response = create_mock_rbac_response("tests/helpers/rbac-mock-data/inv-hosts-read-only.json")
+
+    get_rbac_permissions_mock.return_value = mock_rbac_response
+
+    # Use an identity that implies the user is an org admin
+    admin_identity = deepcopy(USER_IDENTITY)
+    admin_identity["user"]["is_org_admin"] = True
+
+    response_status, _ = api_get(build_resource_types_url(), admin_identity)
+
+    assert_response_status(response_status, 200)


### PR DESCRIPTION
# Overview

This PR is being created to address an issue mentioned in the comments of [RHINENG-1427](https://issues.redhat.com/browse/RHINENG-1427).
It allows User Access Administrators to access our resource-types endpoints. This is effectively a temporary workaround that we can remove once [RHCLOUD-27511](https://issues.redhat.com/browse/RHCLOUD-27511) is implemented.

Basically: Right now, these administrators don't have any permission in their RBAC config that actually identifies them as administrators, so we instead have to use the "is_org_admin" field on the user identity. If that's set, then we can allow them to use the endpoints that require rbac admin permissions.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
