### PR TITLE
Define separate resource params, remove unused floorist params

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -100,11 +100,11 @@ objects:
               optional: true
         resources:
           limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT}
+            cpu: ${CPU_LIMIT_SERVICE}
+            memory: ${MEMORY_LIMIT_SERVICE}
           requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
+            cpu: ${CPU_REQUEST_SERVICE}
+            memory: ${MEMORY_REQUEST_SERVICE}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -206,11 +206,11 @@ objects:
             port: 9000
         resources:
           limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT}
+            cpu: ${CPU_LIMIT_MQ_PMIN}
+            memory: ${MEMORY_LIMIT_MQ_PMIN}
           requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
+            cpu: ${CPU_REQUEST_MQ_PMIN}
+            memory: ${MEMORY_REQUEST_MQ_PMIN}
     - name: mq-p1
       minReplicas: ${{REPLICAS_P1}}
       podSpec:
@@ -289,11 +289,11 @@ objects:
             port: 9000
         resources:
           limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT}
+            cpu: ${CPU_LIMIT_MQ_P1}
+            memory: ${MEMORY_LIMIT_MQ_P1}
           requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
+            cpu: ${CPU_REQUEST_MQ_P1}
+            memory: ${MEMORY_REQUEST_MQ_P1}
     - name: mq-sp
       minReplicas: ${{REPLICAS_SP}}
       podSpec:
@@ -366,11 +366,11 @@ objects:
             port: 9000
         resources:
           limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT}
+            cpu: ${CPU_LIMIT_MQ_SP}
+            memory: ${MEMORY_LIMIT_MQ_SP}
           requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
+            cpu: ${CPU_REQUEST_MQ_SP}
+            memory: ${MEMORY_REQUEST_MQ_SP}
     jobs:
     - name: reaper
       schedule: '@hourly'
@@ -431,10 +431,10 @@ objects:
             value: ${BYPASS_UNLEASH}
         resources:
           limits:
-            cpu: ${CPU_LIMIT}
+            cpu: ${CPU_LIMIT_REAPER}
             memory: ${MEMORY_LIMIT_REAPER}
           requests:
-            cpu: ${CPU_REQUEST}
+            cpu: ${CPU_REQUEST_REAPER}
             memory: ${MEMORY_REQUEST_REAPER}
     - name: sp-validator
       schedule: '@hourly'
@@ -515,11 +515,11 @@ objects:
             value: ${BYPASS_UNLEASH}
         resources:
           limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT}
+            cpu: ${CPU_LIMIT_SP_VALIDATOR}
+            memory: ${MEMORY_LIMIT_SP_VALIDATOR}
           requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
+            cpu: ${CPU_REQUEST_SP_VALIDATOR}
+            memory: ${MEMORY_REQUEST_SP_VALIDATOR}
     - name: pendo-syncher
       schedule: ${PENDO_CRON_SCHEDULE}
       suspend: ${{PENDO_SYNCHER_SUSPEND}}
@@ -564,11 +564,11 @@ objects:
             value: ${BYPASS_UNLEASH}
         resources:
           limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT}
+            cpu: ${CPU_LIMIT_PENDO_SYNCHER}
+            memory: ${MEMORY_LIMIT_PENDO_SYNCHER}
           requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
+            cpu: ${CPU_REQUEST_PENDO_SYNCHER}
+            memory: ${MEMORY_REQUEST_PENDO_SYNCHER}
     - name: synchronizer
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
@@ -630,11 +630,11 @@ objects:
             value: ${REBUILD_EVENTS_TIME_LIMIT}
         resources:
           limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT_SYNC}
+            cpu: ${CPU_LIMIT_SYNCHRONIZER}
+            memory: ${MEMORY_LIMIT_SYNCHRONIZER}
           requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST_SYNC}
+            cpu: ${CPU_REQUEST_SYNCHRONIZER}
+            memory: ${MEMORY_REQUEST_SYNCHRONIZER}
     database:
       name: ${DB_NAME}
       version: 12
@@ -704,30 +704,79 @@ objects:
 parameters:
 - name: LOG_LEVEL
   value: INFO
-- descrpition: Cpu request of service
-  name: CPU_REQUEST
+
+- name: CPU_REQUEST_SERVICE
   value: 250m
-- description: Cpu limit of service
-  name: CPU_LIMIT
+- name: CPU_LIMIT_SERVICE
   value: 500m
-- description: memory limit of service
-  name: MEMORY_LIMIT
-  value: 512Mi
-- description: memory limit of host-synchronizer
-  name: MEMORY_LIMIT_SYNC
-  value: 3Gi
-- description: memory limit of reaper
-  name: MEMORY_LIMIT_REAPER
-  value: 512Mi
-- description: request limit for service
-  name: MEMORY_REQUEST
+- name: MEMORY_REQUEST_SERVICE
   value: 256Mi
-- description: request limit for reaper
-  name: MEMORY_REQUEST_REAPER
+- name: MEMORY_LIMIT_SERVICE
+  value: 512Mi
+
+- name: CPU_REQUEST_MQ_PMIN
+  value: 250m
+- name: CPU_LIMIT_MQ_PMIN
+  value: 500m
+- name: MEMORY_REQUEST_MQ_PMIN
   value: 256Mi
-- description: request limit for host-synchronizer
-  name: MEMORY_REQUEST_SYNC
-  value: 3Gi
+- name: MEMORY_LIMIT_MQ_PMIN
+  value: 512Mi
+
+- name: CPU_REQUEST_MQ_P1
+  value: 250m
+- name: CPU_LIMIT_MQ_P1
+  value: 500m
+- name: MEMORY_REQUEST_MQ_P1
+  value: 256Mi
+- name: MEMORY_LIMIT_MQ_P1
+  value: 512Mi
+
+- name: CPU_REQUEST_MQ_SP
+  value: 250m
+- name: CPU_LIMIT_MQ_SP
+  value: 500m
+- name: MEMORY_REQUEST_MQ_SP
+  value: 256Mi
+- name: MEMORY_LIMIT_MQ_SP
+  value: 512Mi
+
+- name: CPU_REQUEST_REAPER
+  value: 250m
+- name: CPU_LIMIT_REAPER
+  value: 500m
+- name: MEMORY_REQUEST_REAPER
+  value: 256Mi
+- name: MEMORY_LIMIT_REAPER
+  value: 512Mi
+
+- name: CPU_REQUEST_SP_VALIDATOR
+  value: 250m
+- name: CPU_LIMIT_SP_VALIDATOR
+  value: 500m
+- name: MEMORY_REQUEST_SP_VALIDATOR
+  value: 256Mi
+- name: MEMORY_LIMIT_SP_VALIDATOR
+  value: 512Mi
+
+- name: CPU_REQUEST_PENDO_SYNCHER
+  value: 250m
+- name: CPU_LIMIT_PENDO_SYNCHER
+  value: 500m
+- name: MEMORY_REQUEST_PENDO_SYNCHER
+  value: 256Mi
+- name: MEMORY_LIMIT_PENDO_SYNCHER
+  value: 512Mi
+
+- name: CPU_REQUEST_SYNCHRONIZER
+  value: 250m
+- name: CPU_LIMIT_SYNCHRONIZER
+  value: 500m
+- name: MEMORY_REQUEST_SYNCHRONIZER
+  value: 256Mi
+- name: MEMORY_LIMIT_SYNCHRONIZER
+  value: 512Mi
+
 - description: Replica count for p1 consumer
   name: REPLICAS_P1
   value: "5"
@@ -855,14 +904,6 @@ parameters:
   value: 'false'
 
 #floorist
-- name: MEMORY_LIMIT_FLOO
-  value: 200Mi
-- name: MEMORY_REQUEST_FLOO
-  value: 100Mi
-- name: CPU_LIMIT_FLOO
-  value: 100m
-- name: CPU_REQUEST_FLOO
-  value: 50m
 - name: FLOORIST_SUSPEND
   description: Disable Floorist cronjob execution
   required: true
@@ -874,9 +915,6 @@ parameters:
 - name: FLOORIST_LOGLEVEL
   description: Floorist loglevel config
   value: 'INFO'
-- name: FLOORIST_DISABLED
-  description: Determines whether to build the Floorist Job.
-  value: 'false'
 - name: FLOORIST_DB_SECRET_NAME
   description: database secret name
   value: host-inventory-db


### PR DESCRIPTION
Separates CPU/mem requests & limits into separate parameters for each app component -- allowing us to tune them for better resource utilization in ephemeral environments.