### PR TITLE
Revert "Add rhc_client_id to floorist query"

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -754,8 +754,7 @@ objects:
             "system_profile_facts"->'subscription_status' AS "subscription_status",
             "system_profile_facts"->'ansible' AS "ansible_workload",
             "system_profile_facts"->'mssql' AS "mssql_workload",
-            "system_profile_facts"->'sap' AS "sap_workload",
-            "system_profile_facts"->'rhc_client_id' AS "rhc_client_id"
+            "system_profile_facts"->'sap' AS "sap_workload"
           FROM "hosts"
 parameters:
 - name: LOG_LEVEL


### PR DESCRIPTION
Reverts RedHatInsights/insights-host-inventory#1467
We started seeing some Floorist-related issues at around the time this PR went in, so we're going to see if reverting this somehow fixes the problem.