### PR TITLE
RHINENG-4100: Fix Host Inventory Service random restarts

### DIFF
--- a/iqe_tests.sh
+++ b/iqe_tests.sh
@@ -17,6 +17,7 @@ export REF_ENV="insights-stage"
 # Options that must be configured by app owner
 # --------------------------------------------
 COMPONENT_NAME="host-inventory"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+COMPONENTS_W_RESOURCES="host-inventory"  # this gives us resources defined in app-sre, otherwise we run low on memory
 
 IQE_PLUGINS="host_inventory"
 IQE_MARKER_EXPRESSION="not resilience and not cert_auth and not rbac_dependent"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -18,6 +18,7 @@ cat /etc/redhat-release
 # Options that must be configured by app owner
 # --------------------------------------------
 COMPONENT_NAME="host-inventory"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+COMPONENTS_W_RESOURCES="host-inventory"  # this gives us resources defined in app-sre, otherwise we run low on memory
 
 IQE_PLUGINS="host_inventory"
 IQE_MARKER_EXPRESSION="smoke"


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-4100](https://issues.redhat.com/browse/RHINENG-4100).

I found out that the restarts are caused by SIGKILL signals, which are being sent because host-inventory-service is running out of memory. Bonfire is not giving us the resources mentioned in app-sre deployment file. Instead, it only gives us half of that. With the changes in this PR, bonfire should respect the config and give us enough resources.

I wrote a detailed description of what is the root cause of this problem in [this comment of RHINENG-4100](https://issues.redhat.com/browse/RHINENG-4100?focusedId=23718000&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23718000).

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
