### PR TITLE
Fix: Use output_host data for SP message headers

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -307,8 +307,8 @@ def handle_message(message, event_producer, notification_event_producer, message
                 operation_result,
                 insights_id,
                 host.get("reporter"),
-                host.get("system_profile", {}).get("host_type"),
-                host.get("system_profile", {}).get("operating_system", {}).get("name"),
+                output_host.get("system_profile", {}).get("host_type"),
+                output_host.get("system_profile", {}).get("operating_system", {}).get("name"),
             )
             event_producer.write_event(event, str(host_id), headers, wait=True)
         except ValidationException as ve:


### PR DESCRIPTION
# Overview

This PR is being created to address an issue the headers used by Cyndi apps. The "host_type" and "os_name" message headers were being populated from the incoming host data rather than the updated host data, so they would often be blank (as not every reporter provides these values). I've updated it so the values come from `output_host`, which has the full host data, so these fields will always be populated when they exist on the host record in the DB.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
