### PR TITLE
fix(RHINENG-9081) Don't allow simultaneous DB upgrades

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -79,8 +79,12 @@ def run_migrations_online():
 
     try:
         with context.begin_transaction():
+            # Lock so multiple pods don't run the same migration simultaneously
+            context.execute("select pg_advisory_lock(1);")
             context.run_migrations()
     finally:
+        # Release the lock
+        context.execute("select pg_advisory_unlock(1);")
         connection.close()
 
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9081](https://issues.redhat.com/browse/RHINENG-9081).
Uses an advisory lock to make it so multiple pods can't run the DB migration upgrades simultaneously. This will help us to avoid situations similar to what we saw last week, where the pods had all started building the same index concurrently, so there were 3 Postgres processes trying to build it at once.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
