### PR TITLE
fix(ESSNTL-5555): Fixing right return on default api

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -228,7 +228,7 @@ class Config:
             minutes=int(os.environ.get("CULLING_CULLED_OFFSET_MINUTES", "0")),
         )
 
-        self.conventional_staleness_seconds = os.environ.get("CONVENTIONAL_STALENESS_SECONDS", self.days_to_seconds(1))
+        self.conventional_staleness_seconds = os.environ.get("CONVENTIONAL_STALENESS_SECONDS", 104400)
 
         self.conventional_stale_warning_seconds = os.environ.get(
             "CONVENTIONAL_STALENESS_WARNING_SECONDS", self.days_to_seconds(7)

--- a/tests/test_api_staleness_get.py
+++ b/tests/test_api_staleness_get.py
@@ -42,7 +42,7 @@ def test_get_sys_default_staleness(api_get):
     response_status, response_data = api_get(url)
     assert_response_status(response_status, 200)
     expected_result = {
-        "conventional_staleness_delta": 86400,
+        "conventional_staleness_delta": 104400,
         "conventional_stale_warning_delta": 604800,
         "conventional_culling_delta": 1209600,
         "immutable_staleness_delta": 172800,

--- a/tests/test_api_staleness_get.py
+++ b/tests/test_api_staleness_get.py
@@ -9,7 +9,7 @@ def test_get_default_staleness(api_get):
     response_status, response_data = api_get(url)
     assert_response_status(response_status, 200)
     expected_result = {
-        "conventional_staleness_delta": 86400,
+        "conventional_staleness_delta": 104400,
         "conventional_stale_warning_delta": 604800,
         "conventional_culling_delta": 1209600,
         "immutable_staleness_delta": 172800,


### PR DESCRIPTION

# Overview

This PR is being created to address [ESSNTL-5555](https://issues.redhat.com/browse/ESSNTL-5555).

We recently changed the conventional_staleness_delta default from 86400 to 104400, this commit fix that.


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
