### PR TITLE
Convert GET /system_profile/operating_system endpoint from XJoin to DB (Part 1)

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -49,6 +49,7 @@ from app.queue.events import message_headers
 from app.serialization import deserialize_canonical_facts
 from app.serialization import serialize_host
 from app.utils import Tag
+from app.xjoin import pagination_params
 from lib.feature_flags import FLAG_INVENTORY_DISABLE_XJOIN
 from lib.feature_flags import get_flag_value
 from lib.host_delete import delete_hosts
@@ -464,8 +465,9 @@ def get_host_tag_count(host_id_list, page=1, per_page=100, order_by=None, order_
     current_identity = get_current_identity()
     if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
         logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
+        limit, offset = pagination_params(page, per_page)
         host_list, total = get_host_tags_list_by_id_list_postgres(
-            host_id_list, page, per_page, order_by, order_how, rbac_filter
+            host_id_list, limit, offset, order_by, order_how, rbac_filter
         )
     else:
         host_list, total = get_host_tags_list_by_id_list(
@@ -483,8 +485,9 @@ def get_host_tags(host_id_list, page=1, per_page=100, order_by=None, order_how=N
     current_identity = get_current_identity()
     if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
         logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
+        limit, offset = pagination_params(page, per_page)
         host_list, total = get_host_tags_list_by_id_list_postgres(
-            host_id_list, page, per_page, order_by, order_how, rbac_filter
+            host_id_list, limit, offset, order_by, order_how, rbac_filter
         )
     else:
         host_list, total = get_host_tags_list_by_id_list(

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -489,6 +489,10 @@ def build_system_profile_sap_sids_url(query=None):
     return _build_url(base_url=SYSTEM_PROFILE_URL, path="/sap_sids", query=query)
 
 
+def build_system_profile_operating_system_url(query=None):
+    return _build_url(base_url=SYSTEM_PROFILE_URL, path="/operating_system", query=query)
+
+
 def build_facts_url(host_list_or_id, namespace, query=None):
     return build_hosts_url(path=f"/facts/{namespace}", host_list_or_id=host_list_or_id, query=query)
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-7075](https://issues.redhat.com/browse/RHINENG-7075).

* Add feature flag call in system profile API to call DB method
* Add DB method to aggregate on operating systems
* Enable get_host_list_by_id_list_from_db to only filter on the host list if provided
* Add test case to check aggregation function
* Add api util helper since no test case existed for this endpoint before
* Clean up limit and offset to reuse pagination_params method
* Clean up host query db usage to pass limit offset


## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
