### PR TITLE
[RHINENG-9619] Add missing turnpike auth/identity types

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -23,6 +23,8 @@ class AuthType(str, Enum):
     CERT = "cert-auth"
     JWT = "jwt-auth"
     UHC = "uhc-auth"
+    SAML = "saml-auth"
+    X509 = "x509"
 
 
 class CertType(str, Enum):
@@ -37,6 +39,8 @@ class IdentityType(str, Enum):
     SYSTEM = "System"
     USER = "User"
     SERVICE_ACCOUNT = "ServiceAccount"
+    ASSOCIATE = "Associate"
+    X509 = "X509"
 
 
 class Identity:

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -24,7 +24,7 @@ class AuthType(str, Enum):
     JWT = "jwt-auth"
     UHC = "uhc-auth"
     SAML = "saml-auth"
-    X509 = "x509"
+    X509 = "X509"
 
 
 class CertType(str, Enum):


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9619](https://issues.redhat.com/browse/RHINENG-9619).

Hello! Random drive by commit by your friendly neighborhood pipeline QE. We are currently blocked by this on RHCLOUD-30362, and from what we can tell what's missing are the SAML/X509[1] Auth types and the X509/Associate[2] Identity types.

1 - [Here](https://github.com/RedHatInsights/turnpike/blob/master/turnpike/plugins/x509.py#L14) and [Here](https://github.com/RedHatInsights/turnpike/blob/master/turnpike/plugins/saml.py#L139)

2 - [Here](https://github.com/RedHatInsights/turnpike/blob/master/turnpike/plugins/x509.py#L15) and [Here](https://github.com/RedHatInsights/turnpike/blob/master/turnpike/plugins/saml.py#L140)

You can see more context in the slack thread title `Question about Turnpike and identity header.`