### PR TITLE
Fix: Specify the tables on which to run pg_repack

### DIFF
--- a/run_pg_repack.py
+++ b/run_pg_repack.py
@@ -35,6 +35,12 @@ def main(logger):
             str(cfg._db_user),
             "-k",
             str(cfg._db_name),
+            "-t",
+            "hosts",
+            "-t",
+            "groups",
+            "-t",
+            "hosts_groups",
         ],
         capture_output=True,
     )


### PR DESCRIPTION
# Overview

This PR is being created to address an issue that's visible in the [latest pg_repack job run](https://console-openshift-console.apps.crcs02ue1.urby.p1.openshiftapps.com/k8s/ns/host-inventory-stage/pods/host-inventory-pg-repack-28553429-p6kct/logs). [The docs](https://reorg.github.io/pg_repack/#installation) say to use multiple `-t` switches to make it run on multiple tables, so that's what this PR does.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
