### PR TITLE
feat(events): RHINENG-1789 push additional headers with kafka events

### DIFF
--- a/app/queue/events.py
+++ b/app/queue/events.py
@@ -75,12 +75,17 @@ class HostDeleteEvent(Schema):
     metadata = fields.Nested(HostEventMetadataSchema())
 
 
-def message_headers(event_type: EventType, insights_id: str):
+def message_headers(
+    event_type: EventType, insights_id: str = None, reporter: str = None, host_type: str = None, os_name: str = None
+):
     return {
         "event_type": event_type.name,
         "request_id": threadctx.request_id,
         "producer": hostname(),
         "insights_id": insights_id,
+        "reporter": reporter,
+        "host_type": host_type,
+        "os_name": os_name,
     }
 
 

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -44,7 +44,13 @@ def _produce_host_update_events(event_producer, host_id_list, group_id_list=[]):
     for host in host_list:
         host.groups = serialized_groups
         serialized_host = serialize_host(host, staleness_timestamps())
-        headers = message_headers(EventType.updated, serialized_host["insights_id"])
+        headers = message_headers(
+            EventType.updated,
+            host.canonical_facts.get("insights_id"),
+            host.reporter,
+            host.system_profile_facts.get("host_type"),
+            host.system_profile_facts.get("operating_system", {}).get("name"),
+        )
         event = build_event(EventType.updated, serialized_host)
         event_producer.write_event(event, serialized_host["id"], headers, wait=True)
 

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -40,8 +40,13 @@ def _delete_host(session, event_producer, host):
         if host_deleted:
             delete_host_count.inc()
             event = build_event(EventType.delete, host)
-            insights_id = host.canonical_facts.get("insights_id")
-            headers = message_headers(EventType.delete, insights_id)
+            headers = message_headers(
+                EventType.delete,
+                host.canonical_facts.get("insights_id"),
+                host.reporter,
+                host.system_profile_facts.get("host_type"),
+                host.system_profile_facts.get("operating_system", {}).get("name"),
+            )
             event_producer.write_event(event, str(host.id), headers, wait=True)
             session.commit()
             return host_deleted

--- a/lib/host_remove_duplicates.py
+++ b/lib/host_remove_duplicates.py
@@ -138,8 +138,13 @@ def delete_duplicate_hosts(
             log_host_delete_succeeded(logger, host_id, "DEDUP")
             delete_duplicate_host_count.inc()
             event = build_event(EventType.delete, host)
-            insights_id = host.canonical_facts.get("insights_id")
-            headers = message_headers(EventType.delete, insights_id)
+            headers = message_headers(
+                EventType.delete,
+                host.canonical_facts.get("insights_id"),
+                host.reporter,
+                host.system_profile_facts.get("host_type"),
+                host.system_profile_facts.get("operating_system", {}).get("name"),
+            )
             # add back "wait=True", if needed.
             event_producer.write_event(event, str(host.id), headers, wait=True)
 

--- a/lib/host_synchronize.py
+++ b/lib/host_synchronize.py
@@ -27,8 +27,13 @@ def synchronize_hosts(select_query, event_producer, chunk_size, config, interrup
 
             serialized_host = serialize_host(host, Timestamps.from_config(config))
             event = build_event(EventType.updated, serialized_host)
-            insights_id = host.canonical_facts.get("insights_id")
-            headers = message_headers(EventType.updated, insights_id)
+            headers = message_headers(
+                EventType.updated,
+                host.canonical_facts.get("insights_id"),
+                host.reporter,
+                host.system_profile_facts.get("host_type"),
+                host.system_profile_facts.get("operating_system", {}).get("name"),
+            )
             # in case of a failed update event, event_producer logs the message.
             event_producer.write_event(event, str(host.id), headers, wait=True)
             synchronize_host_count.inc()

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -109,7 +109,12 @@ def assert_delete_event_is_valid(event_producer, host, timestamp, expected_reque
 
     assert event_producer.key == str(host.id)
     assert event_producer.headers == expected_headers(
-        "delete", event["request_id"], host.canonical_facts.get("insights_id")
+        "delete",
+        event["request_id"],
+        host.canonical_facts.get("insights_id"),
+        host.reporter,
+        host.system_profile_facts.get("host_type"),
+        host.system_profile_facts.get("operating_system", {}).get("name"),
     )
 
     if expected_request_id:
@@ -174,25 +179,36 @@ def assert_patch_event_is_valid(
     assert event == expected_event
     assert event_producer.key == str(host.id)
     assert event_producer.headers == expected_headers(
-        "updated", expected_request_id, host.canonical_facts.get("insights_id")
+        "updated",
+        expected_request_id,
+        host.canonical_facts.get("insights_id"),
+        host.reporter,
+        host.system_profile_facts.get("host_type"),
+        host.system_profile_facts.get("operating_system", {}).get("name"),
     )
 
 
-def expected_headers(event_type, request_id, insights_id):
+def expected_headers(event_type, request_id, insights_id=None, reporter=None, host_type=None, os_name=None):
     return {
         "event_type": event_type,
         "request_id": request_id,
         "producer": os.uname().nodename,
         "insights_id": insights_id,
+        "reporter": reporter,
+        "host_type": host_type,
+        "os_name": os_name,
     }
 
 
-def expected_encoded_headers(event_type, request_id, insights_id):
+def expected_encoded_headers(event_type, request_id, insights_id=None, reporter=None, host_type=None, os_name=None):
     return [
         ("event_type", event_type.name.encode("utf-8")),
         ("request_id", request_id.encode("utf-8")),
         ("producer", os.uname().nodename.encode("utf-8")),
         ("insights_id", insights_id.encode("utf-8")),
+        ("reporter", reporter.encode("utf-8")),
+        ("host_type", host_type.encode("utf-8")),
+        ("os_name", os_name.encode("utf-8")),
     ]
 
 
@@ -211,7 +227,12 @@ def assert_synchronize_event_is_valid(
     assert host.canonical_facts.get("insights_id") == event["host"]["insights_id"]
     assert str(host.id) in event_producer.key
     assert event_producer.headers == expected_headers(
-        "updated", event["metadata"]["request_id"], host.canonical_facts.get("insights_id")
+        "updated",
+        event["metadata"]["request_id"],
+        host.canonical_facts.get("insights_id"),
+        host.reporter,
+        host.system_profile_facts.get("host_type"),
+        host.system_profile_facts.get("operating_system", {}).get("name"),
     )
 
     if expected_request_id:

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -318,7 +318,7 @@ def test_handle_message_verify_message_headers(mocker, add_host_result, mq_creat
         host, platform_metadata={"request_id": request_id}, return_all_data=True, message_operation=mock_add_host
     )
 
-    assert headers == expected_headers(add_host_result.name, request_id, insights_id)
+    assert headers == expected_headers(add_host_result.name, request_id, insights_id, "rhsm-conduit")
 
 
 def test_add_host_simple(event_datetime_mock, mq_create_or_update_host):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2056,7 +2056,13 @@ class EventProducerTests(TestCase):
         ):
             with self.subTest(event_type=event_type):
                 event = build_event(event_type, host)
-                headers = message_headers(event_type, host_id)
+                headers = message_headers(
+                    event_type,
+                    host_id,
+                    self.basic_host["reporter"],
+                    self.basic_host.get("system_profile", {}).get("host_type"),
+                    self.basic_host.get("system_profile", {}).get("operating_system", {}).get("name"),
+                )
 
                 self.event_producer.write_event(event, host_id, headers)
 
@@ -2084,7 +2090,13 @@ class EventProducerTests(TestCase):
         ):
             with self.subTest(event_type=event_type):
                 event = build_event(event_type, host)
-                headers = message_headers(event_type, host_id)
+                headers = message_headers(
+                    event_type,
+                    host_id,
+                    self.basic_host["reporter"],
+                    self.basic_host.get("system_profile", {}).get("host_type"),
+                    self.basic_host.get("system_profile", {}).get("operating_system", {}).get("name"),
+                )
 
                 self.event_producer.write_event(event, host_id, headers)
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-1789](https://issues.redhat.com/browse/RHINENG-1789).
We need some additional headers for the emitted kafka messages upon database changes for a more fine-grained filtering in cyndi. Vulnerability and patch require the `reporter` field to be exposed as a header, other apps need additinally the OS name and whether the host is an edge host or not.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
