### PR TITLE
Move Reaper's session_guard for smaller rollbacks

### DIFF
--- a/host_reaper.py
+++ b/host_reaper.py
@@ -111,7 +111,7 @@ def find_hosts_to_delete(logger, session):
 def run(config, logger, session, event_producer, shutdown_handler):
     filter_hosts_to_delete = find_hosts_to_delete(logger, session)
 
-    query = session.query(Host).filter(or_(False, *filter_hosts_to_delete)).limit(config.host_delete_chunk_size)
+    query = session.query(Host).filter(or_(False, *filter_hosts_to_delete))
     hosts_processed = config.host_delete_chunk_size
 
     while hosts_processed == config.host_delete_chunk_size:

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -110,14 +110,19 @@ def find_hosts_to_delete(logger, session):
 @host_reaper_fail_count.count_exceptions()
 def run(config, logger, session, event_producer, shutdown_handler):
     filter_hosts_to_delete = find_hosts_to_delete(logger, session)
-    query = session.query(Host).filter(or_(False, *filter_hosts_to_delete))
 
-    events = delete_hosts(query, event_producer, config.host_delete_chunk_size, shutdown_handler.shut_down)
-    for host_id, deleted in events:
-        if deleted:
-            log_host_delete_succeeded(logger, host_id, "REAPER")
-        else:
-            log_host_delete_failed(logger, host_id, "REAPER")
+    query = session.query(Host).filter(or_(False, *filter_hosts_to_delete)).limit(config.host_delete_chunk_size)
+    hosts_processed = config.host_delete_chunk_size
+
+    while hosts_processed == config.host_delete_chunk_size:
+        with session_guard(session):
+            events = delete_hosts(query, event_producer, config.host_delete_chunk_size, shutdown_handler.shut_down)
+            hosts_processed = len(list(events))
+            for host_id, deleted in events:
+                if deleted:
+                    log_host_delete_succeeded(logger, host_id, "REAPER")
+                else:
+                    log_host_delete_failed(logger, host_id, "REAPER")
 
 
 def main(logger):
@@ -140,8 +145,7 @@ def main(logger):
     shutdown_handler = ShutdownHandler()
     shutdown_handler.register()
 
-    with session_guard(session):
-        run(config, logger, session, event_producer, shutdown_handler)
+    run(config, logger, session, event_producer, shutdown_handler)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Overview

This PR is being created to address a Reaper issue. The job runs for a long time, and then when it hits an error, it rolls back _all_ of its changes. With these changes, it will instead only roll back up to a max defined by `host_delete_chunk_size` (default 1000).

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
