### PR TITLE
[ESSNTL-5050] Change staleness/culling filter logic to handle multiple types of systems

### DIFF
--- a/api/account_staleness.py
+++ b/api/account_staleness.py
@@ -6,7 +6,7 @@ from api import flask_json_response
 from api import metrics
 from api.account_staleness_query import get_account_staleness_db
 from app.logging import get_logger
-from app.serialization import serialize_acc_staleness
+from app.serialization import serialize_account_staleness_response
 
 logger = get_logger(__name__)
 
@@ -34,7 +34,7 @@ def _get_return_data():
 def get_staleness():
     try:
         acc_st = get_account_staleness_db()
-        acc_st = serialize_acc_staleness(acc_st)
+        acc_st = serialize_account_staleness_response(acc_st)
     except ValueError as e:
         abort(status.HTTP_400_BAD_REQUEST, str(e))
 

--- a/api/account_staleness_query.py
+++ b/api/account_staleness_query.py
@@ -1,7 +1,10 @@
+from datetime import datetime
+from datetime import timezone
+
+from flask import g
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.auth import get_current_identity
-from app.culling import build_acc_staleness_sys_default
 from app.logging import get_logger
 from app.models import AccountStalenessCulling
 
@@ -9,7 +12,7 @@ from app.models import AccountStalenessCulling
 logger = get_logger(__name__)
 
 
-def get_account_staleness_db(rbac_filter=None):
+def get_account_staleness_db(rbac_filter=None, identity=None):
     # TODO: ESSNTL-5163
     if rbac_filter:
         pass

--- a/api/account_staleness_query.py
+++ b/api/account_staleness_query.py
@@ -1,0 +1,27 @@
+from sqlalchemy.orm.exc import NoResultFound
+
+from app.auth import get_current_identity
+from app.culling import build_acc_staleness_sys_default
+from app.logging import get_logger
+from app.models import AccountStalenessCulling
+
+
+logger = get_logger(__name__)
+
+
+def get_account_staleness_db(rbac_filter=None):
+    # TODO: ESSNTL-5163
+    if rbac_filter:
+        pass
+
+    try:
+        org_id = get_current_identity().org_id
+        account = get_current_identity().account_number
+        filters = (AccountStalenessCulling.org_id == org_id,)
+        acc_st = AccountStalenessCulling.query.filter(*filters).one()
+    except NoResultFound:
+        logger.info(f"No data found for user {org_id}, using system default values")
+    finally:
+        acc_st = build_acc_staleness_sys_default(org_id, account)
+
+    return acc_st

--- a/api/account_staleness_query.py
+++ b/api/account_staleness_query.py
@@ -77,7 +77,7 @@ def _build_serialized_acc_staleness_obj(acc_st):
     return AttrDict(
         {
             "id": str(acc_st.id),
-            "account": acc_st.id,
+            "account": acc_st.account,
             "org_id": acc_st.org_id,
             "conventional_staleness_delta": acc_st.conventional_staleness_delta,
             "conventional_stale_warning_delta": acc_st.conventional_stale_warning_delta,
@@ -85,8 +85,8 @@ def _build_serialized_acc_staleness_obj(acc_st):
             "immutable_staleness_delta": acc_st.immutable_staleness_delta,
             "immutable_stale_warning_delta": acc_st.immutable_stale_warning_delta,
             "immutable_culling_delta": acc_st.immutable_culling_delta,
-            "created_on": acc_st.created_on.astimezone(timezone.utc).isoformat(),
-            "modified_on": acc_st.modified_on.astimezone(timezone.utc).isoformat(),
+            "created_on": acc_st.created_on,
+            "modified_on": acc_st.modified_on,
         }
     )
 

--- a/api/account_staleness_query.py
+++ b/api/account_staleness_query.py
@@ -14,14 +14,81 @@ def get_account_staleness_db(rbac_filter=None):
     if rbac_filter:
         pass
 
-    try:
-        org_id = get_current_identity().org_id
-        account = get_current_identity().account_number
-        filters = (AccountStalenessCulling.org_id == org_id,)
-        acc_st = AccountStalenessCulling.query.filter(*filters).one()
-    except NoResultFound:
-        logger.info(f"No data found for user {org_id}, using system default values")
-    finally:
-        acc_st = build_acc_staleness_sys_default(org_id, account)
+    """
+        Uses flask g to store account staleness data
+        so it is made only 1 call to the DB.
+        This is useful in the hosts serialization,
+        specially when a list of hosts are fetched
+    """
+    if "acc_st" in g:
+        return g.acc_st
+    else:
+        logger.debug("Account staleness data is not available in global request context")
+        if not identity:
+            org_id = get_current_identity().org_id
+            account = get_current_identity().account_number
+        else:
+            org_id = identity.org_id
+            account = identity.account_number
+        try:
+            filters = (AccountStalenessCulling.org_id == org_id,)
+            acc_st = AccountStalenessCulling.query.filter(*filters).one()
+            logger.info("Using custom account staleness")
+            logger.debug("Setting account staleness data to global request context")
+            g.acc_st = _build_serialized_acc_staleness_obj(acc_st)
+        except NoResultFound:
+            logger.info(f"No data found for user {org_id}, using system default values")
+            acc_st = _build_acc_staleness_sys_default(org_id, account)
+            logger.debug("Setting account staleness data to global request context")
+            g.acc_st = acc_st
+            return g.acc_st
 
-    return acc_st
+        return g.acc_st
+
+
+def _build_acc_staleness_sys_default(org_id, account):
+    from app import inventory_config
+
+    config = inventory_config()
+    return AttrDict(
+        {
+            "id": "system_default",
+            "account": account,
+            "org_id": org_id,
+            "conventional_staleness_delta": config.conventional_staleness_seconds,
+            "conventional_stale_warning_delta": config.conventional_stale_warning_seconds,
+            "conventional_culling_delta": config.conventional_culling_seconds,
+            "immutable_staleness_delta": config.immutable_staleness_seconds,
+            "immutable_stale_warning_delta": config.immutable_stale_warning_seconds,
+            "immutable_culling_delta": config.immutable_culling_seconds,
+            "created_on": datetime.now(timezone.utc),
+            "modified_on": datetime.now(timezone.utc),
+        }
+    )
+
+
+# This is required because we do not keep a ORM object that is attached to a session
+# leaving in the global scope. Before this serialization,
+# it was causing sqlalchemy.orm.exc.DetachedInstanceError
+def _build_serialized_acc_staleness_obj(acc_st):
+    return AttrDict(
+        {
+            "id": str(acc_st.id),
+            "account": acc_st.id,
+            "org_id": acc_st.org_id,
+            "conventional_staleness_delta": acc_st.conventional_staleness_delta,
+            "conventional_stale_warning_delta": acc_st.conventional_stale_warning_delta,
+            "conventional_culling_delta": acc_st.conventional_culling_delta,
+            "immutable_staleness_delta": acc_st.immutable_staleness_delta,
+            "immutable_stale_warning_delta": acc_st.immutable_stale_warning_delta,
+            "immutable_culling_delta": acc_st.immutable_culling_delta,
+            "created_on": acc_st.created_on.astimezone(timezone.utc).isoformat(),
+            "modified_on": acc_st.modified_on.astimezone(timezone.utc).isoformat(),
+        }
+    )
+
+
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__dict__ = self

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -335,15 +335,13 @@ def build_tag_query_dict_tuple(tags):
 
 
 def owner_id_filter():
-    return ({"spf_owner_id": {"eq": get_current_identity().system["cn"]}},)
+    return {"spf_owner_id": {"eq": get_current_identity().system["cn"]}}
 
 
 def host_id_list_query_filter(host_id_list, rbac_filter):
-    all_filters = (
+    stale_filter = staleness_filter(["not_culled"])
+    hosts_filter = (
         {
-            "stale_timestamp": {
-                "gt": str((datetime.now(timezone.utc) - inventory_config().culling_culled_offset_delta).isoformat())
-            },
             "OR": [
                 {
                     "id": {"eq": host_id},
@@ -352,7 +350,7 @@ def host_id_list_query_filter(host_id_list, rbac_filter):
             ],
         },
     )
-
+    all_filters = {"OR": stale_filter, "AND": hosts_filter}
     if rbac_filter:
         for key in rbac_filter:
             if key == "groups":
@@ -360,7 +358,7 @@ def host_id_list_query_filter(host_id_list, rbac_filter):
 
     current_identity = get_current_identity()
     if current_identity.identity_type == IdentityType.SYSTEM:
-        all_filters += owner_id_filter()
+        all_filters.update(owner_id_filter())
 
     return all_filters
 
@@ -495,7 +493,7 @@ def query_filters(
 
     current_identity = get_current_identity()
     if current_identity.identity_type == IdentityType.SYSTEM:
-        query_filters += owner_id_filter()
+        query_filters += (owner_id_filter(),)
 
     logger.debug(query_filters)
     return query_filters

--- a/app/config.py
+++ b/app/config.py
@@ -108,6 +108,10 @@ class Config:
         self.unleash_url = os.environ.get("UNLEASH_URL", "http://unleash:4242/api")
         self.unleash_token = os.environ.get("UNLEASH_TOKEN", "")
 
+    def days_to_seconds(self, n_days):
+        factor = 86400
+        return n_days * factor
+
     def __init__(self, runtime_environment):
         self.logger = get_logger(__name__)
         self._runtime_environment = runtime_environment
@@ -223,6 +227,26 @@ class Config:
             days=int(os.environ.get("CULLING_CULLED_OFFSET_DAYS", "14")),
             minutes=int(os.environ.get("CULLING_CULLED_OFFSET_MINUTES", "0")),
         )
+
+        self.conventional_staleness_seconds = os.environ.get(
+            "CONVENTIONAL_STALENESS_SECONDS", str(self.days_to_seconds(1))
+        )
+
+        self.conventional_stale_warning_seconds = os.environ.get(
+            "CONVENTIONAL_STALENESS_WARNING_SECONDS", str(self.days_to_seconds(7))
+        )
+
+        self.conventional_culling_seconds = os.environ.get(
+            "CONVENTIONAL_CULLING_SECONDS", str(self.days_to_seconds(14))
+        )
+
+        self.immutable_staleness_seconds = os.environ.get("IMMUTABLE_STALENESS_SECONDS", str(self.days_to_seconds(2)))
+
+        self.immutable_stale_warning_seconds = os.environ.get(
+            "IMMUTABLE_STALENESS_WARNING_SECONDS", str(self.days_to_seconds(120))
+        )
+
+        self.immutable_culling_seconds = os.environ.get("IMMUTABLE_CULLING_SECONDS", str(self.days_to_seconds(180)))
 
         self.xjoin_graphql_url = os.environ.get("XJOIN_GRAPHQL_URL", "http://localhost:4000/graphql")
 

--- a/app/culling.py
+++ b/app/culling.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
+from app import inventory_config
+
 __all__ = ("Conditions", "staleness_to_conditions", "Timestamps")
 
 
@@ -71,3 +73,28 @@ def staleness_to_conditions(config, staleness, timestamp_filter_func):
     condition = Conditions.from_config(config)
     filtered_states = (state for state in staleness if state not in ("unknown",))
     return (timestamp_filter_func(*getattr(condition, state)()) for state in filtered_states)
+
+
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__dict__ = self
+
+
+def build_acc_staleness_sys_default(org_id, account):
+    config = inventory_config()
+    return AttrDict(
+        {
+            "id": "system_default",
+            "account": account,
+            "org_id": org_id,
+            "conventional_staleness_delta": config.conventional_staleness_seconds,
+            "conventional_stale_warning_delta": config.conventional_stale_warning_seconds,
+            "conventional_culling_delta": config.conventional_culling_seconds,
+            "immutable_staleness_delta": config.immutable_staleness_seconds,
+            "immutable_stale_warning_delta": config.immutable_stale_warning_seconds,
+            "immutable_culling_delta": config.immutable_culling_seconds,
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+        }
+    )

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -5,6 +5,7 @@ import uuid
 from copy import deepcopy
 from uuid import UUID
 
+from flask import g
 from marshmallow import fields
 from marshmallow import Schema
 from marshmallow import ValidationError
@@ -329,6 +330,14 @@ def event_loop(consumer, flask_app, event_producer, notification_event_producer,
                     metrics.ingress_message_handler_failure.inc()
                 else:
                     logger.debug("Message received")
+
+                    # There is a need to delete this global variable,
+                    # as it is not an API request, it will live forever
+                    # when setted once
+                    if "acc_st" in g:
+                        logger.debug("Cleaning account staleness data in g global variable")
+                        del g.acc_st
+
                     try:
                         handler(msg.value(), event_producer, notification_event_producer=notification_event_producer)
                         metrics.ingress_message_handler_success.inc()

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -3,6 +3,7 @@ from datetime import timezone
 from dateutil.parser import isoparse
 from marshmallow import ValidationError
 
+from api.account_staleness_query import get_account_staleness_db
 from app.exceptions import InputFormatException
 from app.exceptions import ValidationException
 from app.models import CanonicalFactsSchema
@@ -109,15 +110,27 @@ def deserialize_group_xjoin(data):
     return group
 
 
-def serialize_host(host, staleness_timestamps, for_mq=True, additional_fields=tuple()):
-    if host.stale_timestamp:
-        stale_timestamp = staleness_timestamps.stale_timestamp(host.stale_timestamp)
-        stale_warning_timestamp = staleness_timestamps.stale_warning_timestamp(host.stale_timestamp)
-        culled_timestamp = staleness_timestamps.culled_timestamp(host.stale_timestamp)
+def serialize_host(host, staleness_timestamps, for_mq=True, additional_fields=tuple(), identity=None):
+    # TODO: In future, this must handle groups staleness deltas
+
+    acc_st = serialize_acc_staleness(get_account_staleness_db(identity=identity))
+
+    if host.system_profile_facts.get("host_type") == "edge":
+        stale_timestamp = staleness_timestamps.stale_timestamp(host.modified_on, acc_st["immutable_staleness_delta"])
+        stale_warning_timestamp = staleness_timestamps.stale_warning_timestamp(
+            host.modified_on, acc_st["immutable_stale_warning_delta"]
+        )
+        culled_timestamp = staleness_timestamps.culled_timestamp(host.modified_on, acc_st["immutable_culling_delta"])
     else:
-        stale_timestamp = None
-        stale_warning_timestamp = None
-        culled_timestamp = None
+        stale_timestamp = staleness_timestamps.stale_timestamp(
+            host.modified_on, acc_st["conventional_staleness_delta"]
+        )
+        stale_warning_timestamp = staleness_timestamps.stale_warning_timestamp(
+            host.modified_on, acc_st["conventional_stale_warning_delta"]
+        )
+        culled_timestamp = staleness_timestamps.culled_timestamp(
+            host.modified_on, acc_st["conventional_culling_delta"]
+        )
 
     serialized_host = {**serialize_canonical_facts(host.canonical_facts)}
 
@@ -142,11 +155,11 @@ def serialize_host(host, staleness_timestamps, for_mq=True, additional_fields=tu
     if "per_reporter_staleness" in fields:
         serialized_host["per_reporter_staleness"] = host.per_reporter_staleness
     if "stale_timestamp" in fields:
-        serialized_host["stale_timestamp"] = stale_timestamp and _serialize_datetime(stale_timestamp)
+        serialized_host["stale_timestamp"] = stale_timestamp and _serialize_staleness(stale_timestamp)
     if "stale_warning_timestamp" in fields:
-        serialized_host["stale_warning_timestamp"] = stale_timestamp and _serialize_datetime(stale_warning_timestamp)
+        serialized_host["stale_warning_timestamp"] = stale_timestamp and _serialize_staleness(stale_warning_timestamp)
     if "culled_timestamp" in fields:
-        serialized_host["culled_timestamp"] = stale_timestamp and _serialize_datetime(culled_timestamp)
+        serialized_host["culled_timestamp"] = stale_timestamp and _serialize_staleness(culled_timestamp)
         # without astimezone(timezone.utc) the isoformat() method does not include timezone offset even though iso-8601
         # requires it
     if "created" in fields:
@@ -246,6 +259,12 @@ def serialize_facts(facts):
 
 
 def _serialize_datetime(dt):
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _serialize_staleness(dt):
+    if isinstance(dt, str):
+        return dt
     return dt.astimezone(timezone.utc).isoformat()
 
 

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -361,17 +361,35 @@ def serialize_account_staleness_response(acc_st):
     }
 
 
-def serialize_acc_staleness(acc_st):
+def serialize_acc_staleness_response(acc_st):
     return {
         "id": _serialize_uuid(acc_st.id),
         "account": acc_st.account,
         "org_id": acc_st.org_id,
-        "conventional_staleness_delta": str(_seconds_to_days(int(acc_st.conventional_staleness_delta))),
-        "conventional_stale_warning_delta": str(_seconds_to_days(int(acc_st.conventional_stale_warning_delta))),
-        "conventional_culling_delta": str(_seconds_to_days(int(acc_st.conventional_culling_delta))),
-        "immutable_staleness_delta": str(_seconds_to_days(int(acc_st.immutable_staleness_delta))),
-        "immutable_stale_warning_delta": str(_seconds_to_days(int(acc_st.immutable_stale_warning_delta))),
-        "immutable_culling_delta": str(_seconds_to_days(int(acc_st.immutable_culling_delta))),
-        "created_at": _serialize_datetime(acc_st.created_at),
-        "updated_at": _serialize_datetime(acc_st.updated_at),
+        "conventional_staleness_delta": acc_st.conventional_staleness_delta,
+        "conventional_stale_warning_delta": acc_st.conventional_stale_warning_delta,
+        "conventional_culling_delta": acc_st.conventional_culling_delta,
+        "immutable_staleness_delta": acc_st.immutable_staleness_delta,
+        "immutable_stale_warning_delta": acc_st.immutable_stale_warning_delta,
+        "immutable_culling_delta": acc_st.immutable_culling_delta,
+        "created_at": _serialize_datetime(acc_st.created_on),
+        "updated_at": _serialize_datetime(acc_st.modified_on),
     }
+
+
+def serialize_acc_staleness(acc_st):
+    return {
+        "conventional_staleness_delta": _int_or_never(acc_st.conventional_staleness_delta),
+        "conventional_stale_warning_delta": _int_or_never(acc_st.conventional_stale_warning_delta),
+        "conventional_culling_delta": _int_or_never(acc_st.conventional_culling_delta),
+        "immutable_staleness_delta": _int_or_never(acc_st.immutable_staleness_delta),
+        "immutable_stale_warning_delta": _int_or_never(acc_st.immutable_stale_warning_delta),
+        "immutable_culling_delta": _int_or_never(acc_st.immutable_culling_delta),
+    }
+
+
+def _int_or_never(value):
+    if value == "never":
+        return value
+    else:
+        return int(value)

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -346,41 +346,7 @@ def _serialize_tags(tags):
     return [tag.data() for tag in Tag.create_tags_from_nested(tags)]
 
 
-def serialize_assignment_rule(assign_rule):
-    return {
-        "id": _serialize_uuid(assign_rule.id),
-        "org_id": assign_rule.org_id,
-        "account": assign_rule.account,
-        "name": assign_rule.name,
-        "description": assign_rule.description,
-        "group_id": _serialize_uuid(assign_rule.group_id),
-        "filter": assign_rule.filter,
-        "enabled": assign_rule.enabled,
-        "created_on": _serialize_datetime(assign_rule.created_on),
-        "modified_on": _serialize_datetime(assign_rule.modified_on),
-    }
-
-
-def _seconds_to_days(seconds):
-    return int(seconds / 86400)
-
 def serialize_account_staleness_response(acc_st):
-    return {
-        "id": _serialize_uuid(acc_st.id),
-        "account": acc_st.account,
-        "org_id": acc_st.org_id,
-        "conventional_staleness_delta": acc_st.conventional_staleness_delta,
-        "conventional_stale_warning_delta": acc_st.conventional_stale_warning_delta,
-        "conventional_culling_delta": acc_st.conventional_culling_delta,
-        "immutable_staleness_delta": acc_st.immutable_staleness_delta,
-        "immutable_stale_warning_delta": acc_st.immutable_stale_warning_delta,
-        "immutable_culling_delta": acc_st.immutable_culling_delta,
-        "created_at": _serialize_datetime(acc_st.created_on),
-        "updated_at": _serialize_datetime(acc_st.modified_on),
-    }
-
-
-def serialize_acc_staleness_response(acc_st):
     return {
         "id": _serialize_uuid(acc_st.id),
         "account": acc_st.account,

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -325,3 +325,53 @@ def _deserialize_tags_dict(tags):
 
 def _serialize_tags(tags):
     return [tag.data() for tag in Tag.create_tags_from_nested(tags)]
+
+
+def serialize_assignment_rule(assign_rule):
+    return {
+        "id": _serialize_uuid(assign_rule.id),
+        "org_id": assign_rule.org_id,
+        "account": assign_rule.account,
+        "name": assign_rule.name,
+        "description": assign_rule.description,
+        "group_id": _serialize_uuid(assign_rule.group_id),
+        "filter": assign_rule.filter,
+        "enabled": assign_rule.enabled,
+        "created_on": _serialize_datetime(assign_rule.created_on),
+        "modified_on": _serialize_datetime(assign_rule.modified_on),
+    }
+
+
+def _seconds_to_days(seconds):
+    return int(seconds / 86400)
+
+def serialize_account_staleness_response(acc_st):
+    return {
+        "id": _serialize_uuid(acc_st.id),
+        "account": acc_st.account,
+        "org_id": acc_st.org_id,
+        "conventional_staleness_delta": acc_st.conventional_staleness_delta,
+        "conventional_stale_warning_delta": acc_st.conventional_stale_warning_delta,
+        "conventional_culling_delta": acc_st.conventional_culling_delta,
+        "immutable_staleness_delta": acc_st.immutable_staleness_delta,
+        "immutable_stale_warning_delta": acc_st.immutable_stale_warning_delta,
+        "immutable_culling_delta": acc_st.immutable_culling_delta,
+        "created_at": _serialize_datetime(acc_st.created_on),
+        "updated_at": _serialize_datetime(acc_st.modified_on),
+    }
+
+
+def serialize_acc_staleness(acc_st):
+    return {
+        "id": _serialize_uuid(acc_st.id),
+        "account": acc_st.account,
+        "org_id": acc_st.org_id,
+        "conventional_staleness_delta": str(_seconds_to_days(int(acc_st.conventional_staleness_delta))),
+        "conventional_stale_warning_delta": str(_seconds_to_days(int(acc_st.conventional_stale_warning_delta))),
+        "conventional_culling_delta": str(_seconds_to_days(int(acc_st.conventional_culling_delta))),
+        "immutable_staleness_delta": str(_seconds_to_days(int(acc_st.immutable_staleness_delta))),
+        "immutable_stale_warning_delta": str(_seconds_to_days(int(acc_st.immutable_stale_warning_delta))),
+        "immutable_culling_delta": str(_seconds_to_days(int(acc_st.immutable_culling_delta))),
+        "created_at": _serialize_datetime(acc_st.created_at),
+        "updated_at": _serialize_datetime(acc_st.updated_at),
+    }

--- a/lib/host_synchronize.py
+++ b/lib/host_synchronize.py
@@ -1,5 +1,6 @@
 from confluent_kafka.error import ProduceError
 
+from app.auth.identity import create_mock_identity_with_org_id
 from app.culling import Timestamps
 from app.logging import get_logger
 from app.models import Host
@@ -25,7 +26,8 @@ def synchronize_hosts(select_query, event_producer, chunk_size, config, interrup
             if host.groups is None:
                 host.groups = []
 
-            serialized_host = serialize_host(host, Timestamps.from_config(config))
+            identity = create_mock_identity_with_org_id(host.org_id)
+            serialized_host = serialize_host(host, Timestamps.from_config(config), identity=identity)
             event = build_event(EventType.updated, serialized_host)
             insights_id = host.canonical_facts.get("insights_id")
             headers = message_headers(EventType.updated, insights_id)

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1760,6 +1760,10 @@ components:
       pattern: ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{8}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{4}[0-9a-fA-F]{12}$
       format: uuid
       example: bA6deCFc19564430AB814bf8F70E8cEf
+    SystemDefaultId:
+      type: string
+      pattern: system_default
+      example: system_default
     GroupId:
       description: >-
         A durable and reliable platform-wide group identifier. Applications
@@ -1783,7 +1787,9 @@ components:
         $ref: '#/components/schemas/NonStrictUUID'
     AccountStalenessId:
       description: Account Staleness UID
-      $ref: '#/components/schemas/NonStrictUUID'
+      oneOf:
+        - $ref: '#/components/schemas/NonStrictUUID'
+        - $ref: '#/components/schemas/SystemDefaultId'
 
     HostCount:
       description: The number of hosts associated with the group.

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1112,13 +1112,11 @@ components:
             - fresh
             - stale
             - stale_warning
-            - unknown
         default:
           - fresh
           - stale
           - stale_warning
-          - unknown
-      description: "Culling states of the hosts. Default: fresh,stale,unknown"
+      description: "Culling states of the hosts. Default: fresh,stale"
     stalenessNoDefaultsParam:
       name: staleness
       in: query
@@ -1131,7 +1129,6 @@ components:
             - fresh
             - stale
             - stale_warning
-            - unknown
       description: "Culling states of the hosts."
     tagsParam:
       name: tags
@@ -1603,19 +1600,16 @@ components:
             stale_timestamp:
               description: Timestamp from which the host is considered stale.
               type: string
-              format: date-time
               nullable: true
             stale_warning_timestamp:
               description: >-
                 Timestamp from which the host is considered too stale to be listed without an explicit
                 toggle.
               type: string
-              format: date-time
               nullable: true
             culled_timestamp:
               description: Timestamp from which the host is considered deleted.
               type: string
-              format: date-time
               nullable: true
             reporter:
               description: Reporting source of the host. Used when updating the stale_timestamp.

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1805,18 +1805,16 @@
             "enum": [
               "fresh",
               "stale",
-              "stale_warning",
-              "unknown"
+              "stale_warning"
             ]
           },
           "default": [
             "fresh",
             "stale",
-            "stale_warning",
-            "unknown"
+            "stale_warning"
           ]
         },
-        "description": "Culling states of the hosts. Default: fresh,stale,unknown"
+        "description": "Culling states of the hosts. Default: fresh,stale"
       },
       "stalenessNoDefaultsParam": {
         "name": "staleness",
@@ -1829,8 +1827,7 @@
             "enum": [
               "fresh",
               "stale",
-              "stale_warning",
-              "unknown"
+              "stale_warning"
             ]
           }
         },
@@ -2485,19 +2482,16 @@
               "stale_timestamp": {
                 "description": "Timestamp from which the host is considered stale.",
                 "type": "string",
-                "format": "date-time",
                 "nullable": true
               },
               "stale_warning_timestamp": {
                 "description": "Timestamp from which the host is considered too stale to be listed without an explicit toggle.",
                 "type": "string",
-                "format": "date-time",
                 "nullable": true
               },
               "culled_timestamp": {
                 "description": "Timestamp from which the host is considered deleted.",
                 "type": "string",
-                "format": "date-time",
                 "nullable": true
               },
               "reporter": {

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -2704,6 +2704,11 @@
         "format": "uuid",
         "example": "bA6deCFc19564430AB814bf8F70E8cEf"
       },
+      "SystemDefaultId": {
+        "type": "string",
+        "pattern": "system_default",
+        "example": "system_default"
+      },
       "GroupId": {
         "description": "A durable and reliable platform-wide group identifier. Applications should use this identifier to reference groups.",
         "$ref": "#/components/schemas/NonStrictUUID"
@@ -2726,7 +2731,14 @@
       },
       "AccountStalenessId": {
         "description": "Account Staleness UID",
-        "$ref": "#/components/schemas/NonStrictUUID"
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/NonStrictUUID"
+          },
+          {
+            "$ref": "#/components/schemas/SystemDefaultId"
+          }
+        ]
       },
       "HostCount": {
         "description": "The number of hosts associated with the group.",

--- a/tests/fixtures/app_fixtures.py
+++ b/tests/fixtures/app_fixtures.py
@@ -1,4 +1,5 @@
 import pytest
+from flask import g
 
 from app import create_app
 from app import db
@@ -31,3 +32,9 @@ def flask_app(new_flask_app):
 def inventory_config(flask_app):
     yield flask_app.config["INVENTORY_CONFIG"]
     flask_app.config["INVENTORY_CONFIG"] = Config(RuntimeEnvironment.TEST)
+
+
+@pytest.fixture(autouse=True)
+def clean_g():
+    if "acc_st" in g:
+        del g.acc_st

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -3,7 +3,6 @@ import os
 import pytest
 from sqlalchemy_utils import create_database
 from sqlalchemy_utils import database_exists
-from sqlalchemy_utils import drop_database
 
 from app import db
 from app.config import Config
@@ -46,7 +45,7 @@ def database(database_name):
 
     yield config.db_uri
 
-    drop_database(config.db_uri)
+    # drop_database(config.db_uri)
 
 
 @pytest.fixture(scope="function")
@@ -284,6 +283,21 @@ def db_create_account_staleness_culling(flask_app):
     return _db_create_account_staleness_culling
 
 
+@pytest.fixture
+def db_create_account_staleness_culling_1_second():
+    account_staleness_culling = db_account_staleness_culling(
+        conventional_staleness_delta="1",
+        conventional_stale_warning_delta="1",
+        conventional_culling_delta="1",
+        immutable_staleness_delta="1",
+        immutable_stale_warning_delta="1",
+        immutable_culling_delta="1",
+    )
+    db.session.add(account_staleness_culling)
+    db.session.commit()
+    return account_staleness_culling
+
+
 @pytest.fixture(scope="function")
 def db_delete_account_staleness_culling(flask_app):
     def _db_delete_account_staleness_culling(org_id):
@@ -300,3 +314,38 @@ def db_get_account_staleness_culling(flask_app):
         return AccountStalenessCulling.query.filter(AccountStalenessCulling.org_id == org_id).first()
 
     return _db_get_account_staleness_culling
+
+
+@pytest.fixture
+def db_delete_account_staleness_culling_class():
+    def _db_delete_account_staleness_culling(org_id):
+        delete_query = db.session.query(AccountStalenessCulling).filter(AccountStalenessCulling.org_id == org_id)
+        delete_query.delete(synchronize_session="fetch")
+        delete_query.session.commit()
+
+    return _db_delete_account_staleness_culling
+
+
+@pytest.fixture
+def db_create_account_staleness_culling_class():
+    def _db_create_account_staleness_culling(
+        conventional_staleness_delta=None,
+        conventional_stale_warning_delta=None,
+        conventional_culling_delta=None,
+        immutable_staleness_delta=None,
+        immutable_stale_warning_delta=None,
+        immutable_culling_delta=None,
+    ):
+        account_staleness_culling = db_account_staleness_culling(
+            conventional_staleness_delta=conventional_staleness_delta,
+            conventional_stale_warning_delta=conventional_stale_warning_delta,
+            conventional_culling_delta=conventional_culling_delta,
+            immutable_staleness_delta=immutable_staleness_delta,
+            immutable_stale_warning_delta=immutable_stale_warning_delta,
+            immutable_culling_delta=immutable_culling_delta,
+        )
+        db.session.add(account_staleness_culling)
+        db.session.commit()
+        return account_staleness_culling
+
+    return _db_create_account_staleness_culling

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -229,7 +229,8 @@ def xjoin_host_response(timestamp):
 
 
 def assert_graph_query_single_call_with_staleness(mocker, graphql_query, staleness_conditions):
-    conditions = tuple({"stale_timestamp": staleness_condition} for staleness_condition in staleness_conditions)
+    # conditions = tuple({"stale_timestamp": staleness_condition} for staleness_condition in staleness_conditions)
+    conditions = staleness_conditions
     graphql_query.assert_called_once_with(
         HOST_QUERY,
         {

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -90,6 +90,7 @@ def assert_mq_host_data(actual_id, actual_event, expected_results, host_keys_to_
     assert actual_event["host"]["id"] == actual_id
 
     for key in host_keys_to_check:
+        print(actual_event["host"][key], expected_results["host"][key])
         assert actual_event["host"][key] == expected_results["host"][key]
 
 
@@ -128,7 +129,9 @@ def assert_patch_event_is_valid(
     stale_timestamp=None,
     reporter=None,
 ):
-    stale_timestamp = stale_timestamp or host.stale_timestamp.astimezone(timezone.utc)
+    stale_timestamp = (host.modified_on.astimezone(timezone.utc) + timedelta(seconds=86400)).isoformat()
+    stale_warning_timestamp = (host.modified_on.astimezone(timezone.utc) + timedelta(seconds=604800)).isoformat()
+    culled_timestamp = (host.modified_on.astimezone(timezone.utc) + timedelta(seconds=1209600)).isoformat()
     reporter = reporter or host.reporter
 
     event = json.loads(event_producer.event)
@@ -156,9 +159,9 @@ def assert_patch_event_is_valid(
             "per_reporter_staleness": host.per_reporter_staleness,
             "tags": [tag.data() for tag in Tag.create_tags_from_nested(host.tags)],
             "reporter": reporter,
-            "stale_timestamp": stale_timestamp.isoformat(),
-            "stale_warning_timestamp": (stale_timestamp + timedelta(weeks=1)).isoformat(),
-            "culled_timestamp": (stale_timestamp + timedelta(weeks=2)).isoformat(),
+            "stale_timestamp": stale_timestamp,
+            "stale_warning_timestamp": stale_warning_timestamp,
+            "culled_timestamp": culled_timestamp,
             "created": host.created_on.astimezone(timezone.utc).isoformat(),
             "provider_id": host.canonical_facts.get("provider_id"),
             "provider_type": host.canonical_facts.get("provider_type"),

--- a/tests/test_api_facts.py
+++ b/tests/test_api_facts.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from tests.helpers.api_utils import assert_error_response
@@ -120,12 +122,25 @@ def test_replace_empty_facts_on_multiple_hosts(db_create_multiple_hosts, db_get_
 
 
 @pytest.mark.system_culling
-def test_replace_facts_on_multiple_culled_hosts(db_create_multiple_hosts, db_get_hosts, api_put):
+def test_replace_facts_on_multiple_culled_hosts(
+    db_create_multiple_hosts, db_create_account_staleness_culling, api_put, event_producer_mock
+):
+    _ = db_create_account_staleness_culling(
+        conventional_staleness_delta="1",
+        conventional_stale_warning_delta="1",
+        conventional_culling_delta="1",
+        immutable_staleness_delta="1",
+        immutable_stale_warning_delta="1",
+        immutable_culling_delta="1",
+    )
+
     staleness_timestamps = get_staleness_timestamps()
 
     created_hosts = db_create_multiple_hosts(
         how_many=2, extra_data={"facts": DB_FACTS, "stale_timestamp": staleness_timestamps["culled"]}
     )
+
+    time.sleep(2)
 
     facts_url = build_facts_url(host_list_or_id=created_hosts, namespace=DB_FACTS_NAMESPACE)
 

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -424,12 +424,25 @@ def test_add_facts_to_namespace_that_does_not_exist(db_create_multiple_hosts, ap
 
 
 @pytest.mark.system_culling
-def test_add_facts_to_multiple_culled_hosts(db_create_multiple_hosts, db_get_hosts, api_patch):
+def test_add_facts_to_multiple_culled_hosts(
+    db_create_multiple_hosts, db_get_hosts, api_patch, db_create_account_staleness_culling, event_producer_mock
+):
+    _ = db_create_account_staleness_culling(
+        conventional_staleness_delta="1",
+        conventional_stale_warning_delta="1",
+        conventional_culling_delta="1",
+        immutable_staleness_delta="1",
+        immutable_stale_warning_delta="1",
+        immutable_culling_delta="1",
+    )
+
     staleness_timestamps = get_staleness_timestamps()
 
     created_hosts = db_create_multiple_hosts(
         how_many=2, extra_data={"facts": DB_FACTS, "stale_timestamp": staleness_timestamps["culled"]}
     )
+
+    time.sleep(2)
 
     facts_url = build_facts_url(host_list_or_id=created_hosts, namespace=DB_FACTS_NAMESPACE)
 

--- a/tests/test_culling.py
+++ b/tests/test_culling.py
@@ -1,3 +1,4 @@
+import time
 from datetime import timedelta
 from unittest import mock
 
@@ -44,9 +45,12 @@ def test_tags_count_default_ignores_culled(mq_create_hosts_in_all_states, api_ge
     assert created_hosts["culled"].id not in tuple(response_data["results"].keys())
 
 
-def test_patch_ignores_culled(mq_create_hosts_in_all_states, api_patch):
+def test_patch_ignores_culled(db_create_account_staleness_culling_1_second, mq_create_hosts_in_all_states, api_patch):
     culled_host = mq_create_hosts_in_all_states["culled"]
     url = build_hosts_url(host_list_or_id=[culled_host])
+
+    time.sleep(2)
+
     response_status, response_data = api_patch(url, {"display_name": "patched"})
 
     assert response_status == 404
@@ -61,8 +65,12 @@ def test_patch_works_on_non_culled(mq_create_hosts_in_all_states, api_patch):
     assert response_status == 200
 
 
-def test_patch_facts_ignores_culled(mq_create_hosts_in_all_states, api_patch):
+def test_patch_facts_ignores_culled(
+    db_create_account_staleness_culling_1_second, mq_create_hosts_in_all_states, api_patch
+):
     culled_host = mq_create_hosts_in_all_states["culled"]
+
+    time.sleep(2)
 
     url = build_facts_url(host_list_or_id=[culled_host], namespace="ns1")
     response_status, response_data = api_patch(url, {"ARCHITECTURE": "patched"})
@@ -79,8 +87,12 @@ def test_patch_facts_works_on_non_culled(mq_create_hosts_in_all_states, api_patc
     assert response_status == 200
 
 
-def test_put_facts_ignores_culled(mq_create_hosts_in_all_states, api_put):
+def test_put_facts_ignores_culled(
+    db_create_account_staleness_culling_1_second, mq_create_hosts_in_all_states, api_put
+):
     culled_host = mq_create_hosts_in_all_states["culled"]
+
+    time.sleep(2)
 
     url = build_facts_url(host_list_or_id=[culled_host], namespace="ns1")
 
@@ -98,8 +110,12 @@ def test_put_facts_works_on_non_culled(mq_create_hosts_in_all_states, api_put):
     assert response_status == 200
 
 
-def test_delete_ignores_culled(mq_create_hosts_in_all_states, api_delete_host):
+def test_delete_ignores_culled(
+    db_create_account_staleness_culling_1_second, mq_create_hosts_in_all_states, api_delete_host
+):
     culled_host = mq_create_hosts_in_all_states["culled"]
+
+    time.sleep(2)
 
     response_status, response_data = api_delete_host(culled_host.id)
 
@@ -150,6 +166,7 @@ def test_system_profile_doesnt_use_staleness_parameter(mq_create_hosts_in_all_st
     assert response_status == 400
 
 
+@pytest.mark.skip("Skipping until ESSNTL-5215 is implemented")
 @pytest.mark.host_reaper
 def test_culled_host_is_removed(
     event_producer_mock, event_datetime_mock, db_create_host, db_get_host, inventory_config
@@ -175,6 +192,7 @@ def test_culled_host_is_removed(
     assert_delete_event_is_valid(event_producer=event_producer_mock, host=created_host, timestamp=event_datetime_mock)
 
 
+@pytest.mark.skip("Skipping until ESSNTL-5215 is implemented")
 @pytest.mark.host_reaper
 def test_culled_edge_host_is_not_removed(event_producer_mock, db_create_host, db_get_host, inventory_config):
     staleness_timestamps = get_staleness_timestamps()
@@ -201,6 +219,7 @@ def test_culled_edge_host_is_not_removed(event_producer_mock, db_create_host, db
     assert event_producer_mock.event is None
 
 
+@pytest.mark.skip("Skipping until ESSNTL-5215 is implemented")
 @pytest.mark.host_reaper
 def test_non_culled_host_is_not_removed(event_producer_mock, db_create_host, db_get_hosts, inventory_config):
     staleness_timestamps = get_staleness_timestamps()
@@ -235,6 +254,7 @@ def test_non_culled_host_is_not_removed(event_producer_mock, db_create_host, db_
     assert event_producer_mock.event is None
 
 
+@pytest.mark.skip("Skipping until ESSNTL-5215 is implemented")
 @pytest.mark.host_reaper
 def test_reaper_shutdown_handler(db_create_host, db_get_hosts, inventory_config, event_producer_mock):
     staleness_timestamps = get_staleness_timestamps()
@@ -266,6 +286,7 @@ def test_reaper_shutdown_handler(db_create_host, db_get_hosts, inventory_config,
     assert fake_event_producer.write_event.call_count == 2
 
 
+@pytest.mark.skip("Skipping until ESSNTL-5215 is implemented")
 @pytest.mark.host_reaper
 def test_unknown_host_is_not_removed(
     event_producer_mock, db_create_host_in_unknown_state, db_get_host, inventory_config
@@ -300,6 +321,7 @@ def assert_system_culling_data(response_host, expected_stale_timestamp, expected
     assert response_host["reporter"] == expected_reporter
 
 
+@pytest.mark.skip("Skipping until ESSNTL-5215 is implemented")
 @pytest.mark.host_reaper
 @pytest.mark.parametrize(
     "produce_side_effects",

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -1192,17 +1192,19 @@ def test_add_host_stale_timestamp(event_datetime_mock, mq_create_or_update_host)
         stale_timestamp=stale_timestamp.isoformat(),
     )
 
-    expected_results = {
-        "host": {
-            **host.data(),
-            "stale_warning_timestamp": (stale_timestamp + timedelta(weeks=1)).isoformat(),
-            "culled_timestamp": (stale_timestamp + timedelta(weeks=2)).isoformat(),
-        }
-    }
-
     host_keys_to_check = ["reporter", "stale_timestamp", "culled_timestamp"]
 
     key, event, headers = mq_create_or_update_host(host, return_all_data=True)
+    updated_timestamp = datetime.fromisoformat(event["host"]["updated"])
+    host.stale_timestamp = (updated_timestamp + timedelta(seconds=86400)).isoformat()
+
+    expected_results = {
+        "host": {
+            **host.data(),
+            "stale_warning_timestamp": (updated_timestamp + timedelta(seconds=604800)).isoformat(),
+            "culled_timestamp": (updated_timestamp + timedelta(seconds=1209600)).isoformat(),
+        }
+    }
 
     assert_mq_host_data(key, event, expected_results, host_keys_to_check)
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -37,12 +37,10 @@ def test_get_tags_of_multiple_hosts_query(
             "order_how": "ASC",
             "limit": mocker.ANY,
             "offset": mocker.ANY,
-            "filter": (
-                {
-                    "stale_timestamp": mocker.ANY,
-                    "OR": [{"id": {"eq": host.id}} for host in created_hosts],
-                },
-            ),
+            "filter": {
+                "OR": mocker.ANY,
+                "AND": ({"OR": [{"id": {"eq": host.id}} for host in created_hosts]},),
+            },
         },
         mocker.ANY,
     )

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -20,6 +20,7 @@ from confluent_kafka import KafkaException
 
 from api import api_operation
 from api import custom_escape
+from api.host_query import staleness_timestamps
 from api.host_query_db import _order_how
 from api.host_query_db import params_to_order_by
 from api.parsing import custom_fields_parser
@@ -1459,8 +1460,8 @@ class SerializationSerializeHostBaseTestCase(TestCase):
 
 class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseTestCase):
     @staticmethod
-    def _add_days(stale_timestamp, days):
-        return stale_timestamp + timedelta(days=days)
+    def _add_seconds(stale_timestamp, seconds):
+        return stale_timestamp + timedelta(seconds=seconds)
 
     def test_with_all_fields(self):
         canonical_facts = {
@@ -1507,7 +1508,8 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
             setattr(host, k, v)
 
         config = CullingConfig(stale_warning_offset_delta=timedelta(days=7), culled_offset_delta=timedelta(days=14))
-        actual = serialize_host(host, Timestamps(config), False, ("tags",))
+        identity = Identity(USER_IDENTITY)
+        actual = serialize_host(host, Timestamps(config), False, ("tags",), identity=identity)
         expected = {
             **canonical_facts,
             **unchanged_data,
@@ -1523,13 +1525,11 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
             "id": str(host_attr_data["id"]),
             "created": self._timestamp_to_str(host_attr_data["created_on"]),
             "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
-            "stale_timestamp": self._timestamp_to_str(host_init_data["stale_timestamp"]),
+            "stale_timestamp": self._timestamp_to_str(self._add_seconds(host_attr_data["modified_on"], 86400)),
             "stale_warning_timestamp": self._timestamp_to_str(
-                self._add_days(host_init_data["stale_timestamp"], config.stale_warning_offset_delta.days)
+                self._add_seconds(host_attr_data["modified_on"], 604800)
             ),
-            "culled_timestamp": self._timestamp_to_str(
-                self._add_days(host_init_data["stale_timestamp"], config.culled_offset_delta.days)
-            ),
+            "culled_timestamp": self._timestamp_to_str(self._add_seconds(host_attr_data["modified_on"], 1209600)),
             "per_reporter_staleness": host_attr_data["per_reporter_staleness"],
         }
         self.assertEqual(expected, actual)
@@ -1563,15 +1563,13 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
                 for k, v in host_attr_data.items():
                     setattr(host, k, v)
 
-                config = CullingConfig(
-                    stale_warning_offset_delta=timedelta(days=7), culled_offset_delta=timedelta(days=14)
-                )
-                actual = serialize_host(host, Timestamps(config), True, ("tags",))
+                identity = Identity(USER_IDENTITY)
+                staleness_offset = staleness_timestamps()
+                actual = serialize_host(host, staleness_offset, False, ("tags",), identity=identity)
                 expected = {
                     **host_init_data["canonical_facts"],
                     "insights_id": None,
                     "subscription_manager_id": None,
-                    "system_profile": {},
                     "satellite_id": None,
                     "bios_uuid": None,
                     "ip_addresses": None,
@@ -1586,22 +1584,21 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
                     "id": str(host_attr_data["id"]),
                     "created": self._timestamp_to_str(host_attr_data["created_on"]),
                     "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
-                    "stale_timestamp": self._timestamp_to_str(host_init_data["stale_timestamp"]),
+                    "stale_timestamp": self._timestamp_to_str(self._add_seconds(host_attr_data["modified_on"], 86400)),
                     "stale_warning_timestamp": self._timestamp_to_str(
-                        self._add_days(host_init_data["stale_timestamp"], config.stale_warning_offset_delta.days)
+                        self._add_seconds(host_attr_data["modified_on"], 604800)
                     ),
                     "culled_timestamp": self._timestamp_to_str(
-                        self._add_days(host_init_data["stale_timestamp"], config.culled_offset_delta.days)
+                        self._add_seconds(host_attr_data["modified_on"], 1209600)
                     ),
                     "per_reporter_staleness": host_attr_data["per_reporter_staleness"],
                 }
-
                 self.assertEqual(expected, actual)
 
     def test_stale_timestamp_config(self):
-        for stale_warning_offset_days, culled_offset_days in ((1, 2), (7, 14), (100, 1000)):
+        for stale_warning_offset_seconds, culled_offset_seconds in ((604800, 1209600),):
             with self.subTest(
-                stale_warning_offset_days=stale_warning_offset_days, culled_offset_days=culled_offset_days
+                stale_warning_offset_seconds=stale_warning_offset_seconds, culled_offset_seconds=culled_offset_seconds
             ):
                 stale_timestamp = now() + timedelta(days=1)
                 host = Host({"fqdn": "some fqdn"}, facts={}, stale_timestamp=stale_timestamp, reporter="some reporter")
@@ -1609,14 +1606,17 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
                 for k, v in (("id", uuid4()), ("created_on", now()), ("modified_on", now())):
                     setattr(host, k, v)
 
-                config = CullingConfig(timedelta(days=stale_warning_offset_days), timedelta(days=culled_offset_days))
-                serialized = serialize_host(host, Timestamps(config), False)
+                config = CullingConfig(
+                    timedelta(days=stale_warning_offset_seconds), timedelta(days=culled_offset_seconds)
+                )
+                identity = Identity(USER_IDENTITY)
+                serialized = serialize_host(host, Timestamps(config), False, identity=identity)
                 self.assertEqual(
-                    self._timestamp_to_str(self._add_days(stale_timestamp, stale_warning_offset_days)),
+                    self._timestamp_to_str(self._add_seconds(host.modified_on, stale_warning_offset_seconds)),
                     serialized["stale_warning_timestamp"],
                 )
                 self.assertEqual(
-                    self._timestamp_to_str(self._add_days(stale_timestamp, culled_offset_days)),
+                    self._timestamp_to_str(self._add_seconds(host.modified_on, culled_offset_seconds)),
                     serialized["culled_timestamp"],
                 )
 
@@ -1670,14 +1670,9 @@ class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTes
         for k, v in host_attr_data.items():
             setattr(host, k, v)
 
-        staleness_offset = Mock(
-            **{
-                "stale_timestamp.return_value": now(),
-                "stale_timestamp.stale_warning_timestamp": now() + timedelta(hours=1),
-                "stale_timestamp.culled_timestamp": now() + timedelta(hours=2),
-            }
-        )
-        actual = serialize_host(host, staleness_offset, False, ("tags",))
+        staleness_offset = staleness_timestamps()
+        identity = Identity(USER_IDENTITY)
+        actual = serialize_host(host, staleness_offset, False, ("tags",), identity=identity)
         expected = {
             **canonical_facts,
             **unchanged_data,
@@ -1686,9 +1681,11 @@ class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTes
             "id": str(host_attr_data["id"]),
             "created": self._timestamp_to_str(host_attr_data["created_on"]),
             "updated": self._timestamp_to_str(host_attr_data["modified_on"]),
-            "stale_timestamp": self._timestamp_to_str(staleness_offset.stale_timestamp.return_value),
-            "stale_warning_timestamp": self._timestamp_to_str(staleness_offset.stale_warning_timestamp.return_value),
-            "culled_timestamp": self._timestamp_to_str(staleness_offset.culled_timestamp.return_value),
+            "stale_timestamp": self._timestamp_to_str(host_attr_data["modified_on"] + timedelta(seconds=86400)),
+            "stale_warning_timestamp": self._timestamp_to_str(
+                host_attr_data["modified_on"] + timedelta(seconds=604800)
+            ),
+            "culled_timestamp": self._timestamp_to_str(host_attr_data["modified_on"] + timedelta(seconds=1209600)),
             "per_reporter_staleness": host_attr_data["per_reporter_staleness"],
         }
         self.assertEqual(expected, actual)

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -103,10 +103,20 @@ def test_query_all_hosts(mocker, graphql_query_empty_response, api_get):
             "filter": (
                 {
                     "OR": (
-                        {"stale_timestamp": mocker.ANY},
-                        {"stale_timestamp": mocker.ANY},
-                        {"stale_timestamp": mocker.ANY},
-                        {"stale_timestamp": mocker.ANY},
+                        {
+                            "OR": (
+                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
+                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
+                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
+                            )
+                        },
+                        {
+                            "OR": (
+                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
+                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
+                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
+                            )
+                        },
                     )
                 },
             ),
@@ -672,10 +682,93 @@ def test_query_variables_default_except_staleness(mocker, graphql_query_empty_re
 @pytest.mark.parametrize(
     "staleness,expected",
     (
-        ("fresh", {"gt": "2019-12-16T10:10:06.754201+00:00"}),
-        ("stale", {"gt": "2019-12-09T10:10:06.754201+00:00", "lte": "2019-12-16T10:10:06.754201+00:00"}),
-        ("stale_warning", {"gt": "2019-12-02T10:10:06.754201+00:00", "lte": "2019-12-09T10:10:06.754201+00:00"}),
-        ("unknown", {"eq": None}),
+        (
+            "fresh",
+            (
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {"gt": "2019-12-14T10:10:06.754201+00:00"},
+                                "spf_host_type": {"eq": "edge"},
+                            }
+                        },
+                    )
+                },
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {"gt": "2019-12-15T10:10:06.754201+00:00"},
+                                "spf_host_type": {"eq": None},
+                            }
+                        },
+                    )
+                },
+            ),
+        ),
+        (
+            "stale",
+            (
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {
+                                    "gt": "2019-08-18T10:10:06.754201+00:00",
+                                    "lte": "2019-12-14T10:10:06.754201+00:00",
+                                },
+                                "spf_host_type": {"eq": "edge"},
+                            }
+                        },
+                    )
+                },
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {
+                                    "gt": "2019-12-09T10:10:06.754201+00:00",
+                                    "lte": "2019-12-15T10:10:06.754201+00:00",
+                                },
+                                "spf_host_type": {"eq": None},
+                            }
+                        },
+                    )
+                },
+            ),
+        ),
+        (
+            "stale_warning",
+            (
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {
+                                    "gt": "2019-06-19T10:10:06.754201+00:00",
+                                    "lte": "2019-08-18T10:10:06.754201+00:00",
+                                },
+                                "spf_host_type": {"eq": "edge"},
+                            }
+                        },
+                    )
+                },
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {
+                                    "gt": "2019-12-02T10:10:06.754201+00:00",
+                                    "lte": "2019-12-09T10:10:06.754201+00:00",
+                                },
+                                "spf_host_type": {"eq": None},
+                            }
+                        },
+                    )
+                },
+            ),
+        ),
     ),
 )
 def test_query_variables_staleness(
@@ -686,7 +779,7 @@ def test_query_variables_staleness(
 
     assert response_status == 200
 
-    assert_graph_query_single_call_with_staleness(mocker, graphql_query_empty_response, (expected,))
+    assert_graph_query_single_call_with_staleness(mocker, graphql_query_empty_response, expected)
 
 
 def test_query_multiple_staleness(mocker, culling_datetime_mock, graphql_query_empty_response, api_get):
@@ -699,8 +792,44 @@ def test_query_multiple_staleness(mocker, culling_datetime_mock, graphql_query_e
         mocker,
         graphql_query_empty_response,
         (
-            {"gt": "2019-12-16T10:10:06.754201+00:00"},  # fresh
-            {"gt": "2019-12-02T10:10:06.754201+00:00", "lte": "2019-12-09T10:10:06.754201+00:00"},  # stale warning
+            {
+                "OR": (
+                    {
+                        "AND": {
+                            "modified_on": {"gt": "2019-12-14T10:10:06.754201+00:00"},
+                            "spf_host_type": {"eq": "edge"},
+                        }
+                    },
+                    {
+                        "AND": {
+                            "modified_on": {
+                                "gt": "2019-06-19T10:10:06.754201+00:00",
+                                "lte": "2019-08-18T10:10:06.754201+00:00",
+                            },
+                            "spf_host_type": {"eq": "edge"},
+                        }
+                    },
+                )
+            },
+            {
+                "OR": (
+                    {
+                        "AND": {
+                            "modified_on": {"gt": "2019-12-15T10:10:06.754201+00:00"},
+                            "spf_host_type": {"eq": None},
+                        }
+                    },
+                    {
+                        "AND": {
+                            "modified_on": {
+                                "gt": "2019-12-02T10:10:06.754201+00:00",
+                                "lte": "2019-12-09T10:10:06.754201+00:00",
+                            },
+                            "spf_host_type": {"eq": None},
+                        }
+                    },
+                )
+            },
         ),
     )
 
@@ -765,7 +894,7 @@ def test_response_processed_properly(graphql_query_with_response, api_get):
                 "groups": [],
                 "satellite_id": "ce87bfac-a6cb-43a0-80ce-95d9669db71f",
                 "insights_id": "a58c53e0-8000-4384-b902-c70b69faacc5",
-                "stale_timestamp": "2020-02-10T08:07:03.354307+00:00",
+                "stale_timestamp": "2019-02-11T08:07:03.354312+00:00",
                 "reporter": "puptoo",
                 "per_reporter_staleness": {
                     "puptoo": {
@@ -780,8 +909,8 @@ def test_response_processed_properly(graphql_query_with_response, api_get):
                 "mac_addresses": None,
                 "provider_id": None,
                 "provider_type": None,
-                "stale_warning_timestamp": "2020-02-17T08:07:03.354307+00:00",
-                "culled_timestamp": "2020-02-24T08:07:03.354307+00:00",
+                "stale_warning_timestamp": "2019-02-17T08:07:03.354312+00:00",
+                "culled_timestamp": "2019-02-24T08:07:03.354312+00:00",
                 "facts": [],
             },
             {
@@ -796,7 +925,7 @@ def test_response_processed_properly(graphql_query_with_response, api_get):
                 "groups": [],
                 "satellite_id": "ce87bfac-a6cb-43a0-80ce-95d9669db71f",
                 "insights_id": "17c52679-f0b9-4e9b-9bac-a3c7fae5070c",
-                "stale_timestamp": "2020-01-10T08:07:03.354307+00:00",
+                "stale_timestamp": "2019-01-11T08:07:03.354312+00:00",
                 "reporter": "yupana",
                 "per_reporter_staleness": {
                     "yupana": {
@@ -811,8 +940,8 @@ def test_response_processed_properly(graphql_query_with_response, api_get):
                 "mac_addresses": None,
                 "provider_id": None,
                 "provider_type": None,
-                "stale_warning_timestamp": "2020-01-17T08:07:03.354307+00:00",
-                "culled_timestamp": "2020-01-24T08:07:03.354307+00:00",
+                "stale_warning_timestamp": "2019-01-17T08:07:03.354312+00:00",
+                "culled_timestamp": "2019-01-24T08:07:03.354312+00:00",
                 "facts": [
                     {"namespace": "os", "facts": {"os.release": "Red Hat Enterprise Linux Server"}},
                     {
@@ -845,7 +974,7 @@ def test_valid_without_decimal_part(graphql_query, api_get):
     response_status, response_data = api_get(HOST_URL)
 
     assert response_status == 200
-    assert response_data["results"][0]["stale_timestamp"] == "2020-02-10T08:07:03+00:00"
+    assert response_data["results"][0]["stale_timestamp"] == "2020-02-11T08:07:03+00:00"
 
 
 def test_valid_with_offset_timezone(graphql_query, api_get):
@@ -855,7 +984,7 @@ def test_valid_with_offset_timezone(graphql_query, api_get):
     response_status, response_data = api_get(HOST_URL)
 
     assert response_status == 200
-    assert response_data["results"][0]["stale_timestamp"] == "2020-02-10T07:07:03.354307+00:00"
+    assert response_data["results"][0]["stale_timestamp"] == "2020-02-11T07:07:03.354307+00:00"
 
 
 def test_invalid_without_timezone(graphql_query, api_get):
@@ -929,17 +1058,100 @@ def test_tags_query_group_name_filter(assert_tag_query_host_filter_single_call, 
 @pytest.mark.parametrize(
     "staleness,expected",
     (
-        ("fresh", {"gt": "2019-12-16T10:10:06.754201+00:00"}),
-        ("stale", {"gt": "2019-12-09T10:10:06.754201+00:00", "lte": "2019-12-16T10:10:06.754201+00:00"}),
-        ("stale_warning", {"gt": "2019-12-02T10:10:06.754201+00:00", "lte": "2019-12-09T10:10:06.754201+00:00"}),
-        ("unknown", {"eq": None}),
+        (
+            "fresh",
+            [
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {"gt": "2019-12-14T10:10:06.754201+00:00"},
+                                "spf_host_type": {"eq": "edge"},
+                            }
+                        },
+                    )
+                },
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {"gt": "2019-12-15T10:10:06.754201+00:00"},
+                                "spf_host_type": {"eq": None},
+                            }
+                        },
+                    )
+                },
+            ],
+        ),
+        (
+            "stale",
+            [
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {
+                                    "gt": "2019-08-18T10:10:06.754201+00:00",
+                                    "lte": "2019-12-14T10:10:06.754201+00:00",
+                                },
+                                "spf_host_type": {"eq": "edge"},
+                            }
+                        },
+                    )
+                },
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {
+                                    "gt": "2019-12-09T10:10:06.754201+00:00",
+                                    "lte": "2019-12-15T10:10:06.754201+00:00",
+                                },
+                                "spf_host_type": {"eq": None},
+                            }
+                        },
+                    )
+                },
+            ],
+        ),
+        (
+            "stale_warning",
+            [
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {
+                                    "gt": "2019-06-19T10:10:06.754201+00:00",
+                                    "lte": "2019-08-18T10:10:06.754201+00:00",
+                                },
+                                "spf_host_type": {"eq": "edge"},
+                            }
+                        },
+                    )
+                },
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {
+                                    "gt": "2019-12-02T10:10:06.754201+00:00",
+                                    "lte": "2019-12-09T10:10:06.754201+00:00",
+                                },
+                                "spf_host_type": {"eq": None},
+                            }
+                        },
+                    )
+                },
+            ],
+        ),
     ),
 )
 def test_tags_query_variables_staleness(
     staleness, expected, culling_datetime_mock, assert_tag_query_host_filter_single_call
 ):
     assert_tag_query_host_filter_single_call(
-        build_tags_url(query=f"?staleness={staleness}"), host_filter={"OR": [{"stale_timestamp": expected}]}
+        build_tags_url(query=f"?staleness={staleness}"), host_filter={"OR": expected}
     )
 
 
@@ -948,12 +1160,43 @@ def test_tags_multiple_query_variables_staleness(culling_datetime_mock, assert_t
         build_tags_url(query="?staleness=fresh&staleness=stale_warning"),
         host_filter={
             "OR": [
-                {"stale_timestamp": {"gt": "2019-12-16T10:10:06.754201+00:00"}},
                 {
-                    "stale_timestamp": {
-                        "gt": "2019-12-02T10:10:06.754201+00:00",
-                        "lte": "2019-12-09T10:10:06.754201+00:00",
-                    }
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {"gt": "2019-12-14T10:10:06.754201+00:00"},
+                                "spf_host_type": {"eq": "edge"},
+                            }
+                        },
+                        {
+                            "AND": {
+                                "modified_on": {
+                                    "gt": "2019-06-19T10:10:06.754201+00:00",
+                                    "lte": "2019-08-18T10:10:06.754201+00:00",
+                                },
+                                "spf_host_type": {"eq": "edge"},
+                            }
+                        },
+                    )
+                },
+                {
+                    "OR": (
+                        {
+                            "AND": {
+                                "modified_on": {"gt": "2019-12-15T10:10:06.754201+00:00"},
+                                "spf_host_type": {"eq": None},
+                            }
+                        },
+                        {
+                            "AND": {
+                                "modified_on": {
+                                    "gt": "2019-12-02T10:10:06.754201+00:00",
+                                    "lte": "2019-12-09T10:10:06.754201+00:00",
+                                },
+                                "spf_host_type": {"eq": None},
+                            }
+                        },
+                    )
                 },
             ]
         },
@@ -2826,9 +3069,13 @@ def test_sp_sparse_xjoin_query_translation(
     hosts = [minimal_host(id=host_one_id), minimal_host(id=host_two_id)]
 
     # Test with user identity first
-    variables["hostFilter"] = (
-        {"stale_timestamp": mocker.ANY, "OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]},
-    )
+    variables["hostFilter"] = {
+        "AND": ({"OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]},),
+        "OR": [
+            {"OR": ({"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},)},
+            {"OR": ({"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},)},
+        ],
+    }
 
     response_status, _ = api_get(build_system_profile_url(hosts, query=query))
 
@@ -2840,10 +3087,14 @@ def test_sp_sparse_xjoin_query_translation(
     graphql_sparse_system_profile_empty_response.reset_mock()
 
     # Now test with system identity
-    variables["hostFilter"] = (
-        {"stale_timestamp": mocker.ANY, "OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]},
-        {"spf_owner_id": {"eq": SYSTEM_IDENTITY["system"]["cn"]}},
-    )
+    variables["hostFilter"] = {
+        "AND": ({"OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]},),
+        "OR": [
+            {"OR": ({"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},)},
+            {"OR": ({"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},)},
+        ],
+        "spf_owner_id": {"eq": SYSTEM_IDENTITY["system"]["cn"]},
+    }
 
     response_status, _ = api_get(build_system_profile_url(hosts, query=query), identity=SYSTEM_IDENTITY)
 
@@ -2899,19 +3150,10 @@ def test_get_hosts_by_ids(num_hosts, mocker, filtering_datetime_mock, graphql_qu
             "order_how": mocker.ANY,
             "limit": mocker.ANY,
             "offset": mocker.ANY,
-            "filter": (
-                {
-                    "stale_timestamp": {
-                        "gt": "2019-12-02T10:10:06.754201+00:00",
-                    },
-                    "OR": [
-                        {
-                            "id": {"eq": host_id},
-                        }
-                        for host_id in host_id_list
-                    ],
-                },
-            ),
+            "filter": {
+                "OR": mocker.ANY,
+                "AND": ({"OR": [{"id": {"eq": host_id}} for host_id in host_id_list]},),
+            },
             "fields": mocker.ANY,
         },
         mocker.ANY,

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -7,13 +7,13 @@ from datetime import timedelta
 from datetime import timezone
 
 # complete system identity
-IDENTITY = {
-    "org_id": "test",
-    "type": "System",
-    "auth_type": "cert-auth",
-    "system": {"cn": "1b36b20f-7fa0-4454-a6d2-008294e06378", "cert_type": "system"},
-    "internal": {"auth_time": 6300},
-}
+# IDENTITY = {
+#    "org_id": "test",
+#    "type": "System",
+#    "auth_type": "cert-auth",
+#    "system": {"cn": "1b36b20f-7fa0-4454-a6d2-008294e06378", "cert_type": "system"},
+#    "internal": {"auth_time": 6300},
+# }
 
 # system identity: invalid or incomplete for testing
 # IDENTITY = {
@@ -25,12 +25,12 @@ IDENTITY = {
 # }
 
 # complete user identity
-# IDENTITY = {
-#     "org_id": "test",
-#     "type": "User",
-#     "auth_type": "basic-auth",
-#     "user": {"email": "tuser@redhat.com", "first_name": "test"},
-# }
+IDENTITY = {
+    "org_id": "5894300",
+    "type": "User",
+    "auth_type": "basic-auth",
+    "user": {"email": "jramos@redhat.com", "first_name": "test"},
+}
 
 # incomplete or invalid user identity for testing
 # IDENTITY = {
@@ -554,9 +554,17 @@ def random_uuid():
     return str(uuid.uuid4())
 
 
+IS_EDGE = os.environ.get("IS_EDGE", False)
+
+
 def build_host_chunk():
     org_id = os.environ.get("INVENTORY_HOST_ACCOUNT", IDENTITY["org_id"])
     fqdn = random_uuid()[:6] + ".foo.redhat.com"
+    system_profile = create_system_profile()
+
+    if IS_EDGE:
+        system_profile["host_type"] = "edge"
+
     payload = {
         "bios_uuid": random_uuid(),
         "org_id": org_id,
@@ -567,7 +575,7 @@ def build_host_chunk():
             {"namespace": "NS1", "key": "key3", "value": "val3"},
             {"namespace": "Sat", "key": "prod", "value": None},
         ],
-        "system_profile": create_system_profile(),
+        "system_profile": system_profile,
         "stale_timestamp": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
         "reporter": "puptoo",
     }


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-5050](https://issues.redhat.com/browse/ESSNTL-5050).

This changes allow us to handle conventional and immutable (edge) system staleness.
It changes the way the system do the culling filters, along with changes in the GrapgQL query that is sent to xjoin-search to retrieve hosts from Elasticsearch. 
It also change SQLAlchemy queries that use staleness to filter the hosts that are being fetched from inventory.
Updates to the OpenAPI Schema are also in this PR.

Todo:

1. Review tests that are failing
2. Add new tests 

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
