### PR TITLE
Make all index create/drop calls concurrent

### DIFF
--- a/migrations/versions/7c97d8464b6b_add_indexes_for_display_name_and_system_.py
+++ b/migrations/versions/7c97d8464b6b_add_indexes_for_display_name_and_system_.py
@@ -17,8 +17,15 @@ depends_on = None
 
 def upgrade():
     with op.get_context().autocommit_block():
-        op.create_index("idxdisplay_name", "hosts", ["display_name"], unique=False, if_not_exists=True)
-        op.drop_index("idxaccount", table_name="hosts", if_exists=True)
+        op.create_index(
+            "idxdisplay_name",
+            "hosts",
+            ["display_name"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.drop_index("idxaccount", table_name="hosts", postgresql_concurrently=True, if_exists=True)
         op.create_index(
             "idxsystem_profile_facts",
             "hosts",
@@ -38,7 +45,7 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_index("idxdisplay_name", table_name="hosts", if_exists=True)
-    op.drop_index("idxsystem_profile_facts", table_name="hosts", if_exists=True)
-    op.drop_index("idxgroups", table_name="hosts", if_exists=True)
-    op.create_index("idxaccount", "hosts", ["account"], unique=False, if_not_exists=True)
+    op.drop_index("idxdisplay_name", table_name="hosts", postgresql_concurrently=True, if_exists=True)
+    op.drop_index("idxsystem_profile_facts", table_name="hosts", postgresql_concurrently=True, if_exists=True)
+    op.drop_index("idxgroups", table_name="hosts", postgresql_concurrently=True, if_exists=True)
+    op.create_index("idxaccount", "hosts", ["account"], unique=False, postgresql_concurrently=True, if_not_exists=True)


### PR DESCRIPTION
# Overview

This PR is being created to address an issue with the latest DB upgrade. This change should make all the index creation and deletion concurrent, so nothing should be locking the DB.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
