### PR TITLE
chore(RHINENG-5842): Remove Edge-Parity RBAC bypass

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -11,14 +11,12 @@ logger = get_logger(__name__)
 FLAG_INVENTORY_ASSIGNMENT_RULES = "hbi.group-assignment-rules"
 FLAG_INVENTORY_CUSTOM_STALENESS = "hbi.custom-staleness"
 FLAG_HIDE_EDGE_HOSTS = "hbi.api.hide-edge-by-default"
-FLAG_EDGE_PARITY_MIGRATION = "edgeParity.groups-migration"
 FLAG_INVENTORY_DISABLE_XJOIN = "hbi.api.disable-xjoin"
 
 FLAG_FALLBACK_VALUES = {
     FLAG_INVENTORY_ASSIGNMENT_RULES: True,
     FLAG_INVENTORY_CUSTOM_STALENESS: True,
     FLAG_HIDE_EDGE_HOSTS: False,
-    FLAG_EDGE_PARITY_MIGRATION: False,
     FLAG_INVENTORY_DISABLE_XJOIN: False,
 }
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-5842](https://issues.redhat.com/browse/RHINENG-5842).
Removes the RBAC bypass that was introduced in #1580, along with the feature flag it was using. It was originally introduced to facilitate the migration to Inventory Groups for the Edge Parity project. 

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
