### PR TITLE
RHINGENG-1751: Enable rebuild_events_topic script to stop after speicified time

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -228,6 +228,7 @@ class Config:
 
         self.host_delete_chunk_size = int(os.getenv("HOST_DELETE_CHUNK_SIZE", "1000"))
         self.script_chunk_size = int(os.getenv("SCRIPT_CHUNK_SIZE", "500"))
+        self.rebuild_events_duration = int(os.getenv("REBUILD_EVENTS_DURATION", "3600"))  # 1 hour
         self.sp_authorized_users = os.getenv("SP_AUTHORIZED_USERS", "tuser@redhat.com").split()
 
         if self._runtime_environment == RuntimeEnvironment.PENDO_JOB:

--- a/app/config.py
+++ b/app/config.py
@@ -228,7 +228,7 @@ class Config:
 
         self.host_delete_chunk_size = int(os.getenv("HOST_DELETE_CHUNK_SIZE", "1000"))
         self.script_chunk_size = int(os.getenv("SCRIPT_CHUNK_SIZE", "500"))
-        self.rebuild_events_duration = int(os.getenv("REBUILD_EVENTS_DURATION", "3600"))  # 1 hour
+        self.rebuild_events_time_limit = int(os.getenv("REBUILD_EVENTS_TIME_LIMIT", "3600"))  # 1 hour
         self.sp_authorized_users = os.getenv("SP_AUTHORIZED_USERS", "tuser@redhat.com").split()
 
         if self._runtime_environment == RuntimeEnvironment.PENDO_JOB:

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -620,6 +620,8 @@ objects:
                 optional: true
           - name: BYPASS_UNLEASH
             value: ${BYPASS_UNLEASH}
+          - name: REBUILD_EVENTS_TIME_LIMIT
+            value: ${REBUILD_EVENTS_TIME_LIMIT}
         resources:
           limits:
             cpu: ${CPU_LIMIT}
@@ -832,7 +834,7 @@ parameters:
   value: '8190'
 - name: SCRIPT_CHUNK_SIZE
   value: '500'
-- name: REBUILD_EVENTS_DURATION
+- name: REBUILD_EVENTS_TIME_LIMIT
   value: '3600'
 
 # Feature flags

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -832,6 +832,8 @@ parameters:
   value: '8190'
 - name: SCRIPT_CHUNK_SIZE
   value: '500'
+- name: REBUILD_EVENTS_DURATION
+  value: '3600'
 
 # Feature flags
 - description: Unleash secret name

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -1,5 +1,7 @@
 import json
 import sys
+from datetime import datetime
+from datetime import timedelta
 from functools import partial
 
 from confluent_kafka import Consumer as KafkaConsumer
@@ -55,30 +57,35 @@ def run(config, logger, session, consumer, event_producer, shutdown_handler):
     partitions = consumer.assignment()
     total_messages_processed = 0
 
+    stop_time = datetime.now() + timedelta(seconds=config.rebuild_events_duration)
     logger.debug("About to start the consumer loop")
     while num_messages > 0 and not shutdown_handler.shut_down():
-        new_messages = consumer.consume(num_messages=config.script_chunk_size, timeout=10)
-        with session_guard(session):
-            for message in new_messages:
-                try:
-                    sync_event_message(json.loads(message.value()), session, event_producer)
+        if datetime.now() < stop_time:
+            new_messages = consumer.consume(num_messages=config.script_chunk_size, timeout=10)
+            with session_guard(session):
+                for message in new_messages:
+                    try:
+                        sync_event_message(json.loads(message.value()), session, event_producer)
 
-                except OperationalError as oe:
-                    """sqlalchemy.exc.OperationalError: This error occurs when an
-                    authentication failure occurs or the DB is not accessible.
-                    """
-                    logger.error(f"Could not access DB {str(oe)}")
-                    sys.exit(3)
-                except Exception:
-                    logger.exception("Unable to process message", extra={"incoming_message": message.value()})
-        try:
-            # pace the events production speed as flush completes sending all buffered records.
-            event_producer._kafka_producer.flush(300)
-        except ProduceError:
-            raise ProduceError("ProduceError: Failed to flush produced Kafka messages within 300 seconds")
+                    except OperationalError as oe:
+                        """sqlalchemy.exc.OperationalError: This error occurs when an
+                        authentication failure occurs or the DB is not accessible.
+                        """
+                        logger.error(f"Could not access DB {str(oe)}")
+                        sys.exit(3)
+                    except Exception:
+                        logger.exception("Unable to process message", extra={"incoming_message": message.value()})
+            try:
+                # pace the events production speed as flush completes sending all buffered records.
+                event_producer._kafka_producer.flush(300)
+            except ProduceError:
+                raise ProduceError("ProduceError: Failed to flush produced Kafka messages within 300 seconds")
 
-        num_messages = len(new_messages)
-        total_messages_processed += num_messages
+            num_messages = len(new_messages)
+            total_messages_processed += num_messages
+        else:
+            logger.info(f"Event topic rebuild halting after {config.rebuild_events_duration} seconds time.")
+            exit(0)  # exit as intended
 
     logger.info(f"Event topic rebuild complete. Processed {total_messages_processed} messages.")
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINGENG-1751](https://issues.redhat.com/browse/RHINGENG-1751).  It enables the `rebuild_events_topic` script to stop after some specified time.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
