### PR TITLE
feat(bootc): Use disable xjoin flow when bootc queries are made

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -95,9 +95,10 @@ def get_host_list(
     total = 0
     host_list = ()
     current_identity = get_current_identity()
+    is_bootc = filter.get("system_profile", {}).get("bootc_status", {})
 
     try:
-        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
             logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
             host_list, total, additional_fields, system_profile_fields = get_host_list_postgres(
                 display_name,


### PR DESCRIPTION
# Overview
* Allow queries that are filtering on bootc to use disable xjoin path for /hosts endpoint
* Allow queries that are filtering on bootc to use disable xjoin path for /hosts/{id}/system_profile endpoint

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
