### PR TITLE
fix(RHINENG-9037) Return tags with null values & refactor

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -218,18 +218,14 @@ def _expand_host_tags(hosts: List[Host]) -> Tuple[dict, dict]:
         host_namespace_tags_dict = host.tags
         for host_namespace, host_namespace_tags in host_namespace_tags_dict.items():
             for tag_key, tag_values in host_namespace_tags.items():
-                if isinstance(tag_values, List):
-                    if not tag_values:
-                        host_tags, host_tags_tracker = _add_tag_values(
-                            host_namespace, tag_key, None, host.id, host_tags, host_tags_tracker
-                        )
+                if isinstance(tag_values, List) and tag_values:
                     for tag_value in tag_values:
                         host_tags, host_tags_tracker = _add_tag_values(
                             host_namespace, tag_key, tag_value, host.id, host_tags, host_tags_tracker
                         )
                 else:
                     host_tags, host_tags_tracker = _add_tag_values(
-                        host_namespace, tag_key, tag_values, host.id, host_tags, host_tags_tracker
+                        host_namespace, tag_key, tag_values or None, host.id, host_tags, host_tags_tracker
                     )
         host_tags_dict[host.id] = host_tags
     return host_tags_dict, host_tags_tracker

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -195,12 +195,13 @@ def get_host_tags_list_by_id_list(
 
 
 def _add_tag_values(host_namespace, tag_key, tag_value, host_id, host_tags, host_tags_tracker) -> Tuple[dict, dict]:
-    converted_tag_value = _convert_null_string(tag_value) if tag_value else None
-    host_tag_str = f"{_convert_null_string(host_namespace)}/{_convert_null_string(tag_key)}={converted_tag_value}"
+    host_tag_str = (
+        f"{_convert_null_string(host_namespace)}/{_convert_null_string(tag_key)}={_convert_null_string(tag_value)}"
+    )
     host_tag_obj = {
         "namespace": _convert_null_string(host_namespace),
         "key": _convert_null_string(tag_key),
-        "value": tag_value,
+        "value": _convert_null_string(tag_value),
     }
     host_tags.append(host_tag_obj)
     if host_tag_str not in host_tags_tracker:
@@ -232,7 +233,7 @@ def _expand_host_tags(hosts: List[Host]) -> Tuple[dict, dict]:
 
 
 def _convert_null_string(input: str):
-    if input == "null":
+    if input == "null" or input == []:
         return None
     return input
 

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -195,9 +195,8 @@ def get_host_tags_list_by_id_list(
 
 
 def _add_tag_values(host_namespace, tag_key, tag_value, host_id, host_tags, host_tags_tracker) -> Tuple[dict, dict]:
-    host_tag_str = (
-        f"{_convert_null_string(host_namespace)}/{_convert_null_string(tag_key)}={_convert_null_string(tag_value)}"
-    )
+    converted_value = _convert_null_string(tag_value) if tag_value else ""
+    host_tag_str = f"{_convert_null_string(host_namespace)}/{_convert_null_string(tag_key)}={converted_value}"
     host_tag_obj = {
         "namespace": _convert_null_string(host_namespace),
         "key": _convert_null_string(tag_key),

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -203,6 +203,20 @@ def _expand_host_tags(hosts: List[Host]) -> Tuple[dict, dict]:
         for host_namespace, host_namespace_tags in host_namespace_tags_dict.items():
             for tag_key, tag_values in host_namespace_tags.items():
                 if isinstance(tag_values, List):
+                    if not tag_values:
+                        host_tag_str = (
+                            f"{_convert_null_string(host_namespace)}/{_convert_null_string(tag_key)}="  # noqa: E501
+                        )
+                        host_tag_obj = {
+                            "namespace": _convert_null_string(host_namespace),
+                            "key": _convert_null_string(tag_key),
+                            "value": None,
+                        }
+                        host_tags.append(host_tag_obj)
+                        if host_tag_str not in host_tags_tracker:
+                            host_tags_tracker[host_tag_str] = {"output": host_tag_obj, "hosts": [host.id]}
+                        else:
+                            host_tags_tracker[host_tag_str].get("hosts").append(host.id)
                     for tag_value in tag_values:
                         host_tag_str = f"{_convert_null_string(host_namespace)}/{_convert_null_string(tag_key)}={_convert_null_string(tag_value)}"  # noqa: E501
                         host_tag_obj = {

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -556,9 +556,23 @@ def test_get_tags_sap_sids(patch_xjoin_post, api_get, subtests):
                 assert response_data["total"] == 1
 
 
-def test_get_host_tags_null_value_via_db(api_get, db_create_host):
-    null_value_tag = {"ns1": {"key1": None}}
-    flattened_tag = {"namespace": "ns1", "key": "key1", "value": None}
+(("key", "ABaOUCuGU"), ("namespace", "insights-client"), ("value", None))
+
+
+@pytest.mark.parametrize(
+    "null_value_tag,flattened_tag",
+    (
+        (
+            {"ns1": {"key1": None}},
+            {"namespace": "ns1", "key": "key1", "value": None},
+        ),
+        (
+            {"insights-client": {"ABaOUCuGU": []}},
+            {"namespace": "insights-client", "key": "ABaOUCuGU", "value": None},
+        ),
+    ),
+)
+def test_get_host_tags_null_value_via_db(api_get, db_create_host, null_value_tag, flattened_tag):
     created_host = db_create_host(extra_data={"tags": null_value_tag})
 
     url = build_host_tags_url(host_list_or_id=created_host.id)
@@ -567,6 +581,13 @@ def test_get_host_tags_null_value_via_db(api_get, db_create_host):
 
     assert response_status == 200
     assert flattened_tag in response_data["results"][str(created_host.id)]
+
+    url = build_tags_url()
+    with patch("api.tag.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert flattened_tag == response_data["results"][0]["tag"]
 
 
 def test_get_host_tags_null_namespace_via_db(api_get, db_create_host):


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9037](https://issues.redhat.com/browse/RHINENG-9037).
It fixes a bug which was preventing tags with null values to be returned by API endpoints. It also refactors the relevant code a bit, and adds a unit test.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
