### PR TITLE
[RHINENG-6095] - Use custom staleness in per_reporter_staleness

### DIFF
--- a/app/serialization.py
+++ b/app/serialization.py
@@ -163,7 +163,9 @@ def serialize_host(
     if "reporter" in fields:
         serialized_host["reporter"] = host.reporter
     if "per_reporter_staleness" in fields:
-        serialized_host["per_reporter_staleness"] = host.per_reporter_staleness
+        serialized_host["per_reporter_staleness"] = _serialize_per_reporter_staleness(
+            host, staleness, staleness_timestamps
+        )
     if "stale_timestamp" in fields:
         serialized_host["stale_timestamp"] = stale_timestamp and _serialize_staleness_to_string(stale_timestamp)
     if "stale_warning_timestamp" in fields:
@@ -409,5 +411,19 @@ def serialize_staleness_to_dict(staleness_obj) -> dict:
     }
 
 
-def _serialize_per_reporter_staleness(per_reporter_staleness):
-    pass
+def _serialize_per_reporter_staleness(host, staleness, staleness_timestamps):
+    for reporter in host.per_reporter_staleness:
+        if host.system_profile_facts.get("host_type") == "edge":
+            stale_timestamp = staleness_timestamps.stale_timestamp(
+                _deserialize_datetime(host.per_reporter_staleness[reporter]["last_check_in"]),
+                staleness["immutable_time_to_stale"],
+            )
+        else:
+            stale_timestamp = staleness_timestamps.stale_timestamp(
+                _deserialize_datetime(host.per_reporter_staleness[reporter]["last_check_in"]),
+                staleness["conventional_time_to_stale"],
+            )
+
+        host.per_reporter_staleness[reporter]["stale_timestamp"] = _serialize_staleness_to_string(stale_timestamp)
+
+        return host.per_reporter_staleness

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -407,3 +407,7 @@ def serialize_staleness_to_dict(staleness_obj) -> dict:
         "immutable_time_to_stale_warning": staleness_obj.immutable_time_to_stale_warning,
         "immutable_time_to_delete": staleness_obj.immutable_time_to_delete,
     }
+
+
+def _serialize_per_reporter_staleness(per_reporter_staleness):
+    pass

--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime
+from datetime import timezone
 from unittest.mock import patch
 
 import pytest
@@ -87,7 +88,9 @@ def mq_create_hosts_in_all_states(mq_create_or_update_host):
 @pytest.fixture(scope="function")
 def mq_create_deleted_hosts(mq_create_or_update_host):
     with patch("app.models.datetime") as mock_datetime:
-        mock_datetime.now.return_value = datetime(year=2023, month=4, day=2, hour=1, minute=1, second=1)
+        mock_datetime.now.return_value = datetime(
+            year=2023, month=4, day=2, hour=1, minute=1, second=1, tzinfo=timezone.utc
+        )
         mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
 
         staleness_timestamps = get_staleness_timestamps()

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -881,7 +881,7 @@ def test_response_processed_properly(graphql_query_with_response, api_get):
                     "puptoo": {
                         "check_in_succeeded": True,
                         "last_check_in": "2020-02-10T08:07:03.354307+00:00",
-                        "stale_timestamp": "2020-02-10T08:07:03.354307+00:00",
+                        "stale_timestamp": "2020-02-11T13:07:03.354307+00:00",
                     }
                 },
                 "subscription_manager_id": None,
@@ -912,7 +912,7 @@ def test_response_processed_properly(graphql_query_with_response, api_get):
                     "yupana": {
                         "check_in_succeeded": True,
                         "last_check_in": "2020-02-10T08:07:03.354307+00:00",
-                        "stale_timestamp": "2020-02-10T08:07:03.354307+00:00",
+                        "stale_timestamp": "2020-02-11T13:07:03.354307+00:00",
                     }
                 },
                 "subscription_manager_id": None,


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-6095](https://issues.redhat.com/browse/RHINENG-6095).

It fixes the wrong stale_timestamp in the per_reporter_staleness

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
