### PR TITLE
feat(RHINENG-6136) Bypass RBAC for org-admin users during Edge Parity migration

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -10,11 +10,13 @@ logger = get_logger(__name__)
 FLAG_INVENTORY_ASSIGNMENT_RULES = "hbi.group-assignment-rules"
 FLAG_INVENTORY_CUSTOM_STALENESS = "hbi.custom-staleness"
 FLAG_HIDE_EDGE_HOSTS = "hbi.api.hide-edge-by-default"
+FLAG_EDGE_PARITY_MIGRATION = "edgeParity.groups-migration"
 
 FLAG_FALLBACK_VALUES = {
     FLAG_INVENTORY_ASSIGNMENT_RULES: True,
     FLAG_INVENTORY_CUSTOM_STALENESS: True,
     FLAG_HIDE_EDGE_HOSTS: False,
+    FLAG_EDGE_PARITY_MIGRATION: False,
 }
 
 

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -23,6 +23,8 @@ from app.instrumentation import rbac_failure
 from app.instrumentation import rbac_group_permission_denied
 from app.instrumentation import rbac_permission_denied
 from app.logging import get_logger
+from lib.feature_flags import FLAG_EDGE_PARITY_MIGRATION
+from lib.feature_flags import get_flag_value
 
 
 logger = get_logger(__name__)
@@ -76,10 +78,16 @@ def rbac(resource_type, required_permission, permission_base="inventory"):
     def other_func(func):
         @wraps(func)
         def modified_func(*args, **kwargs):
-            if inventory_config().bypass_rbac:
+            current_identity = get_current_identity()
+
+            # TODO: Remove the Edge Parity migration RBAC bypass once the migration is complete (RHINENG-6136)
+            if inventory_config().bypass_rbac or (
+                current_identity.identity_type == IdentityType.USER
+                and current_identity.user.get("is_org_admin")
+                and get_flag_value(FLAG_EDGE_PARITY_MIGRATION)
+            ):
                 return func(*args, **kwargs)
 
-            current_identity = get_current_identity()
             if current_identity.identity_type != CHECKED_TYPE:
                 if resource_type == RbacResourceType.HOSTS:
                     return func(*args, **kwargs)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-6136](https://issues.redhat.com/browse/RHINENG-6136).
In order to complete the Edge Parity migration, the Edge team will need to bypass rbac to create inventory groups (to replace their corresponding edge groups). This PR makes it so that requests bypass RBAC if all 3 conditions are met:

- identity.identity_type is "User"
- identity.user.is_org_admin is True
- The "edgeParity.groups-migration" feature flag  is True

We will remove this code after the migration is complete ([RHINENG-5446](https://issues.redhat.com/browse/RHINENG-5446)).

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
