### PR TITLE
feat(RHINENG-5449): add new prometheus metrics

### DIFF
--- a/app/queue/event_producer.py
+++ b/app/queue/event_producer.py
@@ -5,6 +5,8 @@ from confluent_kafka import Producer as KafkaProducer
 from app.instrumentation import message_not_produced
 from app.instrumentation import message_produced
 from app.logging import get_logger
+from app.queue.metrics import produce_large_message_failure
+from app.queue.metrics import produced_message_size
 
 logger = get_logger(__name__)
 
@@ -29,6 +31,7 @@ class MessageDetails:
                 message_to_send = message
             message_not_produced(logger, error, self.topic, self.event, self.key, self.headers, message_to_send)
         else:
+            produced_message_size.observe(len(message.encode("utf8")))
             message_produced(logger, message, self.headers)
 
 

--- a/app/queue/event_producer.py
+++ b/app/queue/event_producer.py
@@ -29,9 +29,10 @@ class MessageDetails:
         if error:
             if error.code() == KafkaError.MSG_SIZE_TOO_LARGE:
                 message_to_send = message
+                produce_large_message_failure.inc()
             message_not_produced(logger, error, self.topic, self.event, self.key, self.headers, message_to_send)
         else:
-            produced_message_size.observe(len(message.encode("utf8")))
+            produced_message_size.observe(len(str(message).encode("utf-8")))
             message_produced(logger, message, self.headers)
 
 

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -32,6 +32,11 @@ ingress_message_handler_failure = Counter(
 ingress_message_handler_time = Summary(
     "inventory_ingress_message_handler_seconds", "Total time spent handling messages from the ingress queue"
 )
+consumed_message_size = Summary("inventory_consumed_message_size", "Size of incoming messages in bytes")
+produced_message_size = Summary("invenotry_produced_message_size", "Size of outgoing messages in bytes")
+produce_large_message_failure = Counter(
+    "inventory_produce_large_message_failures", "Total amount of failures producing messages due to their size"
+)
 version = Info("inventory_mq_service_version", "Build version for the inventory message queue service")
 version.info({"version": get_build_version()})
 event_producer_success = Counter(

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -33,7 +33,7 @@ ingress_message_handler_time = Summary(
     "inventory_ingress_message_handler_seconds", "Total time spent handling messages from the ingress queue"
 )
 consumed_message_size = Summary("inventory_consumed_message_size", "Size of incoming messages in bytes")
-produced_message_size = Summary("invenotry_produced_message_size", "Size of outgoing messages in bytes")
+produced_message_size = Summary("inventory_produced_message_size", "Size of outgoing messages in bytes")
 produce_large_message_failure = Counter(
     "inventory_produce_large_message_failures", "Total amount of failures producing messages due to their size"
 )

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -344,6 +344,7 @@ def event_loop(consumer, flask_app, event_producer, notification_event_producer,
 
                     try:
                         handler(msg.value(), event_producer, notification_event_producer=notification_event_producer)
+                        metrics.consumed_message_size.observe(len(msg.encode("utf8")))
                         metrics.ingress_message_handler_success.inc()
                     except OperationalError as oe:
                         """sqlalchemy.exc.OperationalError: This error occurs when an

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -344,7 +344,7 @@ def event_loop(consumer, flask_app, event_producer, notification_event_producer,
 
                     try:
                         handler(msg.value(), event_producer, notification_event_producer=notification_event_producer)
-                        metrics.consumed_message_size.observe(len(msg.encode("utf8")))
+                        metrics.consumed_message_size.observe(len(str(msg).encode("utf-8")))
                         metrics.ingress_message_handler_success.inc()
                     except OperationalError as oe:
                         """sqlalchemy.exc.OperationalError: This error occurs when an


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-5449](https://issues.redhat.com/browse/RHINENG-5449).
This PR adds the following metrics to HBI: `consumed_message_size`, `produced_message_size` and `produce_large_message_failure`.

Since I'll be away, please feel free to merge commits with fixes if needed, so this PR can be merged as soon as possible.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
