### PR TITLE
perf(RHINENG-2320): Use logger for logging Groups' API actions

### DIFF
--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -116,6 +116,10 @@ def log_create_group_failed(logger, group_name):
     logger.info("Error adding group '%s'.", group_name, extra={"access_rule": get_control_rule()})
 
 
+def log_create_group_not_allowed(logger):
+    logger.info("Error adding group due to filtered inventory:groups:write RBAC permission.")
+
+
 # create host_group_assoc
 def log_host_group_add_succeeded(logger, host_id_list, group_id):
     logger.info(
@@ -156,6 +160,10 @@ def log_host_group_delete_failed(logger, host_id, group_id, control_rule):
         f"Failed to remove association between host {host_id} and group {group_id}",
         extra={"access_rule": control_rule},
     )
+
+
+def log_delete_hosts_from_group_failed(logger):
+    logger.info("Failed to remove hosts from group.")
 
 
 # get tags
@@ -279,6 +287,11 @@ def rbac_permission_denied(logger, required_permission, user_permissions):
         "Access denied due to RBAC",
         extra={"required_permission": required_permission, "user_permissions": user_permissions},
     )
+    rbac_access_denied.labels(required_permission=required_permission).inc()
+
+
+def rbac_group_permission_denied(logger, group_ids, required_permission):
+    logger.debug(f"You do not have access to the the following groups: {group_ids}")
     rbac_access_denied.labels(required_permission=required_permission).inc()
 
 

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -4,6 +4,7 @@ from api.host_query import staleness_timestamps
 from app.auth import get_current_identity
 from app.exceptions import InventoryException
 from app.instrumentation import get_control_rule
+from app.instrumentation import log_get_group_list_failed
 from app.instrumentation import log_group_delete_failed
 from app.instrumentation import log_group_delete_succeeded
 from app.instrumentation import log_host_group_add_failed
@@ -205,6 +206,7 @@ def _remove_hosts_from_group(group_id, host_id_list):
     # First, find the group to make sure the org_id matches
     found_group = group_query.one_or_none()
     if not found_group:
+        log_get_group_list_failed(logger)
         return []
 
     host_group_query = HostGroupAssoc.query.filter(

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -20,6 +20,7 @@ from app import REQUEST_ID_HEADER
 from app.auth import get_current_identity
 from app.auth.identity import IdentityType
 from app.instrumentation import rbac_failure
+from app.instrumentation import rbac_group_permission_denied
 from app.instrumentation import rbac_permission_denied
 from app.logging import get_logger
 
@@ -169,5 +170,8 @@ def rbac_group_id_check(rbac_filter: dict, requested_ids: set) -> None:
         # Find the IDs that are in requested_ids but not rbac_filter
         disallowed_ids = requested_ids.difference(rbac_filter["groups"])
         if len(disallowed_ids) > 0:
+            # id check is only called before writing to groups, permission so far is always the same
+            required_permission = "inventory:groups:write"
             joined_ids = ", ".join(disallowed_ids)
+            rbac_group_permission_denied(logger, joined_ids, required_permission)
             abort(status.HTTP_403_FORBIDDEN, f"You do not have access to the the following groups: {joined_ids}")


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-2320](https://issues.redhat.com/browse/RHINENG-2320).
This PR adds logs to abort functions in `groups.py` and also to `rbac_group_id_check` in `middleware.py` which is used vastly in groups.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
