### PR TITLE
feat(RHINENG-8613): Fix blueprint serving customer facing openapi spec

### DIFF
--- a/api/spec.py
+++ b/api/spec.py
@@ -1,8 +1,11 @@
 import json
+import os
 
 from flask import Blueprint
 from flask import jsonify
 
+CURRENT_DIR = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+SPECIFICATION_FILE = os.path.join(CURRENT_DIR, "swagger", "openapi.json")
 spec_blueprint = Blueprint("openapispec", __name__)
 
 
@@ -10,7 +13,8 @@ spec_blueprint = Blueprint("openapispec", __name__)
 def openapi():
     openapi_spec = {}
     try:
-        openapi_spec = json.loads("../swagger/openapi.json")
+        with open(SPECIFICATION_FILE) as spec_file:
+            openapi_spec = json.load(spec_file)
     except ValueError:
         pass
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -181,7 +181,11 @@ def process_system_profile_spec():
 
 
 def create_app(runtime_environment):
-    connexion_options = {"swagger_ui": True, "uri_parser_class": customURIParser}
+    connexion_options = {
+        "swagger_ui": True,
+        "uri_parser_class": customURIParser,
+        "openapi_spec_path": "/dev/openapi.json",
+    }
     # This feels like a hack but it is needed.  The logging configuration
     # needs to be setup before the flask app is initialized.
     configure_logging()


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-xxxx](https://issues.redhat.com/browse/RHINENG-xxxx).
* Altered the dev spec path of the connexion openapi spec to avoid conflicts
* Corrected file loading

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
