### PR TITLE
fix(RHINENG-4856): Handle KafkaException in host-synchronizer

### DIFF
--- a/lib/host_synchronize.py
+++ b/lib/host_synchronize.py
@@ -1,3 +1,4 @@
+from confluent_kafka.error import KafkaException
 from confluent_kafka.error import ProduceError
 
 from api.staleness_query import get_sys_default_staleness
@@ -55,7 +56,7 @@ def synchronize_hosts(
                 logger.info("Synchronized host: %s", str(host.id))
 
                 num_synchronized += 1
-            except ProduceError:
+            except (ProduceError, KafkaException):
                 logger.error(f"Failed to synchronize host: {str(host.id)} because of {ProduceError.code}")
                 continue
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-4856](https://issues.redhat.com/browse/RHINENG-4856).
The latest host-synchronizer run failed with `cimpl.KafkaException: KafkaError{code=MSG_SIZE_TOO_LARGE,val=10,str="Unable to produce message: Broker: Message size too large"}`.
The PR just makes it so that all KafkaExceptions are also handled on a per-message basis, so that the synchronizer does not quit out too early.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
