### PR TITLE
fix(RHINENG-4565): Refactor staleness GET endpoint and add permission tests

### DIFF
--- a/api/staleness.py
+++ b/api/staleness.py
@@ -49,28 +49,28 @@ def _validate_input_data(body):
 @rbac(RbacResourceType.STALENESS, RbacPermission.READ, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
-def get_staleness():
+def get_staleness(rbac_filter=None):
     try:
         staleness = get_staleness_obj()
         staleness = serialize_staleness_response(staleness)
+
+        return flask_json_response(staleness, status.HTTP_200_OK)
     except ValueError as e:
         abort(status.HTTP_400_BAD_REQUEST, str(e))
-
-    return flask_json_response(staleness, status.HTTP_200_OK)
 
 
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.READ, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
-def get_default_staleness():
+def get_default_staleness(rbac_filter=None):
     try:
         staleness = get_sys_default_staleness()
         staleness = serialize_staleness_response(staleness)
+
+        return flask_json_response(staleness, status.HTTP_200_OK)
     except ValueError as e:
         abort(status.HTTP_400_BAD_REQUEST, str(e))
-
-    return flask_json_response(staleness, status.HTTP_200_OK)
 
 
 @api_operation

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -144,6 +144,7 @@ STALENESS_READ_PROHIBITED_RBAC_RESPONSE_FILES = (
     "tests/helpers/rbac-mock-data/inv-staleness-read-only.json",
     "tests/helpers/rbac-mock-data/inv-staleness-write-only.json",
 )
+STALENESS_READ_ALLOWED_RBAC_RESPONSE_FILES = ("tests/helpers/rbac-mock-data/inv-staleness-hosts-read-only.json",)
 STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES = ("tests/helpers/rbac-mock-data/inv-staleness-hosts-write-only.json",)
 RBAC_ADMIN_PROHIBITED_RBAC_RESPONSE_FILES = (
     "tests/helpers/rbac-mock-data/inv-read-write.json",

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -138,6 +138,12 @@ STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES = (
     "tests/helpers/rbac-mock-data/inv-star-read.json",
     "tests/helpers/rbac-mock-data/inv-staleness-write-only.json",
 )
+STALENESS_READ_PROHIBITED_RBAC_RESPONSE_FILES = (
+    "tests/helpers/rbac-mock-data/inv-none.json",
+    "tests/helpers/rbac-mock-data/inv-hosts-read-only.json",
+    "tests/helpers/rbac-mock-data/inv-staleness-read-only.json",
+    "tests/helpers/rbac-mock-data/inv-staleness-write-only.json",
+)
 STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES = ("tests/helpers/rbac-mock-data/inv-staleness-hosts-write-only.json",)
 RBAC_ADMIN_PROHIBITED_RBAC_RESPONSE_FILES = (
     "tests/helpers/rbac-mock-data/inv-read-write.json",

--- a/tests/helpers/rbac-mock-data/inv-staleness-read-only.json
+++ b/tests/helpers/rbac-mock-data/inv-staleness-read-only.json
@@ -1,19 +1,27 @@
 {
   "meta": {
-      "count": 1,
-      "limit": 1000,
-      "offset": 0
+    "count": 1,
+    "limit": 1000,
+    "offset": 0
   },
   "links": {
-      "first": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0",
-      "next": null,
-      "previous": null,
-      "last": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0"
+    "first": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0",
+    "next": null,
+    "previous": null,
+    "last": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0"
   },
   "data": [
-      {
-          "resourceDefinitions": [],
-          "permission": "staleness:staleness:read"
-      }
+    {
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "group.id",
+            "value": [],
+            "operation": "in"
+          }
+        }
+      ],
+      "permission": "staleness:staleness:read"
+    }
   ]
 }

--- a/tests/test_api_staleness_get.py
+++ b/tests/test_api_staleness_get.py
@@ -2,6 +2,8 @@ from tests.helpers.api_utils import _INPUT_DATA
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_staleness_url
 from tests.helpers.api_utils import build_sys_default_staleness_url
+from tests.helpers.api_utils import create_mock_rbac_response
+from tests.helpers.api_utils import STALENESS_READ_PROHIBITED_RBAC_RESPONSE_FILES
 
 
 def test_get_default_staleness(api_get):
@@ -55,3 +57,18 @@ def test_get_sys_default_staleness(api_get):
     assert response_data["immutable_time_to_stale"] == expected_result["immutable_time_to_stale"]
     assert response_data["immutable_time_to_stale_warning"] == expected_result["immutable_time_to_stale_warning"]
     assert response_data["immutable_time_to_delete"] == expected_result["immutable_time_to_delete"]
+
+
+def test_get_staleness_rbac_denied(subtests, mocker, api_get, db_get_staleness_culling, enable_rbac):
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+    url = build_sys_default_staleness_url()
+
+    for response_file in STALENESS_READ_PROHIBITED_RBAC_RESPONSE_FILES:
+        mock_rbac_response = create_mock_rbac_response(response_file)
+
+        with subtests.test():
+            get_rbac_permissions_mock.return_value = mock_rbac_response
+
+            response_status, _ = api_get(url)
+
+            assert_response_status(response_status, 403)

--- a/tests/test_api_staleness_get.py
+++ b/tests/test_api_staleness_get.py
@@ -31,8 +31,7 @@ def test_get_default_staleness(api_get):
 
 @pytest.mark.parametrize("rbac_filter", ["test"])
 def test_get_custom_staleness(api_create_staleness, api_get, rbac_filter):
-    created_response_status, _ = api_create_staleness(_INPUT_DATA)
-    url = build_staleness_url(query=f"?rbac_filter={rbac_filter}")
+    url = build_sys_default_staleness_url()
     response_status, response_data = api_get(url)
     assert response_data["conventional_time_to_stale"] == _INPUT_DATA["conventional_time_to_stale"]
     assert response_data["conventional_time_to_stale_warning"] == _INPUT_DATA["conventional_time_to_stale_warning"]
@@ -69,6 +68,8 @@ def test_get_staleness_rbac_denied(subtests, mocker, api_get, db_get_staleness_c
 
     for response_file in STALENESS_READ_PROHIBITED_RBAC_RESPONSE_FILES:
         mock_rbac_response = create_mock_rbac_response(response_file)
+        if mock_rbac_response and len(mock_rbac_response[0]["resourceDefinitions"]) > 0:
+            mock_rbac_response[0]["resourceDefinitions"][0]["attributeFilter"]["value"] = [None]
 
         with subtests.test():
             get_rbac_permissions_mock.return_value = mock_rbac_response

--- a/tests/test_api_staleness_get.py
+++ b/tests/test_api_staleness_get.py
@@ -1,5 +1,3 @@
-import pytest
-
 from tests.helpers.api_utils import _INPUT_DATA
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_staleness_url
@@ -29,8 +27,7 @@ def test_get_default_staleness(api_get):
     assert response_data["immutable_time_to_delete"] == expected_result["immutable_time_to_delete"]
 
 
-@pytest.mark.parametrize("rbac_filter", ["test"])
-def test_get_custom_staleness(api_create_staleness, api_get, rbac_filter):
+def test_get_custom_staleness(api_get):
     url = build_sys_default_staleness_url()
     response_status, response_data = api_get(url)
     assert response_data["conventional_time_to_stale"] == _INPUT_DATA["conventional_time_to_stale"]
@@ -62,7 +59,7 @@ def test_get_sys_default_staleness(api_get):
     assert response_data["immutable_time_to_delete"] == expected_result["immutable_time_to_delete"]
 
 
-def test_get_staleness_rbac_denied(subtests, mocker, api_get, db_get_staleness_culling, enable_rbac):
+def test_get_staleness_rbac_denied(subtests, mocker, api_get, enable_rbac):
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
     url = build_sys_default_staleness_url()
 
@@ -79,7 +76,7 @@ def test_get_staleness_rbac_denied(subtests, mocker, api_get, db_get_staleness_c
             assert_response_status(response_status, 403)
 
 
-def test_get_staleness_rbac_allowed(subtests, mocker, api_get, db_get_staleness_culling, enable_rbac):
+def test_get_staleness_rbac_allowed(subtests, mocker, api_get, enable_rbac):
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
     url = build_sys_default_staleness_url()
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-4565](https://issues.redhat.com/browse/RHINENG-4565).

- Make sure we test RBAC permissions to GET staleness endpoint
- Refactor staleness GET endpoint

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
