### PR TITLE
feat(ESSNTL-5197): RBAC structuring, group data censoring

### DIFF
--- a/api/account_staleness.py
+++ b/api/account_staleness.py
@@ -40,14 +40,14 @@ def _get_return_data():
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.READ)
 @metrics.api_request_time.time()
-def get_staleness(rbac_filter: RbacFilter = RbacFilter()):
+def get_staleness(rbac_filter: RbacFilter):
     return flask_json_response(_get_return_data(), status.HTTP_200_OK)
 
 
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def create_staleness(body, rbac_filter: RbacFilter = RbacFilter()):
+def create_staleness(body, rbac_filter: RbacFilter):
     # Validate account staleness input data
     try:
         validated_data = InputAccountStalenessSchema().load(body)
@@ -73,12 +73,12 @@ def create_staleness(body, rbac_filter: RbacFilter = RbacFilter()):
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def update_staleness(rbac_filter: RbacFilter = RbacFilter()):
+def update_staleness(rbac_filter: RbacFilter):
     return flask_json_response(_get_return_data(), status.HTTP_200_OK)
 
 
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def reset_staleness(rbac_filter: RbacFilter = RbacFilter()):
+def reset_staleness(rbac_filter: RbacFilter):
     return flask_json_response(_get_return_data(), status.HTTP_200_OK)

--- a/api/account_staleness.py
+++ b/api/account_staleness.py
@@ -15,6 +15,7 @@ from app.models import InputAccountStalenessSchema
 from app.serialization import serialize_account_staleness_response
 from lib.account_staleness import add_account_staleness
 from lib.middleware import rbac
+from lib.middleware import RbacFilter
 
 logger = get_logger(__name__)
 
@@ -39,14 +40,14 @@ def _get_return_data():
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.READ)
 @metrics.api_request_time.time()
-def get_staleness():
+def get_staleness(rbac_filter: RbacFilter = RbacFilter()):
     return flask_json_response(_get_return_data(), status.HTTP_200_OK)
 
 
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def create_staleness(body):
+def create_staleness(body, rbac_filter: RbacFilter = RbacFilter()):
     # Validate account staleness input data
     try:
         validated_data = InputAccountStalenessSchema().load(body)
@@ -72,12 +73,12 @@ def create_staleness(body):
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def update_staleness():
+def update_staleness(rbac_filter: RbacFilter = RbacFilter()):
     return flask_json_response(_get_return_data(), status.HTTP_200_OK)
 
 
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def reset_staleness():
+def reset_staleness(rbac_filter: RbacFilter = RbacFilter()):
     return flask_json_response(_get_return_data(), status.HTTP_200_OK)

--- a/api/assignment_rule.py
+++ b/api/assignment_rule.py
@@ -61,7 +61,7 @@ def get_assignment_rules_list(
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def create_assignment_rule(body, rbac_filter: RbacFilter = RbacFilter()):
+def create_assignment_rule(body, rbac_filter: RbacFilter):
     if not get_flag_value(FLAG_INVENTORY_ASSIGNMENT_RULES):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 

--- a/api/assignment_rule.py
+++ b/api/assignment_rule.py
@@ -39,7 +39,7 @@ def get_assignment_rules_list(
     per_page=100,
     order_by=None,
     order_how=None,
-    rbac_filter: RbacFilter = None,
+    rbac_filter: RbacFilter = RbacFilter(),
 ):
     if not get_flag_value(FLAG_INVENTORY_ASSIGNMENT_RULES):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
@@ -61,7 +61,7 @@ def get_assignment_rules_list(
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def create_assignment_rule(body, rbac_filter: RbacFilter = None):
+def create_assignment_rule(body, rbac_filter: RbacFilter = RbacFilter()):
     if not get_flag_value(FLAG_INVENTORY_ASSIGNMENT_RULES):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
@@ -102,7 +102,7 @@ def get_assignment_rules_by_id(
     per_page=100,
     order_by=None,
     order_how=None,
-    rbac_filter: RbacFilter = None,
+    rbac_filter: RbacFilter = RbacFilter(),
 ):
     if not get_flag_value(FLAG_INVENTORY_ASSIGNMENT_RULES):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)

--- a/api/assignment_rule.py
+++ b/api/assignment_rule.py
@@ -24,6 +24,7 @@ from lib.assignment_rule_repository import add_assignment_rule
 from lib.feature_flags import FLAG_INVENTORY_ASSIGNMENT_RULES
 from lib.feature_flags import get_flag_value
 from lib.middleware import rbac
+from lib.middleware import RbacFilter
 
 
 logger = get_logger(__name__)
@@ -38,7 +39,7 @@ def get_assignment_rules_list(
     per_page=100,
     order_by=None,
     order_how=None,
-    rbac_filter=None,
+    rbac_filter: RbacFilter = None,
 ):
     if not get_flag_value(FLAG_INVENTORY_ASSIGNMENT_RULES):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
@@ -60,7 +61,7 @@ def get_assignment_rules_list(
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def create_assignment_rule(body, rbac_filter=None):
+def create_assignment_rule(body, rbac_filter: RbacFilter = None):
     if not get_flag_value(FLAG_INVENTORY_ASSIGNMENT_RULES):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
@@ -101,7 +102,7 @@ def get_assignment_rules_by_id(
     per_page=100,
     order_by=None,
     order_how=None,
-    rbac_filter=None,
+    rbac_filter: RbacFilter = None,
 ):
     if not get_flag_value(FLAG_INVENTORY_ASSIGNMENT_RULES):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)

--- a/api/assignment_rule_query.py
+++ b/api/assignment_rule_query.py
@@ -26,7 +26,7 @@ ASSIGNMENT_RULES_ORDER_HOW = {"asc": asc, "desc": desc}
 
 def get_assignment_rules_list_db(filters, page, per_page, param_order_by, param_order_how, rbac_filter: RbacFilter):
     # Apply RBAC group ID filter, if provided
-    if rbac_filter and rbac_filter.filter_by.resource == RbacResourceType.GROUPS:
+    if rbac_filter.filter_by and rbac_filter.filter_by.resource == RbacResourceType.GROUPS:
         filters += (AssignmentRule.group_id.in_(rbac_filter.filter_by.id_set),)
 
     order_by_str = param_order_by or "name"

--- a/api/assignment_rule_query.py
+++ b/api/assignment_rule_query.py
@@ -3,10 +3,12 @@ from sqlalchemy import desc
 from sqlalchemy import func
 
 from app import db
+from app import RbacResourceType
 from app.auth import get_current_identity
 from app.logging import get_logger
 from app.models import AssignmentRule
 from app.serialization import serialize_assignment_rule
+from lib.middleware import RbacFilter
 
 
 logger = get_logger(__name__)
@@ -22,9 +24,10 @@ ASSIGNMENT_RULES_ORDER_HOW_BY_FIELD = {"org_id": asc, "account": desc, "name": a
 ASSIGNMENT_RULES_ORDER_HOW = {"asc": asc, "desc": desc}
 
 
-def get_assignment_rules_list_db(filters, page, per_page, param_order_by, param_order_how, rbac_filter):
-    if rbac_filter and "assignment_rules" in rbac_filter:
-        filters += (AssignmentRule.id.in_(rbac_filter["assignment_rules"]),)
+def get_assignment_rules_list_db(filters, page, per_page, param_order_by, param_order_how, rbac_filter: RbacFilter):
+    # Apply RBAC group ID filter, if provided
+    if rbac_filter and rbac_filter.filter_by.resource == RbacResourceType.GROUPS:
+        filters += (AssignmentRule.group_id.in_(rbac_filter.filter_by.id_set),)
 
     order_by_str = param_order_by or "name"
     order_by = ASSIGNMENT_RULES_ORDER_BY_MAPPING[order_by_str]
@@ -44,7 +47,9 @@ def get_assignment_rules_list_db(filters, page, per_page, param_order_by, param_
     return assignment_rules_list, total
 
 
-def get_assignment_rules_list_by_id_list_db(assignment_rule_id_list, page, per_page, order_by, order_how, rbac_filter):
+def get_assignment_rules_list_by_id_list_db(
+    assignment_rule_id_list, page, per_page, order_by, order_how, rbac_filter: RbacFilter
+):
     filters = (
         AssignmentRule.org_id == get_current_identity().org_id,
         AssignmentRule.id.in_(assignment_rule_id_list),
@@ -52,7 +57,7 @@ def get_assignment_rules_list_by_id_list_db(assignment_rule_id_list, page, per_p
     return get_assignment_rules_list_db(filters, page, per_page, order_by, order_how, rbac_filter)
 
 
-def get_filtered_assignment_rule_list_db(rule_name, page, per_page, order_by, order_how, rbac_filter):
+def get_filtered_assignment_rule_list_db(rule_name, page, per_page, order_by, order_how, rbac_filter: RbacFilter):
     filters = (AssignmentRule.org_id == get_current_identity().org_id,)
     if rule_name:
         filters += (func.lower(AssignmentRule.name).contains(func.lower(rule_name)),)

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -355,9 +355,8 @@ def host_id_list_query_filter(host_id_list, rbac_filter: RbacFilter):
         },
     )
 
-    if rbac_filter:
-        if rbac_filter.filter_by.resource == RbacResourceType.GROUPS:
-            all_filters += _group_id_list_query_filter(rbac_filter.filter_by.id_set)
+    if rbac_filter.filter_by and rbac_filter.filter_by.resource == RbacResourceType.GROUPS:
+        all_filters += _group_id_list_query_filter(rbac_filter.filter_by.id_set)
 
     current_identity = get_current_identity()
     if current_identity.identity_type == IdentityType.SYSTEM:
@@ -429,7 +428,7 @@ def query_filters(
     staleness=None,
     registered_with=None,
     filter=None,
-    rbac_filter: RbacFilter = None,
+    rbac_filter: RbacFilter = RbacFilter(),
 ):
     num_ids = 0
     for id_param in [fqdn, display_name, hostname_or_id, insights_id]:
@@ -489,9 +488,8 @@ def query_filters(
             else:
                 raise ValidationException("filter key is invalid")
 
-    if rbac_filter:
-        if rbac_filter.filter_by.resource == RbacResourceType.GROUPS:
-            query_filters += _group_id_list_query_filter(rbac_filter.filter_by.id_set)
+    if rbac_filter.filter_by and rbac_filter.filter_by.resource == RbacResourceType.GROUPS:
+        query_filters += _group_id_list_query_filter(rbac_filter.filter_by.id_set)
 
     current_identity = get_current_identity()
     if current_identity.identity_type == IdentityType.SYSTEM:

--- a/api/group.py
+++ b/api/group.py
@@ -34,6 +34,7 @@ from lib.group_repository import remove_hosts_from_group
 from lib.metrics import create_group_count
 from lib.middleware import rbac
 from lib.middleware import rbac_group_id_check
+from lib.middleware import RbacFilter
 
 logger = get_logger(__name__)
 
@@ -47,7 +48,7 @@ def get_group_list(
     per_page=100,
     order_by=None,
     order_how=None,
-    rbac_filter=None,
+    rbac_filter: RbacFilter = None,
 ):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
@@ -66,7 +67,7 @@ def get_group_list(
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def create_group(body, rbac_filter=None):
+def create_group(body, rbac_filter: RbacFilter = None):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
@@ -114,7 +115,7 @@ def create_group(body, rbac_filter=None):
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def patch_group_by_id(group_id, body, rbac_filter=None):
+def patch_group_by_id(group_id, body, rbac_filter: RbacFilter = None):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
@@ -155,7 +156,7 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def delete_groups(group_id_list, rbac_filter=None):
+def delete_groups(group_id_list, rbac_filter: RbacFilter = None):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
@@ -178,7 +179,7 @@ def get_groups_by_id(
     per_page=100,
     order_by=None,
     order_how=None,
-    rbac_filter=None,
+    rbac_filter: RbacFilter = None,
 ):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
@@ -201,7 +202,7 @@ def get_groups_by_id(
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
+def delete_hosts_from_group(group_id, host_id_list, rbac_filter: RbacFilter = None):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 

--- a/api/group.py
+++ b/api/group.py
@@ -67,7 +67,7 @@ def get_group_list(
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def create_group(body, rbac_filter: RbacFilter = RbacFilter()):
+def create_group(body, rbac_filter: RbacFilter):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
@@ -115,7 +115,7 @@ def create_group(body, rbac_filter: RbacFilter = RbacFilter()):
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def patch_group_by_id(group_id, body, rbac_filter: RbacFilter = RbacFilter()):
+def patch_group_by_id(group_id, body, rbac_filter: RbacFilter):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
@@ -156,7 +156,7 @@ def patch_group_by_id(group_id, body, rbac_filter: RbacFilter = RbacFilter()):
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def delete_groups(group_id_list, rbac_filter: RbacFilter = RbacFilter()):
+def delete_groups(group_id_list, rbac_filter: RbacFilter):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
@@ -202,7 +202,7 @@ def get_groups_by_id(
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def delete_hosts_from_group(group_id, host_id_list, rbac_filter: RbacFilter = RbacFilter()):
+def delete_hosts_from_group(group_id, host_id_list, rbac_filter: RbacFilter):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 

--- a/api/group.py
+++ b/api/group.py
@@ -48,7 +48,7 @@ def get_group_list(
     per_page=100,
     order_by=None,
     order_how=None,
-    rbac_filter: RbacFilter = None,
+    rbac_filter: RbacFilter = RbacFilter(),
 ):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
@@ -67,13 +67,13 @@ def get_group_list(
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def create_group(body, rbac_filter: RbacFilter = None):
+def create_group(body, rbac_filter: RbacFilter = RbacFilter()):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
     # If there is an attribute filter on the RBAC permissions,
     # the user should not be allowed to create a group.
-    if rbac_filter is not None:
+    if rbac_filter.filter_by:
         abort(
             status.HTTP_403_FORBIDDEN,
             "Unfiltered inventory:groups:write RBAC permission is required in order to create new groups.",
@@ -115,7 +115,7 @@ def create_group(body, rbac_filter: RbacFilter = None):
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def patch_group_by_id(group_id, body, rbac_filter: RbacFilter = None):
+def patch_group_by_id(group_id, body, rbac_filter: RbacFilter = RbacFilter()):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
@@ -156,7 +156,7 @@ def patch_group_by_id(group_id, body, rbac_filter: RbacFilter = None):
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def delete_groups(group_id_list, rbac_filter: RbacFilter = None):
+def delete_groups(group_id_list, rbac_filter: RbacFilter = RbacFilter()):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
@@ -179,7 +179,7 @@ def get_groups_by_id(
     per_page=100,
     order_by=None,
     order_how=None,
-    rbac_filter: RbacFilter = None,
+    rbac_filter: RbacFilter = RbacFilter(),
 ):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
@@ -202,7 +202,7 @@ def get_groups_by_id(
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def delete_hosts_from_group(group_id, host_id_list, rbac_filter: RbacFilter = None):
+def delete_hosts_from_group(group_id, host_id_list, rbac_filter: RbacFilter = RbacFilter()):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 

--- a/api/group_query.py
+++ b/api/group_query.py
@@ -61,7 +61,7 @@ __all__ = (
 
 def get_group_list_from_db(filters, page, per_page, param_order_by, param_order_how, rbac_filter: RbacFilter):
     # Apply RBAC group ID filter, if provided
-    if rbac_filter and rbac_filter.filter_by.resource == RbacResourceType.GROUPS:
+    if rbac_filter.filter_by and rbac_filter.filter_by.resource == RbacResourceType.GROUPS:
         filters += (Group.id.in_(rbac_filter.filter_by.id_set),)
 
     order_by_str = param_order_by or "name"

--- a/api/host.py
+++ b/api/host.py
@@ -60,7 +60,7 @@ logger = get_logger(__name__)
 
 
 @api_operation
-@rbac(RbacResourceType.HOSTS, RbacPermission.READ, additional_permissions=["inventory:groups:read"])
+@rbac(RbacResourceType.HOSTS, RbacPermission.READ, additional_restrictions=["inventory:groups:read"])
 @metrics.api_request_time.time()
 def get_host_list(
     display_name=None,

--- a/api/host.py
+++ b/api/host.py
@@ -255,7 +255,7 @@ def delete_all_hosts(confirm_delete_all=None, rbac_filter: RbacFilter = RbacFilt
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def delete_host_by_id(host_id_list, rbac_filter: RbacFilter = RbacFilter()):
+def delete_host_by_id(host_id_list, rbac_filter: RbacFilter):
     delete_count = _delete_host_list(host_id_list, rbac_filter)
 
     if not delete_count:
@@ -323,7 +323,7 @@ def _emit_patch_event(serialized_host, host_id, insights_id):
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def patch_host_by_id(host_id_list, body, rbac_filter: RbacFilter = RbacFilter()):
+def patch_host_by_id(host_id_list, body, rbac_filter: RbacFilter):
     try:
         validated_patch_host_data = PatchHostSchema().load(body)
     except ValidationError as e:
@@ -353,14 +353,14 @@ def patch_host_by_id(host_id_list, body, rbac_filter: RbacFilter = RbacFilter())
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def replace_facts(host_id_list, namespace, body, rbac_filter: RbacFilter = RbacFilter()):
+def replace_facts(host_id_list, namespace, body, rbac_filter: RbacFilter):
     return update_facts_by_namespace(FactOperations.replace, host_id_list, namespace, body, rbac_filter)
 
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def merge_facts(host_id_list, namespace, body, rbac_filter: RbacFilter = RbacFilter()):
+def merge_facts(host_id_list, namespace, body, rbac_filter: RbacFilter):
     if not body:
         error_msg = "ERROR: Invalid request.  Merging empty facts into existing facts is a no-op."
         logger.debug(error_msg)
@@ -456,7 +456,7 @@ def _build_paginated_host_tags_response(total, page, per_page, tags_list):
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def host_checkin(body, rbac_filter: RbacFilter = RbacFilter()):
+def host_checkin(body, rbac_filter: RbacFilter):
     current_identity = get_current_identity()
     canonical_facts = deserialize_canonical_facts(body)
     existing_host = find_existing_host(current_identity, canonical_facts)

--- a/api/host.py
+++ b/api/host.py
@@ -265,7 +265,7 @@ def delete_host_by_id(host_id_list, rbac_filter: RbacFilter):
 
 
 @api_operation
-@rbac(RbacResourceType.HOSTS, RbacPermission.READ)
+@rbac(RbacResourceType.HOSTS, RbacPermission.READ, additional_restrictions=["inventory:groups:read"])
 @metrics.api_request_time.time()
 def get_host_by_id(
     host_id_list,
@@ -286,7 +286,7 @@ def get_host_by_id(
 
     log_get_host_list_succeeded(logger, host_list)
 
-    json_data = build_paginated_host_list_response(total, page, per_page, host_list, additional_fields)
+    json_data = build_paginated_host_list_response(total, page, per_page, host_list, additional_fields, rbac_filter)
     return flask_json_response(json_data)
 
 

--- a/api/host_group.py
+++ b/api/host_group.py
@@ -20,6 +20,7 @@ from lib.group_repository import remove_hosts_from_group
 from lib.host_repository import get_host_list_by_id_list_from_db
 from lib.middleware import rbac
 from lib.middleware import rbac_group_id_check
+from lib.middleware import RbacFilter
 
 logger = get_logger(__name__)
 
@@ -27,7 +28,7 @@ logger = get_logger(__name__)
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def add_host_list_to_group(group_id, body, rbac_filter=None):
+def add_host_list_to_group(group_id, body, rbac_filter: RbacFilter = None):
     if type(body) is not list:
         return abort(status.HTTP_400_BAD_REQUEST, f"Body content must be an array with groups UUIDs, not {type(body)}")
 
@@ -63,7 +64,7 @@ def add_host_list_to_group(group_id, body, rbac_filter=None):
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
+def delete_hosts_from_group(group_id, host_id_list, rbac_filter: RbacFilter = None):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 

--- a/api/host_group.py
+++ b/api/host_group.py
@@ -28,7 +28,7 @@ logger = get_logger(__name__)
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def add_host_list_to_group(group_id, body, rbac_filter: RbacFilter = RbacFilter()):
+def add_host_list_to_group(group_id, body, rbac_filter: RbacFilter):
     if type(body) is not list:
         return abort(status.HTTP_400_BAD_REQUEST, f"Body content must be an array with groups UUIDs, not {type(body)}")
 
@@ -64,7 +64,7 @@ def add_host_list_to_group(group_id, body, rbac_filter: RbacFilter = RbacFilter(
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def delete_hosts_from_group(group_id, host_id_list, rbac_filter: RbacFilter = RbacFilter()):
+def delete_hosts_from_group(group_id, host_id_list, rbac_filter: RbacFilter):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 

--- a/api/host_group.py
+++ b/api/host_group.py
@@ -28,7 +28,7 @@ logger = get_logger(__name__)
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def add_host_list_to_group(group_id, body, rbac_filter: RbacFilter = None):
+def add_host_list_to_group(group_id, body, rbac_filter: RbacFilter = RbacFilter()):
     if type(body) is not list:
         return abort(status.HTTP_400_BAD_REQUEST, f"Body content must be an array with groups UUIDs, not {type(body)}")
 
@@ -49,7 +49,7 @@ def add_host_list_to_group(group_id, body, rbac_filter: RbacFilter = None):
         return abort(status.HTTP_404_NOT_FOUND)
 
     host_id_list = body
-    if not get_host_list_by_id_list_from_db(host_id_list):
+    if not get_host_list_by_id_list_from_db(host_id_list, rbac_filter):
         return abort(status.HTTP_404_NOT_FOUND)
 
     # Next, add the host-group associations
@@ -64,7 +64,7 @@ def add_host_list_to_group(group_id, body, rbac_filter: RbacFilter = None):
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def delete_hosts_from_group(group_id, host_id_list, rbac_filter: RbacFilter = None):
+def delete_hosts_from_group(group_id, host_id_list, rbac_filter: RbacFilter = RbacFilter()):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -11,8 +11,9 @@ def build_paginated_host_list_response(
     total, page, per_page, host_list, additional_fields=tuple(), rbac_filter: RbacFilter = RbacFilter()
 ):
     timestamps = staleness_timestamps()
+
     allowed_group_read_ids = (
-        rbac_filter.other_permissions.get("inventory:groups:read").id_set if rbac_filter.other_permissions else None
+        rbac_filter.data_restrictions.get("inventory:groups:read").id_set if rbac_filter.data_restrictions else None
     )
 
     json_host_list = [

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -13,7 +13,9 @@ def build_paginated_host_list_response(
     timestamps = staleness_timestamps()
 
     allowed_group_read_ids = (
-        rbac_filter.data_restrictions.get("inventory:groups:read").id_set if rbac_filter.data_restrictions else None
+        rbac_filter.data_restrictions.get("inventory:groups:read").id_set
+        if rbac_filter.data_restrictions.get("inventory:groups:read")
+        else None
     )
 
     json_host_list = [

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -1,14 +1,23 @@
 from app import inventory_config
 from app.culling import Timestamps
 from app.serialization import serialize_host
+from lib.middleware import RbacFilter
 
 
 __all__ = ("build_paginated_host_list_response", "staleness_timestamps")
 
 
-def build_paginated_host_list_response(total, page, per_page, host_list, additional_fields=tuple()):
+def build_paginated_host_list_response(
+    total, page, per_page, host_list, additional_fields=tuple(), rbac_filter: RbacFilter = RbacFilter()
+):
     timestamps = staleness_timestamps()
-    json_host_list = [serialize_host(host, timestamps, False, additional_fields) for host in host_list]
+    allowed_group_read_ids = (
+        rbac_filter.other_permissions.get("inventory:groups:read").id_set if rbac_filter.other_permissions else None
+    )
+
+    json_host_list = [
+        serialize_host(host, timestamps, False, additional_fields, allowed_group_read_ids) for host in host_list
+    ]
     return {
         "total": total,
         "count": len(json_host_list),

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -217,7 +217,7 @@ def get_host_list(
 
 
 def get_host_list_by_id_list(
-    host_id_list, page, per_page, param_order_by, param_order_how, fields=None, rbac_filter: RbacFilter = None
+    host_id_list, page, per_page, param_order_by, param_order_how, fields=None, rbac_filter: RbacFilter = RbacFilter()
 ):
     all_filters = host_id_list_query_filter(host_id_list, rbac_filter)
 
@@ -246,7 +246,7 @@ def get_host_ids_list(
     staleness,
     tags,
     filter,
-    rbac_filter,
+    rbac_filter: RbacFilter,
 ):
     all_filters = query_filters(
         fqdn,

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -9,6 +9,7 @@ from app.xjoin import check_pagination
 from app.xjoin import graphql_query
 from app.xjoin import pagination_params
 from app.xjoin import params_to_order
+from lib.middleware import RbacFilter
 
 __all__ = ("get_host_list", "get_host_ids_list", "query_filters")
 
@@ -216,14 +217,16 @@ def get_host_list(
 
 
 def get_host_list_by_id_list(
-    host_id_list, page, per_page, param_order_by, param_order_how, fields=None, rbac_filter=None
+    host_id_list, page, per_page, param_order_by, param_order_how, fields=None, rbac_filter: RbacFilter = None
 ):
     all_filters = host_id_list_query_filter(host_id_list, rbac_filter)
 
     return get_host_list_using_filters(all_filters, page, per_page, param_order_by, param_order_how, fields)
 
 
-def get_host_tags_list_by_id_list(host_id_list, page, per_page, param_order_by, param_order_how, rbac_filter):
+def get_host_tags_list_by_id_list(
+    host_id_list, page, per_page, param_order_by, param_order_how, rbac_filter: RbacFilter
+):
     all_filters = host_id_list_query_filter(host_id_list, rbac_filter)
 
     return get_host_tags_list_using_filters(all_filters, page, per_page, param_order_by, param_order_how)

--- a/api/resource_type.py
+++ b/api/resource_type.py
@@ -19,6 +19,7 @@ from app.serialization import serialize_group
 from lib.feature_flags import FLAG_INVENTORY_GROUPS
 from lib.feature_flags import get_flag_value
 from lib.middleware import rbac
+from lib.middleware import RbacFilter
 
 logger = get_logger(__name__)
 
@@ -54,7 +55,7 @@ def get_resource_type_groups_list(
     per_page=100,
     order_by=None,
     order_how=None,
-    rbac_filter=None,
+    rbac_filter: RbacFilter = None,
 ):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)

--- a/api/resource_type.py
+++ b/api/resource_type.py
@@ -27,10 +27,7 @@ logger = get_logger(__name__)
 @api_operation
 @rbac(RbacResourceType.ALL, RbacPermission.ADMIN, "rbac")
 @metrics.api_request_time.time()
-def get_resource_type_list(
-    page=1,
-    per_page=10,
-):
+def get_resource_type_list(page=1, per_page=10, rbac_filter: RbacFilter = RbacFilter()):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
@@ -55,7 +52,7 @@ def get_resource_type_groups_list(
     per_page=100,
     order_by=None,
     order_how=None,
-    rbac_filter: RbacFilter = None,
+    rbac_filter: RbacFilter = RbacFilter(),
 ):
     if not get_flag_value(FLAG_INVENTORY_GROUPS):
         return Response(None, status.HTTP_501_NOT_IMPLEMENTED)

--- a/api/sparse_host_list_system_profile.py
+++ b/api/sparse_host_list_system_profile.py
@@ -9,6 +9,7 @@ from app.xjoin import check_pagination
 from app.xjoin import graphql_query
 from app.xjoin import pagination_params
 from app.xjoin import params_to_order
+from lib.middleware import RbacFilter
 
 
 logger = get_logger(__name__)
@@ -67,7 +68,7 @@ SYSTEM_PROFILE_FULL_QUERY = """
 """
 
 
-def get_sparse_system_profile(host_id_list, page, per_page, order_by, order_how, fields, rbac_filter):
+def get_sparse_system_profile(host_id_list, page, per_page, order_by, order_how, fields, rbac_filter: RbacFilter):
     limit, offset = pagination_params(page, per_page)
 
     try:

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -126,7 +126,7 @@ def get_sap_system(
     staleness=None,
     registered_with=None,
     filter=None,
-    rbac_filter: RbacFilter = None,
+    rbac_filter: RbacFilter = RbacFilter(),
 ):
     limit, offset = pagination_params(page, per_page)
 
@@ -167,7 +167,7 @@ def get_sap_sids(
     staleness=None,
     registered_with=None,
     filter=None,
-    rbac_filter: RbacFilter = None,
+    rbac_filter: RbacFilter = RbacFilter(),
 ):
     limit, offset = pagination_params(page, per_page)
 
@@ -215,7 +215,7 @@ def get_operating_system(
     staleness: Optional[str] = None,
     registered_with: Optional[str] = None,
     filter=None,
-    rbac_filter: RbacFilter = None,
+    rbac_filter: RbacFilter = RbacFilter(),
 ):
     limit, offset = pagination_params(page, per_page)
 
@@ -254,7 +254,11 @@ def get_operating_system(
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.schema_validation_time.time()
 def validate_schema(
-    repo_fork="RedHatInsights", repo_branch="master", days=1, max_messages=10000, rbac_filter: RbacFilter = None
+    repo_fork="RedHatInsights",
+    repo_branch="master",
+    days=1,
+    max_messages=10000,
+    rbac_filter: RbacFilter = RbacFilter(),
 ):
     # Use the identity header to make sure the user is someone from our team.
     config = Config(RuntimeEnvironment.SERVICE)

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -26,6 +26,7 @@ from app.xjoin import graphql_query
 from app.xjoin import pagination_params
 from app.xjoin import staleness_filter
 from lib.middleware import rbac
+from lib.middleware import RbacFilter
 from lib.system_profile_validate import validate_sp_for_branch
 
 logger = get_logger(__name__)
@@ -119,7 +120,13 @@ OPERATING_SYSTEM_QUERY = """
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
 def get_sap_system(
-    tags=None, page=None, per_page=None, staleness=None, registered_with=None, filter=None, rbac_filter=None
+    tags=None,
+    page=None,
+    per_page=None,
+    staleness=None,
+    registered_with=None,
+    filter=None,
+    rbac_filter: RbacFilter = None,
 ):
     limit, offset = pagination_params(page, per_page)
 
@@ -160,7 +167,7 @@ def get_sap_sids(
     staleness=None,
     registered_with=None,
     filter=None,
-    rbac_filter=None,
+    rbac_filter: RbacFilter = None,
 ):
     limit, offset = pagination_params(page, per_page)
 
@@ -208,7 +215,7 @@ def get_operating_system(
     staleness: Optional[str] = None,
     registered_with: Optional[str] = None,
     filter=None,
-    rbac_filter=None,
+    rbac_filter: RbacFilter = None,
 ):
     limit, offset = pagination_params(page, per_page)
 
@@ -246,7 +253,9 @@ def get_operating_system(
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.schema_validation_time.time()
-def validate_schema(repo_fork="RedHatInsights", repo_branch="master", days=1, max_messages=10000, rbac_filter=None):
+def validate_schema(
+    repo_fork="RedHatInsights", repo_branch="master", days=1, max_messages=10000, rbac_filter: RbacFilter = None
+):
     # Use the identity header to make sure the user is someone from our team.
     config = Config(RuntimeEnvironment.SERVICE)
     identity = get_current_identity()

--- a/api/tag.py
+++ b/api/tag.py
@@ -16,6 +16,7 @@ from app.xjoin import graphql_query
 from app.xjoin import pagination_params
 from app.xjoin import staleness_filter
 from lib.middleware import rbac
+from lib.middleware import RbacFilter
 
 
 logger = get_logger(__name__)
@@ -73,7 +74,7 @@ def get_tags(
     staleness=None,
     registered_with=None,
     filter=None,
-    rbac_filter=None,
+    rbac_filter: RbacFilter = None,
 ):
     limit, offset = pagination_params(page, per_page)
 

--- a/api/tag.py
+++ b/api/tag.py
@@ -74,7 +74,7 @@ def get_tags(
     staleness=None,
     registered_with=None,
     filter=None,
-    rbac_filter: RbacFilter = None,
+    rbac_filter: RbacFilter = RbacFilter(),
 ):
     limit, offset = pagination_params(page, per_page)
 

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -165,7 +165,7 @@ def serialize_host(host, staleness_timestamps, for_mq=True, additional_fields=tu
             ]
         else:
             # If allowed_group_ids is provided, we need to limit which groups are displayed.
-            if allowed_group_ids:
+            if allowed_group_ids is not None:
                 serialized_host["groups"] = [g for g in host.groups if g["id"] in allowed_group_ids] or []
             else:
                 serialized_host["groups"] = host.groups or []

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -76,7 +76,7 @@ def deserialize_canonical_facts(raw_data, all=False):
     return _deserialize_canonical_facts(validated_data)
 
 
-def deserialize_host_xjoin(data, rbac_filter=None):
+def deserialize_host_xjoin(data):
     host = Host(
         canonical_facts=data["canonical_facts"],
         display_name=data["display_name"],

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -283,13 +283,13 @@ def update_system_profile(input_host, identity, staleness_offset):
             )
 
 
-def get_host_list_by_id_list_from_db(host_id_list, rbac_filter: RbacFilter = None):
+def get_host_list_by_id_list_from_db(host_id_list, rbac_filter: RbacFilter = RbacFilter()):
     current_identity = get_current_identity()
     filters = (
         Host.org_id == current_identity.org_id,
         Host.id.in_(host_id_list),
     )
-    if rbac_filter and rbac_filter.filter_by.resource == RbacResourceType.GROUPS:
+    if rbac_filter.filter_by and rbac_filter.filter_by.resource == RbacResourceType.GROUPS:
         rbac_group_filters = (HostGroupAssoc.group_id.in_(rbac_filter.filter_by.id_set),)
         if None in rbac_filter.filter_by.id_set:
             rbac_group_filters += (HostGroupAssoc.group_id.is_(None),)

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -1,5 +1,6 @@
 from functools import partial
 from functools import wraps
+from typing import Dict
 from typing import List
 from typing import Set
 from typing import Tuple
@@ -54,7 +55,7 @@ class RbacFilter:
         resource: RbacResourceType = RbacResourceType.HOSTS,
         permission: RbacPermission = RbacPermission.READ,
         filter_by: RbacIdFilter = None,
-        other_permissions: dict = {},
+        other_permissions: Dict[str, RbacIdFilter] = {},
     ) -> None:
         # The resource and permission this filter applies to (e.g. hosts:read)
         self.resource = resource

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -217,10 +217,17 @@ def rbac(
             # Get the allowed IDs for any additional restrictions
             data_restrictions = {}
             for additional_permission in additional_restrictions:
-                additional_ids, _ = _get_allowed_ids(
+                additional_ids, match_found = _get_allowed_ids(
                     rbac_data, *(_parse_rbac_permission_string(additional_permission))
                 )
-                data_restrictions[additional_permission] = RbacIdFilter(RbacResourceType.GROUPS, additional_ids)
+
+                if not match_found or (match_found and len(additional_ids) > 0):
+                    # If no matching permission was found, or it was found and it's limited to a set of IDs,
+                    # we should restrict the data.
+                    data_restrictions[additional_permission] = RbacIdFilter(RbacResourceType.GROUPS, additional_ids)
+                else:
+                    # If a match was found but it's not limited to any IDs, we should not restrict the data.
+                    data_restrictions[additional_permission] = None
 
             # If all applicable permissions are restricted to specific groups,
             # call the endpoint with the RBAC filtering data.

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -104,6 +104,19 @@ XJOIN_HOSTS_RESPONSE = {
                     "insights_id": "a58c53e0-8000-4384-b902-c70b69faacc5",
                 },
                 "facts": None,
+                "groups": {
+                    "data": [
+                        {
+                            "id": "28c52679-f0b9-4e9b-9bac-a3c7fae5070c",
+                            "org_id": "test",
+                            "account": "test",
+                            "name": "group 1",
+                            "created": "2019-02-10T08:07:03.354307Z",
+                            "updated": "2019-02-10T08:07:03.354312Z",
+                        }
+                    ],
+                    "meta": {"total": 1},
+                },
                 "stale_timestamp": "2020-02-10T08:07:03.354307Z",
                 "reporter": "puptoo",
                 "per_reporter_staleness": {
@@ -139,6 +152,19 @@ XJOIN_HOSTS_RESPONSE = {
                         "bios.release_date": "2014-04-01",
                         "bios.version": "1.11.0-2.el7",
                     },
+                },
+                "groups": {
+                    "data": [
+                        {
+                            "id": "39c52679-f0b9-4e9b-9bac-a3c7fae5070c",
+                            "org_id": "test",
+                            "account": "test",
+                            "name": "group 2",
+                            "created": "2019-02-10T08:07:03.354307Z",
+                            "updated": "2019-02-10T08:07:03.354312Z",
+                        },
+                    ],
+                    "meta": {"total": 1},
                 },
                 "stale_timestamp": "2020-01-10T08:07:03.354307Z",
                 "reporter": "yupana",

--- a/tests/helpers/rbac-mock-data/inv-hosts-read-groups-read-resource-defs-template.json
+++ b/tests/helpers/rbac-mock-data/inv-hosts-read-groups-read-resource-defs-template.json
@@ -1,0 +1,31 @@
+{
+  "meta": {
+      "count": 1,
+      "limit": 1000,
+      "offset": 0
+  },
+  "links": {
+      "first": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0",
+      "next": null,
+      "previous": null,
+      "last": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0"
+  },
+  "data": [
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "group.id",
+            "value": [],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "inventory:groups:read"
+    },
+    {
+      "resourceDefinitions": [],
+      "permission": "inventory:hosts:read"
+    }
+  ]
+}

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -476,7 +476,7 @@ def test_get_hosts_timestamp_invalid_value_graceful_rejection(patch_xjoin_post, 
     assert 400 == api_get(build_hosts_url(query="?filter[system_profile][last_boot_time][eq]=foo"))[0]
 
 
-def test_host_list_hidden_group_names(mocker, patch_xjoin_post, api_get):
+def test_host_list_hidden_group_names(mocker, enable_rbac, patch_xjoin_post, api_get):
     # Patch the xjoin response; it should get 2 hosts.
     # One host is in "group 1", and the other is in "group 2"
     patch_xjoin_post(response={"data": XJOIN_HOSTS_RESPONSE})

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -762,7 +762,16 @@ def test_response_processed_properly(graphql_query_with_response, api_get):
                 "created": "2019-02-10T08:07:03.354307+00:00",
                 "updated": "2019-02-10T08:07:03.354312+00:00",
                 "fqdn": "fqdn.test01.rhel7.jharting.local",
-                "groups": [],
+                "groups": [
+                    {
+                        "id": "28c52679-f0b9-4e9b-9bac-a3c7fae5070c",
+                        "org_id": "test",
+                        "account": "test",
+                        "name": "group 1",
+                        "created": "2019-02-10T08:07:03.354307Z",
+                        "updated": "2019-02-10T08:07:03.354312Z",
+                    }
+                ],
                 "satellite_id": "ce87bfac-a6cb-43a0-80ce-95d9669db71f",
                 "insights_id": "a58c53e0-8000-4384-b902-c70b69faacc5",
                 "stale_timestamp": "2020-02-10T08:07:03.354307+00:00",
@@ -793,7 +802,16 @@ def test_response_processed_properly(graphql_query_with_response, api_get):
                 "created": "2019-01-10T08:07:03.354307+00:00",
                 "updated": "2019-01-10T08:07:03.354312+00:00",
                 "fqdn": "fqdn.test02.rhel7.jharting.local",
-                "groups": [],
+                "groups": [
+                    {
+                        "id": "39c52679-f0b9-4e9b-9bac-a3c7fae5070c",
+                        "org_id": "test",
+                        "account": "test",
+                        "name": "group 2",
+                        "created": "2019-02-10T08:07:03.354307Z",
+                        "updated": "2019-02-10T08:07:03.354312Z",
+                    },
+                ],
                 "satellite_id": "ce87bfac-a6cb-43a0-80ce-95d9669db71f",
                 "insights_id": "17c52679-f0b9-4e9b-9bac-a3c7fae5070c",
                 "stale_timestamp": "2020-01-10T08:07:03.354307+00:00",


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-5197](https://issues.redhat.com/browse/ESSNTL-5197).

- Gives `rbac_filter` a rigid structure to make its usage more clear
- Gives `rbac_filter` default values instead of the whole object being `None` if not provided
- Removes group data from host API responses if the user does not have `groups:read` permission for that group
- Add test and modify an existing one

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
