### PR TITLE
fix(RHINENG-1492): Remove RBAC admin workaround

### DIFF
--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -93,15 +93,6 @@ def rbac(resource_type, required_permission, permission_base="inventory"):
             # If populated, limits the allowed resources to specific group IDs
             allowed_group_ids = set()
 
-            # TODO: Remove this workaround after RHCLOUD-27511 is implemented.
-            # If the required permission is RBAC admin, we can check the Identity instead.
-            if (
-                permission_base == "rbac"
-                and current_identity.identity_type == IdentityType.USER
-                and current_identity.user.get("is_org_admin")
-            ):
-                return func(*args, **kwargs)
-
             for rbac_permission in rbac_data:
                 if (
                     rbac_permission["permission"]  # inventory:*:*

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,13 +1,9 @@
-from copy import deepcopy
-
 import pytest
 from requests import exceptions
 
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_hosts_url
-from tests.helpers.api_utils import build_resource_types_url
 from tests.helpers.api_utils import create_mock_rbac_response
-from tests.helpers.test_utils import USER_IDENTITY
 
 
 def test_rbac_retry_error_handling(mocker, db_create_host, api_get, enable_rbac):
@@ -76,20 +72,3 @@ def test_RBAC_invalid_UUIDs(mocker, api_get, enable_rbac):
     response_status, _ = api_get(build_hosts_url())
 
     assert_response_status(response_status, 503)
-
-
-def test_RBAC_admin_workaround(mocker, api_get, enable_rbac):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-
-    # Grant permissions that are irrelevant to the endpoint we want to access
-    mock_rbac_response = create_mock_rbac_response("tests/helpers/rbac-mock-data/inv-hosts-read-only.json")
-
-    get_rbac_permissions_mock.return_value = mock_rbac_response
-
-    # Use an identity that implies the user is an org admin
-    admin_identity = deepcopy(USER_IDENTITY)
-    admin_identity["user"]["is_org_admin"] = True
-
-    response_status, _ = api_get(build_resource_types_url(), admin_identity)
-
-    assert_response_status(response_status, 200)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-1492](https://issues.redhat.com/browse/RHINENG-1492).
This PR removes the RBAC is_admin workaround set up in RHINENG-1427.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
