### PR TITLE
RHINENG-4837: Add dumb-init to enable hbi processes using PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ENV PIPENV_VENV_IN_PROJECT=1
 
 RUN python3 -m pip install --upgrade pip setuptools wheel && \
     python3 -m pip install pipenv && \
+    python3 -m pip install dumb-init && \
     pipenv install --system --dev
 
 # allows pre-commit and unit tests to run successfully within the container if image is built in "test" environment
@@ -46,4 +47,4 @@ RUN microdnf remove -y $( comm -13 packages-before-devel-install.txt packages-af
 
 USER 1001
 
-CMD bash -c 'make upgrade_db && make run_inv_mq_service'
+ENTRYPOINT [ "dumb-init", ]

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -138,9 +138,7 @@ objects:
       minReplicas: ${{REPLICAS_PMIN}}
       podSpec:
         command:
-        - /bin/sh
-        - -c
-        - python3 inv_mq_service.py
+        - ./inv_mq_service.py
         env:
         - name: INVENTORY_LOG_LEVEL
           value: ${LOG_LEVEL}
@@ -221,9 +219,7 @@ objects:
           - FLASK_APP=manage.py flask db upgrade
           inheritEnv: true
         command:
-        - /bin/sh
-        - -c
-        - python3 inv_mq_service.py
+        - ./inv_mq_service.py
         env:
         - name: INVENTORY_LOG_LEVEL
           value: ${LOG_LEVEL}
@@ -298,9 +294,7 @@ objects:
       minReplicas: ${{REPLICAS_SP}}
       podSpec:
         command:
-        - /bin/sh
-        - -c
-        - python3 inv_mq_service.py
+        - ./inv_mq_service.py
         env:
         - name: INVENTORY_LOG_LEVEL
           value: ${LOG_LEVEL}
@@ -379,9 +373,7 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: Never
         command:
-          - /bin/sh
-          - -c
-          - python3 host_reaper.py
+          - ./host_reaper.py
         env:
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
@@ -443,9 +435,7 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: Never
         command:
-          - /bin/sh
-          - -c
-          - python3 system_profile_validator.py
+          - ./system_profile_validator.py
         env:
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
@@ -527,9 +517,7 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: Never
         command:
-          - /bin/sh
-          - -c
-          - python3 pendo_syncher.py
+          - ./pendo_syncher.py
         env:
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
@@ -574,9 +562,7 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: OnFailure
         command:
-          - /bin/sh
-          - -c
-          - python3 rebuild_events_topic.py && python3 host_synchronizer.py
+          - ./rebuild_events_topic.py && ./host_synchronizer.py
         env:
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -1,3 +1,4 @@
+#!/bin/python
 import sys
 from functools import partial
 

--- a/host_synchronizer.py
+++ b/host_synchronizer.py
@@ -1,3 +1,4 @@
+#!/bin/python
 import sys
 from functools import partial
 

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -1,3 +1,4 @@
+#!/bin/python
 from functools import partial
 
 from confluent_kafka import Consumer as KafkaConsumer

--- a/pendo_syncher.py
+++ b/pendo_syncher.py
@@ -1,3 +1,4 @@
+#!/bin/python
 import json
 import sys
 from functools import partial

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -1,3 +1,4 @@
+#!/bin/python
 import json
 import sys
 from datetime import datetime

--- a/system_profile_validator.py
+++ b/system_profile_validator.py
@@ -1,3 +1,4 @@
+#!/bin/python
 import json
 import sys
 from functools import partial


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-4837](https://issues.redhat.com/browse/RHINENG-4837).
@RonnyPfannschmidt here is the PR for your review.  

With the use of `ENTRYPOINT [ "dumb-init", ]`, now the HBI process run with `PID 1`
```
$ k exec -it host-inventory-mq-pmin-6869b8df94-cpxll -- top

top - 22:53:39 up 46 min,  0 users,  load average: 0.34, 0.48, 0.66
Tasks:   2 total,   1 running,   1 sleeping,   0 stopped,   0 zombie
%Cpu(s):  3.2 us,  1.4 sy,  0.0 ni, 94.2 id,  1.1 wa,  0.0 hi,  0.1 si,  0.1 st
MiB Mem :  15995.9 total,   2702.1 free,   4734.1 used,   8559.7 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.  10352.0 avail Mem 

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                                                                
      1 1001      20   0 1717820  82560  19340 S   0.3   0.5   0:10.93 inv_mq_service.                                                                        
    564 1001      20   0   52144   4172   3452 R   0.0   0.0   0:00.00 top                                                                                    

$ k exec -it host-inventory-service-b5498db47-5pqlp -- top

top - 22:55:19 up 48 min,  0 users,  load average: 0.67, 0.51, 0.65
Tasks:   6 total,   1 running,   5 sleeping,   0 stopped,   0 zombie
%Cpu(s):  2.3 us,  2.3 sy,  0.0 ni, 94.3 id,  1.1 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :  15995.9 total,   2679.2 free,   4746.2 used,   8570.5 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.  10330.5 avail Mem 

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                                                                
      1 1001      20   0  350228  70784  14452 S   0.0   0.4   0:01.43 gunicorn                                                                               
      8 1001      20   0 1203212  77488  13592 S   0.0   0.5   0:07.69 gunicorn                                                                               
      9 1001      20   0 1276948  77424  13508 S   0.0   0.5   0:06.87 gunicorn                                                                               
     10 1001      20   0 1277460  79244  14416 S   0.0   0.5   0:06.44 gunicorn                                                                               
     11 1001      20   0 1276948  77496  13592 S   0.0   0.5   0:06.68 gunicorn                                                                               
    213 1001      20   0   52144   4232   3508 R   0.0   0.0   0:00.00 top                                                                                    
```

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
