### PR TITLE
perf(RHINENG-5451): log large messages to kibana

### DIFF
--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -49,9 +49,11 @@ def message_produced(logger, message, headers):
         event_producer_success.labels(event_type=dict(headers)["event_type"].decode("utf-8"), topic=topic).inc()
 
 
-def message_not_produced(logger, error, topic, event, key, headers):
+def message_not_produced(logger, error, topic, event, key, headers, message=None):
     status = "NOT PRODUCED"
     msg = f"Message status={status}, topic={topic}, key={key}, headers={headers}, error={str(error)}, event={event}"
+    if message:
+        msg += f", message={message}"
 
     logger.error(msg)
     if "notification" in topic:

--- a/app/queue/event_producer.py
+++ b/app/queue/event_producer.py
@@ -20,7 +20,7 @@ class MessageDetails:
         self.event = event
         self.headers = headers
         self.key = key
-        self.topic = ""
+        self.topic = topic
 
     def on_delivered(self, error, message):
         message_to_send = None

--- a/app/queue/event_producer.py
+++ b/app/queue/event_producer.py
@@ -1,3 +1,4 @@
+from confluent_kafka import KafkaError
 from confluent_kafka import KafkaException
 from confluent_kafka import Producer as KafkaProducer
 
@@ -19,11 +20,14 @@ class MessageDetails:
         self.event = event
         self.headers = headers
         self.key = key
-        self.topic = topic
+        self.topic = ""
 
     def on_delivered(self, error, message):
+        message_to_send = None
         if error:
-            message_not_produced(logger, error, self.topic, self.event, self.key, self.headers)
+            if error.code() == KafkaError.MSG_SIZE_TOO_LARGE:
+                message_to_send = message
+            message_not_produced(logger, error, self.topic, self.event, self.key, self.headers, message_to_send)
         else:
             message_produced(logger, message, self.headers)
 

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -432,7 +432,7 @@ def test_delete_with_callback_receiving_error(
     msgdet = MessageDetails(topic=None, event=event, headers=headers, key=host.id)
     event_producer._kafka_producer.produce.side_effects = msgdet.on_delivered(error, message)
 
-    response_status, response_data = api_delete_host(",".join([str(host.id)]))
+    response_status, _ = api_delete_host(",".join([str(host.id)]))
 
     assert_response_status(response_status, expected_status=200)
 

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -424,11 +424,12 @@ def test_delete_with_callback_receiving_error(
     mocker.patch("lib.host_delete.kafka_available")
     host = db_create_host()
     headers = mock.MagicMock()
-    message = mock.MagicMock()
+    event = mock.MagicMock()
+    message = None  # message is only sent when message is too long to be produced
     error = mock.MagicMock()
     message_not_produced_mock = mocker.patch("app.queue.event_producer.message_not_produced")
 
-    msgdet = MessageDetails(topic=None, event=message, headers=headers, key=host.id)
+    msgdet = MessageDetails(topic=None, event=event, headers=headers, key=host.id)
     event_producer._kafka_producer.produce.side_effects = msgdet.on_delivered(error, message)
 
     response_status, response_data = api_delete_host(",".join([str(host.id)]))
@@ -439,7 +440,9 @@ def test_delete_with_callback_receiving_error(
 
     assert remaining_hosts.count() == 0
     assert event_producer._kafka_producer.produce.call_count == 1
-    message_not_produced_mock.assert_called_once_with(event_producer_logger, error, None, message, host.id, headers)
+    message_not_produced_mock.assert_called_once_with(
+        event_producer_logger, error, None, event, host.id, headers, message
+    )
 
 
 def test_delete_host_that_belongs_to_group_success(


### PR DESCRIPTION
Related: RHINENG-5451

# Overview

This PR is being created to address [RHINENG-5451](https://issues.redhat.com/browse/RHINENG-5451).
Logs large messages to kibana if the message can not be produced.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
