### PR TITLE
RHINENG-6099: use list when checking for kafka brokers

### DIFF
--- a/lib/host_kafka.py
+++ b/lib/host_kafka.py
@@ -11,7 +11,7 @@ logger = get_logger(__name__)
 def _any_bootstrap_server_connects(kafka_socket, servers) -> bool:
     if not servers:
         config = Config(RuntimeEnvironment.SERVICE)
-        servers = [config.bootstrap_servers] if isinstance(config.bootstrap_servers, str) else config.bootstrap_servers
+        servers = config.bootstrap_servers
 
     for server in servers:
         try:

--- a/lib/host_kafka.py
+++ b/lib/host_kafka.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import socket
 from contextlib import closing
 
@@ -8,10 +10,10 @@ from app.logging import get_logger
 logger = get_logger(__name__)
 
 
-def _any_bootstrap_server_connects(kafka_socket, servers) -> bool:
+def _any_bootstrap_server_connects(kafka_socket, servers: list[str] | None) -> bool:
     if not servers:
         config = Config(RuntimeEnvironment.SERVICE)
-        servers = config.bootstrap_servers
+        servers = config.bootstrap_servers.split(",")
 
     for server in servers:
         try:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2407,6 +2407,12 @@ class KafkaAvailabilityTests(TestCase):
         self.config = Config(RuntimeEnvironment.TEST)
 
     @patch("socket.socket.connect_ex")
+    def test_happy_path(self, connect_ex):
+        connect_ex.return_value = 0
+        assert host_kafka.kafka_available()
+        connect_ex.assert_called_once()
+
+    @patch("socket.socket.connect_ex")
     def test_valid_server(self, connect_ex):
         connect_ex.return_value = 0
         akafka = [self.config.bootstrap_servers]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2407,12 +2407,6 @@ class KafkaAvailabilityTests(TestCase):
         self.config = Config(RuntimeEnvironment.TEST)
 
     @patch("socket.socket.connect_ex")
-    def test_happy_path(self, connect_ex):
-        connect_ex.return_value = 0
-        assert host_kafka.kafka_available(["127.0.0.1:29092"])
-        connect_ex.assert_called_once()
-
-    @patch("socket.socket.connect_ex")
     def test_valid_server(self, connect_ex):
         connect_ex.return_value = 0
         akafka = [self.config.bootstrap_servers]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2409,7 +2409,7 @@ class KafkaAvailabilityTests(TestCase):
     @patch("socket.socket.connect_ex")
     def test_happy_path(self, connect_ex):
         connect_ex.return_value = 0
-        assert host_kafka.kafka_available()
+        assert host_kafka.kafka_available(["127.0.0.1:29092"])
         connect_ex.assert_called_once()
 
     @patch("socket.socket.connect_ex")


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-6099](https://issues.redhat.com/browse/RHINENG-6099).  Previously a string was expected for a single broker.  Now a list is expected as multiple brokers are used now.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
