### PR TITLE
fix(RHINENG-5479): Update fields for Service Account Identity

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -9,7 +9,6 @@ import marshmallow as m
 
 from app.logging import get_logger
 from app.logging import threadctx
-from app.validators import verify_uuid_format
 
 
 __all__ = ["Identity", "from_auth_header", "from_bearer_token"]
@@ -165,8 +164,8 @@ class SystemIdentitySchema(IdentityBaseSchema):
 
 
 class ServiceAccountInfoIdentitySchema(IdentityBaseSchema):
-    client_id = m.fields.Str(required=True, validate=verify_uuid_format)
-    username = m.fields.Str(required=True, validate=m.validate.Length(min=1))
+    client_id = m.fields.Str(required=True)
+    username = m.fields.Str(required=True)
 
 
 class ServiceAccountIdentitySchema(IdentityBaseSchema):

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -40,8 +40,8 @@ SERVICE_ACCOUNT_IDENTITY = {
     "auth_type": "jwt-auth",
     "internal": {"auth_time": 500, "cross_access": False, "org_id": "456"},
     "service_account": {
-        "client_id": "b9757340-f839-4541-9af6-f7535edf08db",
-        "username": "service-account-b9757340-f839-4541-9af6-f7535edf08db",
+        "client_id": "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+        "username": "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
     },
     "type": "ServiceAccount",
 }

--- a/tests/test_identity_schema.py
+++ b/tests/test_identity_schema.py
@@ -120,7 +120,7 @@ def test_service_account_identity_missing_required(required):
     # Test blank values
     bad_identity = copy.deepcopy(SERVICE_ACCOUNT_IDENTITY)
     assert "service_account" in bad_identity
-    bad_identity["service_account"][required] = ""
+    bad_identity["service_account"][required] = 51549684651
     with pytest.raises(ValueError):
         identity_test_common(bad_identity)
 
@@ -128,6 +128,13 @@ def test_service_account_identity_missing_required(required):
     bad_identity = copy.deepcopy(SERVICE_ACCOUNT_IDENTITY)
     assert "service_account" in bad_identity
     bad_identity["service_account"].pop(required, None)
+    with pytest.raises(ValueError):
+        identity_test_common(bad_identity)
+
+    # Test missing service_account
+    bad_identity = copy.deepcopy(SERVICE_ACCOUNT_IDENTITY)
+    assert "service_account" in bad_identity
+    bad_identity.pop("service_account", None)
     with pytest.raises(ValueError):
         identity_test_common(bad_identity)
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-5479](https://issues.redhat.com/browse/RHINENG-5479).
The [previous PR](https://github.com/RedHatInsights/insights-host-inventory/pull/1588) introduced an error regarding the validation for the fields in the Service Account Identity Schema, this PR fixes it.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
