### PR TITLE
bug(rhineng-9037): Naively handle null string conversion in tags

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -212,6 +212,12 @@ def params_to_order_by_for_tags(order_by: str = None, order_how: str = None) -> 
     return ordering
 
 
+def _convert_null_string(input: str):
+    if input == "null":
+        return None
+    return input
+
+
 def get_tag_list(
     display_name: str,
     fqdn: str,
@@ -298,7 +304,10 @@ def get_tag_list(
     query_results = query.offset(offset).limit(limit).all()
     tag_list = []
     for result in query_results:
-        tag = {"tag": {"namespace": result[0], "key": result[1], "value": result[2]}, "count": result[3]}
+        namespace = _convert_null_string(result[0])
+        tagkey = _convert_null_string(result[1])
+        tagvalue = _convert_null_string(result[2])
+        tag = {"tag": {"namespace": namespace, "key": tagkey, "value": tagvalue}, "count": result[3]}
         tag_list.append(tag)
     return tag_list, query_count
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -174,7 +174,7 @@ def test_get_list_of_tags_with_host_filters_via_db(db_create_multiple_hosts, api
     insights_id = generate_uuid()
     provider_id = generate_uuid()
     display_name = "test-example-host"
-    namespace = "insights-client"
+    namespace = None
     tag_key = "database"
     tag_value = "postgresql"
     per_reporter_staleness = {


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9037](https://issues.redhat.com/browse/RHINENG-9037).
* All of the search and filtering converts tag items to text creating "null" strings
* Naively convert "null" strings back to null values
* Assume edge case of intended "null" string is not necessary and could be documented

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
