### PR TITLE
Fixed bug caused when User-Agent header is missing.

### DIFF
--- a/api/segmentio.py
+++ b/api/segmentio.py
@@ -5,9 +5,14 @@ from app.auth import get_current_identity
 
 
 def segmentio_track(op_name, processing_time, contextual_data, logger):
-    identity = get_current_identity()
-
     if analytics.write_key:
+        user_agent_header = connexion.request.headers.get("User-Agent", "")
+        if not user_agent_header:
+            logger.debug("Skipping analytics.track(), User-Agent header not set")
+            return None
+
+        identity = get_current_identity()
+
         logger.debug(f"Calling analytics.track({identity.org_id}, {op_name}, ...)")
         analytics.track(
             identity.org_id,
@@ -15,7 +20,7 @@ def segmentio_track(op_name, processing_time, contextual_data, logger):
             properties={
                 "processing_time": processing_time,
                 "status_code": contextual_data["status_code"],
-                "user_agent": connexion.request.headers["User-Agent"],
+                "user_agent": user_agent_header,
                 "auth_type": identity.auth_type,
             },
             context={

--- a/tests/test_segmentio.py
+++ b/tests/test_segmentio.py
@@ -36,3 +36,15 @@ def test_segmentio_track_without_write_key(mocker, api_get):
 
     assert analytics.write_key == ""
     assert mock_track.call_count == 0
+
+
+def test_segmentio_track_without_user_agent(mocker, api_get):
+    mock_track = mocker.patch("api.segmentio.analytics.track")
+    analytics.write_key = "test_write_key"
+
+    response_status, response_data = api_get(build_resource_types_url(), extra_headers={"User-Agent": ""})
+
+    assert_response_status(response_status, 200)
+
+    assert [] == mock_track.call_args_list
+    assert mock_track.call_count == 0


### PR DESCRIPTION
# Overview

API requests with no User-Agent header fail with a response code of 500.
This change ensures we don't try to reference a header that doesn't exist (the cause of the error).
And it doesn't attempt to track such requests, as we filter on User-Agent.