### PR TITLE
fix: Remove configure_logging() from host_reaper.py

### DIFF
--- a/host_reaper.py
+++ b/host_reaper.py
@@ -14,7 +14,6 @@ from app.config import Config
 from app.environment import RuntimeEnvironment
 from app.instrumentation import log_host_delete_failed
 from app.instrumentation import log_host_delete_succeeded
-from app.logging import configure_logging
 from app.logging import get_logger
 from app.logging import threadctx
 from app.models import Host
@@ -145,8 +144,6 @@ def main(logger):
 
 
 if __name__ == "__main__":
-    configure_logging()
-
     logger = get_logger(LOGGER_NAME)
     sys.excepthook = partial(_excepthook, logger)
 


### PR DESCRIPTION
# Overview

After #1569 was merged, the create_app() function is now being run whenever reaper launches. create_app() configures the logger itself, so the host_reaper.py logging configuration call is redundant. It also causes the reaper to hang in certain environments.

This commit removes the redundant call to configure_logging()


## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
