### PR TITLE
fix(ESSNTL-5404): Moving from str to int for staleness fields

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -850,12 +850,12 @@ class InputAssignmentRule(MarshmallowSchema):
 
 
 class InputAccountStalenessSchema(MarshmallowSchema):
-    conventional_staleness_delta = fields.Str(validate=marshmallow_validate.Length(min=1, max=36))
-    conventional_stale_warning_delta = fields.Str(validate=marshmallow_validate.Length(min=1, max=36))
-    conventional_culling_delta = fields.Str(validate=marshmallow_validate.Length(min=1, max=36))
-    immutable_staleness_delta = fields.Str(validate=marshmallow_validate.Length(min=1, max=36))
-    immutable_stale_warning_delta = fields.Str(validate=marshmallow_validate.Length(min=1, max=36))
-    immutable_culling_delta = fields.Str(validate=marshmallow_validate.Length(min=1, max=36))
+    conventional_staleness_delta = fields.Int()
+    conventional_stale_warning_delta = fields.Int()
+    conventional_culling_delta = fields.Int()
+    immutable_staleness_delta = fields.Int()
+    immutable_stale_warning_delta = fields.Int()
+    immutable_culling_delta = fields.Int()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -2037,23 +2037,29 @@ components:
       anyOf:
         - properties:
             conventional_staleness_delta:
-              type: string
-              maxLength: 36
+              type: integer
+              minimum: 1
+              maximum: 2147483647
             conventional_stale_warning_delta:
-              type: string
-              maxLength: 36
+              type: integer
+              minimum: 1
+              maximum: 2147483647
             conventional_culling_delta:
-              type: string
-              maxLength: 36
+              type: integer
+              minimum: 1
+              maximum: 2147483647
             immutable_staleness_delta:
-              type: string
-              maxLength: 36
+              type: integer
+              minimum: 1
+              maximum: 2147483647
             immutable_stale_warning_delta:
-              type: string
-              maxLength: 36
+              type: integer
+              minimum: 1
+              maximum: 2147483647
             immutable_culling_delta:
-              type: string
-              maxLength: 36
+              type: integer
+              minimum: 1
+              maximum: 2147483647
     AccountStalenessOutput:
       title: Account Staleness Out
       description: >-
@@ -2067,23 +2073,17 @@ components:
         org_id:
           $ref: "#/components/schemas/OrgId"
         conventional_staleness_delta:
-          type: string
-          maxLength: 36
+          type: integer
         conventional_stale_warning_delta:
-          type: string
-          maxLength: 36
+          type: integer
         conventional_culling_delta:
-          type: string
-          maxLength: 36
+          type: integer
         immutable_staleness_delta:
-          type: string
-          maxLength: 36
+          type: integer
         immutable_stale_warning_delta:
-          type: string
-          maxLength: 36
+          type: integer
         immutable_culling_delta:
-          type: string
-          maxLength: 36
+          type: integer
         created_at:
           description: A timestamp when the entry was created.
           type: string

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -3090,28 +3090,34 @@
           {
             "properties": {
               "conventional_staleness_delta": {
-                "type": "string",
-                "maxLength": 36
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 2147483647
               },
               "conventional_stale_warning_delta": {
-                "type": "string",
-                "maxLength": 36
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 2147483647
               },
               "conventional_culling_delta": {
-                "type": "string",
-                "maxLength": 36
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 2147483647
               },
               "immutable_staleness_delta": {
-                "type": "string",
-                "maxLength": 36
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 2147483647
               },
               "immutable_stale_warning_delta": {
-                "type": "string",
-                "maxLength": 36
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 2147483647
               },
               "immutable_culling_delta": {
-                "type": "string",
-                "maxLength": 36
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 2147483647
               }
             }
           }
@@ -3132,28 +3138,22 @@
             "$ref": "#/components/schemas/OrgId"
           },
           "conventional_staleness_delta": {
-            "type": "string",
-            "maxLength": 36
+            "type": "integer"
           },
           "conventional_stale_warning_delta": {
-            "type": "string",
-            "maxLength": 36
+            "type": "integer"
           },
           "conventional_culling_delta": {
-            "type": "string",
-            "maxLength": 36
+            "type": "integer"
           },
           "immutable_staleness_delta": {
-            "type": "string",
-            "maxLength": 36
+            "type": "integer"
           },
           "immutable_stale_warning_delta": {
-            "type": "string",
-            "maxLength": 36
+            "type": "integer"
           },
           "immutable_culling_delta": {
-            "type": "string",
-            "maxLength": 36
+            "type": "integer"
           },
           "created_at": {
             "description": "A timestamp when the entry was created.",

--- a/tests/test_api_account_staleness_create.py
+++ b/tests/test_api_account_staleness_create.py
@@ -4,12 +4,12 @@ from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import create_mock_rbac_response
 
 _INPUT_DATA = {
-    "conventional_staleness_delta": "1",
-    "conventional_stale_warning_delta": "7",
-    "conventional_culling_delta": "14",
-    "immutable_staleness_delta": "7",
-    "immutable_stale_warning_delta": "120",
-    "immutable_culling_delta": "120",
+    "conventional_staleness_delta": 1,
+    "conventional_stale_warning_delta": 7,
+    "conventional_culling_delta": 14,
+    "immutable_staleness_delta": 7,
+    "immutable_stale_warning_delta": 120,
+    "immutable_culling_delta": 120,
 }
 
 
@@ -35,7 +35,7 @@ def test_create_staleness(api_create_account_staleness, db_get_account_staleness
 
 def test_create_staleness_with_only_one_data(api_create_account_staleness, db_get_account_staleness_culling):
     input_data = {
-        "conventional_staleness_delta": "1",
+        "conventional_staleness_delta": 1,
     }
     response_status, response_data = api_create_account_staleness(input_data)
     assert_response_status(response_status, 201)
@@ -61,7 +61,7 @@ def test_create_same_staleness(api_create_account_staleness):
 
 def test_create_staleness_with_wrong_input(api_create_account_staleness):
     input_data = {
-        "test_wrong_payload_data": "1",
+        "test_wrong_payload_data": 1,
     }
     response_status, response_data = api_create_account_staleness(input_data)
     assert_response_status(response_status, 400)


### PR DESCRIPTION


# Overview

This PR is being created to address [ESSNTL-5404](https://issues.redhat.com/browse/ESSNTL-5404).
Moving from `str` to `int` for staleness fields

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
