### PR TITLE
fix(RHINENG-3099) Add COALESCE to operating_system GIN

### DIFF
--- a/migrations/versions/3ecc428e69cb_add_coalesce_to_operating_system_gin.py
+++ b/migrations/versions/3ecc428e69cb_add_coalesce_to_operating_system_gin.py
@@ -21,7 +21,7 @@ def upgrade():
     op.create_index(
         "idx_operating_system",
         "hosts",
-        [sa.text("(COALESCE(system_profile_facts -> 'operating_system' ->> 'name')) gin_trgm_ops")],
+        [sa.text("(COALESCE(system_profile_facts -> 'operating_system' ->> 'name', '')) gin_trgm_ops")],
         postgresql_using="gin",
     )
 

--- a/migrations/versions/3ecc428e69cb_add_coalesce_to_operating_system_gin.py
+++ b/migrations/versions/3ecc428e69cb_add_coalesce_to_operating_system_gin.py
@@ -1,0 +1,32 @@
+"""Add COALESCE to operating_system GIN
+
+Revision ID: 3ecc428e69cb
+Revises: bb9701f29a05
+Create Date: 2023-11-15 09:01:49.968782
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "3ecc428e69cb"
+down_revision = "bb9701f29a05"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index("idx_operating_system", table_name="hosts")
+    op.create_index(
+        "idx_operating_system",
+        "hosts",
+        [sa.text("(COALESCE(system_profile_facts -> 'operating_system' ->> 'name')) gin_trgm_ops")],
+        postgresql_using="gin",
+    )
+
+
+def downgrade():
+    # No point downgrading to an incorrect index.
+    # Downgrading one migration further will remove the index as intended.
+    pass


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-3099](https://issues.redhat.com/browse/RHINENG-3099).
Adds a COALESCE statement to the `operating_system` GIN; I overlooked it in #1541.
I left the migration's downgrade function empty because IMO there's no point reverting to an incorrect index; if the intent is the remove the index, it can just be downgraded to the one before that.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
