### PR TITLE
Fix AssignmentRuleOut in API spec

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1840,28 +1840,27 @@ components:
       description: >-
         Data for a single Assignment Rule
       type: object
-      allOf:
-        - properties:
-            name:
-              type: string
-              minLength: 1
-              maxLength: 255
-            description:
-              type: string
-              minLength: 1
-              maxLength: 255
-              nullable: true
-            group_id:
-              $ref: "#/components/schemas/GroupId"
-            filter:
-              type: object
-            enabled:
-              type: boolean
-          required:
-            - name
-            - group_id
-            - filter
-            - enabled
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+          minLength: 1
+          maxLength: 255
+          nullable: true
+        group_id:
+          $ref: "#/components/schemas/GroupId"
+        filter:
+          type: object
+        enabled:
+          type: boolean
+      required:
+        - name
+        - group_id
+        - filter
+        - enabled
     AssignmentRuleOut:
       title: Assignment Rule response
       description: >-

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1867,40 +1867,39 @@ components:
       description: >-
         Data for a single Assignment Rule response
       type: object
-      allOf:
-        - properties:
-            id:
-              $ref: '#/components/schemas/NonStrictUUID'
-            org_id:
-              $ref: '#/components/schemas/OrgId'
-            account:
-              $ref: '#/components/schemas/AccountNumber'
-            name:
-              type: string
-              minLength: 1
-            description:
-              type: string
-              minLength: 1
-              nullable: true
-            group_id:
-              $ref: "#/components/schemas/GroupId"
-            filter:
-              type: object
-            enabled:
-              type: boolean
-            created_on:
-              type: string
-              format: date-time
-            modified_on:
-              type: string
-              format: date-time
-          required:
-            - name
-            - group_id
-            - filter
-            - enabled
-            - created_on
-            - modified_on
+      properties:
+        id:
+          $ref: '#/components/schemas/NonStrictUUID'
+        org_id:
+          $ref: '#/components/schemas/OrgId'
+        account:
+          $ref: '#/components/schemas/AccountNumber'
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+          minLength: 1
+          nullable: true
+        group_id:
+          $ref: "#/components/schemas/GroupId"
+        filter:
+          type: object
+        enabled:
+          type: boolean
+        created_on:
+          type: string
+          format: date-time
+        modified_on:
+          type: string
+          format: date-time
+      required:
+        - name
+        - group_id
+        - filter
+        - enabled
+        - created_on
+        - modified_on
     GroupOutWithHostCount:
       title: Group properties with host count
       description: >-

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -2802,37 +2802,33 @@
         "title": "Assignment Rule In",
         "description": "Data for a single Assignment Rule",
         "type": "object",
-        "allOf": [
-          {
-            "properties": {
-              "name": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 255
-              },
-              "description": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 255,
-                "nullable": true
-              },
-              "group_id": {
-                "$ref": "#/components/schemas/GroupId"
-              },
-              "filter": {
-                "type": "object"
-              },
-              "enabled": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "name",
-              "group_id",
-              "filter",
-              "enabled"
-            ]
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "nullable": true
+          },
+          "group_id": {
+            "$ref": "#/components/schemas/GroupId"
+          },
+          "filter": {
+            "type": "object"
+          },
+          "enabled": {
+            "type": "boolean"
           }
+        },
+        "required": [
+          "name",
+          "group_id",
+          "filter",
+          "enabled"
         ]
       },
       "AssignmentRuleOut": {

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -2839,54 +2839,50 @@
         "title": "Assignment Rule response",
         "description": "Data for a single Assignment Rule response",
         "type": "object",
-        "allOf": [
-          {
-            "properties": {
-              "id": {
-                "$ref": "#/components/schemas/NonStrictUUID"
-              },
-              "org_id": {
-                "$ref": "#/components/schemas/OrgId"
-              },
-              "account": {
-                "$ref": "#/components/schemas/AccountNumber"
-              },
-              "name": {
-                "type": "string",
-                "minLength": 1
-              },
-              "description": {
-                "type": "string",
-                "minLength": 1,
-                "nullable": true
-              },
-              "group_id": {
-                "$ref": "#/components/schemas/GroupId"
-              },
-              "filter": {
-                "type": "object"
-              },
-              "enabled": {
-                "type": "boolean"
-              },
-              "created_on": {
-                "type": "string",
-                "format": "date-time"
-              },
-              "modified_on": {
-                "type": "string",
-                "format": "date-time"
-              }
-            },
-            "required": [
-              "name",
-              "group_id",
-              "filter",
-              "enabled",
-              "created_on",
-              "modified_on"
-            ]
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/NonStrictUUID"
+          },
+          "org_id": {
+            "$ref": "#/components/schemas/OrgId"
+          },
+          "account": {
+            "$ref": "#/components/schemas/AccountNumber"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "nullable": true
+          },
+          "group_id": {
+            "$ref": "#/components/schemas/GroupId"
+          },
+          "filter": {
+            "type": "object"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "created_on": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modified_on": {
+            "type": "string",
+            "format": "date-time"
           }
+        },
+        "required": [
+          "name",
+          "group_id",
+          "filter",
+          "enabled",
+          "created_on",
+          "modified_on"
         ]
       },
       "GroupOutWithHostCount": {


### PR DESCRIPTION
# Overview

The OpenAPI codegen is generating some weird stuff with the current implementation of AssignmentRuleOut. I'm not sure why, but anyway, the `allOf` field is not needed if we don't import fields from other objects and removing it fixes the issue.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
