### PR TITLE
feat(ESSNTL-5348): Deny cert-auth requests to non-host endpoints

### DIFF
--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -80,7 +80,10 @@ def rbac(resource_type, required_permission, permission_base="inventory"):
 
             current_identity = get_current_identity()
             if current_identity.identity_type != CHECKED_TYPE:
-                return func(*args, **kwargs)
+                if resource_type == RbacResourceType.HOSTS:
+                    return func(*args, **kwargs)
+                else:
+                    abort(status.HTTP_403_FORBIDDEN)
 
             # track that RBAC is being used to control access
             g.access_control_rule = "RBAC"

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -2,8 +2,12 @@ import pytest
 from requests import exceptions
 
 from tests.helpers.api_utils import assert_response_status
+from tests.helpers.api_utils import build_account_staleness_url
+from tests.helpers.api_utils import build_assignment_rules_url
+from tests.helpers.api_utils import build_groups_url
 from tests.helpers.api_utils import build_hosts_url
 from tests.helpers.api_utils import create_mock_rbac_response
+from tests.helpers.test_utils import SYSTEM_IDENTITY
 
 
 def test_rbac_retry_error_handling(mocker, db_create_host, api_get, enable_rbac):
@@ -72,3 +76,14 @@ def test_RBAC_invalid_UUIDs(mocker, api_get, enable_rbac):
     response_status, _ = api_get(build_hosts_url())
 
     assert_response_status(response_status, 503)
+
+
+@pytest.mark.parametrize(
+    "url_builder",
+    [build_account_staleness_url, build_assignment_rules_url, build_groups_url],
+)
+def test_non_host_endpoints_cannot_bypass_RBAC(api_get, enable_rbac, url_builder):
+    url = url_builder()
+    response_status, response_data = api_get(url, SYSTEM_IDENTITY)
+
+    assert_response_status(response_status, 403)


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-5348](https://issues.redhat.com/browse/ESSNTL-5348).
Denies access to non-`/hosts` endpoints for requests that are using cert-auth.

Reasoning: We allow cert-auth requests to bypass RBAC for `/hosts` endpoints because we also have the `owner_id` check limiting access, and insights-client needs to use those endpoints. However, insights-client does not use `/groups`, `/assignment-rules`, or `/account/staleness` endpoints, so we need to lock them down so users cannot use cert-auth to bypass RBAC.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
