### PR TITLE
[ESSNTL-5424] Create GET /api/inventory/v1/account/staleness/defaults endpoint

### DIFF
--- a/api/account_staleness.py
+++ b/api/account_staleness.py
@@ -150,10 +150,3 @@ def update_staleness(body):
         return flask_json_response(serialize_account_staleness_response(updated_staleness), status.HTTP_200_OK)
     except NoResultFound:
         abort(status.HTTP_404_NOT_FOUND, "Account Staleness not found.")
-
-
-@api_operation
-@rbac(RbacResourceType.STALENESS, RbacPermission.WRITE)
-@metrics.api_request_time.time()
-def reset_staleness():
-    return flask_json_response(_get_return_data(), status.HTTP_200_OK)

--- a/api/account_staleness.py
+++ b/api/account_staleness.py
@@ -10,6 +10,7 @@ from api import flask_json_response
 from api import json_error_response
 from api import metrics
 from api.account_staleness_query import get_account_staleness_db
+from api.account_staleness_query import get_sys_default_staleness
 from app import RbacPermission
 from app import RbacResourceType
 from app.auth import get_current_identity
@@ -63,6 +64,19 @@ def _validate_input_data(body):
 def get_staleness():
     try:
         acc_st = get_account_staleness_db()
+        acc_st = serialize_account_staleness_response(acc_st)
+    except ValueError as e:
+        abort(status.HTTP_400_BAD_REQUEST, str(e))
+
+    return flask_json_response(acc_st, status.HTTP_200_OK)
+
+
+@api_operation
+@rbac(RbacResourceType.STALENESS, RbacPermission.READ)
+@metrics.api_request_time.time()
+def get_default_staleness():
+    try:
+        acc_st = get_sys_default_staleness()
         acc_st = serialize_account_staleness_response(acc_st)
     except ValueError as e:
         abort(status.HTTP_400_BAD_REQUEST, str(e))

--- a/api/account_staleness_query.py
+++ b/api/account_staleness_query.py
@@ -46,6 +46,13 @@ def get_account_staleness_db(rbac_filter=None, identity=None):
         return g.acc_st
 
 
+def get_sys_default_staleness():
+    org_id = get_current_identity().org_id
+    account = get_current_identity().account_number
+    acc_st = _build_acc_staleness_sys_default(org_id, account)
+    return acc_st
+
+
 def _build_acc_staleness_sys_default(org_id, account):
     from app import inventory_config
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -839,21 +839,21 @@ paths:
         '404':
           description: Account Staleness not found.
 
-  /account/staleness/reset:
-    patch:
-      operationId: api.account_staleness.reset_staleness
+  /account/staleness/defaults:
+    get:
+      operationId: api.account_staleness.get_default_staleness
       tags:
         - accounts_staleness
-      summary: Reset account staleness
+      summary: Read the entire list of account staleness
       description: >-
-        Reset account staleness record.
+        Read the entire list of all accounts staleness available.
         Required permissions: inventory:TODO:read
       security:
         - ApiKeyAuth: []
         - BearerAuth: []
       responses:
         '200':
-          description: Successfully reset account staleness.
+          description: Successfully read the staleness account.
           content:
             application/json:
               schema:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1412,14 +1412,14 @@
         }
       }
     },
-    "/account/staleness/reset": {
-      "patch": {
-        "operationId": "api.account_staleness.reset_staleness",
+    "/account/staleness/defaults": {
+      "get": {
+        "operationId": "api.account_staleness.get_default_staleness",
         "tags": [
           "accounts_staleness"
         ],
-        "summary": "Reset account staleness",
-        "description": "Reset account staleness record. Required permissions: inventory:TODO:read",
+        "summary": "Read the entire list of account staleness",
+        "description": "Read the entire list of all accounts staleness available. Required permissions: inventory:TODO:read",
         "security": [
           {
             "ApiKeyAuth": []
@@ -1430,7 +1430,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successfully reset account staleness.",
+            "description": "Successfully read the staleness account.",
             "content": {
               "application/json": {
                 "schema": {

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -515,6 +515,10 @@ def build_account_staleness_url(path=None, query=None):
     return _build_url(base_url=STALENESS_URL, path=path, query=query)
 
 
+def build_sys_default_staleness_url(path=None, query=None):
+    return _build_url(base_url=STALENESS_URL + "/defaults", path=path, query=query)
+
+
 def inject_qs(url, **kwargs):
     scheme, netloc, path, query, fragment = urlsplit(url)
     params = parse_qs(query)

--- a/tests/test_api_account_staleness_get.py
+++ b/tests/test_api_account_staleness_get.py
@@ -1,6 +1,7 @@
 from tests.helpers.api_utils import _INPUT_DATA
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_account_staleness_url
+from tests.helpers.api_utils import build_sys_default_staleness_url
 
 
 def test_get_default_staleness(api_get):
@@ -34,3 +35,23 @@ def test_get_custom_staleness(api_create_account_staleness, api_get):
     assert response_data["immutable_stale_warning_delta"] == _INPUT_DATA["immutable_stale_warning_delta"]
     assert response_data["immutable_culling_delta"] == _INPUT_DATA["immutable_culling_delta"]
     assert_response_status(response_status, 200)
+
+
+def test_get_sys_default_staleness(api_get):
+    url = build_sys_default_staleness_url()
+    response_status, response_data = api_get(url)
+    assert_response_status(response_status, 200)
+    expected_result = {
+        "conventional_staleness_delta": "86400",
+        "conventional_stale_warning_delta": "604800",
+        "conventional_culling_delta": "1209600",
+        "immutable_staleness_delta": "172800",
+        "immutable_stale_warning_delta": "10368000",
+        "immutable_culling_delta": "15552000",
+    }
+    assert response_data["conventional_staleness_delta"] == expected_result["conventional_staleness_delta"]
+    assert response_data["conventional_stale_warning_delta"] == expected_result["conventional_stale_warning_delta"]
+    assert response_data["conventional_culling_delta"] == expected_result["conventional_culling_delta"]
+    assert response_data["immutable_staleness_delta"] == expected_result["immutable_staleness_delta"]
+    assert response_data["immutable_stale_warning_delta"] == expected_result["immutable_stale_warning_delta"]
+    assert response_data["immutable_culling_delta"] == expected_result["immutable_culling_delta"]

--- a/tests/test_api_account_staleness_update.py
+++ b/tests/test_api_account_staleness_update.py
@@ -52,9 +52,3 @@ def test_update_staleness_rbac_denied(subtests, mocker, api_patch, db_create_acc
             response_status, _ = api_patch(url, _INPUT_DATA)
 
             assert_response_status(response_status, 403)
-
-
-def test_reset_staleness(api_patch, subtests):
-    url = build_account_staleness_url(path="/reset")
-    response_status, response_data = api_patch(url, host_data=None)
-    assert_response_status(response_status, 200)


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-5424](https://issues.redhat.com/browse/ESSNTL-5424).

This PR adds a simple API resource that returns the system defaults staleness values.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
