### PR TITLE
Increase sel-container memory request

### DIFF
--- a/deploy/testing-integration.yml
+++ b/deploy/testing-integration.yml
@@ -84,11 +84,11 @@ objects:
                 optional: true
           resources:
             limits:
-              cpu: "1"
-              memory: 2Gi
+              cpu: ${IQE_CPU_LIMIT}
+              memory: ${IQE_MEMORY_LIMIT}
             requests:
-              cpu: 500m
-              memory: 1Gi
+              cpu: ${IQE_CPU_REQUEST}
+              memory: ${IQE_MEMORY_REQUEST}
           volumeMounts:
             - name: insights-qa-private-key
               readOnly: true
@@ -102,11 +102,11 @@ objects:
           image: ${IQE_SEL_IMAGE}
           resources:
             limits:
-              cpu: 500m
-              memory: 1.5Gi
+              cpu: ${SELENIUM_CPU_LIMIT}
+              memory: ${SELENIUM_MEMORY_LIMIT}
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: ${SELENIUM_CPU_REQUEST}
+              memory: ${SELENIUM_MEMORY_REQUEST}
           volumeMounts:
             - name: sel-shm
               mountPath: /dev/shm
@@ -141,3 +141,19 @@ parameters:
   value: ''
 - name: IQE_SEL_IMAGE
   value: 'quay.io/redhatqe/selenium-standalone:ff_91.9.1esr_chrome_103.0.5060.114'
+- name: IQE_CPU_LIMIT
+  value: "1"
+- name: IQE_MEMORY_LIMIT
+  value: 2Gi
+- name: IQE_CPU_REQUEST
+  value: 500m
+- name: IQE_MEMORY_REQUEST
+  value: 1Gi
+- name: SELENIUM_CPU_LIMIT
+  value: 500m
+- name: SELENIUM_MEMORY_LIMIT
+  value: 2Gi
+- name: SELENIUM_CPU_REQUEST
+  value: 100m
+- name: SELENIUM_MEMORY_REQUEST
+  value: 1Gi


### PR DESCRIPTION
Running the integration tests hits the limit of
memory usage that causes tests to fail. We need to increase the requested memory.