### PR TITLE
feat(RHINENG-2631): Support new reporter values for yupana

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -19,6 +19,7 @@ from app.auth import get_current_identity
 from app.auth.identity import IdentityType
 from app.exceptions import ValidationException
 from app.logging import get_logger
+from app.models import OLD_TO_NEW_REPORTER_MAP
 from app.utils import Tag
 from app.validators import is_custom_date as is_timestamp
 from app.xjoin import staleness_filter
@@ -288,6 +289,12 @@ def build_registered_with_filter(registered_with):
         prs_list.append({"NOT": {"insights_id": {"eq": None}}})
         reg_with_copy.remove("insights")
     if reg_with_copy:
+        # When filtering on old reporter name, include the names of the
+        # new reporters associated with the old reporter.
+        for old_reporter in OLD_TO_NEW_REPORTER_MAP:
+            if old_reporter in reg_with_copy:
+                reg_with_copy.extend(OLD_TO_NEW_REPORTER_MAP[old_reporter])
+                reg_with_copy = list(set(reg_with_copy))  # Remove duplicates
         for item in reg_with_copy:
             prs_item = {
                 "per_reporter_staleness": {

--- a/app/models.py
+++ b/app/models.py
@@ -55,6 +55,11 @@ SYSTEM_PROFILE_SPECIFICATION_FILE = "system_profile.spec.yaml"
 # set edge host stale_timestamp way out in future to Year 2260
 EDGE_HOST_STALE_TIMESTAMP = datetime(2260, 1, 1, tzinfo=timezone.utc)
 
+# Used when updating per_reporter_staleness from old to new keys.
+NEW_TO_OLD_REPORTER_MAP = {"satellite": "yupana", "discovery": "yupana"}
+# Used in filtering.
+OLD_TO_NEW_REPORTER_MAP = {"yupana": ("satellite", "discovery")}
+
 
 class ProviderType(str, Enum):
     ALIBABA = "alibaba"
@@ -321,6 +326,9 @@ class Host(LimitedHost):
 
         if not self.per_reporter_staleness.get(reporter):
             self.per_reporter_staleness[reporter] = {}
+
+        if old_reporter := NEW_TO_OLD_REPORTER_MAP.get(reporter):
+            self.per_reporter_staleness.pop(old_reporter, None)
 
         self.per_reporter_staleness[reporter].update(
             stale_timestamp=self.stale_timestamp.isoformat(),

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -10,6 +10,7 @@ from api.system_profile import SAP_SIDS_QUERY
 from api.system_profile import SAP_SYSTEM_QUERY
 from api.tag import TAGS_QUERY
 from app import process_spec
+from app.models import OLD_TO_NEW_REPORTER_MAP
 from app.models import ProviderType
 from tests.helpers.api_utils import build_hosts_url
 from tests.helpers.api_utils import build_system_profile_sap_sids_url
@@ -490,6 +491,10 @@ def test_query_variables_tags_with_search(field, mocker, graphql_query_empty_res
 # Build the expected PRS filter based on reporters
 def _build_prs_array(mocker, reporters):
     prs_array = []
+    for old_reporter in OLD_TO_NEW_REPORTER_MAP:
+        if old_reporter in reporters:
+            reporters.extend(OLD_TO_NEW_REPORTER_MAP[old_reporter])
+            reporters = list(set(reporters))  # Remove duplicates
     for reporter in reporters:
         prs_item = {
             "per_reporter_staleness": {


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-2631](https://issues.redhat.com/browse/RHINENG-2631).

In addition to "yupana", HBI must start supporting "satellite" and "discovery" for the reporter field. In order to transition smoothly to the new values, a few extra steps are needed.

When filtering on "registered_with=yupana", also include hosts that have been updated recently with the "satellite" or "discovery" reporter.

When updating per_reporter_staleness (PRS), if the reporter is "satellite" or "discovery", remove the "yupana" entry afterwards.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
