### PR TITLE
Run dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     # Allow up to 3 open pull requests for pip dependencies
     open-pull-requests-limit: 3
     reviewers:


### PR DESCRIPTION
# Overview

This PR is being created to change dependabot's schedule to `daily`. The number of open PRs is still limited to 3, so this will just give us new dependencies to upgrade each day if we've already resolved some of them.
