### PR TITLE
Fix fixture to let test_unit.py be tested by itself

### DIFF
--- a/tests/fixtures/app_fixtures.py
+++ b/tests/fixtures/app_fixtures.py
@@ -34,7 +34,7 @@ def inventory_config(flask_app):
     flask_app.config["INVENTORY_CONFIG"] = Config(RuntimeEnvironment.TEST)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="function")
 def clean_g():
     if "acc_st" in g:
         del g.acc_st

--- a/tests/test_api_staleness_get.py
+++ b/tests/test_api_staleness_get.py
@@ -24,7 +24,7 @@ def test_get_default_staleness(api_get):
     assert response_data["immutable_culling_delta"] == expected_result["immutable_culling_delta"]
 
 
-def test_get_custom_staleness(api_create_staleness, api_get):
+def test_get_custom_staleness(api_create_staleness, api_get, clean_g):
     created_response_status, _ = api_create_staleness(_INPUT_DATA)
     url = build_staleness_url()
     response_status, response_data = api_get(url)


### PR DESCRIPTION
# Overview

@jpramos123, this PR fixes the `clean_g()` fixture, which is used by only one test.  Without this fix the tests in `tests/test_unit.py` fail.  This bug was discovered while reviewing the [segmentio PR ](https://github.com/RedHatInsights/insights-host-inventory/pull/1472)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
