### PR TITLE
RHINENG-1653: Create DELETE /groups/hosts endpoint

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -8,6 +8,7 @@ from flask_api import status
 
 from api.metrics import api_request_count
 from app.logging import get_logger
+from lib.feature_flags import get_flag_value
 
 __all__ = ["api_operation"]
 
@@ -76,3 +77,8 @@ def custom_escape(expression):
 
 def json_error_response(title, detail, status=status.HTTP_400_BAD_REQUEST):
     return flask_json_response({"title": title, "detail": detail}, status)
+
+
+def check_unleash_flag(FLAG_NAME):
+    if not get_flag_value(FLAG_NAME):
+        return flask.Response(None, status.HTTP_501_NOT_IMPLEMENTED)

--- a/api/group.py
+++ b/api/group.py
@@ -29,6 +29,7 @@ from lib.feature_flags import get_flag_value
 from lib.group_repository import add_group
 from lib.group_repository import delete_group_list
 from lib.group_repository import get_group_by_id_from_db
+from lib.group_repository import get_group_from_host_id
 from lib.group_repository import patch_group
 from lib.group_repository import remove_hosts_from_group
 from lib.metrics import create_group_count
@@ -36,6 +37,11 @@ from lib.middleware import rbac
 from lib.middleware import rbac_group_id_check
 
 logger = get_logger(__name__)
+
+
+def check_inventory_groups_flag():
+    if not get_flag_value(FLAG_INVENTORY_GROUPS):
+        return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
 
 @api_operation
@@ -49,8 +55,7 @@ def get_group_list(
     order_how=None,
     rbac_filter=None,
 ):
-    if not get_flag_value(FLAG_INVENTORY_GROUPS):
-        return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
+    check_inventory_groups_flag()
 
     try:
         group_list, total = get_filtered_group_list_db(name, page, per_page, order_by, order_how, rbac_filter)
@@ -67,8 +72,7 @@ def get_group_list(
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def create_group(body, rbac_filter=None):
-    if not get_flag_value(FLAG_INVENTORY_GROUPS):
-        return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
+    check_inventory_groups_flag()
 
     # If there is an attribute filter on the RBAC permissions,
     # the user should not be allowed to create a group.
@@ -115,8 +119,7 @@ def create_group(body, rbac_filter=None):
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def patch_group_by_id(group_id, body, rbac_filter=None):
-    if not get_flag_value(FLAG_INVENTORY_GROUPS):
-        return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
+    check_inventory_groups_flag()
 
     rbac_group_id_check(rbac_filter, {group_id})
 
@@ -156,8 +159,7 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_groups(group_id_list, rbac_filter=None):
-    if not get_flag_value(FLAG_INVENTORY_GROUPS):
-        return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
+    check_inventory_groups_flag()
 
     rbac_group_id_check(rbac_filter, set(group_id_list))
 
@@ -180,8 +182,7 @@ def get_groups_by_id(
     order_how=None,
     rbac_filter=None,
 ):
-    if not get_flag_value(FLAG_INVENTORY_GROUPS):
-        return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
+    check_inventory_groups_flag()
 
     rbac_group_id_check(rbac_filter, set(group_id_list))
 
@@ -202,8 +203,7 @@ def get_groups_by_id(
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
-    if not get_flag_value(FLAG_INVENTORY_GROUPS):
-        return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
+    check_inventory_groups_flag()
 
     rbac_group_id_check(rbac_filter, {group_id})
 
@@ -211,5 +211,40 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
 
     if delete_count == 0:
         abort(status.HTTP_404_NOT_FOUND, "Group or hosts not found.")
+
+    return Response(None, status.HTTP_204_NO_CONTENT)
+
+
+@api_operation
+@rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
+@metrics.api_request_time.time()
+def delete_hosts_from_different_groups(host_id_list, rbac_filter=None):
+    check_inventory_groups_flag()
+
+    hosts_per_group = {}
+
+    for host_id in host_id_list:
+        group = get_group_from_host_id(host_id)
+
+        if group and group.id not in hosts_per_group:
+            hosts_per_group[group.id] = [host_id]
+        else:
+            hosts_per_group[group.id].append(host_id)
+            # or I can use something similar to the ... notation
+
+    requested_group_ids = list(hosts_per_group.keys())
+
+    rbac_group_id_check(rbac_filter, requested_group_ids)
+
+    delete_count = 0
+
+    for group_id in requested_group_ids:
+        deleted_for_group = remove_hosts_from_group(
+            group_id, hosts_per_group.get(group_id), current_app.event_producer
+        )
+        delete_count += deleted_for_group
+
+    if delete_count == 0:
+        abort(status.HTTP_404_NOT_FOUND, "Hosts not found.")
 
     return Response(None, status.HTTP_204_NO_CONTENT)

--- a/api/group.py
+++ b/api/group.py
@@ -6,6 +6,7 @@ from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError
 
 from api import api_operation
+from api import check_unleash_flag
 from api import flask_json_response
 from api import json_error_response
 from api import metrics
@@ -25,11 +26,10 @@ from app.instrumentation import log_patch_group_success
 from app.logging import get_logger
 from app.models import InputGroupSchema
 from lib.feature_flags import FLAG_INVENTORY_GROUPS
-from lib.feature_flags import get_flag_value
 from lib.group_repository import add_group
 from lib.group_repository import delete_group_list
 from lib.group_repository import get_group_by_id_from_db
-from lib.group_repository import get_group_from_host_id
+from lib.group_repository import get_group_using_host_id
 from lib.group_repository import patch_group
 from lib.group_repository import remove_hosts_from_group
 from lib.metrics import create_group_count
@@ -37,11 +37,6 @@ from lib.middleware import rbac
 from lib.middleware import rbac_group_id_check
 
 logger = get_logger(__name__)
-
-
-def check_inventory_groups_flag():
-    if not get_flag_value(FLAG_INVENTORY_GROUPS):
-        return Response(None, status.HTTP_501_NOT_IMPLEMENTED)
 
 
 @api_operation
@@ -55,7 +50,7 @@ def get_group_list(
     order_how=None,
     rbac_filter=None,
 ):
-    check_inventory_groups_flag()
+    check_unleash_flag(FLAG_INVENTORY_GROUPS)
 
     try:
         group_list, total = get_filtered_group_list_db(name, page, per_page, order_by, order_how, rbac_filter)
@@ -72,7 +67,7 @@ def get_group_list(
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def create_group(body, rbac_filter=None):
-    check_inventory_groups_flag()
+    check_unleash_flag(FLAG_INVENTORY_GROUPS)
 
     # If there is an attribute filter on the RBAC permissions,
     # the user should not be allowed to create a group.
@@ -119,7 +114,7 @@ def create_group(body, rbac_filter=None):
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def patch_group_by_id(group_id, body, rbac_filter=None):
-    check_inventory_groups_flag()
+    check_unleash_flag(FLAG_INVENTORY_GROUPS)
 
     rbac_group_id_check(rbac_filter, {group_id})
 
@@ -159,7 +154,7 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_groups(group_id_list, rbac_filter=None):
-    check_inventory_groups_flag()
+    check_unleash_flag(FLAG_INVENTORY_GROUPS)
 
     rbac_group_id_check(rbac_filter, set(group_id_list))
 
@@ -182,7 +177,7 @@ def get_groups_by_id(
     order_how=None,
     rbac_filter=None,
 ):
-    check_inventory_groups_flag()
+    check_unleash_flag(FLAG_INVENTORY_GROUPS)
 
     rbac_group_id_check(rbac_filter, set(group_id_list))
 
@@ -203,7 +198,7 @@ def get_groups_by_id(
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
-    check_inventory_groups_flag()
+    check_unleash_flag(FLAG_INVENTORY_GROUPS)
 
     rbac_group_id_check(rbac_filter, {group_id})
 
@@ -219,32 +214,30 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_hosts_from_different_groups(host_id_list, rbac_filter=None):
-    check_inventory_groups_flag()
+    check_unleash_flag(FLAG_INVENTORY_GROUPS)
 
     hosts_per_group = {}
 
+    # Separate hosts per group
     for host_id in host_id_list:
-        group = get_group_from_host_id(host_id)
+        group = get_group_using_host_id(host_id)
 
-        if group and group.id not in hosts_per_group:
-            hosts_per_group[group.id] = [host_id]
-        else:
-            hosts_per_group[group.id].append(host_id)
-            # or I can use something similar to the ... notation
+        if group:
+            hosts_per_group.setdefault(str(group.id), []).append(host_id)
 
-    requested_group_ids = list(hosts_per_group.keys())
+    requested_group_ids = set(hosts_per_group.keys())
 
     rbac_group_id_check(rbac_filter, requested_group_ids)
 
     delete_count = 0
 
     for group_id in requested_group_ids:
-        deleted_for_group = remove_hosts_from_group(
+        deleted_from_group = remove_hosts_from_group(
             group_id, hosts_per_group.get(group_id), current_app.event_producer
         )
-        delete_count += deleted_for_group
+        delete_count += deleted_from_group
 
     if delete_count == 0:
-        abort(status.HTTP_404_NOT_FOUND, "Hosts not found.")
+        abort(status.HTTP_404_NOT_FOUND, "The provided hosts are ungrouped.")
 
     return Response(None, status.HTTP_204_NO_CONTENT)

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -273,9 +273,10 @@ def _update_group_update_time(group_id: str):
     db.session.flush()
 
 
-def get_group_from_host_id(host_id: str):
+def get_group_using_host_id(host_id: str):
     assoc = HostGroupAssoc.query.filter(HostGroupAssoc.host_id == host_id).one_or_none()
     if assoc:
+        # check current identity against db
         return get_group_by_id_from_db(str(assoc.group_id))
     else:
         return None

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -271,3 +271,11 @@ def _update_group_update_time(group_id: str):
     group.update_modified_on()
     db.session.add(group)
     db.session.flush()
+
+
+def get_group_from_host_id(host_id: str):
+    assoc = HostGroupAssoc.query.filter(HostGroupAssoc.host_id == host_id).one_or_none()
+    if assoc:
+        return get_group_by_id_from_db(str(assoc.group_id))
+    else:
+        return None

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -537,9 +537,9 @@ paths:
       operationId: api.group.delete_hosts_from_different_groups
       tags:
         - groups
-      summary: Delete a list of hosts from the groups they are in [Not Implemented]
+      summary: Delete a list of hosts from the groups they are in
       description: >-
-        Delete a list of hosts from the groups they are in. [Not Implemented]
+        Delete a list of hosts from the groups they are in.
         <br /><br />
         Required permissions: inventory:groups:write
       security:
@@ -548,9 +548,11 @@ paths:
         - $ref: '#/components/parameters/hostIdList'
       responses:
         '204':
-          description: The hosts were successfully removed from groups.
+          description: The hosts were successfully removed from their groups.
         '400':
           description: Invalid request.
+        '404':
+          description: The provided hosts are ungrouped.
 
 
   /resource-types:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -532,6 +532,26 @@ paths:
           description: Invalid request.
         '404':
           description: Group not found.
+  '/groups/hosts/{host_id_list}':
+    delete:
+      operationId: api.group.delete_hosts_from_different_groups
+      tags:
+        - groups
+      summary: Delete a list of hosts from the groups they are in [Not Implemented]
+      description: >-
+        Delete a list of hosts from the groups they are in. [Not Implemented]
+        <br /><br />
+        Required permissions: inventory:groups:write
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: '#/components/parameters/hostIdList'
+      responses:
+        '204':
+          description: The hosts were successfully removed from groups.
+        '400':
+          description: Invalid request.
+
 
   /resource-types:
     get:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -898,8 +898,8 @@
         "tags": [
           "groups"
         ],
-        "summary": "Delete a list of hosts from the groups they are in [Not Implemented]",
-        "description": "Delete a list of hosts from the groups they are in. [Not Implemented] <br /><br /> Required permissions: inventory:groups:write",
+        "summary": "Delete a list of hosts from the groups they are in",
+        "description": "Delete a list of hosts from the groups they are in. <br /><br /> Required permissions: inventory:groups:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -912,10 +912,13 @@
         ],
         "responses": {
           "204": {
-            "description": "The hosts were successfully removed from groups."
+            "description": "The hosts were successfully removed from their groups."
           },
           "400": {
             "description": "Invalid request."
+          },
+          "404": {
+            "description": "The provided hosts are ungrouped."
           }
         }
       }

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -892,6 +892,34 @@
         }
       }
     },
+    "/groups/hosts/{host_id_list}": {
+      "delete": {
+        "operationId": "api.group.delete_hosts_from_different_groups",
+        "tags": [
+          "groups"
+        ],
+        "summary": "Delete a list of hosts from the groups they are in [Not Implemented]",
+        "description": "Delete a list of hosts from the groups they are in. [Not Implemented] <br /><br /> Required permissions: inventory:groups:write",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/hostIdList"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The hosts were successfully removed from groups."
+          },
+          "400": {
+            "description": "Invalid request."
+          }
+        }
+      }
+    },
     "/resource-types": {
       "get": {
         "operationId": "api.resource_type.get_resource_type_list",

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -141,6 +141,19 @@ def api_patch_group(flask_client):
 
 
 @pytest.fixture(scope="function")
+def api_remove_hosts_from_diff_groups(flask_client):
+    def _api_remove_hosts_from_diff_groups(
+        host_id_list, identity=USER_IDENTITY, query_parameters=None, extra_headers=None
+    ):
+        url = f"{GROUP_URL}/hosts/{','.join([str(host_id) for host_id in host_id_list])}"
+        return do_request(
+            flask_client.delete, url, identity, query_parameters=query_parameters, extra_headers=extra_headers
+        )
+
+    return _api_remove_hosts_from_diff_groups
+
+
+@pytest.fixture(scope="function")
 def api_create_assign_rule(flask_client):
     def _api_create_assign_rule(assign_rule_data, identity=USER_IDENTITY, query_parameters=None, extra_headers=None):
         return do_request(

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -157,3 +157,56 @@ def test_delete_groups_RBAC_denied_specific_groups(mocker, db_create_group, api_
 
     # Should be denied because access is not granted to two of the groups
     assert_response_status(response_status, 403)
+
+
+def test_delete_hosts_from_different_groups(
+    db_create_group,
+    db_create_host,
+    db_get_hosts_for_group,
+    db_create_host_group_assoc,
+    api_remove_hosts_from_diff_groups,
+    event_producer,
+    mocker,
+):
+    mocker.patch.object(event_producer, "write_event")
+
+    # Create 2 groups and 4 hosts
+    group1_id = str(db_create_group("test_group1").id)
+    group2_id = str(db_create_group("test_group2").id)
+
+    host_id_list1 = [str(db_create_host().id) for _ in range(2)]
+    host_id_list2 = [str(db_create_host().id) for _ in range(2)]
+
+    # Add 2 hosts to each group
+    for host_id in host_id_list1:
+        db_create_host_group_assoc(host_id, group1_id)
+    for host_id in host_id_list2:
+        db_create_host_group_assoc(host_id, group2_id)
+
+    # Confirm that the associations exist
+    hosts_before1 = db_get_hosts_for_group(group1_id)
+    assert len(hosts_before1) == 2
+    hosts_before2 = db_get_hosts_for_group(group2_id)
+    assert len(hosts_before2) == 2
+
+    # Remove one host from each group
+    hosts_to_delete = [host_id_list1[0], host_id_list2[0]]
+    response_status, _ = api_remove_hosts_from_diff_groups(hosts_to_delete)
+    assert response_status == 204
+
+    # Confirm that the groups now only contain the last host
+    hosts1_after = db_get_hosts_for_group(group1_id)
+    assert len(hosts1_after) == 1
+    assert str(hosts1_after[0].id) == host_id_list1[1]
+    hosts2_after = db_get_hosts_for_group(group2_id)
+    assert len(hosts2_after) == 1
+    assert str(hosts2_after[0].id) == host_id_list2[1]
+
+    assert event_producer.write_event.call_count == 2
+    for call_arg in event_producer.write_event.call_args_list:
+        host = json.loads(call_arg[0][0])["host"]
+        assert host["id"] in hosts_to_delete
+        assert len(host["groups"]) == 0
+
+
+# TODO: add another test for when the user tries a host with no group and hosts from a group in a different org

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -192,7 +192,7 @@ def test_delete_hosts_from_different_groups(
     # Remove one host from each group
     hosts_to_delete = [host_id_list1[0], host_id_list2[0]]
     response_status, _ = api_remove_hosts_from_diff_groups(hosts_to_delete)
-    assert response_status == 204
+    assert_response_status(response_status, 204)
 
     # Confirm that the groups now only contain the last host
     hosts1_after = db_get_hosts_for_group(group1_id)
@@ -209,4 +209,92 @@ def test_delete_hosts_from_different_groups(
         assert len(host["groups"]) == 0
 
 
-# TODO: add another test for when the user tries a host with no group and hosts from a group in a different org
+def test_delete_hosts_from_different_groups_RBAC_denied(
+    db_create_group,
+    db_create_host,
+    db_get_hosts_for_group,
+    db_create_host_group_assoc,
+    api_remove_hosts_from_diff_groups,
+    event_producer,
+    mocker,
+    enable_rbac,
+):
+    mocker.patch.object(event_producer, "write_event")
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+
+    # Create 2 groups and 4 hosts
+    group1_id = str(db_create_group("test_group1").id)
+    group2_id = str(db_create_group("test_group2").id)
+
+    host_id_list1 = [str(db_create_host().id) for _ in range(2)]
+    host_id_list2 = [str(db_create_host().id) for _ in range(2)]
+
+    # Add 2 hosts to each group
+    for host_id in host_id_list1:
+        db_create_host_group_assoc(host_id, group1_id)
+    for host_id in host_id_list2:
+        db_create_host_group_assoc(host_id, group2_id)
+
+    # Confirm that the associations exist
+    hosts_before1 = db_get_hosts_for_group(group1_id)
+    assert len(hosts_before1) == 2
+    hosts_before2 = db_get_hosts_for_group(group2_id)
+    assert len(hosts_before2) == 2
+
+    mock_rbac_response = create_mock_rbac_response(
+        "tests/helpers/rbac-mock-data/inv-groups-write-resource-defs-template.json"
+    )
+
+    # Only grant permission to one group
+    mock_rbac_response[0]["resourceDefinitions"][0]["attributeFilter"]["value"] = [group1_id]
+    get_rbac_permissions_mock.return_value = mock_rbac_response
+
+    # Try to remove one host from each group
+    hosts_to_delete = [host_id_list1[0], host_id_list2[0]]
+
+    response_status, _ = api_remove_hosts_from_diff_groups(hosts_to_delete)
+    assert_response_status(response_status, 403)
+
+    # Check that the hosts weren't deleted
+    hosts_after1 = db_get_hosts_for_group(group1_id)
+    assert len(hosts_after1) == 2
+    hosts_after2 = db_get_hosts_for_group(group2_id)
+    assert len(hosts_after2) == 2
+
+    # No messages should have been sent
+    assert event_producer.write_event.call_count == 0
+
+
+def test_delete_hosts_no_group(
+    db_create_group,
+    db_create_host,
+    db_get_hosts_for_group,
+    db_create_host_group_assoc,
+    api_remove_hosts_from_diff_groups,
+    event_producer,
+    mocker,
+):
+    mocker.patch.object(event_producer, "write_event")
+
+    group_id = str(db_create_group("test_group1").id)
+    host_id_list = [str(db_create_host().id) for _ in range(2)]
+
+    # Add one host to the group
+    db_create_host_group_assoc(host_id_list[0], group_id)
+
+    # Confirm that the associations exist
+    hosts_before = db_get_hosts_for_group(group_id)
+    assert len(hosts_before) == 1
+
+    response_status, _ = api_remove_hosts_from_diff_groups(host_id_list)
+    assert_response_status(response_status, 204)
+
+    # Confirm that the host was removed from the group
+    hosts1_after = db_get_hosts_for_group(group_id)
+    assert len(hosts1_after) == 0
+
+    assert event_producer.write_event.call_count == 1
+    for call_arg in event_producer.write_event.call_args_list:
+        host = json.loads(call_arg[0][0])["host"]
+        assert host["id"] == host_id_list[0]
+        assert len(host["groups"]) == 0


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-1653](https://issues.redhat.com/browse/RHINENG-1653).
It implements the DELETE `/groups/hosts/{host_id_list}` endpoint. The api spec was updated and tests were added for the new functionality.

I also did extracted the code for checking feature flags on the groups file to its own function since it is used multiple times in the code.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
