### PR TITLE
Add ssh key volume to the testing-integration.yml

### DIFF
--- a/deploy/testing-integration.yml
+++ b/deploy/testing-integration.yml
@@ -22,6 +22,11 @@ objects:
         - name: sel-shm
           emptyDir:
             medium: Memory
+        - name: insights-qa-private-key
+          secret:
+            secretName: insights-qa-private-key
+            defaultMode: 0400
+            optional: true
         containers:
         - name: host-inventory-e2e-iqe-${IMAGE_TAG}-${UID}
           image: ${IQE_IMAGE}
@@ -84,6 +89,13 @@ objects:
             requests:
               cpu: 500m
               memory: 1Gi
+          volumeMounts:
+            - name: insights-qa-private-key
+              readOnly: true
+              # We need to hardcode the path to reflect the $HOME variable being set here:
+              # https://gitlab.cee.redhat.com/insights-qe/iqe-core/-/blob/master/Dockerfile?ref_type=heads#L73
+              mountPath: /iqe_venv/.ssh/insights-qa.pem
+              subPath: insights-qa.pem
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: host-inventory-e2e-selenium-${UID}


### PR DESCRIPTION
# Overview

#### What:
* add `volume` and `volumeMount` needed for storing insights-qa ssh key

#### Why:
We need the SSH key for running our integration tests on Ibutsu. Currently, it is not possible
to connect to the provisioned machines due to missing SSH key.

This PR is connected to this one: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/86391
