### PR TITLE
fix(ESSNTL-3085): Strip whitespace from group name input

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -831,6 +831,13 @@ class InputGroupSchema(MarshmallowSchema):
     name = fields.Str(validate=marshmallow_validate.Length(min=1, max=255))
     host_ids = fields.List(fields.Str(validate=verify_uuid_format))
 
+    @pre_load
+    def strip_whitespace_from_name(self, in_data, **kwargs):
+        if "name" in in_data:
+            in_data["name"] = in_data["name"].strip()
+
+        return in_data
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/tests/test_api_groups_create.py
+++ b/tests/test_api_groups_create.py
@@ -67,7 +67,15 @@ def test_create_group_with_hosts(
         assert parser.isoparse(host["updated"]) == db_get_host(host["id"]).modified_on
 
 
-def test_create_group_invalid_name(api_create_group):
+@pytest.mark.parametrize(
+    "new_name",
+    [
+        "",
+        "  ",
+        "  ",
+    ],
+)
+def test_create_group_invalid_name(api_create_group, new_name):
     group_data = {"name": "", "host_ids": []}
 
     response_status, _ = api_create_group(group_data)
@@ -84,10 +92,15 @@ def test_create_group_null_name(api_create_group):
     assert "Group name cannot be null" in response_data["detail"]
 
 
-def test_create_group_taken_name(api_create_group):
+@pytest.mark.parametrize(
+    "new_name",
+    ["test_group", " test_group", "test_group ", " test_group "],
+)
+def test_create_group_taken_name(api_create_group, new_name):
     group_data = {"name": "test_group", "host_ids": []}
 
-    response_status, _ = api_create_group(group_data)
+    api_create_group(group_data)
+    group_data["name"] = new_name
     response_status, response_data = api_create_group(group_data)
 
     assert_response_status(response_status, expected_status=400)


### PR DESCRIPTION
# Overview

This PR is being created to address [ESSNTL-3085](https://issues.redhat.com/browse/RHINENG-3085).
It strips whitespace from the beginning and end of the group name input, so that you can't have 3 separate groups named (for instance) "testGroup", " testGroup", and "testGroup ". I baked this into the pre-load of the input validator so that it happens automatically, as long as the data is loaded into the schema (InputGroupSchema).

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
