### PR TITLE
fix(ESSNTL-5937): Adding back basic auth on staleness endpoint

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -761,6 +761,7 @@ paths:
         Required permissions: inventory:TODO:read
       security:
         - ApiKeyAuth: []
+        - BearerAuth: []
       responses:
         '200':
           description: Successfully read the staleness account.
@@ -778,6 +779,7 @@ paths:
         Required permissions: inventory:TODO:write
       security:
         - ApiKeyAuth: []
+        - BearerAuth: []
       requestBody:
         description: Data required to create a record for a account staleness.
         required: true
@@ -802,6 +804,7 @@ paths:
         Required permissions: inventory:TODO:write
       security:
         - ApiKeyAuth: []
+        - BearerAuth: []
       responses:
         '200':
           description: Successfully account staleness updated.
@@ -820,6 +823,7 @@ paths:
         Required permissions: inventory:staleness:write
       security:
         - ApiKeyAuth: []
+        - BearerAuth: []
       responses:
         '204':
           description: Successfully deleted account staleness.
@@ -839,6 +843,7 @@ paths:
         Required permissions: inventory:TODO:read
       security:
         - ApiKeyAuth: []
+        - BearerAuth: []
       responses:
         '200':
           description: Successfully reset account staleness.

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1288,6 +1288,9 @@
         "security": [
           {
             "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
           }
         ],
         "responses": {
@@ -1313,6 +1316,9 @@
         "security": [
           {
             "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
           }
         ],
         "requestBody": {
@@ -1349,6 +1355,9 @@
         "security": [
           {
             "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
           }
         ],
         "responses": {
@@ -1374,6 +1383,9 @@
         "security": [
           {
             "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
           }
         ],
         "responses": {
@@ -1400,6 +1412,9 @@
         "security": [
           {
             "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
           }
         ],
         "responses": {


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-5937](https://issues.redhat.com/browse/ESSNTL-5937).

Adding back BearerAuth on staleness endpoint
## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
