### PR TITLE
fix(ESSNTL-5406): Fix wrong 500 http response

### DIFF
--- a/api/staleness.py
+++ b/api/staleness.py
@@ -51,11 +51,12 @@ def _validate_input_data(body):
     # Validate account staleness input data
     try:
         validated_data = StalenessSchema().load(body)
+
+        return validated_data
+
     except ValidationError as e:
         logger.exception(f'Input validation error, "{str(e.messages)}", while creating account staleness: {body}')
-        return json_error_response("Validation Error", str(e.messages), status.HTTP_400_BAD_REQUEST)
-
-    return validated_data
+        abort(status.HTTP_400_BAD_REQUEST, f"Validation Error: {str(e.messages)}")
 
 
 @api_operation

--- a/tests/test_api_staleness_update.py
+++ b/tests/test_api_staleness_update.py
@@ -22,6 +22,12 @@ def test_update_non_existing_record(api_patch):
     assert_response_status(response_status, 404)
 
 
+def test_update_with_wrong_data(api_patch):
+    url = build_staleness_url()
+    response_status, response_data = api_patch(url, host_data={"conventional_staleness_delta": "9999"})
+    assert_response_status(response_status, 400)
+
+
 def test_update_staleness_rbac_allowed(subtests, mocker, api_patch, db_create_staleness_culling, enable_rbac):
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
     db_create_staleness_culling(conventional_staleness_delta=1)


### PR DESCRIPTION

# Overview

This PR is being created to address [ESSNTL-5406](https://issues.redhat.com/browse/ESSNTL-5406).
When api receives a wrong data in `patch` or `post` we need to return `400` and the validation error instead `500`


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
