### PR TITLE
fix(RHINENG-2470): change error message for DELETE endpoint

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -228,6 +228,6 @@ def delete_hosts_from_different_groups(host_id_list, rbac_filter=None):
 
     if delete_count == 0:
         log_delete_hosts_from_group_failed(logger)
-        abort(status.HTTP_404_NOT_FOUND, "The provided hosts are ungrouped.")
+        abort(status.HTTP_404_NOT_FOUND, "The provided hosts were not found.")
 
     return Response(None, status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-2470](https://issues.redhat.com/browse/RHINENG-2470).
It changes the error message for the DELETE /groups/hosts/<host_ids> endpoint.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
