### PR TITLE
Change deploy integration template value from int to str

### DIFF
--- a/deploy/testing-integration.yml
+++ b/deploy/testing-integration.yml
@@ -171,4 +171,4 @@ parameters:
 - name: IQE_PARALLEL_ENABLED
   value: 'false'
 - name: SE_NODE_MAX_SESSIONS
-  value: 2
+  value: '2'


### PR DESCRIPTION
# Overview

I updated a few variables in this PR https://github.com/RedHatInsights/insights-host-inventory/pull/1719 and it seems our pipelines don't accept integers so I'm updating the value to a string.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs