### PR TITLE
[RHINENG-6095] - fix staleness filter

### DIFF
--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -496,66 +496,28 @@ def _build_prs_array(mocker, reporters):
             reporters.extend(OLD_TO_NEW_REPORTER_MAP[old_reporter])
             reporters = list(set(reporters))  # Remove duplicates
     for reporter in reporters:
-        prs_item = {
-            "per_reporter_staleness": {
-                "reporter": {"eq": reporter.replace("!", "")},
-                "AND": (
-                    {
-                        "AND": {
-                            "last_check_in": {"gt": mocker.ANY},
-                            "hostFilter": {"spf_host_type": {"eq": "edge"}},
-                        }
-                    },
-                    {
-                        "AND": {
-                            "last_check_in": {
-                                "gt": mocker.ANY,
-                                "lte": mocker.ANY,
-                            },
-                            "hostFilter": {"spf_host_type": {"eq": "edge"}},
-                        }
-                    },
-                    {
-                        "AND": {
-                            "last_check_in": {
-                                "gt": mocker.ANY,
-                                "lte": mocker.ANY,
-                            },
-                            "hostFilter": {"spf_host_type": {"eq": "edge"}},
-                        }
-                    },
-                    {
-                        "AND": {
-                            "last_check_in": {"gt": mocker.ANY},
-                            "hostFilter": {"spf_host_type": {"eq": None}},
-                        }
-                    },
-                    {
-                        "AND": {
-                            "last_check_in": {
-                                "gt": mocker.ANY,
-                                "lte": mocker.ANY,
-                            },
-                            "hostFilter": {"spf_host_type": {"eq": None}},
-                        }
-                    },
-                    {
-                        "AND": {
-                            "last_check_in": {
-                                "gt": mocker.ANY,
-                                "lte": mocker.ANY,
-                            },
-                            "hostFilter": {"spf_host_type": {"eq": None}},
-                        }
-                    },
-                ),
-            }
-        }
+        prs_item = [
+            {
+                "per_reporter_staleness": {
+                    "last_check_in": {"gt": mocker.ANY},
+                    "hostFilter": {"spf_host_type": {"eq": "edge"}},
+                    "reporter": {"eq": reporter},
+                }
+            },
+            {
+                "per_reporter_staleness": {
+                    "last_check_in": {"gt": mocker.ANY},
+                    "hostFilter": {"spf_host_type": {"eq": None}},
+                    "reporter": {"eq": reporter},
+                }
+            },
+        ]
 
         if reporter.startswith("!"):
             prs_item = {"NOT": prs_item}
 
-        prs_array.append(prs_item)
+        for items in prs_item:
+            prs_array.append(items)
 
     return prs_array
 
@@ -587,10 +549,7 @@ def test_query_variables_registered_with_per_reporter(mocker, graphql_query_empt
             "order_how": mocker.ANY,
             "limit": mocker.ANY,
             "offset": mocker.ANY,
-            "filter": (
-                {"OR": mocker.ANY},
-                {"OR": prs_array},
-            ),
+            "filter": ({"OR": prs_array},),
             "fields": mocker.ANY,
         },
         mocker.ANY,


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-6095](https://issues.redhat.com/browse/RHINENG-6095).

It fixes a issue found when filtering hosts with `registered_with=`, before the it was not able to identify the correct staleness for each of the reporters. Now it is able to filter the hosts by the reporter_staleness correctly.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
