### PR TITLE
fix(ESSNTL-5465): Fix filter key check when hide-edge-hosts flag is enabled

### DIFF
--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -288,14 +288,20 @@ def test_get_hosts_sap_system_bad_parameter_values(patch_xjoin_post, api_get, su
             assert_response_status(eq_response_status, 400)
 
 
-def test_get_hosts_unsupported_filter(patch_xjoin_post, api_get):
+@pytest.mark.parametrize(
+    "hide_edge_hosts",
+    (True, False),
+)
+def test_get_hosts_unsupported_filter(mocker, patch_xjoin_post, api_get, hide_edge_hosts):
     patch_xjoin_post(response={})
+    # Should work whether hide-edge-hosts feature flag is on or off
+    mocker.patch("api.filtering.filtering.get_flag_value", return_value=hide_edge_hosts)
 
     implicit_url = build_hosts_url(query="?filter[system_profile][bad_thing]=Banana")
     eq_url = build_hosts_url(query="?filter[Bad_thing][Extra_bad_one][eq]=Pinapple")
 
-    implicit_response_status, implicit_response_data = api_get(implicit_url)
-    eq_response_status, eq_response_data = api_get(eq_url)
+    implicit_response_status, _ = api_get(implicit_url)
+    eq_response_status, _ = api_get(eq_url)
 
     assert_response_status(implicit_response_status, 400)
     assert_response_status(eq_response_status, 400)


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-5465](https://issues.redhat.com/browse/ESSNTL-5465). It fixes a bug that occurs when the feature flag to hide Edge hosts is turned on, and the user makes a request with an invalid filter key. For instance, if the user filters using `?filter[bad_key]`, it would error and return 500 instead of 400.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
