### PR TITLE
bug(rhineng-9037): Handle embedded percents and colons values

### DIFF
--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -190,6 +190,15 @@ def _unique_paths(
     return all_filters
 
 
+def escape_sql_from_string_val(val: str) -> str:
+    value = val
+    if "%" in value:
+        value = value.replace("%", r"\%")
+    if ":" in value:
+        value = value.replace(":", r"\:")
+    return value
+
+
 def build_single_text_filter(filter_param: dict) -> str:
     field_name = next(iter(filter_param.keys()))
 
@@ -203,6 +212,7 @@ def build_single_text_filter(filter_param: dict) -> str:
         logger.debug(f"generating filter: field: {field_name}, type: {field_filter}, field_input: {field_input}")
 
         jsonb_path, pg_op, value = _convert_dict_to_text_filter_and_value(filter_param, field_filter == "array")
+        value = escape_sql_from_string_val(value)
 
         if not pg_op:
             pg_op = POSTGRES_DEFAULT_COMPARATOR.get(field_filter)

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1173,6 +1173,33 @@ def test_query_all_sparse_fields(db_create_multiple_hosts, api_get):
         assert "owner_id" not in result["system_profile"]
 
 
+def test_query_sys_profile_with_sql_characters(db_create_multiple_hosts, api_get):
+    # Create hosts that have a system profile
+    sp_data = {
+        "system_profile_facts": {
+            "arch": "x86_64",
+            "os_kernel_version": "4.18.2",
+            "host_type": "edge",
+            "owner_id": "1b36b20f-7fa0-4454-a6d2-008294e06378",
+        }
+    }
+    db_create_multiple_hosts(how_many=3, extra_data=sp_data)
+    url = build_hosts_url(query="?filter[system_profile][bios_vendor]=%3E/%3AX%26x5wVZCj%25mC")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+
+    # Assert that the system_profile is not in the response by default
+    for result in response_data["results"]:
+        assert "system_profile" in result
+        assert "arch" in result["system_profile"]
+        assert "host_type" in result["system_profile"]
+        assert "os_kernel_version" not in result["system_profile"]
+        assert "owner_id" not in result["system_profile"]
+
+
 def test_query_by_id_sparse_fields(db_create_multiple_hosts, api_get):
     # Create hosts that have a system profile
     sp_data = {


### PR DESCRIPTION


# Overview

This PR is being created to address [RHINENG-9037](https://issues.redhat.com/browse/RHINENG-9037).
* escape values with percents and colons to avoid unintended SQL interaction.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
