### PR TITLE
chore(RHINENG-3099): Add GIN for operating_system.name

### DIFF
--- a/migrations/versions/bb9701f29a05_add_gin_for_operating_system_name.py
+++ b/migrations/versions/bb9701f29a05_add_gin_for_operating_system_name.py
@@ -1,0 +1,31 @@
+"""Add GIN for operating_system name
+
+Revision ID: bb9701f29a05
+Revises: cc3494db47ea
+Create Date: 2023-11-10 16:53:02.882106
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "bb9701f29a05"
+down_revision = "cc3494db47ea"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    op.create_index(
+        "idx_operating_system",
+        "hosts",
+        [sa.text("(system_profile_facts -> 'operating_system' ->> 'name') gin_trgm_ops")],
+        postgresql_using="gin",
+    )
+
+
+def downgrade():
+    op.drop_index("idx_operating_system", table_name="hosts")
+    op.execute("DROP EXTENSION IF EXISTS pg_trgm")


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-3099](https://issues.redhat.com/browse/RHINENG-3099).
It adds a GIN for `system_profile_facts.operating_system.name`. This should improve performance when querying that field. 

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
