### PR TITLE
chore(RHINENG-3099): Add indexes for reporter and host_type

### DIFF
--- a/migrations/versions/cc3494db47ea_add_indexes_for_reporter_host_type_os_.py
+++ b/migrations/versions/cc3494db47ea_add_indexes_for_reporter_host_type_os_.py
@@ -1,0 +1,26 @@
+"""Add indexes for reporter, host_type, OS name
+
+Revision ID: cc3494db47ea
+Revises: f8c3af70df12
+Create Date: 2023-11-08 09:38:18.821767
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "cc3494db47ea"
+down_revision = "f8c3af70df12"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index("idx_reporter", "hosts", ["reporter"])
+    op.create_index("idx_host_type", "hosts", [sa.text("(system_profile_facts ->> 'host_type')")])
+
+
+def downgrade():
+    op.drop_index("idx_host_type", table_name="hosts")
+    op.drop_index("idx_reporter", table_name="hosts")


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-3099](https://issues.redhat.com/browse/RHINENG-3099).
It adds indexes for `reporter` and `system_profile_facts.host_type`, which will speed up queries that use these fields.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
