### PR TITLE
Update selenium image and disable parallel testing in integration testing

### DIFF
--- a/deploy/testing-integration.yml
+++ b/deploy/testing-integration.yml
@@ -145,7 +145,7 @@ parameters:
 - name: IQE_TEST_IMPORTANCE
   value: ''
 - name: IQE_SEL_IMAGE
-  value: 'quay.io/redhatqe/selenium-standalone:ff_91.9.1esr_chrome_103.0.5060.114'
+  value: 'quay.io/redhatqe/selenium-standalone:ff_102.9.0esr_chrome_112.0.5615.121'
 - name: IQE_CPU_LIMIT
   value: "1"
 - name: IQE_MEMORY_LIMIT
@@ -164,3 +164,5 @@ parameters:
   value: 1Gi
 - name: VNC_GEOMETRY
   value: '1920x1080'
+- name: IQE_PARALLEL_ENABLED
+  value: 'false'

--- a/deploy/testing-integration.yml
+++ b/deploy/testing-integration.yml
@@ -145,7 +145,7 @@ parameters:
 - name: IQE_TEST_IMPORTANCE
   value: ''
 - name: IQE_SEL_IMAGE
-  value: 'quay.io/redhatqe/selenium-standalone:ff_102.9.0esr_chrome_112.0.5615.121'
+  value: 'quay.io/redhatqe/selenium-standalone:latest'
 - name: IQE_CPU_LIMIT
   value: "1"
 - name: IQE_MEMORY_LIMIT


### PR DESCRIPTION
# Overview

Update the selenium standalone image to the latest image in quay.io/redhatqe/.
I also att a new value `IQE_PARALLEL_ENABLED` to false. The default value was true but we are not using parallel testing right now.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs