### PR TITLE
fix(RHINENG-3425) Fix dict & tuple mismatches

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -337,12 +337,14 @@ def build_tag_query_dict_tuple(tags):
 
 
 def owner_id_filter():
-    return {"spf_owner_id": {"eq": get_current_identity().system["cn"]}}
+    return ({"spf_owner_id": {"eq": get_current_identity().system["cn"]}},)
 
 
 def host_id_list_query_filter(host_id_list, rbac_filter):
-    stale_filter = staleness_filter(["not_culled"])
-    hosts_filter = (
+    all_filters = (
+        {
+            "OR": staleness_filter(["not_culled"]),
+        },
         {
             "OR": [
                 {
@@ -352,7 +354,6 @@ def host_id_list_query_filter(host_id_list, rbac_filter):
             ],
         },
     )
-    all_filters = {"OR": stale_filter, "AND": hosts_filter}
     if rbac_filter:
         for key in rbac_filter:
             if key == "groups":
@@ -360,7 +361,7 @@ def host_id_list_query_filter(host_id_list, rbac_filter):
 
     current_identity = get_current_identity()
     if current_identity.identity_type == IdentityType.SYSTEM:
-        all_filters.update(owner_id_filter())
+        all_filters += owner_id_filter()
 
     return all_filters
 
@@ -503,7 +504,7 @@ def query_filters(
 
     current_identity = get_current_identity()
     if current_identity.identity_type == IdentityType.SYSTEM:
-        query_filters += (owner_id_filter(),)
+        query_filters += owner_id_filter()
 
     logger.debug(query_filters)
     return query_filters

--- a/app/xjoin.py
+++ b/app/xjoin.py
@@ -89,10 +89,11 @@ def params_to_order(param_order_by, param_order_how):
 
 def staleness_filter(staleness):
     staleness_obj = serialize_staleness_to_dict(get_staleness_obj())
-    staleness_conditions = [
-        {"OR": tuple(staleness_to_conditions(staleness_obj, staleness, host_type, _stale_timestamp_filter))}
-        for host_type in HOST_TYPES
-    ]
+    staleness_conditions = tuple()
+    for host_type in HOST_TYPES:
+        staleness_conditions += tuple(
+            staleness_to_conditions(staleness_obj, staleness, host_type, _stale_timestamp_filter)
+        )
     return staleness_conditions
 
 

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -236,7 +236,7 @@ def assert_graph_query_single_call_with_staleness(mocker, graphql_query, stalene
             "order_how": mocker.ANY,
             "limit": mocker.ANY,
             "offset": mocker.ANY,
-            "filter": ({"OR": staleness_conditions},),
+            "filter": staleness_conditions,
             "fields": mocker.ANY,
         },
         mocker.ANY,

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -37,10 +37,10 @@ def test_get_tags_of_multiple_hosts_query(
             "order_how": "ASC",
             "limit": mocker.ANY,
             "offset": mocker.ANY,
-            "filter": {
-                "OR": mocker.ANY,
-                "AND": ({"OR": [{"id": {"eq": host.id}} for host in created_hosts]},),
-            },
+            "filter": (
+                {"OR": mocker.ANY},
+                {"OR": [{"id": {"eq": host.id}} for host in created_hosts]},
+            ),
         },
         mocker.ANY,
     )

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -103,20 +103,12 @@ def test_query_all_hosts(mocker, graphql_query_empty_response, api_get):
             "filter": (
                 {
                     "OR": (
-                        {
-                            "OR": (
-                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                            )
-                        },
-                        {
-                            "OR": (
-                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                            )
-                        },
+                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
+                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
+                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
+                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
+                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
+                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
                     )
                 },
             ),
@@ -693,10 +685,6 @@ def test_query_variables_default_except_staleness(mocker, graphql_query_empty_re
                                 "spf_host_type": {"eq": "edge"},
                             }
                         },
-                    )
-                },
-                {
-                    "OR": (
                         {
                             "AND": {
                                 "modified_on": {"gt": "2019-12-15T05:10:06.754201+00:00"},
@@ -721,10 +709,6 @@ def test_query_variables_default_except_staleness(mocker, graphql_query_empty_re
                                 "spf_host_type": {"eq": "edge"},
                             }
                         },
-                    )
-                },
-                {
-                    "OR": (
                         {
                             "AND": {
                                 "modified_on": {
@@ -752,10 +736,6 @@ def test_query_variables_default_except_staleness(mocker, graphql_query_empty_re
                                 "spf_host_type": {"eq": "edge"},
                             }
                         },
-                    )
-                },
-                {
-                    "OR": (
                         {
                             "AND": {
                                 "modified_on": {
@@ -809,10 +789,6 @@ def test_query_multiple_staleness(mocker, culling_datetime_mock, graphql_query_e
                             "spf_host_type": {"eq": "edge"},
                         }
                     },
-                )
-            },
-            {
-                "OR": (
                     {
                         "AND": {
                             "modified_on": {"gt": "2019-12-15T05:10:06.754201+00:00"},
@@ -1062,24 +1038,16 @@ def test_tags_query_group_name_filter(assert_tag_query_host_filter_single_call, 
             "fresh",
             [
                 {
-                    "OR": (
-                        {
-                            "AND": {
-                                "modified_on": {"gt": "2019-12-14T10:10:06.754201+00:00"},
-                                "spf_host_type": {"eq": "edge"},
-                            }
-                        },
-                    )
+                    "AND": {
+                        "modified_on": {"gt": "2019-12-14T10:10:06.754201+00:00"},
+                        "spf_host_type": {"eq": "edge"},
+                    },
                 },
                 {
-                    "OR": (
-                        {
-                            "AND": {
-                                "modified_on": {"gt": "2019-12-15T05:10:06.754201+00:00"},
-                                "spf_host_type": {"eq": None},
-                            }
-                        },
-                    )
+                    "AND": {
+                        "modified_on": {"gt": "2019-12-15T05:10:06.754201+00:00"},
+                        "spf_host_type": {"eq": None},
+                    }
                 },
             ],
         ),
@@ -1087,30 +1055,22 @@ def test_tags_query_group_name_filter(assert_tag_query_host_filter_single_call, 
             "stale",
             [
                 {
-                    "OR": (
-                        {
-                            "AND": {
-                                "modified_on": {
-                                    "gt": "2019-08-18T10:10:06.754201+00:00",
-                                    "lte": "2019-12-14T10:10:06.754201+00:00",
-                                },
-                                "spf_host_type": {"eq": "edge"},
-                            }
+                    "AND": {
+                        "modified_on": {
+                            "gt": "2019-08-18T10:10:06.754201+00:00",
+                            "lte": "2019-12-14T10:10:06.754201+00:00",
                         },
-                    )
+                        "spf_host_type": {"eq": "edge"},
+                    },
                 },
                 {
-                    "OR": (
-                        {
-                            "AND": {
-                                "modified_on": {
-                                    "gt": "2019-12-09T10:10:06.754201+00:00",
-                                    "lte": "2019-12-15T05:10:06.754201+00:00",
-                                },
-                                "spf_host_type": {"eq": None},
-                            }
+                    "AND": {
+                        "modified_on": {
+                            "gt": "2019-12-09T10:10:06.754201+00:00",
+                            "lte": "2019-12-15T05:10:06.754201+00:00",
                         },
-                    )
+                        "spf_host_type": {"eq": None},
+                    }
                 },
             ],
         ),
@@ -1118,30 +1078,22 @@ def test_tags_query_group_name_filter(assert_tag_query_host_filter_single_call, 
             "stale_warning",
             [
                 {
-                    "OR": (
-                        {
-                            "AND": {
-                                "modified_on": {
-                                    "gt": "2019-06-19T10:10:06.754201+00:00",
-                                    "lte": "2019-08-18T10:10:06.754201+00:00",
-                                },
-                                "spf_host_type": {"eq": "edge"},
-                            }
+                    "AND": {
+                        "modified_on": {
+                            "gt": "2019-06-19T10:10:06.754201+00:00",
+                            "lte": "2019-08-18T10:10:06.754201+00:00",
                         },
-                    )
+                        "spf_host_type": {"eq": "edge"},
+                    },
                 },
                 {
-                    "OR": (
-                        {
-                            "AND": {
-                                "modified_on": {
-                                    "gt": "2019-12-02T10:10:06.754201+00:00",
-                                    "lte": "2019-12-09T10:10:06.754201+00:00",
-                                },
-                                "spf_host_type": {"eq": None},
-                            }
+                    "AND": {
+                        "modified_on": {
+                            "gt": "2019-12-02T10:10:06.754201+00:00",
+                            "lte": "2019-12-09T10:10:06.754201+00:00",
                         },
-                    )
+                        "spf_host_type": {"eq": None},
+                    }
                 },
             ],
         ),
@@ -1161,42 +1113,34 @@ def test_tags_multiple_query_variables_staleness(culling_datetime_mock, assert_t
         host_filter={
             "OR": [
                 {
-                    "OR": (
-                        {
-                            "AND": {
-                                "modified_on": {"gt": "2019-12-14T10:10:06.754201+00:00"},
-                                "spf_host_type": {"eq": "edge"},
-                            }
-                        },
-                        {
-                            "AND": {
-                                "modified_on": {
-                                    "gt": "2019-06-19T10:10:06.754201+00:00",
-                                    "lte": "2019-08-18T10:10:06.754201+00:00",
-                                },
-                                "spf_host_type": {"eq": "edge"},
-                            }
-                        },
-                    )
+                    "AND": {
+                        "modified_on": {"gt": "2019-12-14T10:10:06.754201+00:00"},
+                        "spf_host_type": {"eq": "edge"},
+                    }
                 },
                 {
-                    "OR": (
-                        {
-                            "AND": {
-                                "modified_on": {"gt": "2019-12-15T05:10:06.754201+00:00"},
-                                "spf_host_type": {"eq": None},
-                            }
+                    "AND": {
+                        "modified_on": {
+                            "gt": "2019-06-19T10:10:06.754201+00:00",
+                            "lte": "2019-08-18T10:10:06.754201+00:00",
                         },
-                        {
-                            "AND": {
-                                "modified_on": {
-                                    "gt": "2019-12-02T10:10:06.754201+00:00",
-                                    "lte": "2019-12-09T10:10:06.754201+00:00",
-                                },
-                                "spf_host_type": {"eq": None},
-                            }
+                        "spf_host_type": {"eq": "edge"},
+                    }
+                },
+                {
+                    "AND": {
+                        "modified_on": {"gt": "2019-12-15T05:10:06.754201+00:00"},
+                        "spf_host_type": {"eq": None},
+                    }
+                },
+                {
+                    "AND": {
+                        "modified_on": {
+                            "gt": "2019-12-02T10:10:06.754201+00:00",
+                            "lte": "2019-12-09T10:10:06.754201+00:00",
                         },
-                    )
+                        "spf_host_type": {"eq": None},
+                    }
                 },
             ]
         },
@@ -3069,13 +3013,15 @@ def test_sp_sparse_xjoin_query_translation(
     hosts = [minimal_host(id=host_one_id), minimal_host(id=host_two_id)]
 
     # Test with user identity first
-    variables["hostFilter"] = {
-        "AND": ({"OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]},),
-        "OR": [
-            {"OR": ({"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},)},
-            {"OR": ({"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},)},
-        ],
-    }
+    variables["hostFilter"] = (
+        {
+            "OR": (
+                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
+                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
+            ),
+        },
+        {"OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]},
+    )
 
     response_status, _ = api_get(build_system_profile_url(hosts, query=query))
 
@@ -3087,14 +3033,16 @@ def test_sp_sparse_xjoin_query_translation(
     graphql_sparse_system_profile_empty_response.reset_mock()
 
     # Now test with system identity
-    variables["hostFilter"] = {
-        "AND": ({"OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]},),
-        "OR": [
-            {"OR": ({"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},)},
-            {"OR": ({"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},)},
-        ],
-        "spf_owner_id": {"eq": SYSTEM_IDENTITY["system"]["cn"]},
-    }
+    variables["hostFilter"] = (
+        {
+            "OR": (
+                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
+                {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
+            )
+        },
+        {"OR": [{"id": {"eq": host_one_id}}, {"id": {"eq": host_two_id}}]},
+        {"spf_owner_id": {"eq": SYSTEM_IDENTITY["system"]["cn"]}},
+    )
 
     response_status, _ = api_get(build_system_profile_url(hosts, query=query), identity=SYSTEM_IDENTITY)
 
@@ -3150,10 +3098,10 @@ def test_get_hosts_by_ids(num_hosts, mocker, filtering_datetime_mock, graphql_qu
             "order_how": mocker.ANY,
             "limit": mocker.ANY,
             "offset": mocker.ANY,
-            "filter": {
-                "OR": mocker.ANY,
-                "AND": ({"OR": [{"id": {"eq": host_id}} for host_id in host_id_list]},),
-            },
+            "filter": (
+                {"OR": mocker.ANY},
+                {"OR": [{"id": {"eq": host_id}} for host_id in host_id_list]},
+            ),
             "fields": mocker.ANY,
         },
         mocker.ANY,


### PR DESCRIPTION
# Overview

This PR is being created to fix [RHINENG-3425](https://issues.redhat.com/browse/RHINENG-3425), an issue introduced by #1516. It changes some of the dicts back to tuples, and simplifies some of the xjoin logic (so it's not wrapping multiple `OR`s in more `OR`s, for instance).

I wanted to figure out how to further simplify `staleness_conditions` in `staleness_filter`, but I wasn't able to figure out how to correctly do this kind of tuple comprehension in a reasonable amount of time. If you have any suggestions, please let me know.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
