### PR TITLE
Fixed typo in error message in add_host_list_to_group().

### DIFF
--- a/api/host_group.py
+++ b/api/host_group.py
@@ -28,10 +28,10 @@ logger = get_logger(__name__)
 @metrics.api_request_time.time()
 def add_host_list_to_group(group_id, body, rbac_filter=None):
     if type(body) is not list:
-        return abort(HTTPStatus.BAD_REQUEST, f"Body content must be an array with groups UUIDs, not {type(body)}")
+        return abort(HTTPStatus.BAD_REQUEST, f"Body content must be an array with system UUIDs, not {type(body)}")
 
     if len(body) == 0:
-        return abort(HTTPStatus.BAD_REQUEST, "Body content must be an array with groups UUIDs, not an empty array")
+        return abort(HTTPStatus.BAD_REQUEST, "Body content must be an array with system UUIDs, not an empty array")
 
     rbac_group_id_check(rbac_filter, {group_id})
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-8436](https://issues.redhat.com/browse/RHINENG-8436).

When getting a 400 error message on /groups/{group_id}/hosts, the text mentions 'Body content must be an array with **groups** UUIDs' when the expected list should be the an array with **system** UUIDs'.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
