### PR TITLE
hot-fix(RHINENG-4856): Skip specific host on being synchronized

### DIFF
--- a/lib/host_synchronize.py
+++ b/lib/host_synchronize.py
@@ -35,11 +35,17 @@ def synchronize_hosts(select_query, event_producer, chunk_size, config, interrup
                 host.system_profile_facts.get("operating_system", {}).get("name"),
             )
             # in case of a failed update event, event_producer logs the message.
-            event_producer.write_event(event, str(host.id), headers, wait=True)
-            synchronize_host_count.inc()
-            logger.info("Synchronized host: %s", str(host.id))
 
-            num_synchronized += 1
+            # Workaround to solve: https://issues.redhat.com/browse/RHINENG-4856
+            try:
+                event_producer.write_event(event, str(host.id), headers, wait=True)
+                synchronize_host_count.inc()
+                logger.info("Synchronized host: %s", str(host.id))
+
+                num_synchronized += 1
+            except ProduceError:
+                logger.error(f"Failed to synchronize host: {str(host.id)} because of {ProduceError.code}")
+                continue
 
         try:
             # pace the events production speed as flush completes sending all buffered records.


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-4856](https://issues.redhat.com/browse/RHINENG-4856).

This is a workaround for us to be able to run host-synchronizer successfully in prod.
Details in Jira ticket

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
