### PR TITLE
fix(ESSNTL-5038): Return N/A for created and updated

### DIFF
--- a/api/account_staleness_query.py
+++ b/api/account_staleness_query.py
@@ -1,6 +1,3 @@
-from datetime import datetime
-from datetime import timezone
-
 from flask import g
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -64,8 +61,8 @@ def _build_acc_staleness_sys_default(org_id, account):
             "immutable_staleness_delta": config.immutable_staleness_seconds,
             "immutable_stale_warning_delta": config.immutable_stale_warning_seconds,
             "immutable_culling_delta": config.immutable_culling_seconds,
-            "created_on": datetime.now(timezone.utc),
-            "modified_on": datetime.now(timezone.utc),
+            "created_on": "N/A",
+            "modified_on": "N/A",
         }
     )
 

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -338,6 +338,10 @@ def serialize_account_staleness_response(account_staleness):
         "immutable_staleness_delta": account_staleness.immutable_staleness_delta,
         "immutable_stale_warning_delta": account_staleness.immutable_stale_warning_delta,
         "immutable_culling_delta": account_staleness.immutable_culling_delta,
-        "created": _serialize_datetime(account_staleness.created_on),
-        "updated": _serialize_datetime(account_staleness.modified_on),
+        "created": "N/A"
+        if account_staleness.created_on == "N/A"
+        else _serialize_datetime(account_staleness.created_on),
+        "updated": "N/A"
+        if account_staleness.modified_on == "N/A"
+        else _serialize_datetime(account_staleness.modified_on),
     }


### PR DESCRIPTION
 Return N/A for created and updated field of sys default response

# Overview

This PR is being created to address [ESSNTL-5038](https://issues.redhat.com/browse/ESSNTL-5038).
(A description of your PR's changes, along with why/context to the PR, goes here.)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
