### PR TITLE
bugfix(rhineng-9699): Resolve 500 when os query is combined with other system profile query

### DIFF
--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -208,7 +208,7 @@ def _unique_paths(
             if key in ignore_nodes:
                 # Skip recursion on ignored nodes.
                 # Instead, just add the whole thing to the output.
-                all_filters.append(node)
+                all_filters.append({key: node[key]})
             else:
                 all_filters += _unique_paths(node[key], ignore_nodes, [*current_path, key])
     else:

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1762,3 +1762,49 @@ def test_query_all_sp_filters_sql_char_contents(db_create_host, api_get, sp_filt
         # Assert that the request succeeds but no hosts are returned
         assert response_status == 200
         assert len(response_data["results"]) == 1
+
+
+def test_query_sp_filters_os_and_rhc_client_id(db_create_host, api_get):
+    # Create host with this system profile
+    match_sp_data = {
+        "system_profile_facts": {
+            "arch": "x86_64",
+            "insights_client_version": "3.0.1-2.el4_2",
+            "host_type": "edge",
+            "sap": {"sap_system": True, "sids": ["ABC", "DEF"]},
+            "bootc_status": {"booted": {"image": "quay.io/centos-bootc/fedora-bootc-cloud:eln"}},
+            "sap_sids": ["ABC", "DEF"],
+            "systemd": {"failed_services": ["foo", "bar"]},
+            "system_memory_bytes": 8292048963606259,
+            "rhc_client_id": "6b655c07-0daf-4564-9e1b-f6fb95510370",
+            "operating_system": {"name": "RHEL", "major": 8, "minor": 6},
+        }
+    }
+    match_host_id = str(db_create_host(extra_data=match_sp_data).id)
+
+    # Create host with differing SP
+    nomatch_sp_data = {
+        "system_profile_facts": {
+            "arch": "ARM",
+            "insights_client_version": "1.2.3",
+            "greenboot_status": "green",
+            "bootc_status": {"booted": {"image": "192.168.0.1:5000/foo/foo:latest"}},
+            "sap_sids": ["DEF"],
+            "number_of_cpus": 8,
+        }
+    }
+    nomatch_host_id = str(db_create_host(extra_data=nomatch_sp_data).id)
+
+    url = build_hosts_url(
+        query="?filter[system_profile][operating_system][RHEL][version][eq][]=8.6&filter[system_profile][rhc_client_id][]=not_nil"  # noqa: E501
+    )
+
+    with patch("api.host.get_flag_value", return_value=True):
+        response_status, response_data = api_get(url)
+
+    assert response_status == 200
+
+    # Assert that only the matching host is returned
+    response_ids = [result["id"] for result in response_data["results"]]
+    assert match_host_id in response_ids
+    assert nomatch_host_id not in response_ids


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9699](https://issues.redhat.com/browse/RHINENG-9699).

* ignore_nodes flow was errantly adding entire system profile filter instead of only the isolated operating_system component causing bad processing

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
