### PR TITLE
[RHINENG-6095] - Fix registered_with and staleness filters

### DIFF
--- a/api/filtering/filtering.py
+++ b/api/filtering/filtering.py
@@ -472,13 +472,14 @@ def query_filters(
     if tags:
         tag_filters = build_tag_query_dict_tuple(tags)
         query_filters += ({"OR": tag_filters},)
+
     if staleness:
-        if not registered_with:
-            staleness_filters = tuple(staleness_filter(staleness))
-            query_filters += ({"OR": staleness_filters},)
+        staleness_filters = tuple(staleness_filter(staleness))
+        query_filters += ({"OR": staleness_filters},)
 
     if registered_with:
         query_filters += build_registered_with_filter(registered_with)
+
     if provider_type:
         query_filters += ({"provider_type": {"eq": provider_type.casefold()}},)
     if provider_id:

--- a/tests/fixtures/graphql_fixtures.py
+++ b/tests/fixtures/graphql_fixtures.py
@@ -152,62 +152,125 @@ def assert_tag_query_host_filter_single_call(mocker, api_get, graphql_tag_query_
 @pytest.fixture(scope="function")
 def assert_tag_query_host_filter_for_field(mocker, assert_tag_query_host_filter_single_call):
     def _assert_tag_query_host_filter_for_field(url, field, matcher, value, status=200):
-        return assert_tag_query_host_filter_single_call(
-            url=url,
-            host_filter={
-                "AND": ({field: {matcher: value.casefold() if field in CASEFOLDED_FIELDS else value}},),
-                "OR": [
+        if "provider" in field:
+            return assert_tag_query_host_filter_single_call(
+                url=url,
+                host_filter=(
                     {
-                        "AND": {
-                            "modified_on": {"gt": mocker.ANY},
-                            "spf_host_type": {"eq": "edge"},
-                        }
-                    },
-                    {
-                        "AND": {
-                            "modified_on": {
-                                "gt": mocker.ANY,
-                                "lte": mocker.ANY,
+                        "OR": (
+                            {
+                                "AND": {
+                                    "modified_on": {"gt": mocker.ANY},
+                                    "spf_host_type": {"eq": "edge"},
+                                }
                             },
-                            "spf_host_type": {"eq": "edge"},
-                        }
-                    },
-                    {
-                        "AND": {
-                            "modified_on": {
-                                "gt": mocker.ANY,
-                                "lte": mocker.ANY,
+                            {
+                                "AND": {
+                                    "modified_on": {
+                                        "gt": mocker.ANY,
+                                        "lte": mocker.ANY,
+                                    },
+                                    "spf_host_type": {"eq": "edge"},
+                                }
                             },
-                            "spf_host_type": {"eq": "edge"},
-                        }
-                    },
-                    {
-                        "AND": {
-                            "modified_on": {"gt": mocker.ANY},
-                            "spf_host_type": {"eq": None},
-                        }
-                    },
-                    {
-                        "AND": {
-                            "modified_on": {
-                                "gt": mocker.ANY,
-                                "lte": mocker.ANY,
+                            {
+                                "AND": {
+                                    "modified_on": {
+                                        "gt": mocker.ANY,
+                                        "lte": mocker.ANY,
+                                    },
+                                    "spf_host_type": {"eq": "edge"},
+                                }
                             },
-                            "spf_host_type": {"eq": None},
-                        }
-                    },
-                    {
-                        "AND": {
-                            "modified_on": {
-                                "gt": mocker.ANY,
-                                "lte": mocker.ANY,
+                            {
+                                "AND": {
+                                    "modified_on": {"gt": mocker.ANY},
+                                    "spf_host_type": {"eq": None},
+                                }
                             },
-                            "spf_host_type": {"eq": None},
-                        }
+                            {
+                                "AND": {
+                                    "modified_on": {
+                                        "gt": mocker.ANY,
+                                        "lte": mocker.ANY,
+                                    },
+                                    "spf_host_type": {"eq": None},
+                                }
+                            },
+                            {
+                                "AND": {
+                                    "modified_on": {
+                                        "gt": mocker.ANY,
+                                        "lte": mocker.ANY,
+                                    },
+                                    "spf_host_type": {"eq": None},
+                                }
+                            },
+                        )
                     },
-                ],
-            },
-            status=status,
-        )
+                    {field: {matcher: value.casefold() if field in CASEFOLDED_FIELDS else value}},
+                ),
+                status=status,
+            )
+        else:
+            return assert_tag_query_host_filter_single_call(
+                url=url,
+                host_filter=(
+                    {field: {matcher: value.casefold() if field in CASEFOLDED_FIELDS else value}},
+                    {
+                        "OR": (
+                            {
+                                "AND": {
+                                    "modified_on": {"gt": mocker.ANY},
+                                    "spf_host_type": {"eq": "edge"},
+                                }
+                            },
+                            {
+                                "AND": {
+                                    "modified_on": {
+                                        "gt": mocker.ANY,
+                                        "lte": mocker.ANY,
+                                    },
+                                    "spf_host_type": {"eq": "edge"},
+                                }
+                            },
+                            {
+                                "AND": {
+                                    "modified_on": {
+                                        "gt": mocker.ANY,
+                                        "lte": mocker.ANY,
+                                    },
+                                    "spf_host_type": {"eq": "edge"},
+                                }
+                            },
+                            {
+                                "AND": {
+                                    "modified_on": {"gt": mocker.ANY},
+                                    "spf_host_type": {"eq": None},
+                                }
+                            },
+                            {
+                                "AND": {
+                                    "modified_on": {
+                                        "gt": mocker.ANY,
+                                        "lte": mocker.ANY,
+                                    },
+                                    "spf_host_type": {"eq": None},
+                                }
+                            },
+                            {
+                                "AND": {
+                                    "modified_on": {
+                                        "gt": mocker.ANY,
+                                        "lte": mocker.ANY,
+                                    },
+                                    "spf_host_type": {"eq": None},
+                                }
+                            },
+                        )
+                    },
+                ),
+                status=status,
+            )
 
     return _assert_tag_query_host_filter_for_field


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-6095](https://issues.redhat.com/browse/RHINENG-6095).

It fixes a reported issue that was found in production where the hosts were being marked as stale and it was not able to query hosts using `registered_with` and `staleness` filters together.

Also, it standardize the Tags and System profile graphQL query filters to match the same structure of Hosts query.


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
