### PR TITLE
RHINENG-7661: Document "edge" hosts hidden by default

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1245,6 +1245,16 @@ components:
       description: >-
         Filters hosts based on system_profile fields. For example:
         <br /><br />
+        &nbsp;&nbsp;&nbsp;&nbsp;{"system_profile": {"sap_system": {"eq": "true"}}}
+        <br /><br />
+        which equates to the URL param:
+        <br /><br />
+        &nbsp;&nbsp;&nbsp;&nbsp;"?filter[system_profile][sap_system][eq]=true"
+        <br /><br />
+        Hosts with host_type "edge" are filtered out by default.
+        <br /><br />
+        To get "edge" hosts, use this explicit filter:
+        <br /><br />
         &nbsp;&nbsp;&nbsp;&nbsp;{"system_profile": {"host_type": {"eq": "edge"}}}
         <br /><br />
         which equates to the URL param:

--- a/swagger/openapi.dev.json
+++ b/swagger/openapi.dev.json
@@ -1981,7 +1981,7 @@
         "in": "query",
         "name": "filter",
         "required": false,
-        "description": "Filters hosts based on system_profile fields. For example: <br /><br /> &nbsp;&nbsp;&nbsp;&nbsp;{\"system_profile\": {\"host_type\": {\"eq\": \"edge\"}}} <br /><br /> which equates to the URL param: <br /><br /> &nbsp;&nbsp;&nbsp;&nbsp;\"?filter[system_profile][host_type][eq]=edge\"",
+        "description": "Filters hosts based on system_profile fields. For example: <br /><br /> &nbsp;&nbsp;&nbsp;&nbsp;{\"system_profile\": {\"sap_system\": {\"eq\": \"true\"}}} <br /><br /> which equates to the URL param: <br /><br /> &nbsp;&nbsp;&nbsp;&nbsp;\"?filter[system_profile][sap_system][eq]=true\" <br /><br /> Hosts with host_type \"edge\" are filtered out by default. <br /><br /> To get \"edge\" hosts, use this explicit filter: <br /><br /> &nbsp;&nbsp;&nbsp;&nbsp;{\"system_profile\": {\"host_type\": {\"eq\": \"edge\"}}} <br /><br /> which equates to the URL param: <br /><br /> &nbsp;&nbsp;&nbsp;&nbsp;\"?filter[system_profile][host_type][eq]=edge\"",
         "style": "deepObject",
         "explode": true,
         "example": {},


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-7661](https://issues.redhat.com/browse/RHINENG-7661).

Mentioning "feature flag" in api call did not look right, so I did not included it.  If we think that it should be included, then the description in swagger/api doc should be:
`Read the entire list of all hosts available to the account, except "edge" hosts, which are hidden by default.  To get "edge" hosts, either use "?filter[system_profile][host_type][eq]=edge" or set the feature flag, "hbi.api.hide-edge-by-default", to "false"`

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
