### PR TITLE
bug(rhineng-9037): Fix 500s when values have SQL chars that need escaping

### DIFF
--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -227,8 +227,12 @@ def escape_sql_from_string_val(val: str) -> str:
     value = val
     if "%" in value:
         value = value.replace("%", r"\%")
+    if "/" in value:
+        value = value.replace("/", r"\/")
     if ":" in value:
         value = value.replace(":", r"\:")
+    if "'" in value:
+        value = value.replace("'", r"''")
     return value
 
 

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1687,3 +1687,21 @@ def test_query_all_sp_filters_invalid_operating_system(api_get, sp_filter_param)
         response_status, _ = api_get(url)
 
     assert response_status == 400
+
+
+@pytest.mark.parametrize(
+    "sp_filter_param",
+    (
+        "[arch]=RkFz%60Z%2Ag%5D9_tW%3A%2CR%27v%22sjJsEo%23R%5D%27%27n.N2%3D%60G%22R%7C%7C.ER/1/wd6%603w-71%3CxC2",
+        "[arch]=%5B%3Cb_Tu%7Dd%21%5D%7C/%22%29IS-%3Ct%28EwU%3F%3C4s7%7Cv%5DRE5hSU%3AQRJ%7D%29%230%27Vcf7%60eU%25k%2B/Cp%3CSxgKopb%3E%60",  # noqa E501
+        "[arch]=%26.%40%7DE%21_A%2AE%26dgjV%7D%60yPc%22wO%7B%21b0%28kAGL%24-3mh%5EV%3E86%27RmG%7D.%2C5xQI~W/d%23/n%5DAr%22T",  # noqa E501
+        "[arch]=EElM%298Z%28%29HjNL%21oRSc/gxC2%24%5Dpc%27tv%2A~mW%22kiF%7Ddos%60TE%7D%7DpAZ9C%3CNCRsEb%5BxH0",
+    ),
+)
+def test_query_all_sp_filters_sql_character_issues(api_get, sp_filter_param):
+    url = build_hosts_url(query=f"?filter[system_profile]{sp_filter_param}")
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, _ = api_get(url)
+
+    assert response_status == 200


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9037](https://issues.redhat.com/browse/RHINENG-9037).

* Update escape character set
* Add test case for these query parameters

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
