### PR TITLE
[RHINENG-6096] - Return all dynamically calculated staleness timestamps in per_reporter_staleness

### DIFF
--- a/app/serialization.py
+++ b/app/serialization.py
@@ -418,12 +418,32 @@ def _serialize_per_reporter_staleness(host, staleness, staleness_timestamps):
                 _deserialize_datetime(host.per_reporter_staleness[reporter]["last_check_in"]),
                 staleness["immutable_time_to_stale"],
             )
+            stale_warning_timestamp = staleness_timestamps.stale_timestamp(
+                _deserialize_datetime(host.per_reporter_staleness[reporter]["last_check_in"]),
+                staleness["immutable_time_to_stale_warning"],
+            )
+            delete_timestamp = staleness_timestamps.stale_timestamp(
+                _deserialize_datetime(host.per_reporter_staleness[reporter]["last_check_in"]),
+                staleness["immutable_time_to_delete"],
+            )
         else:
             stale_timestamp = staleness_timestamps.stale_timestamp(
                 _deserialize_datetime(host.per_reporter_staleness[reporter]["last_check_in"]),
                 staleness["conventional_time_to_stale"],
             )
+            stale_warning_timestamp = staleness_timestamps.stale_timestamp(
+                _deserialize_datetime(host.per_reporter_staleness[reporter]["last_check_in"]),
+                staleness["conventional_time_to_stale_warning"],
+            )
+            delete_timestamp = staleness_timestamps.stale_timestamp(
+                _deserialize_datetime(host.per_reporter_staleness[reporter]["last_check_in"]),
+                staleness["conventional_time_to_delete"],
+            )
 
         host.per_reporter_staleness[reporter]["stale_timestamp"] = _serialize_staleness_to_string(stale_timestamp)
+        host.per_reporter_staleness[reporter]["stale_warning_timestamp"] = _serialize_staleness_to_string(
+            stale_warning_timestamp
+        )
+        host.per_reporter_staleness[reporter]["culled_timestamp"] = _serialize_staleness_to_string(delete_timestamp)
 
     return host.per_reporter_staleness

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1761,6 +1761,14 @@ components:
           type: string
           format: date-time
           example: '2020-02-17T08:07:03.354307+00:00'
+        stale_warning_timestamp:
+          type: string
+          format: date-time
+          example: '2020-02-17T08:07:03.354307+00:00'
+        culled_timestamp:
+          type: string
+          format: date-time
+          example: '2020-02-17T08:07:03.354307+00:00'
         check_in_succeeded:
           type: boolean
     ActiveTags:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -2683,6 +2683,16 @@
             "format": "date-time",
             "example": "2020-02-17T08:07:03.354307+00:00"
           },
+          "stale_warning_timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2020-02-17T08:07:03.354307+00:00"
+          },
+          "culled_timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2020-02-17T08:07:03.354307+00:00"
+          },
           "check_in_succeeded": {
             "type": "boolean"
           }

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -929,8 +929,10 @@ def test_response_processed_properly(graphql_query_with_response, api_get):
                 "per_reporter_staleness": {
                     "puptoo": {
                         "check_in_succeeded": True,
+                        "culled_timestamp": "2020-02-24T08:07:03.354307+00:00",
                         "last_check_in": "2020-02-10T08:07:03.354307+00:00",
                         "stale_timestamp": "2020-02-11T13:07:03.354307+00:00",
+                        "stale_warning_timestamp": "2020-02-17T08:07:03.354307+00:00",
                     }
                 },
                 "subscription_manager_id": None,
@@ -960,8 +962,10 @@ def test_response_processed_properly(graphql_query_with_response, api_get):
                 "per_reporter_staleness": {
                     "yupana": {
                         "check_in_succeeded": True,
+                        "culled_timestamp": "2020-02-24T08:07:03.354307+00:00",
                         "last_check_in": "2020-02-10T08:07:03.354307+00:00",
                         "stale_timestamp": "2020-02-11T13:07:03.354307+00:00",
+                        "stale_warning_timestamp": "2020-02-17T08:07:03.354307+00:00",
                     }
                 },
                 "subscription_manager_id": None,


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-6096](https://issues.redhat.com/browse/RHINENG-6096).

It adds `stale_warning_timestamp` and `culled_timestamp` to `per_reporter_staleness` using custom staleness

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
