### PR TITLE
feat(RHINENG-5892) Re-allow "unknown" value for staleness filter

### DIFF
--- a/app/culling.py
+++ b/app/culling.py
@@ -85,5 +85,5 @@ class Conditions:
 
 def staleness_to_conditions(staleness, staleness_states, host_type, timestamp_filter_func):
     condition = Conditions(staleness, host_type)
-    filtered_states = (state for state in staleness_states)
+    filtered_states = (state for state in staleness_states if state != "unknown")
     return (timestamp_filter_func(*getattr(condition, state)(), host_type=host_type) for state in filtered_states)

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1156,6 +1156,7 @@ components:
             - fresh
             - stale
             - stale_warning
+            - unknown
         default:
           - fresh
           - stale
@@ -1173,6 +1174,7 @@ components:
             - fresh
             - stale
             - stale_warning
+            - unknown
       description: "Culling states of the hosts."
     tagsParam:
       name: tags

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1870,7 +1870,8 @@
             "enum": [
               "fresh",
               "stale",
-              "stale_warning"
+              "stale_warning",
+              "unknown"
             ]
           },
           "default": [
@@ -1892,7 +1893,8 @@
             "enum": [
               "fresh",
               "stale",
-              "stale_warning"
+              "stale_warning",
+              "unknown"
             ]
           }
         },

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -763,7 +763,7 @@ def test_query_variables_staleness(
 
 
 def test_query_multiple_staleness(mocker, culling_datetime_mock, graphql_query_empty_response, api_get):
-    url = build_hosts_url(query="?staleness=fresh&staleness=stale_warning")
+    url = build_hosts_url(query="?staleness=fresh&staleness=stale_warning&staleness=unknown")
     response_status, response_data = api_get(url)
 
     assert response_status == 200


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-5892](https://issues.redhat.com/browse/RHINENG-5892).
#1569 removed the "unknown" staleness filter value; we made sure UIs weren't explicitly sending this value, but it turns out that the ansible-collections-insights Inventory plugin was still sending it, so it broke. I opened [CCT-196](https://issues.redhat.com/browse/CCT-196) requesting that they stop sending that value (and explicit values for that filter in general), and we'll remove the value ([RHINENG-5893](https://issues.redhat.com/browse/RHINENG-5893)) after that goes in.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
