### PR TITLE
fix(RHINENG-6095): Fix DELETE /hosts endpoint 

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -66,7 +66,7 @@ paths:
         - $ref: '#/components/parameters/updatedEnd'
         - $ref: '#/components/parameters/groupNameListParam'
         - $ref: '#/components/parameters/registered_with'
-        - $ref: '#/components/parameters/stalenessParam'
+        - $ref: '#/components/parameters/stalenessNoDefaultsParam'
         - $ref: '#/components/parameters/tagsParam'
         - $ref: '#/components/parameters/filter_param'
       responses:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -135,7 +135,7 @@
             "$ref": "#/components/parameters/registered_with"
           },
           {
-            "$ref": "#/components/parameters/stalenessParam"
+            "$ref": "#/components/parameters/stalenessNoDefaultsParam"
           },
           {
             "$ref": "#/components/parameters/tagsParam"

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -2228,19 +2228,7 @@ def test_xjoin_search_query_using_hostfilter(
     graphql_query_empty_response.assert_called_once_with(
         HOST_IDS_QUERY,
         {
-            "filter": (
-                {field: {"eq": value}},
-                {
-                    "OR": (
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                    )
-                },
-            ),
+            "filter": ({field: {"eq": value}},),
             "limit": mocker.ANY,
             "offset": 0,
         },
@@ -2258,19 +2246,7 @@ def test_xjoin_search_query_using_hostfilter_display_name(
     graphql_query_empty_response.assert_called_once_with(
         HOST_IDS_QUERY,
         {
-            "filter": (
-                {"display_name": {"matches_lc": f"*{query_params['display_name']}*"}},
-                {
-                    "OR": (
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                    )
-                },
-            ),
+            "filter": ({"display_name": {"matches_lc": f"*{query_params['display_name']}*"}},),
             "limit": mocker.ANY,
             "offset": 0,
         },
@@ -2405,19 +2381,7 @@ def test_xjoin_search_using_hostfilters_tags(
     graphql_query_empty_response.assert_called_once_with(
         HOST_IDS_QUERY,
         {
-            "filter": (
-                {"OR": tag_filters},
-                {
-                    "OR": (
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                    )
-                },
-            ),
+            "filter": ({"OR": tag_filters},),
             "limit": mocker.ANY,
             "offset": 0,
         },
@@ -2445,16 +2409,6 @@ def test_xjoin_search_query_using_hostfilter_provider(
         HOST_IDS_QUERY,
         {
             "filter": (
-                {
-                    "OR": (
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
-                    )
-                },
                 {"provider_type": {"eq": provider["type"]}},
                 {"provider_id": {"eq": provider["id"]}},
             ),
@@ -2478,6 +2432,38 @@ def test_spf_rhc_client_invalid_field_value(subtests, graphql_query_empty_respon
             response_status, response_data = api_get(url)
             assert response_status == 400
             assert response_data["title"] == "Validation Error"
+
+
+@pytest.mark.parametrize(
+    "staleness",
+    (
+        {"type": "fresh"},
+        {"type": "stale"},
+        {"type": "stale_warning"},
+    ),
+)
+def test_xjoin_search_query_using_hostfilter_staleness(
+    mocker, graphql_query_empty_response, staleness, api_delete_filtered_hosts
+):
+    query_params = {"staleness": staleness["type"]}
+    api_delete_filtered_hosts(query_params)
+
+    graphql_query_empty_response.assert_called_once_with(
+        HOST_IDS_QUERY,
+        {
+            "limit": mocker.ANY,
+            "offset": 0,
+            "filter": (
+                {
+                    "OR": (
+                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": "edge"}}},
+                        {"AND": {"modified_on": mocker.ANY, "spf_host_type": {"eq": None}}},
+                    )
+                },
+            ),
+        },
+        mocker.ANY,
+    )
 
 
 # system_profile owner_id tests


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-6095](https://issues.redhat.com/browse/RHINENG-6095).
This PR reverts an bug that was introduced on #1603 

It reintroduce `stalenessNoDefaultsParam`  to `DELETE /hosts`

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
