### PR TITLE
fix(RHINENG-8730): Change max values of time_to_delete to 2 years

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -904,12 +904,22 @@ class InputAssignmentRule(MarshmallowSchema):
 
 
 class StalenessSchema(MarshmallowSchema):
-    conventional_time_to_stale = fields.Integer(validate=marshmallow_validate.Range(min=1, max=2147483647))
-    conventional_time_to_stale_warning = fields.Integer(validate=marshmallow_validate.Range(min=1, max=2147483647))
-    conventional_time_to_delete = fields.Integer(validate=marshmallow_validate.Range(min=1, max=2147483647))
-    immutable_time_to_stale = fields.Integer(validate=marshmallow_validate.Range(min=1, max=2147483647))
-    immutable_time_to_stale_warning = fields.Integer(validate=marshmallow_validate.Range(min=1, max=2147483647))
-    immutable_time_to_delete = fields.Integer(validate=marshmallow_validate.Range(min=1, max=2147483647))
+    conventional_time_to_stale = fields.Integer(
+        validate=marshmallow_validate.Range(min=1, max=604800)
+    )  # Max of 7 days
+    conventional_time_to_stale_warning = fields.Integer(
+        validate=marshmallow_validate.Range(min=1, max=15552000)
+    )  # Max of 180 days
+    conventional_time_to_delete = fields.Integer(
+        validate=marshmallow_validate.Range(min=1, max=63072000)
+    )  # Max of 2 years
+    immutable_time_to_stale = fields.Integer(validate=marshmallow_validate.Range(min=1, max=604800))  # Max of 7 days
+    immutable_time_to_stale_warning = fields.Integer(
+        validate=marshmallow_validate.Range(min=1, max=15552000)
+    )  # Max of 180 days
+    immutable_time_to_delete = fields.Integer(
+        validate=marshmallow_validate.Range(min=1, max=63072000)
+    )  # Max of 2 years
 
     @validates_schema
     def validate_staleness(self, data, **kwargs):


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-8730](https://issues.redhat.com/browse/RHINENG-8730).
Change the max value of `time_to_delete` to 2 years. It fixes an issue where xjoin-search was not accepting values larger than 54 years.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
