### PR TITLE
Enable development openapi spec and customer facing spec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
   rev: v4.0.4
   hooks:
   - id: swagger-validation
-    args: ["bundle", "swagger/api.spec.yaml", "-o", "swagger/openapi.json"]
+    args: ["bundle", "swagger/api.spec.yaml", "-o", "swagger/openapi.dev.json"]
 - repo: https://github.com/APIDevTools/swagger-cli
   rev: v4.0.4
   hooks:

--- a/api/spec.py
+++ b/api/spec.py
@@ -1,0 +1,17 @@
+import json
+
+from flask import Blueprint
+from flask import jsonify
+
+spec_blueprint = Blueprint("openapispec", __name__)
+
+
+@spec_blueprint.route("/openapi.json", methods=["GET"])
+def openapi():
+    openapi_spec = {}
+    try:
+        openapi_spec = json.loads("../swagger/openapi.json")
+    except ValueError:
+        pass
+
+    return jsonify(openapi_spec)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,6 +14,7 @@ from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
 
 from api.mgmt import monitoring_blueprint
 from api.parsing import customURIParser
+from api.spec import spec_blueprint
 from app import payload_tracker
 from app.config import Config
 from app.custom_validator import build_validator_map
@@ -43,7 +44,7 @@ REQUEST_ID_HEADER = "x-rh-insights-request-id"
 
 # temporary replaced for ESSNTL-746 - correct normalization of the bundled spec
 # SPECIFICATION_FILE = join(SPECIFICATION_DIR, "api.spec.yaml")
-SPECIFICATION_FILE = join(SPECIFICATION_DIR, "openapi.json")
+SPECIFICATION_FILE = join(SPECIFICATION_DIR, "openapi.dev.json")
 SYSTEM_PROFILE_SPECIFICATION_FILE = join(SPECIFICATION_DIR, "system_profile.spec.yaml")
 SYSTEM_PROFILE_BLOCK_LIST_FILE = join(SPECIFICATION_DIR, "system_profile_block_list.yaml")
 
@@ -253,6 +254,8 @@ def create_app(runtime_environment):
     register_shutdown(db.get_engine(flask_app).dispose, "Closing database")
 
     flask_app.register_blueprint(monitoring_blueprint, url_prefix=app_config.mgmt_url_path_prefix)
+    for api_url in app_config.api_urls:
+        flask_app.register_blueprint(spec_blueprint, url_prefix=api_url, name=f"{api_url}{spec_blueprint.name}")
 
     @flask_app.before_request
     def set_request_id():

--- a/swagger/openapi.dev.json
+++ b/swagger/openapi.dev.json
@@ -1472,6 +1472,139 @@
           }
         }
       }
+    },
+    "/assignment-rules": {
+      "get": {
+        "operationId": "api.assignment_rule.get_assignment_rules_list",
+        "tags": [
+          "groups"
+        ],
+        "summary": "Read the entire list of assignment-rules [Not Implemented]",
+        "description": "Read the entire list of all assignment-rules available to the account. [Not Implemented] Required permissions: inventory:groups:read",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/assignmentRuleName"
+          },
+          {
+            "$ref": "#/components/parameters/perPageParam"
+          },
+          {
+            "$ref": "#/components/parameters/pageParam"
+          },
+          {
+            "$ref": "#/components/parameters/assignmentRuleOrderByParam"
+          },
+          {
+            "$ref": "#/components/parameters/assignmentRuleOrderHowParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully read the assignment-rules list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignmentRuleQueryOutput"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "api.assignment_rule.create_assignment_rule",
+        "tags": [
+          "groups"
+        ],
+        "summary": "Create Assignment Rule object",
+        "description": "Create Assignment Rule object using post request <br /><br /> Required permissions: inventory:groups:write",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "description": "Data required to create Assignment Rule object",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignmentRuleIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Assignment Rule created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignmentRuleOut"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/assignment-rules/{assignment_rule_id_list}": {
+      "get": {
+        "operationId": "api.assignment_rule.get_assignment_rules_by_id",
+        "tags": [
+          "groups"
+        ],
+        "summary": "Find assignment rules by their IDs",
+        "description": "Find one or more assignment rules by their IDs. <br /><br /> Required permissions: inventory:groups:read",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/assignmentRuleIdList"
+          },
+          {
+            "$ref": "#/components/parameters/perPageParam"
+          },
+          {
+            "$ref": "#/components/parameters/pageParam"
+          },
+          {
+            "$ref": "#/components/parameters/assignmentRuleOrderByParam"
+          },
+          {
+            "$ref": "#/components/parameters/assignmentRuleOrderHowParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully searched for assignment rules.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignmentRuleQueryOutput"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request."
+          },
+          "404": {
+            "description": "Assignment rules not found."
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-8613](https://issues.redhat.com/browse/RHINENG-8613).
* Duplicate existing openapi spec for development use with connexion
* Update cutomer facing openapi spec to remove assignment-rules endpoints
* Add new blueprint for serving customer facing spec
* Alter connexion to load from the development spec
* Update pre-commit check to update the development spec now
* In order to make API visible you will need to update the customer facing spec

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
