### PR TITLE
[RHIENG-7073] Convert GET /hosts/{host_id_list}/tags endpoint from XJoin to DB

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -450,7 +450,17 @@ def get_host_tag_count(host_id_list, page=1, per_page=100, order_by=None, order_
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
 def get_host_tags(host_id_list, page=1, per_page=100, order_by=None, order_how=None, search=None, rbac_filter=None):
-    host_list, total = get_host_tags_list_by_id_list(host_id_list, page, per_page, order_by, order_how, rbac_filter)
+    current_identity = get_current_identity()
+    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+        logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
+        host_list, total = get_host_tags_list_by_id_list_postgres(
+            host_id_list, page, per_page, order_by, order_how, rbac_filter
+        )
+    else:
+        host_list, total = get_host_tags_list_by_id_list(
+            host_id_list, page, per_page, order_by, order_how, rbac_filter
+        )
+
     filtered_list = {host_id: Tag.filter_tags(host_tags, search) for host_id, host_tags in host_list.items()}
 
     return _build_paginated_host_tags_response(total, page, per_page, filtered_list)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-7073](https://issues.redhat.com/browse/RHINENG-7073).

Convert GET /hosts/{host_id_list}/tags endpoint from XJoin to DB
* Use feature flag to determine postgres or xjoin flow
* Add test cases for postgres flow of querying tags

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
