### PR TITLE
Change Jira link template to reflect new project

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,6 +1,6 @@
 # Overview
 
-This PR is being created to address [ESSNTL-xxxx](https://issues.redhat.com/browse/ESSNTL-xxxx).
+This PR is being created to address [RHINENG-xxxx](https://issues.redhat.com/browse/RHINENG-xxxx).
 (A description of your PR's changes, along with why/context to the PR, goes here.)
 
 ## PR Checklist


### PR DESCRIPTION
# Overview

This PR is being created simply to update the Jira link template in our PR template. It changes the project in the link from ESSNTL to RHINENG, since we're supposed to be using that project for all new tickets.