### PR TITLE
feat(RHINENG-7070) GET /hosts DB implementation (Part 1)

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -13,6 +13,7 @@ from api import metrics
 from api.host_query import build_paginated_host_list_response
 from api.host_query import staleness_timestamps
 from api.host_query_db import get_all_hosts
+from api.host_query_db import get_host_list as get_host_list_postgres
 from api.host_query_xjoin import get_host_ids_list as get_host_ids_list_xjoin
 from api.host_query_xjoin import get_host_list as get_host_list_xjoin
 from api.host_query_xjoin import get_host_list_by_id_list
@@ -90,31 +91,52 @@ def get_host_list(
     host_list = ()
     current_identity = get_current_identity()
 
-    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
-        logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
-
     try:
-        host_list, total, additional_fields, system_profile_fields = get_host_list_xjoin(
-            display_name,
-            fqdn,
-            hostname_or_id,
-            insights_id,
-            provider_id,
-            provider_type,
-            updated_start,
-            updated_end,
-            group_name,
-            tags,
-            page,
-            per_page,
-            order_by,
-            order_how,
-            staleness,
-            registered_with,
-            filter,
-            fields,
-            rbac_filter,
-        )
+        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+            logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
+            host_list, total, additional_fields, system_profile_fields = get_host_list_postgres(
+                display_name,
+                fqdn,
+                hostname_or_id,
+                insights_id,
+                provider_id,
+                provider_type,
+                updated_start,
+                updated_end,
+                group_name,
+                tags,
+                page,
+                per_page,
+                order_by,
+                order_how,
+                staleness,
+                registered_with,
+                filter,
+                fields,
+                rbac_filter,
+            )
+        else:
+            host_list, total, additional_fields, system_profile_fields = get_host_list_xjoin(
+                display_name,
+                fqdn,
+                hostname_or_id,
+                insights_id,
+                provider_id,
+                provider_type,
+                updated_start,
+                updated_end,
+                group_name,
+                tags,
+                page,
+                per_page,
+                order_by,
+                order_how,
+                staleness,
+                registered_with,
+                filter,
+                fields,
+                rbac_filter,
+            )
     except ValueError as e:
         log_get_host_list_failed(logger)
         flask.abort(400, str(e))

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -247,7 +247,7 @@ def get_host_list_by_id_list(
     host_id_list, page, per_page, param_order_by, param_order_how, fields=None, rbac_filter=None
 ):
     all_filters = _host_id_list_filter(host_id_list)
-    all_filters += rbac_filter
+    all_filters += _rbac_filter(rbac_filter)
 
     return _get_host_list_using_filters(all_filters, page, per_page, param_order_by, param_order_how, fields)
 

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -274,8 +274,20 @@ def params_to_order_by(order_by: str = None, order_how: str = None) -> Tuple:
             ordering = (_order_how(Host.display_name, order_how),)
         else:
             ordering = (Host.display_name.asc(),)
+    elif order_by == "group_name":
+        if order_how:
+            ordering = (_order_how(Group.name, order_how),)
+        else:
+            ordering = (Group.name.asc(),)
+    elif order_by == "operating_system":
+        if order_how:
+            ordering = (_order_how(Host.operating_system, order_how),)
+        else:
+            ordering = (Host.operating_system.asc(),)
     elif order_by:
-        raise ValueError('Unsupported ordering column, use "updated" or "display_name".')
+        raise ValueError(
+            'Unsupported ordering column: use "updated", "display_name", "group_name", or "operating_system".'
+        )
     elif order_how:
         raise ValueError(
             "Providing ordering direction without a column is not supported. "
@@ -285,7 +297,7 @@ def params_to_order_by(order_by: str = None, order_how: str = None) -> Tuple:
     return ordering + modified_on_ordering + (Host.id.desc(),)
 
 
-def _order_how(column: str, order_how: str):
+def _order_how(column, order_how: str):
     if order_how == "ASC":
         return column.asc()
     elif order_how == "DESC":
@@ -300,7 +312,7 @@ def _find_all_hosts() -> Query:
         Host.query.join(HostGroupAssoc, isouter=True)
         .join(Group, isouter=True)
         .filter(Host.org_id == identity.org_id)
-        .group_by(Host.id)
+        .group_by(Host.id, Group.name)
     )
     return update_query_for_owner_id(identity, query)
 

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -1,7 +1,17 @@
+from typing import Tuple
+from uuid import UUID
+
+from dateutil import parser
+from sqlalchemy import and_
+from sqlalchemy import or_
+
 from app.auth import get_current_identity
 from app.instrumentation import log_get_host_list_succeeded
 from app.logging import get_logger
+from app.models import Group
 from app.models import Host
+from app.models import HostGroupAssoc
+from app.utils import Tag
 from lib.host_repository import update_query_for_owner_id
 
 __all__ = ("get_all_hosts", "params_to_order_by")
@@ -18,6 +28,227 @@ def get_all_hosts():
 
     log_get_host_list_succeeded(logger, ids_list)
     return ids_list
+
+
+def _canonical_fact_filter(canonical_fact, value):
+    return (Host.canonical_facts[canonical_fact].astext == value,)
+
+
+def _display_name_filter(display_name):
+    return (Host.display_name.comparator.contains(display_name),)
+
+
+def _tags_filter(string_tags):
+    tags = []
+
+    for string_tag in string_tags:
+        tags.append(Tag.from_string(string_tag))
+
+    tags_to_find = Tag.create_nested_from_tags(tags)
+
+    return (Host.tags.contains(tags_to_find),)
+
+
+def _group_names_filter(group_name_list):
+    _query_filter = tuple()
+    if len(group_name_list) > 0:
+        group_filters = (Group.name.in_(group_name_list),)
+        if "" in group_name_list:
+            group_filters += (HostGroupAssoc.group_id.is_(None),)
+
+        _query_filter += (or_(*group_filters),)
+
+    return _query_filter
+
+
+def _group_ids_filter(group_id_list):
+    _query_filter = tuple()
+    if len(group_id_list) > 0:
+        group_filters = (HostGroupAssoc.group_id.in_(group_id_list),)
+        if None in group_id_list:
+            group_filters += (HostGroupAssoc.group_id.is_(None),)
+
+        _query_filter += (or_(*group_filters),)
+
+    return _query_filter
+
+
+def _staleness_filter(staleness):
+    _query_filter = tuple()
+    # TODO
+    return _query_filter
+
+
+def _registered_with_filter(registered_with):
+    _query_filter = tuple()
+    # TODO
+    return _query_filter
+
+
+def _system_profile_factor(sp_filter):
+    _query_filter = tuple()
+    # TODO
+    return _query_filter
+
+
+def _hostname_or_id_filter(hostname_or_id):
+    filter_list = [
+        Host.display_name.comparator.contains(hostname_or_id),
+        Host.canonical_facts["fqdn"].astext.contains(hostname_or_id),
+    ]
+
+    try:
+        UUID(hostname_or_id)
+        host_id = hostname_or_id
+        filter_list.append(Host.id == host_id)
+        logger.debug("Adding id (uuid) to the filter list")
+    except Exception:
+        # Do not filter using the id
+        logger.debug("The hostname (%s) could not be converted into a UUID", hostname_or_id, exc_info=True)
+
+    return (or_(*filter_list),)
+
+
+def _modified_on_filter(updated_start: str, updated_end: str) -> Tuple:
+    modified_on_filter = tuple()
+    updated_start_date = parser.isoparse(updated_start) if updated_start else None
+    updated_end_date = parser.isoparse(updated_end) if updated_end else None
+
+    if updated_start_date and updated_end_date and updated_start_date > updated_end_date:
+        raise ValueError("updated_start cannot be after updated_end.")
+
+    if updated_start_date and updated_start_date.year > 1970:
+        modified_on_filter += (Host.modified_on >= updated_start_date,)
+    if updated_end_date and updated_end_date.year > 1970:
+        modified_on_filter += (Host.modified_on <= updated_end_date,)
+
+    return (and_(*modified_on_filter),)
+
+
+def _host_id_list_filter(host_id_list):
+    return (Host.id.in_(host_id_list),)
+
+
+def _rbac_filter(rbac_filter):
+    _query_filter = tuple()
+    if rbac_filter and "groups" in rbac_filter:
+        _query_filter = _group_ids_filter(rbac_filter["groups"])
+
+    return _query_filter
+
+
+def query_filters(
+    fqdn=None,
+    display_name=None,
+    hostname_or_id=None,
+    insights_id=None,
+    provider_id=None,
+    provider_type=None,
+    updated_start=None,
+    updated_end=None,
+    group_name=None,
+    group_ids=None,
+    tags=None,
+    staleness=None,
+    registered_with=None,
+    filter=None,
+    rbac_filter=None,
+):
+    filters = tuple()
+    if fqdn:
+        filters += _canonical_fact_filter("fqdn", fqdn)
+    elif display_name:
+        filters += _display_name_filter(display_name)
+    elif hostname_or_id:
+        filters += _hostname_or_id_filter(hostname_or_id)
+    elif insights_id:
+        filters += _canonical_fact_filter("insights_id", insights_id)
+
+    if provider_id:
+        filters += _canonical_fact_filter("provider_id", provider_id)
+    if provider_type:
+        filters += _canonical_fact_filter("provider_type", provider_type)
+    if updated_start or updated_end:
+        filters += _modified_on_filter(updated_start, updated_end)
+    if group_name:
+        filters += _group_names_filter(group_name)
+    if group_ids:
+        filters += _group_ids_filter(group_ids)
+    if tags:
+        filters += _tags_filter(tags)
+    if staleness:
+        filters += _staleness_filter(staleness)
+    if registered_with:
+        filters += _registered_with_filter(registered_with)
+    if filter:
+        filters += _system_profile_factor(filter)
+    if rbac_filter:
+        filters += _rbac_filter(rbac_filter)
+
+    return filters
+
+
+def _get_host_list_using_filters(all_filters, page, per_page, param_order_by, param_order_how, fields):
+    host_query = _find_all_hosts().filter(*all_filters).order_by(*params_to_order_by(param_order_by, param_order_how))
+
+    query_results = host_query.paginate(page, per_page, True)
+
+    # TODO: additional_fields and system_profile_fields
+    additional_fields = tuple()
+    system_profile_fields = tuple()
+
+    return query_results.items, query_results.total, additional_fields, system_profile_fields
+
+
+def get_host_list(
+    display_name,
+    fqdn,
+    hostname_or_id,
+    insights_id,
+    provider_id,
+    provider_type,
+    updated_start,
+    updated_end,
+    group_name,
+    tags,
+    page,
+    per_page,
+    param_order_by,
+    param_order_how,
+    staleness,
+    registered_with,
+    filter,
+    fields,
+    rbac_filter,
+):
+    all_filters = query_filters(
+        fqdn,
+        display_name,
+        hostname_or_id,
+        insights_id,
+        provider_id,
+        provider_type,
+        updated_start,
+        updated_end,
+        group_name,
+        None,
+        tags,
+        staleness,
+        registered_with,
+        filter,
+        rbac_filter,
+    )
+
+    return _get_host_list_using_filters(all_filters, page, per_page, param_order_by, param_order_how, fields)
+
+
+def get_host_list_by_id_list(
+    host_id_list, page, per_page, param_order_by, param_order_how, fields=None, rbac_filter=None
+):
+    all_filters = _host_id_list_filter(host_id_list)
+    all_filters += rbac_filter
+
+    return _get_host_list_using_filters(all_filters, page, per_page, param_order_by, param_order_how, fields)
 
 
 def params_to_order_by(order_by=None, order_how=None):
@@ -54,5 +285,10 @@ def _order_how(column, order_how):
 
 def _find_all_hosts():
     identity = get_current_identity()
-    query = Host.query.filter(Host.org_id == identity.org_id)
+    query = (
+        Host.query.join(HostGroupAssoc, isouter=True)
+        .join(Group, isouter=True)
+        .filter(Host.org_id == identity.org_id)
+        .group_by(Host.id)
+    )
     return update_query_for_owner_id(identity, query)

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import List
 from uuid import UUID
 
 from dateutil import parser
@@ -31,11 +31,11 @@ def get_all_hosts():
 
 
 def _canonical_fact_filter(canonical_fact, value):
-    return (Host.canonical_facts[canonical_fact].astext == value,)
+    return [Host.canonical_facts[canonical_fact].astext == value]
 
 
 def _display_name_filter(display_name):
-    return (Host.display_name.comparator.contains(display_name),)
+    return [Host.display_name.comparator.contains(display_name)]
 
 
 def _tags_filter(string_tags):
@@ -46,15 +46,15 @@ def _tags_filter(string_tags):
 
     tags_to_find = Tag.create_nested_from_tags(tags)
 
-    return (Host.tags.contains(tags_to_find),)
+    return [Host.tags.contains(tags_to_find)]
 
 
 def _group_names_filter(group_name_list):
-    _query_filter = tuple()
+    _query_filter = []
     if len(group_name_list) > 0:
-        group_filters = (Group.name.in_(group_name_list),)
+        group_filters = [Group.name.in_(group_name_list)]
         if "" in group_name_list:
-            group_filters += (HostGroupAssoc.group_id.is_(None),)
+            group_filters += [HostGroupAssoc.group_id.is_(None)]
 
         _query_filter += (or_(*group_filters),)
 
@@ -62,31 +62,31 @@ def _group_names_filter(group_name_list):
 
 
 def _group_ids_filter(group_id_list):
-    _query_filter = tuple()
+    _query_filter = []
     if len(group_id_list) > 0:
-        group_filters = (HostGroupAssoc.group_id.in_(group_id_list),)
+        group_filters = [HostGroupAssoc.group_id.in_(group_id_list)]
         if None in group_id_list:
-            group_filters += (HostGroupAssoc.group_id.is_(None),)
+            group_filters += [HostGroupAssoc.group_id.is_(None)]
 
-        _query_filter += (or_(*group_filters),)
+        _query_filter += [or_(*group_filters)]
 
     return _query_filter
 
 
 def _staleness_filter(staleness):
-    _query_filter = tuple()
+    _query_filter = []
     # TODO
     return _query_filter
 
 
 def _registered_with_filter(registered_with):
-    _query_filter = tuple()
+    _query_filter = []
     # TODO
     return _query_filter
 
 
-def _system_profile_factor(sp_filter):
-    _query_filter = tuple()
+def _system_profile_filter(sp_filter):
+    _query_filter = []
     # TODO
     return _query_filter
 
@@ -109,8 +109,8 @@ def _hostname_or_id_filter(hostname_or_id):
     return (or_(*filter_list),)
 
 
-def _modified_on_filter(updated_start: str, updated_end: str) -> Tuple:
-    modified_on_filter = tuple()
+def _modified_on_filter(updated_start: str, updated_end: str) -> List:
+    modified_on_filter = []
     updated_start_date = parser.isoparse(updated_start) if updated_start else None
     updated_end_date = parser.isoparse(updated_end) if updated_end else None
 
@@ -118,19 +118,19 @@ def _modified_on_filter(updated_start: str, updated_end: str) -> Tuple:
         raise ValueError("updated_start cannot be after updated_end.")
 
     if updated_start_date and updated_start_date.year > 1970:
-        modified_on_filter += (Host.modified_on >= updated_start_date,)
+        modified_on_filter += [Host.modified_on >= updated_start_date]
     if updated_end_date and updated_end_date.year > 1970:
-        modified_on_filter += (Host.modified_on <= updated_end_date,)
+        modified_on_filter += [Host.modified_on <= updated_end_date]
 
-    return (and_(*modified_on_filter),)
+    return [and_(*modified_on_filter)]
 
 
 def _host_id_list_filter(host_id_list):
-    return (Host.id.in_(host_id_list),)
+    return [Host.id.in_(host_id_list)]
 
 
 def _rbac_filter(rbac_filter):
-    _query_filter = tuple()
+    _query_filter = []
     if rbac_filter and "groups" in rbac_filter:
         _query_filter = _group_ids_filter(rbac_filter["groups"])
 
@@ -154,7 +154,7 @@ def query_filters(
     filter=None,
     rbac_filter=None,
 ):
-    filters = tuple()
+    filters = []
     if fqdn:
         filters += _canonical_fact_filter("fqdn", fqdn)
     elif display_name:
@@ -181,7 +181,7 @@ def query_filters(
     if registered_with:
         filters += _registered_with_filter(registered_with)
     if filter:
-        filters += _system_profile_factor(filter)
+        filters += _system_profile_filter(filter)
     if rbac_filter:
         filters += _rbac_filter(rbac_filter)
 

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -414,6 +414,13 @@ def build_expected_host_list(host_list):
     ]
 
 
+# Since python3.6, dicts retain key order, so asserting that a list of dicts is equal
+# doesn't work unless we're certain that the keys are going to be in the same order.
+def assert_host_lists_equal(expected_host_list, actual_host_list):
+    for i in range(len(expected_host_list)):
+        assert expected_host_list[i] == actual_host_list[i]
+
+
 def build_order_query_parameters(order_by=None, order_how=None):
     query_parameters = {}
     if order_by:

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1,12 +1,17 @@
 from itertools import chain
+from unittest.mock import patch
 
 import pytest
 
 from lib.host_repository import find_hosts_by_staleness
+from tests.helpers.api_utils import api_base_pagination_test
 from tests.helpers.api_utils import api_pagination_invalid_parameters_test
+from tests.helpers.api_utils import api_pagination_test
 from tests.helpers.api_utils import api_query_test
 from tests.helpers.api_utils import assert_error_response
+from tests.helpers.api_utils import assert_host_lists_equal
 from tests.helpers.api_utils import assert_response_status
+from tests.helpers.api_utils import build_expected_host_list
 from tests.helpers.api_utils import build_fields_query_parameters
 from tests.helpers.api_utils import build_hosts_url
 from tests.helpers.api_utils import build_order_query_parameters
@@ -18,6 +23,8 @@ from tests.helpers.api_utils import create_mock_rbac_response
 from tests.helpers.api_utils import HOST_READ_ALLOWED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import HOST_READ_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import HOST_URL
+from tests.helpers.api_utils import quote
+from tests.helpers.api_utils import quote_everything
 from tests.helpers.graphql_utils import XJOIN_HOSTS_RESPONSE
 from tests.helpers.graphql_utils import XJOIN_SYSTEM_PROFILE_SAP_SIDS
 from tests.helpers.graphql_utils import XJOIN_SYSTEM_PROFILE_SAP_SYSTEM
@@ -480,3 +487,505 @@ def test_get_hosts_contains_invalid_on_string_not_array(patch_xjoin_post, api_ge
 
 def test_get_hosts_timestamp_invalid_value_graceful_rejection(patch_xjoin_post, api_get):
     assert 400 == api_get(build_hosts_url(query="?filter[system_profile][last_boot_time][eq]=foo"))[0]
+
+
+def test_query_all(mq_create_three_specific_hosts, api_get, subtests):
+    created_hosts = mq_create_three_specific_hosts
+    expected_host_list = build_expected_host_list(created_hosts)
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(HOST_URL)
+        api_base_pagination_test(api_get, subtests, HOST_URL, expected_total=len(expected_host_list))
+
+    assert response_status == 200
+    assert_host_lists_equal(expected_host_list, response_data["results"])
+
+
+def test_query_using_display_name(mq_create_three_specific_hosts, api_get):
+    created_hosts = mq_create_three_specific_hosts
+    expected_host_list = build_expected_host_list([created_hosts[0]])
+    url = build_hosts_url(query=f"?display_name={created_hosts[0].display_name}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 1
+    assert_host_lists_equal(expected_host_list, response_data["results"])
+
+
+def test_query_using_fqdn_two_results(mq_create_three_specific_hosts, api_get):
+    created_hosts = mq_create_three_specific_hosts
+    expected_host_list = build_expected_host_list([created_hosts[0], created_hosts[1]])
+
+    url = build_hosts_url(query=f"?fqdn={created_hosts[0].fqdn}")
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 2
+    assert_host_lists_equal(expected_host_list, response_data["results"])
+
+
+def test_query_using_fqdn_one_result(mq_create_three_specific_hosts, api_get):
+    created_hosts = mq_create_three_specific_hosts
+    expected_host_list = build_expected_host_list([created_hosts[2]])
+    url = build_hosts_url(query=f"?fqdn={created_hosts[2].fqdn}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 1
+    assert_host_lists_equal(expected_host_list, response_data["results"])
+
+
+def test_query_using_non_existent_fqdn(api_get):
+    url = build_hosts_url(query="?fqdn=NONEXISTENT.com")
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 0
+
+
+def test_query_using_display_name_substring(mq_create_three_specific_hosts, api_get, subtests):
+    created_hosts = mq_create_three_specific_hosts
+    expected_host_list = build_expected_host_list(created_hosts)
+    host_name_substr = created_hosts[0].display_name[:4]
+    url = build_hosts_url(query=f"?display_name={host_name_substr}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+        api_pagination_test(api_get, subtests, url, expected_total=len(created_hosts))
+
+    assert response_status == 200
+    assert_host_lists_equal(expected_host_list, response_data["results"])
+
+
+def test_query_using_display_name_as_hostname(mq_create_three_specific_hosts, api_get, subtests):
+    created_hosts = mq_create_three_specific_hosts
+    url = build_hosts_url(query=f"?hostname_or_id={created_hosts[0].display_name}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+        api_pagination_test(api_get, subtests, url, expected_total=2)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 2
+
+
+def test_query_using_fqdn_as_hostname(mq_create_three_specific_hosts, api_get, subtests):
+    created_hosts = mq_create_three_specific_hosts
+    url = build_hosts_url(query=f"?hostname_or_id={created_hosts[2].display_name}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+        api_pagination_test(api_get, subtests, url, expected_total=1)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 1
+
+
+def test_query_using_id(mq_create_three_specific_hosts, api_get, subtests):
+    created_hosts = mq_create_three_specific_hosts
+    url = build_hosts_url(query=f"?hostname_or_id={created_hosts[0].id}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+        api_pagination_test(api_get, subtests, url, expected_total=1)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 1
+
+
+def test_query_using_non_existent_hostname(mq_create_three_specific_hosts, api_get, subtests):
+    url = build_hosts_url(query="?hostname_or_id=NotGonnaFindMe")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+        api_pagination_test(api_get, subtests, url, expected_total=0)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 0
+
+
+def test_query_using_non_existent_id(mq_create_three_specific_hosts, api_get, subtests):
+    url = build_hosts_url(query=f"?hostname_or_id={generate_uuid()}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+        api_pagination_test(api_get, subtests, url, expected_total=0)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 0
+
+
+def test_query_using_insights_id(mq_create_three_specific_hosts, api_get, subtests):
+    created_hosts = mq_create_three_specific_hosts
+    url = build_hosts_url(query=f"?insights_id={created_hosts[0].insights_id}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+        api_pagination_test(api_get, subtests, url, expected_total=1)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 1
+
+
+def test_get_host_by_tag(mq_create_three_specific_hosts, api_get, subtests):
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[0]]
+    url = build_hosts_url(query="?tags=SPECIAL/tag=ToFind")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+def test_get_multiple_hosts_by_tag(mq_create_three_specific_hosts, api_get, subtests):
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[0], created_hosts[1]]
+    url = build_hosts_url(query="?tags=NS1/key1=val1&order_by=updated&order_how=ASC")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+def test_get_host_by_multiple_tags(mq_create_three_specific_hosts, api_get, subtests):
+    """
+    Get only the host with all three tags on it, and not the other hosts,
+    which both have some (but not all) of the tags we query for.
+    """
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[1]]
+    url = build_hosts_url(query="?tags=NS1/key1=val1&tags=NS2/key2=val2&tags=NS3/key3=val3")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+def test_get_host_by_subset_of_tags(mq_create_three_specific_hosts, api_get, subtests):
+    """
+    Get a host using a subset of its tags
+    """
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[1]]
+    url = build_hosts_url(query="?tags=NS1/key1=val1&tags=NS3/key3=val3")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+def test_get_host_with_different_tags_same_namespace(mq_create_three_specific_hosts, api_get, subtests):
+    """
+    get a host with two tags in the same namespace with diffent key and same value
+    """
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[0]]
+    url = build_hosts_url(query="?tags=NS1/key1=val1&tags=NS1/key2=val1")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+def test_get_no_host_with_different_tags_same_namespace(mq_create_three_specific_hosts, api_get, subtests):
+    """
+    Don’t get a host with two tags in the same namespace, from which only one match. This is a
+    regression test.
+    """
+    url = build_hosts_url(query="?tags=NS1/key1=val2&tags=NS1/key2=val1")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 0
+
+
+def test_get_host_with_same_tags_different_namespaces(mq_create_three_specific_hosts, api_get, subtests):
+    """
+    get a host with two tags in the same namespace with different key and same value
+    """
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[2]]
+    url = build_hosts_url(query="?tags=NS3/key3=val3&tags=NS1/key3=val3")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+def test_get_host_with_tag_no_value_at_all(mq_create_three_specific_hosts, api_get, subtests):
+    """
+    Attempt to find host with a tag with no stored value
+    """
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[0]]
+    url = build_hosts_url(query="?tags=no/key")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+def test_get_host_with_tag_no_value_in_query(mq_create_three_specific_hosts, api_get, subtests):
+    """
+    Attempt to find host with a tag with a stored value by a value-less query
+    """
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[0]]
+    url = build_hosts_url(query="?tags=NS1/key2")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+def test_get_host_with_tag_no_namespace(mq_create_three_specific_hosts, api_get, subtests):
+    """
+    Attempt to find host with a tag with no namespace.
+    """
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[2]]
+    url = build_hosts_url(query="?tags=key4=val4")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+def test_get_host_with_tag_only_key(mq_create_three_specific_hosts, api_get, subtests):
+    """
+    Attempt to find host with a tag with no namespace.
+    """
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[2]]
+    url = build_hosts_url(query="?tags=key5")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+def test_get_host_by_display_name_and_tag(mq_create_three_specific_hosts, api_get, subtests):
+    """
+    Attempt to get only the host with the specified key and
+    the specified display name
+    """
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[0]]
+    url = build_hosts_url(query="?tags=NS1/key1=val1&display_name=host1")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+def test_get_host_by_display_name_and_tag_backwards(mq_create_three_specific_hosts, api_get, subtests):
+    """
+    Attempt to get only the host with the specified key and
+    the specified display name, but the parameters are backwards
+    """
+    created_hosts = mq_create_three_specific_hosts
+    expected_response_list = [created_hosts[0]]
+    url = build_hosts_url(query="?display_name=host1&tags=NS1/key1=val1")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        api_pagination_test(api_get, subtests, url, expected_total=len(expected_response_list))
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(expected_response_list) == len(response_data["results"])
+
+    for host, result in zip(expected_response_list, response_data["results"]):
+        assert host.id == result["id"]
+
+
+@pytest.mark.parametrize("tag_query", (";?:@&+$/-_.!~*'()'=#", " \t\n\r\f\v/ \t\n\r\f\v= \t\n\r\f\v"))
+def test_get_host_with_unescaped_special_characters(tag_query, mq_create_or_update_host, api_get, subtests):
+    tags = [
+        {"namespace": ";?:@&+$", "key": "-_.!~*'()'", "value": "#"},
+        {"namespace": " \t\n\r\f\v", "key": " \t\n\r\f\v", "value": " \t\n\r\f\v"},
+    ]
+
+    host = minimal_host(tags=tags)
+    created_host = mq_create_or_update_host(host)
+    url = build_hosts_url(query=f"?tags={quote(tag_query)}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert response_data["count"]
+    assert response_data["results"][0]["id"] == created_host.id
+
+
+@pytest.mark.parametrize(
+    "namespace,key,value", ((";,/?:@&=+$", "-_.!~*'()", "#"), (" \t\n\r\f\v", " \t\n\r\f\v", " \t\n\r\f\v"))
+)
+def test_get_host_with_escaped_special_characters(namespace, key, value, mq_create_or_update_host, api_get):
+    tags = [
+        {"namespace": ";,/?:@&=+$", "key": "-_.!~*'()", "value": "#"},
+        {"namespace": " \t\n\r\f\v", "key": " \t\n\r\f\v", "value": " \t\n\r\f\v"},
+    ]
+
+    host = minimal_host(tags=tags)
+    created_host = mq_create_or_update_host(host)
+    tags_query = quote(f"{quote_everything(namespace)}/{quote_everything(key)}={quote_everything(value)}")
+    url = build_hosts_url(query=f"?tags={tags_query}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert response_data["count"]
+    assert response_data["results"][0]["id"] == created_host.id
+
+
+@pytest.mark.parametrize("num_groups", (1, 3, 5))
+def test_query_using_group_name(db_create_group_with_hosts, api_get, num_groups):
+    hosts_per_group = 3
+    for i in range(num_groups):
+        db_create_group_with_hosts(f"existing_group_{i}", hosts_per_group).id
+
+    # Some other group that we don't want to see in the response
+    db_create_group_with_hosts("some_other_group", 5)
+
+    group_name_params = "&".join([f"group_name=existing_group_{i}" for i in range(num_groups)])
+    url = build_hosts_url(query=f"?{group_name_params}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == num_groups * hosts_per_group
+
+
+def test_query_ungrouped_hosts(db_create_group_with_hosts, mq_create_three_specific_hosts, api_get):
+    # Create 3 hosts that are not in a group
+    ungrouped_hosts = mq_create_three_specific_hosts
+
+    # Also create 5 hosts that are in a group
+    db_create_group_with_hosts("group_with_hosts", 5)
+    url = build_hosts_url(query="?group_name=")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert_host_lists_equal(build_expected_host_list(ungrouped_hosts), response_data["results"])
+
+
+def test_query_hosts_filter_updated_start_end(mq_create_or_update_host, api_get):
+    host_list = [mq_create_or_update_host(minimal_host(insights_id=generate_uuid())) for _ in range(3)]
+
+    with patch("api.host.get_flag_value", return_value=True):
+        url = build_hosts_url(query=f"?updated_start={host_list[0].updated.replace('+00:00', 'Z')}")
+        response_status, response_data = api_get(url)
+        assert response_status == 200
+
+        # This query should return all 3 hosts
+        assert len(response_data["results"]) == 3
+
+        url = build_hosts_url(query=f"?updated_end={host_list[0].updated.replace('+00:00', 'Z')}")
+        response_status, response_data = api_get(url)
+        assert response_status == 200
+
+        # This query should return only the first host
+        assert len(response_data["results"]) == 1
+        assert response_data["results"][0]["insights_id"] == host_list[0].insights_id
+
+        url = build_hosts_url(
+            query=(
+                f"?updated_start={host_list[0].updated.replace('+00:00', 'Z')}"
+                f"&updated_end={host_list[1].updated.replace('+00:00', 'Z')}"
+            )
+        )
+        response_status, response_data = api_get(url)
+        assert response_status == 200
+        # This query should return 2 hosts
+        assert len(response_data["results"]) == 2
+
+        url = build_hosts_url(query=f"?updated_start={host_list[2].updated.replace('+00:00', 'Z')}")
+        response_status, response_data = api_get(url)
+        assert response_status == 200
+        # This query should return only the last host
+        assert len(response_data["results"]) == 1
+        assert response_data["results"][0]["insights_id"] == host_list[2].insights_id
+
+        url = build_hosts_url(query=f"?updated_end={host_list[2].updated.replace('+00:00', 'Z')}")
+        response_status, response_data = api_get(url)
+        assert response_status == 200
+        # This query should return all 3 hosts
+        assert len(response_data["results"]) == 3


### PR DESCRIPTION
# Overview

This PR is being created to address the first part of [RHINENG-7070](https://issues.redhat.com/browse/RHINENG-7070).
It implements most of the DB implementation for the GET /hosts endpoint. The 3 remaining filters are more complex, and this PR was already getting large, so I'm going to do those in a follow-up PR. 

For this PR, the DB version of the endpoint should function the same way as the XJoin version, minus the use of these params:
- `staleness`
- `registered_with`
- `filter` (i.e. System Profile filter)
- `fields` (i.e. sparse System Profile fields)

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
