### PR TITLE
fix(RHINENG-6139) Use pg_repack 1.4.6 specifically

### DIFF
--- a/pg_repack.dockerfile
+++ b/pg_repack.dockerfile
@@ -56,7 +56,7 @@ RUN python3 -m pip install --upgrade pip setuptools wheel && \
     python3 -m pip install pipenv && \
     python3 -m pip install dumb-init && \
     pipenv install --system --dev && \
-    pgxn install pg_repack
+    pgxn install 'pg_repack=1.4.6'
 
 # allows pre-commit and unit tests to run successfully within the container if image is built in "test" environment
 RUN if [ "$TEST_IMAGE" = "true" ]; then \


### PR DESCRIPTION
# Overview

This PR is being created so that the pg_repack job uses pg_repack v 1.4.6 specifically. This is required because the job will not run unless the version installed on the DB exactly matches the version installed on the client.