### PR TITLE
[RHINENG-6095] Fix per reporter staleness filters

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -310,10 +310,6 @@ def build_registered_with_filter(registered_with):
         for reporter in reg_with_copy:
             prs_item = per_reporter_staleness_filter(DEFAULT_STALENESS_VALUES, reporter)
 
-            # If registered_with starts with "!", we want to invert the condition.
-            if reporter.startswith("!"):
-                prs_item = {"NOT": prs_item}
-
             for n_items in prs_item:
                 prs_list.append(n_items)
 

--- a/app/xjoin.py
+++ b/app/xjoin.py
@@ -148,10 +148,24 @@ def _stale_timestamp_per_reporter_filter(gt=None, lte=None, host_type=None, repo
         filter_["gt"] = gt.isoformat()
     if lte:
         filter_["lte"] = lte.isoformat()
-    return {
-        "per_reporter_staleness": {
-            "reporter": {"eq": reporter},
-            "last_check_in": filter_,
-            "hostFilter": {"spf_host_type": {"eq": host_type}},
+
+    if reporter.startswith("!"):
+        return {
+            "AND": {
+                "spf_host_type": {"eq": host_type},
+                "NOT": {
+                    "per_reporter_staleness": {"reporter": {"eq": reporter.replace("!", "")}},
+                },
+                "modified_on": filter_,
+            }
         }
-    }
+    else:
+        return {
+            "AND": {
+                "spf_host_type": {"eq": host_type},
+                "per_reporter_staleness": {
+                    "reporter": {"eq": reporter.replace("!", "")},
+                    "last_check_in": filter_,
+                },
+            }
+        }


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-6095](https://issues.redhat.com/browse/RHINENG-6095).
It fixes the issue with the `registered_with=!reporter` and also the issue @msager27 found when retrieving a host with two reporters. Before if the custom staleness was just set for the `conventional` hosts, the graphql was ignoring the host_type and returning all systems independently.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
