### PR TITLE
Enforce validation of User Identity field types

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -143,7 +143,7 @@ class UserInfoIdentitySchema(IdentityBaseSchema):
 
 
 class UserIdentitySchema(IdentityBaseSchema):
-    user = m.fields.Nested(UserInfoIdentitySchema, required=True)
+    user = m.fields.Nested(UserInfoIdentitySchema)
 
 
 class SystemInfoIdentitySchema(IdentityBaseSchema):

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -131,8 +131,19 @@ class IdentitySchema(IdentityBaseSchema):
         return result
 
 
+class UserInfoIdentitySchema(IdentityBaseSchema):
+    first_name = m.fields.Str(validate=m.validate.Length(min=1))
+    last_name = m.fields.Str(validate=m.validate.Length(min=1))
+    locale = m.fields.Str(validate=m.validate.Length(min=1))
+    is_active = m.fields.Bool()
+    is_internal = m.fields.Bool()
+    is_org_admin = m.fields.Bool()
+    username = m.fields.Str(validate=m.validate.Length(min=1))
+    email = m.fields.Email()
+
+
 class UserIdentitySchema(IdentityBaseSchema):
-    user = m.fields.Dict()
+    user = m.fields.Nested(UserInfoIdentitySchema, required=True)
 
 
 class SystemInfoIdentitySchema(IdentityBaseSchema):

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -132,13 +132,13 @@ class IdentitySchema(IdentityBaseSchema):
 
 
 class UserInfoIdentitySchema(IdentityBaseSchema):
-    first_name = m.fields.Str(validate=m.validate.Length(min=1))
-    last_name = m.fields.Str(validate=m.validate.Length(min=1))
-    locale = m.fields.Str(validate=m.validate.Length(min=1))
+    first_name = m.fields.Str()
+    last_name = m.fields.Str()
+    locale = m.fields.Str()
     is_active = m.fields.Bool()
     is_internal = m.fields.Bool()
     is_org_admin = m.fields.Bool()
-    username = m.fields.Str(validate=m.validate.Length(min=1))
+    username = m.fields.Str()
     email = m.fields.Email()
 
 

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -4,7 +4,6 @@ from tests.helpers.api_utils import ASSIGNMENT_RULE_URL
 from tests.helpers.api_utils import do_request
 from tests.helpers.api_utils import GROUP_URL
 from tests.helpers.api_utils import HOST_URL
-from tests.helpers.api_utils import MockUserIdentity
 from tests.helpers.api_utils import STALENESS_URL
 from tests.helpers.test_utils import USER_IDENTITY
 
@@ -176,13 +175,6 @@ def enable_org_id_translation(inventory_config):
 @pytest.fixture(scope="function")
 def enable_unleash(inventory_config):
     inventory_config.unleash_token = "mockUnleashTokenValue"
-
-
-@pytest.fixture(scope="function")
-def user_identity_mock(flask_app):
-    flask_app.user_identity = MockUserIdentity()
-    yield flask_app.user_identity
-    # flask_app.user_identity = None
 
 
 @pytest.fixture(scope="function")

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -1,6 +1,5 @@
 import json
 import math
-import unittest.mock as mock
 from base64 import b64encode
 from datetime import timedelta
 from itertools import product
@@ -593,32 +592,3 @@ def assert_resource_types_pagination(
         assert links["next"] is None
 
     assert links["last"] == f"{expected_path_base}?per_page={expected_per_page}&page={expected_number_of_pages}"
-
-
-ClassMock = mock.MagicMock
-
-
-class MockUserIdentity(ClassMock):
-    def __init__(self):
-        super().__init__()
-        self.is_trusted_system = False
-        self.account_number = "test"
-        self.identity_type = "User"
-        self.user = {"email": "tuser@redhat.com", "first_name": "test"}
-
-    def patch(self, mocker, method, expectation):
-        return mocker.patch(method, wraps=expectation)
-
-    def assert_called_once_with(param, value):
-        super.assert_called_once_with(param, value)
-
-
-class MockSystemIdentity:
-    def __init__(self):
-        self.is_trusted_system = False
-        self.account_number = "test"
-        self.identity_type = "System"
-        self.system = {"cert_type": "system", "cn": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"}
-
-    def assert_called_once_with(self, identity, param, value):
-        return True


### PR DESCRIPTION
# Overview

This PR is being created to address concerns that were [raised on Slack](https://redhat-internal.slack.com/archives/CQFKM031T/p1704444852691029). Although the `is_org_admin` field in the x-rh-identity header is a boolean value, it's safer for us to validate the types for these fields, so this PR enforces that. It also adds a test to make sure that various falsy/invalid values for `is_org_admin` are not interpreted as truthy in our rbac bypass.

Follows up on #1580.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
