### PR TITLE
[RHINENG-6037] - Inventory group's host count reflects host that is culled

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -13,10 +13,10 @@ from api.filtering.filtering_common import lookup_graphql_operations
 from api.filtering.filtering_common import lookup_operations
 from api.filtering.filtering_common import SUPPORTED_FORMATS
 from app import custom_filter_fields
-from app import inventory_config
 from app import system_profile_spec
 from app.auth import get_current_identity
 from app.auth.identity import IdentityType
+from app.common import inventory_config
 from app.exceptions import ValidationException
 from app.logging import get_logger
 from app.models import OLD_TO_NEW_REPORTER_MAP

--- a/api/group_query.py
+++ b/api/group_query.py
@@ -109,7 +109,8 @@ def get_filtered_group_list_db(group_name, page, per_page, order_by, order_how, 
 
 
 def build_paginated_group_list_response(total, page, per_page, group_list):
-    json_group_list = [serialize_group(group) for group in group_list]
+    identity = get_current_identity()
+    json_group_list = [serialize_group(group, identity) for group in group_list]
     return {
         "total": total,
         "count": len(json_group_list),
@@ -120,4 +121,5 @@ def build_paginated_group_list_response(total, page, per_page, group_list):
 
 
 def build_group_response(group):
-    return serialize_group(group)
+    identity = get_current_identity()
+    return serialize_group(group, identity)

--- a/api/host.py
+++ b/api/host.py
@@ -20,11 +20,11 @@ from api.host_query_xjoin import get_host_tags_list_by_id_list
 from api.sparse_host_list_system_profile import get_sparse_system_profile
 from api.staleness_query import get_staleness_obj
 from app import db
-from app import inventory_config
 from app import RbacPermission
 from app import RbacResourceType
 from app.auth import get_current_identity
 from app.auth.identity import to_auth_header
+from app.common import inventory_config
 from app.instrumentation import get_control_rule
 from app.instrumentation import log_get_host_list_failed
 from app.instrumentation import log_get_host_list_succeeded

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -1,6 +1,6 @@
 from api.staleness_query import get_staleness_obj
-from app import inventory_config
 from app.auth import get_current_identity
+from app.common import inventory_config
 from app.culling import Timestamps
 from app.serialization import serialize_host
 

--- a/api/resource_type.py
+++ b/api/resource_type.py
@@ -8,6 +8,7 @@ from api.resource_query import build_paginated_resource_list_response
 from api.resource_query import get_resources_types
 from app import RbacPermission
 from app import RbacResourceType
+from app.auth import get_current_identity
 from app.instrumentation import log_get_group_list_failed
 from app.instrumentation import log_get_group_list_succeeded
 from app.instrumentation import log_get_resource_type_list_failed
@@ -15,6 +16,7 @@ from app.instrumentation import log_get_resource_type_list_succeeded
 from app.logging import get_logger
 from app.serialization import serialize_group
 from lib.middleware import rbac
+
 
 logger = get_logger(__name__)
 
@@ -56,7 +58,9 @@ def get_resource_type_groups_list(
         flask.abort(400, str(e))
 
     log_get_group_list_succeeded(logger, group_list)
-
+    identity = get_current_identity()
     return flask_json_response(
-        build_paginated_resource_list_response(total, page, per_page, [serialize_group(group) for group in group_list])
+        build_paginated_resource_list_response(
+            total, page, per_page, [serialize_group(group, identity) for group in group_list]
+        )
     )

--- a/api/staleness_query.py
+++ b/api/staleness_query.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import inventory_config
 from app.auth import get_current_identity
+from app.common import inventory_config
 from app.logging import get_logger
 from app.models import Staleness
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -115,10 +115,6 @@ def shutdown_hook(close_function, name):
     close_function()
 
 
-def inventory_config():
-    return current_app.config["INVENTORY_CONFIG"]
-
-
 def system_profile_spec():
     return current_app.config["SYSTEM_PROFILE_SPEC"]
 

--- a/app/common.py
+++ b/app/common.py
@@ -1,5 +1,11 @@
 import os
 
+from flask import current_app
+
 
 def get_build_version():
     return os.getenv("OPENSHIFT_BUILD_COMMIT", "Unknown")
+
+
+def inventory_config():
+    return current_app.config["INVENTORY_CONFIG"]

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -11,10 +11,10 @@ from marshmallow import ValidationError
 from sqlalchemy.exc import OperationalError
 
 from api.staleness_query import get_staleness_obj
-from app import inventory_config
 from app.auth.identity import create_mock_identity_with_org_id
 from app.auth.identity import Identity
 from app.auth.identity import IdentityType
+from app.common import inventory_config
 from app.culling import Timestamps
 from app.exceptions import InventoryException
 from app.exceptions import ValidationException

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -198,18 +198,20 @@ def serialize_host(
 
 
 # get hosts not marked for deletion
-def _get_unculled_hosts(group):
+def _get_unculled_hosts(group, identity):
     hosts = []
+    staleness_timestamps = Timestamps.from_config(inventory_config())
+    staleness = get_staleness_obj(identity)
     for host in group.hosts:
-        staleness_delta = datetime.now(tz=timezone.utc) - host.stale_timestamp
-        if staleness_delta < current_app.config["INVENTORY_CONFIG"].culling_culled_offset_delta:
+        serialized_host = serialize_host(host, staleness_timestamps=staleness_timestamps, staleness=staleness)
+        if _deserialize_datetime(serialized_host["culled_timestamp"]) > datetime.now(tz=timezone.utc):
             hosts.append(host)
 
     return hosts
 
 
-def serialize_group(group):
-    unculled_hosts = _get_unculled_hosts(group)
+def serialize_group(group, identity):
+    unculled_hosts = _get_unculled_hosts(group, identity)
     return {
         "id": _serialize_uuid(group.id),
         "org_id": group.org_id,

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -2,9 +2,11 @@ from datetime import datetime
 from datetime import timezone
 
 from dateutil.parser import isoparse
-from flask import current_app
 from marshmallow import ValidationError
 
+from api.staleness_query import get_staleness_obj
+from app.common import inventory_config
+from app.culling import Timestamps
 from app.exceptions import InputFormatException
 from app.exceptions import ValidationException
 from app.models import CanonicalFactsSchema

--- a/host_dumper.py
+++ b/host_dumper.py
@@ -3,7 +3,7 @@ import argparse
 import pprint
 
 from app import create_app
-from app import inventory_config
+from app.common import inventory_config
 from app.culling import Timestamps
 from app.environment import RuntimeEnvironment
 from app.models import Host

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -36,13 +36,14 @@ logger = get_logger(__name__)
 
 
 def _produce_host_update_events(event_producer, host_id_list, group_id_list=[], staleness=None):
-    serialized_groups = [serialize_group(get_group_by_id_from_db(group_id)) for group_id in group_id_list]
+    identity = get_current_identity() # Note: This should be moved to an API file
+    serialized_groups = [serialize_group(get_group_by_id_from_db(group_id), identity) for group_id in group_id_list]
 
     # Update groups data on each host record
     Host.query.filter(Host.id.in_(host_id_list)).update({"groups": serialized_groups}, synchronize_session="fetch")
     db.session.commit()
     host_list = get_host_list_by_id_list_from_db(host_id_list)
-    metadata = {"b64_identity": to_auth_header(get_current_identity())}
+    metadata = {"b64_identity": to_auth_header(get_current_identity())} # Note: This should be moved to an API file
 
     # Send messages
     for host in host_list:

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -36,14 +36,14 @@ logger = get_logger(__name__)
 
 
 def _produce_host_update_events(event_producer, host_id_list, group_id_list=[], staleness=None):
-    identity = get_current_identity() # Note: This should be moved to an API file
+    identity = get_current_identity()  # Note: This should be moved to an API file
     serialized_groups = [serialize_group(get_group_by_id_from_db(group_id), identity) for group_id in group_id_list]
 
     # Update groups data on each host record
     Host.query.filter(Host.id.in_(host_id_list)).update({"groups": serialized_groups}, synchronize_session="fetch")
     db.session.commit()
     host_list = get_host_list_by_id_list_from_db(host_id_list)
-    metadata = {"b64_identity": to_auth_header(get_current_identity())} # Note: This should be moved to an API file
+    metadata = {"b64_identity": to_auth_header(get_current_identity())}  # Note: This should be moved to an API file
 
     # Send messages
     for host in host_list:

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -13,12 +13,12 @@ from requests.packages.urllib3.util.retry import Retry
 
 from api.metrics import outbound_http_response_time
 from app import IDENTITY_HEADER
-from app import inventory_config
 from app import RbacPermission
 from app import RbacResourceType
 from app import REQUEST_ID_HEADER
 from app.auth import get_current_identity
 from app.auth.identity import IdentityType
+from app.common import inventory_config
 from app.instrumentation import rbac_failure
 from app.instrumentation import rbac_group_permission_denied
 from app.instrumentation import rbac_permission_denied

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -6,6 +6,7 @@ from sqlalchemy_utils import database_exists
 from sqlalchemy_utils import drop_database
 
 from app import db
+from app.auth.identity import Identity
 from app.config import Config
 from app.config import RuntimeEnvironment
 from app.models import AssignmentRule
@@ -22,6 +23,7 @@ from tests.helpers.db_utils import minimal_db_host_dict
 from tests.helpers.test_utils import now
 from tests.helpers.test_utils import set_environment
 from tests.helpers.test_utils import SYSTEM_IDENTITY
+from tests.helpers.test_utils import USER_IDENTITY
 
 
 @pytest.fixture(scope="session")
@@ -192,8 +194,8 @@ def db_create_host_group_assoc(flask_app, db_get_group_by_id):
     def _db_create_host_group_assoc(host_id, group_id):
         host_group = HostGroupAssoc(host_id=host_id, group_id=group_id)
         db.session.add(host_group)
-
-        serialized_groups = [serialize_group(db_get_group_by_id(group_id))]
+        identity = Identity(USER_IDENTITY)
+        serialized_groups = [serialize_group(db_get_group_by_id(group_id), identity)]
         db.session.query(Host).filter(Host.id == host_id).update({"groups": serialized_groups})
 
         db.session.commit()

--- a/tests/test_api_host_group.py
+++ b/tests/test_api_host_group.py
@@ -265,7 +265,7 @@ def test_group_with_culled_hosts(
     assert len(hosts_after) == 3
 
     culled_host = db_get_host(hosts_after[0].id)
-    culled_host.stale_timestamp = culling_time
+    culled_host.modified_on = culling_time
 
     _, response_data = api_get(GROUP_URL + "/" + ",".join([str(group_id)]))
     host_count = response_data["results"][0]["host_count"]


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-6037](https://issues.redhat.com/browse/RHINENG-6037).

It fixes the group `host_count` to reflect culled hosts correctly.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
