### PR TITLE
fix(RHINENG-4810): filtering logic for multiple  values for the same SP field

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -261,7 +261,11 @@ def _base_filter_builder(builder_function, field_name, field_value, field_filter
             isolated_expression = _isolate_object_filter_expression(field_value, value)
             foo_list.append(builder_function(xjoin_field_name, isolated_expression, field_filter, operation, spec)[0])
         list_operator = _get_list_operator(field_name, field_filter)
-        field_filter = ({list_operator: foo_list},)
+        if len(foo_list) > 1:
+            # Filtering system_profile fields by multiple values of the same field uses OR logic
+            field_filter = ({"OR": foo_list},)
+        else:
+            field_filter = ({list_operator: foo_list},)
     elif isinstance(base_value, str):
         logger.debug("filter value is a string")
         isolated_expression = _isolate_object_filter_expression(field_value, base_value)

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -261,7 +261,8 @@ def _base_filter_builder(builder_function, field_name, field_value, field_filter
             isolated_expression = _isolate_object_filter_expression(field_value, value)
             foo_list.append(builder_function(xjoin_field_name, isolated_expression, field_filter, operation, spec)[0])
         list_operator = _get_list_operator(field_name, field_filter)
-        if len(foo_list) > 1:
+
+        if len(foo_list) > 1 and operation == "eq":
             # Filtering system_profile fields by multiple values of the same field uses OR logic
             field_filter = ({"OR": foo_list},)
         else:

--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -263,7 +263,7 @@ def _base_filter_builder(builder_function, field_name, field_value, field_filter
             foo_list.append(builder_function(xjoin_field_name, isolated_expression, field_filter, operation, spec)[0])
         list_operator = _get_list_operator(field_name, field_filter)
 
-        if len(foo_list) > 1 and operation == "eq" and not is_array:
+        if operation == "eq" and not is_array:
             # Filtering system_profile fields by multiple values of the same field uses OR logic,
             # fields with type array should have the default operator
             field_filter = ({"OR": foo_list},)

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -149,11 +149,7 @@ XJOIN_HOSTS_RESPONSE = {
                         "stale_timestamp": "2020-02-10T08:07:03.354307+00:00",
                     }
                 },
-                "system_profile_facts": {
-                    "arch": "1.2.3",
-                    "kernel_modules": ["data"],
-                    "owner_id": "ce87bfac-a6cb-43a0-80ce-95d9669db71f",
-                },
+                "system_profile_facts": {"arch": "1.2.3", "kernel_modules": ["data"]},
             },
         ],
     }
@@ -215,31 +211,19 @@ XJOIN_SPARSE_SYSTEM_PROFILE_EMPTY_RESPONSE = {"hosts": {"meta": {"count": 2, "to
 CASEFOLDED_FIELDS = ("fqdn", "insights_id", "provider_type", "provider_id")
 
 
-def xjoin_host_response(timestamp, quantity=1):
-    data = [
-        {
-            **XJOIN_HOSTS_RESPONSE["hosts"]["data"][0],
-            "created_on": timestamp,
-            "modified_on": timestamp,
-            "stale_timestamp": timestamp,
-        }
-    ]
-
-    if quantity != 1:
-        data.append(
-            {
-                **XJOIN_HOSTS_RESPONSE["hosts"]["data"][1],
-                "created_on": timestamp,
-                "modified_on": timestamp,
-                "stale_timestamp": timestamp,
-            }
-        )
-
+def xjoin_host_response(timestamp):
     return {
         "hosts": {
             **XJOIN_HOSTS_RESPONSE["hosts"],
-            "meta": {"total": quantity},
-            "data": data,
+            "meta": {"total": 1},
+            "data": [
+                {
+                    **XJOIN_HOSTS_RESPONSE["hosts"]["data"][0],
+                    "created_on": timestamp,
+                    "modified_on": timestamp,
+                    "stale_timestamp": timestamp,
+                }
+            ],
         }
     }
 

--- a/tests/helpers/graphql_utils.py
+++ b/tests/helpers/graphql_utils.py
@@ -149,7 +149,11 @@ XJOIN_HOSTS_RESPONSE = {
                         "stale_timestamp": "2020-02-10T08:07:03.354307+00:00",
                     }
                 },
-                "system_profile_facts": {"arch": "1.2.3", "kernel_modules": ["data"]},
+                "system_profile_facts": {
+                    "arch": "1.2.3",
+                    "kernel_modules": ["data"],
+                    "owner_id": "ce87bfac-a6cb-43a0-80ce-95d9669db71f",
+                },
             },
         ],
     }
@@ -211,19 +215,31 @@ XJOIN_SPARSE_SYSTEM_PROFILE_EMPTY_RESPONSE = {"hosts": {"meta": {"count": 2, "to
 CASEFOLDED_FIELDS = ("fqdn", "insights_id", "provider_type", "provider_id")
 
 
-def xjoin_host_response(timestamp):
+def xjoin_host_response(timestamp, quantity=1):
+    data = [
+        {
+            **XJOIN_HOSTS_RESPONSE["hosts"]["data"][0],
+            "created_on": timestamp,
+            "modified_on": timestamp,
+            "stale_timestamp": timestamp,
+        }
+    ]
+
+    if quantity != 1:
+        data.append(
+            {
+                **XJOIN_HOSTS_RESPONSE["hosts"]["data"][1],
+                "created_on": timestamp,
+                "modified_on": timestamp,
+                "stale_timestamp": timestamp,
+            }
+        )
+
     return {
         "hosts": {
             **XJOIN_HOSTS_RESPONSE["hosts"],
-            "meta": {"total": 1},
-            "data": [
-                {
-                    **XJOIN_HOSTS_RESPONSE["hosts"]["data"][0],
-                    "created_on": timestamp,
-                    "modified_on": timestamp,
-                    "stale_timestamp": timestamp,
-                }
-            ],
+            "meta": {"total": quantity},
+            "data": data,
         }
     }
 

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -2497,8 +2497,6 @@ def test_spf_host_type_invalid_field_value(subtests, graphql_query_empty_respons
 def test_query_hosts_filter_spf_insights_client_version(
     mocker, subtests, graphql_query_empty_response, patch_xjoin_post, api_get
 ):
-    # filter_paths = ("[system_profile][insights_client_version]", "[system_profile][insights_client_version][eq]")
-    # values = ("3.0.6-2.el7_6", "3.*", "nil", "not_nil")
     http_queries = (
         "filter[system_profile][insights_client_version]=3.0.6-2.el7_6",
         "filter[system_profile][insights_client_version][eq]=3.*",

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1858,21 +1858,14 @@ def test_query_system_profile_sap_system_filter_spf_sap_sids(
 def test_query_hosts_filter_spf_sap_sids(mocker, subtests, graphql_query_empty_response, api_get):
     filter_paths = ("[system_profile][sap_sids][]", "[system_profile][sap_sids][contains][]")
     value_sets = (("XQC",), ("ABC", "A12"), ("M80", "BEN"))
-    queries = [
-        (
-            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
-            ({"OR": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
-            ({"OR": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
-        ),
-        (
-            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
-            ({"AND": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
-            ({"AND": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
-        ),
-    ]
+    queries = (
+        ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
+        ({"AND": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
+        ({"AND": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
+    )
 
-    for idx, path in enumerate(filter_paths):
-        for values, query in zip(value_sets, queries[idx]):
+    for path in filter_paths:
+        for values, query in zip(value_sets, queries):
             with subtests.test(values=values, query=query, path=path):
                 graphql_query_empty_response.reset_mock()
                 url = build_hosts_url(query="?" + "".join([f"filter{path}={value}&" for value in values]))
@@ -1900,21 +1893,14 @@ def test_query_tags_filter_spf_sap_sids(
 ):
     filter_paths = ("[system_profile][sap_sids][]", "[system_profile][sap_sids][contains][]")
     value_sets = (("XQC",), ("ABC", "A12"), ("M80", "BEN"))
-    queries = [
-        (
-            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
-            ({"OR": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
-            ({"OR": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
-        ),
-        (
-            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
-            ({"AND": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
-            ({"AND": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
-        ),
-    ]
+    queries = (
+        ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
+        ({"AND": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
+        ({"AND": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
+    )
 
-    for idx, path in enumerate(filter_paths):
-        for values, query in zip(value_sets, queries[idx]):
+    for path in filter_paths:
+        for values, query in zip(value_sets, queries):
             with subtests.test(values=values, query=query, path=path):
                 assert_tag_query_host_filter_single_call(
                     build_tags_url(query="?" + "".join([f"filter{path}={value}&" for value in values])),
@@ -1928,21 +1914,14 @@ def test_query_system_profile_sap_sids_filter_spf_sap_sids(
 ):
     filter_paths = ("[system_profile][sap_sids][]", "[system_profile][sap_sids][contains][]")
     value_sets = (("XQC",), ("ABC", "A12"), ("M80", "BEN"))
-    queries = [
-        (
-            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
-            ({"OR": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
-            ({"OR": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
-        ),
-        (
-            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
-            ({"AND": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
-            ({"AND": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
-        ),
-    ]
+    queries = (
+        ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
+        ({"AND": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
+        ({"AND": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
+    )
 
-    for idx, path in enumerate(filter_paths):
-        for values, query in zip(value_sets, queries[idx]):
+    for path in filter_paths:
+        for values, query in zip(value_sets, queries):
             with subtests.test(values=values, query=query, path=path):
                 graphql_system_profile_sap_sids_query_empty_response.reset_mock()
 
@@ -2066,6 +2045,44 @@ def test_query_hosts_filter_spf_rhc_client_id_multiple(
                 {"spf_rhc_client_id": {"eq": "6e2c3332-936c-4167-b9be-c219f4303c85"}},
             ]
         },
+    )
+
+    for param, query in zip(query_params, queries):
+        with subtests.test(param=param, query=query):
+            url = build_hosts_url(query=param)
+
+            response_status, response_data = api_get(url)
+
+            assert response_status == 200
+
+            graphql_query_empty_response.assert_called_once_with(
+                HOST_QUERY,
+                {
+                    "order_by": mocker.ANY,
+                    "order_how": mocker.ANY,
+                    "limit": mocker.ANY,
+                    "offset": mocker.ANY,
+                    "filter": ({"OR": mocker.ANY}, query),
+                    "fields": mocker.ANY,
+                },
+                mocker.ANY,
+            )
+            graphql_query_empty_response.reset_mock()
+
+
+def test_query_hosts_filter_spf_multiple_values_same_field(
+    mocker, subtests, graphql_query_empty_response, patch_xjoin_post, api_get
+):
+    query_params = (
+        "?filter[system_profile][cloud_provider][]=ibm" "&filter[system_profile][cloud_provider][]=aws",
+        "?filter[system_profile][is_marketplace][]=false" "&filter[system_profile][is_marketplace][]=nil",
+        "?filter[system_profile][owner_id][]=8dd97934-8ce4-11eb-8dcd-0242ac130003"
+        "&filter[system_profile][owner_id][]=nil",
+    )
+    queries = (
+        {"OR": [{"spf_cloud_provider": {"eq": "ibm"}}, {"spf_cloud_provider": {"eq": "aws"}}]},
+        {"OR": [{"spf_is_marketplace": {"is": False}}, {"spf_is_marketplace": {"is": None}}]},
+        {"OR": [{"spf_owner_id": {"eq": "8dd97934-8ce4-11eb-8dcd-0242ac130003"}}, {"spf_owner_id": {"eq": None}}]},
     )
 
     for param, query in zip(query_params, queries):

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1858,14 +1858,21 @@ def test_query_system_profile_sap_system_filter_spf_sap_sids(
 def test_query_hosts_filter_spf_sap_sids(mocker, subtests, graphql_query_empty_response, api_get):
     filter_paths = ("[system_profile][sap_sids][]", "[system_profile][sap_sids][contains][]")
     value_sets = (("XQC",), ("ABC", "A12"), ("M80", "BEN"))
-    queries = (
-        ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
-        ({"OR": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
-        ({"OR": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
-    )
+    queries = [
+        (
+            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
+            ({"OR": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
+            ({"OR": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
+        ),
+        (
+            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
+            ({"AND": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
+            ({"AND": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
+        ),
+    ]
 
-    for path in filter_paths:
-        for values, query in zip(value_sets, queries):
+    for idx, path in enumerate(filter_paths):
+        for values, query in zip(value_sets, queries[idx]):
             with subtests.test(values=values, query=query, path=path):
                 graphql_query_empty_response.reset_mock()
                 url = build_hosts_url(query="?" + "".join([f"filter{path}={value}&" for value in values]))
@@ -1893,14 +1900,21 @@ def test_query_tags_filter_spf_sap_sids(
 ):
     filter_paths = ("[system_profile][sap_sids][]", "[system_profile][sap_sids][contains][]")
     value_sets = (("XQC",), ("ABC", "A12"), ("M80", "BEN"))
-    queries = (
-        ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
-        ({"OR": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
-        ({"OR": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
-    )
+    queries = [
+        (
+            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
+            ({"OR": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
+            ({"OR": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
+        ),
+        (
+            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
+            ({"AND": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
+            ({"AND": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
+        ),
+    ]
 
-    for path in filter_paths:
-        for values, query in zip(value_sets, queries):
+    for idx, path in enumerate(filter_paths):
+        for values, query in zip(value_sets, queries[idx]):
             with subtests.test(values=values, query=query, path=path):
                 assert_tag_query_host_filter_single_call(
                     build_tags_url(query="?" + "".join([f"filter{path}={value}&" for value in values])),
@@ -1914,14 +1928,21 @@ def test_query_system_profile_sap_sids_filter_spf_sap_sids(
 ):
     filter_paths = ("[system_profile][sap_sids][]", "[system_profile][sap_sids][contains][]")
     value_sets = (("XQC",), ("ABC", "A12"), ("M80", "BEN"))
-    queries = (
-        ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
-        ({"OR": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
-        ({"OR": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
-    )
+    queries = [
+        (
+            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
+            ({"OR": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
+            ({"OR": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
+        ),
+        (
+            ({"AND": [{"spf_sap_sids": {"eq": "XQC"}}]},),
+            ({"AND": [{"spf_sap_sids": {"eq": "ABC"}}, {"spf_sap_sids": {"eq": "A12"}}]},),
+            ({"AND": [{"spf_sap_sids": {"eq": "M80"}}, {"spf_sap_sids": {"eq": "BEN"}}]},),
+        ),
+    ]
 
-    for path in filter_paths:
-        for values, query in zip(value_sets, queries):
+    for idx, path in enumerate(filter_paths):
+        for values, query in zip(value_sets, queries[idx]):
             with subtests.test(values=values, query=query, path=path):
                 graphql_system_profile_sap_sids_query_empty_response.reset_mock()
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-4810](https://issues.redhat.com/browse/RHINENG-4810).
It changes the logic to always use OR when filtering for multiple values in the same system_profile field.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
