### PR TITLE
feat(RHINENG-5460): Add rh-pre-commit installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ pre-commit install
 ```
 
 After that, all your commited files will be linted. If the checks don’t succeed, the commit will be rejected, but the altered files from the linting will be ready for you to commit again if the issue was automatically correctable.
+
+If you're inside the Red Hat network, please also make sure you have rh-pre-commit installed; instructions on installation can be found [here](https://gitlab.corp.redhat.com/infosec-public/developer-workbench/tools/-/tree/main/rh-pre-commit#quickstart-install).
+If you follow the instructions for Quickstart Install, and then re-enable running hooks in the repo's `.pre-commit-config.yaml` (instructions in the [Manual Install section](https://gitlab.corp.redhat.com/infosec-public/developer-workbench/tools/-/tree/main/rh-pre-commit#manual-install)), both hooks should run upon making a commit.
+
 Please make sure all checks pass before submitting a pull request. Thanks!
 
 ## Running the server locally

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ pre-commit install
 
 After that, all your commited files will be linted. If the checks don’t succeed, the commit will be rejected, but the altered files from the linting will be ready for you to commit again if the issue was automatically correctable.
 
-If you're inside the Red Hat network, please also make sure you have rh-pre-commit installed; instructions on installation can be found [here](https://gitlab.corp.redhat.com/infosec-public/developer-workbench/tools/-/tree/main/rh-pre-commit#quickstart-install). Then, verify the installation by following the [Testing the Installation](https://gitlab.corp.redhat.com/infosec-public/developer-workbench/tools/-/tree/main/rh-pre-commit#testing-the-installation) section.
-If you follow the instructions for Quickstart Install, and then re-enable running hooks in the repo's `.pre-commit-config.yaml` (instructions in the [Manual Install section](https://gitlab.corp.redhat.com/infosec-public/developer-workbench/tools/-/tree/main/rh-pre-commit#manual-install)), both hooks should run upon making a commit.
+If you're inside the Red Hat network, please also make sure you have rh-pre-commit installed; instructions on installation can be found [here](https://url.corp.redhat.com/rh-pre-commit#quickstart-install). Then, verify the installation by following the [Testing the Installation](https://url.corp.redhat.com/rh-pre-commit#testing-the-installation) section.
+If you follow the instructions for Quickstart Install, and then re-enable running hooks in the repo's `.pre-commit-config.yaml` (instructions in the [Manual Install section](https://url.corp.redhat.com/rh-pre-commit#manual-install)), both hooks should run upon making a commit.
 
 Please make sure all checks pass before submitting a pull request. Thanks!
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ pre-commit install
 
 After that, all your commited files will be linted. If the checks don’t succeed, the commit will be rejected, but the altered files from the linting will be ready for you to commit again if the issue was automatically correctable.
 
-If you're inside the Red Hat network, please also make sure you have rh-pre-commit installed; instructions on installation can be found [here](https://gitlab.corp.redhat.com/infosec-public/developer-workbench/tools/-/tree/main/rh-pre-commit#quickstart-install).
+If you're inside the Red Hat network, please also make sure you have rh-pre-commit installed; instructions on installation can be found [here](https://gitlab.corp.redhat.com/infosec-public/developer-workbench/tools/-/tree/main/rh-pre-commit#quickstart-install). Then, verify the installation by following the [Testing the Installation](https://gitlab.corp.redhat.com/infosec-public/developer-workbench/tools/-/tree/main/rh-pre-commit#testing-the-installation) section.
 If you follow the instructions for Quickstart Install, and then re-enable running hooks in the repo's `.pre-commit-config.yaml` (instructions in the [Manual Install section](https://gitlab.corp.redhat.com/infosec-public/developer-workbench/tools/-/tree/main/rh-pre-commit#manual-install)), both hooks should run upon making a commit.
 
 Please make sure all checks pass before submitting a pull request. Thanks!


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-5460](https://issues.redhat.com/browse/RHINENG-5460).
It adds a note to our Contributing section instructing users to install rh-pre-commit before contributing. I specified that this only applies if you're on the RH network, because rh-pre-commit only works when you're on the VPN.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [x] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
