### PR TITLE
[RHINENG-6095] - Use custom staleness in per_reporter_staleness

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -31,6 +31,7 @@ logger = get_logger(__name__)
 NIL_STRING = "nil"
 NOT_NIL_STRING = "not_nil"
 OR_FIELDS = ("owner_id", "rhc_client_id", "host_type", "system_update_method")
+STALENESS_VALUES = ["fresh", "stale", "stale_warning"]
 
 
 def _invalid_value_error(field_name, field_value):
@@ -291,12 +292,12 @@ def _generic_filter_builder(
 
 
 def build_registered_with_filter(registered_with, staleness):
-    # if API is calling /api/inventory/v1/tags
-    # staleness is None by default, so we need
-    # to add the staleness values as a expection when
-    # when registered_with is set
+    # If /api/inventory/v1/tags is called,
+    # staleness variable is set to None by default.
+    # To use custom staleness, we to make sure we have
+    # staleness values set
     if staleness is None:
-        staleness = ["fresh", "stale", "stale_warning"]
+        staleness = STALENESS_VALUES
 
     reg_with_copy = deepcopy(registered_with)
     prs_list = []
@@ -311,7 +312,7 @@ def build_registered_with_filter(registered_with, staleness):
                 reg_with_copy.extend(OLD_TO_NEW_REPORTER_MAP[old_reporter])
                 reg_with_copy = list(set(reg_with_copy))  # Remove duplicates
 
-        # I need to get the per_report_staleness check_in value for the reporter
+        # Get the per_report_staleness check_in value for the reporter
         # and build the filter based on it
         for item in reg_with_copy:
             prs_item = {

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -426,4 +426,4 @@ def _serialize_per_reporter_staleness(host, staleness, staleness_timestamps):
 
         host.per_reporter_staleness[reporter]["stale_timestamp"] = _serialize_staleness_to_string(stale_timestamp)
 
-        return host.per_reporter_staleness
+    return host.per_reporter_staleness

--- a/app/xjoin.py
+++ b/app/xjoin.py
@@ -97,6 +97,16 @@ def staleness_filter(staleness):
     return staleness_conditions
 
 
+def per_reporter_staleness_filter(staleness):
+    staleness_obj = serialize_staleness_to_dict(get_staleness_obj())
+    staleness_conditions = tuple()
+    for host_type in HOST_TYPES:
+        staleness_conditions += tuple(
+            staleness_to_conditions(staleness_obj, staleness, host_type, _stale_timestamp_per_reporter_filter)
+        )
+    return staleness_conditions
+
+
 def string_contains(string):
     return {"matches": f"*{string}*"}
 
@@ -127,3 +137,12 @@ def _stale_timestamp_filter(gt=None, lte=None, host_type=None):
     if lte:
         filter_["lte"] = lte.isoformat()
     return {"AND": ({"modified_on": filter_, "spf_host_type": {"eq": host_type}})}
+
+
+def _stale_timestamp_per_reporter_filter(gt=None, lte=None, host_type=None):
+    filter_ = {}
+    if gt:
+        filter_["gt"] = gt.isoformat()
+    if lte:
+        filter_["lte"] = lte.isoformat()
+    return {"AND": ({"last_check_in": filter_, "hostFilter": {"spf_host_type": {"eq": host_type}}})}

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -66,7 +66,7 @@ paths:
         - $ref: '#/components/parameters/updatedEnd'
         - $ref: '#/components/parameters/groupNameListParam'
         - $ref: '#/components/parameters/registered_with'
-        - $ref: '#/components/parameters/stalenessNoDefaultsParam'
+        - $ref: '#/components/parameters/stalenessParam'
         - $ref: '#/components/parameters/tagsParam'
         - $ref: '#/components/parameters/filter_param'
       responses:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -135,7 +135,7 @@
             "$ref": "#/components/parameters/registered_with"
           },
           {
-            "$ref": "#/components/parameters/stalenessNoDefaultsParam"
+            "$ref": "#/components/parameters/stalenessParam"
           },
           {
             "$ref": "#/components/parameters/tagsParam"

--- a/tests/fixtures/graphql_fixtures.py
+++ b/tests/fixtures/graphql_fixtures.py
@@ -156,7 +156,56 @@ def assert_tag_query_host_filter_for_field(mocker, assert_tag_query_host_filter_
             url=url,
             host_filter={
                 "AND": ({field: {matcher: value.casefold() if field in CASEFOLDED_FIELDS else value}},),
-                "OR": mocker.ANY,
+                "OR": [
+                    {
+                        "AND": {
+                            "modified_on": {"gt": mocker.ANY},
+                            "spf_host_type": {"eq": "edge"},
+                        }
+                    },
+                    {
+                        "AND": {
+                            "modified_on": {
+                                "gt": mocker.ANY,
+                                "lte": mocker.ANY,
+                            },
+                            "spf_host_type": {"eq": "edge"},
+                        }
+                    },
+                    {
+                        "AND": {
+                            "modified_on": {
+                                "gt": mocker.ANY,
+                                "lte": mocker.ANY,
+                            },
+                            "spf_host_type": {"eq": "edge"},
+                        }
+                    },
+                    {
+                        "AND": {
+                            "modified_on": {"gt": mocker.ANY},
+                            "spf_host_type": {"eq": None},
+                        }
+                    },
+                    {
+                        "AND": {
+                            "modified_on": {
+                                "gt": mocker.ANY,
+                                "lte": mocker.ANY,
+                            },
+                            "spf_host_type": {"eq": None},
+                        }
+                    },
+                    {
+                        "AND": {
+                            "modified_on": {
+                                "gt": mocker.ANY,
+                                "lte": mocker.ANY,
+                            },
+                            "spf_host_type": {"eq": None},
+                        }
+                    },
+                ],
             },
             status=status,
         )


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-6095](https://issues.redhat.com/browse/RHINENG-6095).

It adds custom staleness to per_reporter_staleness graphql filter.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
