### PR TITLE
remove rebuild_event_topic and run just host_sync

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -570,7 +570,7 @@ objects:
         command:
           - /bin/sh
           - -c
-          - python rebuild_events_topic.py && python host_synchronizer.py
+          - python host_synchronizer.py
         env:
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}


### PR DESCRIPTION
# Overview

This PR is being created to investigate  [RHINENG-1401](https://issues.redhat.com/browse/RHINENG-1401).
The issue at hand is that host_synchronizer script does not stop/complete despite allowing it to run for 5 days or so.  Checking the pod log suggests that the rebuild_event_topic.py does not complete and hosts synchronization does even start.

This PR removed the `rebuild_event_topic` command and runs `host_synchronization" only to see if the problem goes away.  

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
