### PR TITLE
RHINENG-9031: Fix paths to python scripts

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -368,7 +368,7 @@ objects:
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: Never
-        args: ["host_reaper.py"]
+        args: ["./host_reaper.py"]
         env:
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
@@ -429,7 +429,7 @@ objects:
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: Never
-        args: ["system_profile_validator.py"]
+        args: ["./system_profile_validator.py"]
         env:
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
@@ -510,7 +510,7 @@ objects:
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: Never
-        args: ["pendo_syncher.py"]
+        args: ["./pendo_syncher.py"]
         env:
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
@@ -554,7 +554,7 @@ objects:
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         restartPolicy: OnFailure
-        args: ["rebuild_events_topic.py", "&&", "python3 host_synchronizer.py"]
+        args: ["./rebuild_events_topic.py", "&&", "./host_synchronizer.py"]
         env:
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9031](https://issues.redhat.com/browse/RHINENG-9031
Paths to some python scripts were not updated to work with dumb-init.  Now they have been.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
