### PR TITLE
bugfix(rhineng-9706): Use disable.xjoin flow for bootc on tags endpoint

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -95,7 +95,7 @@ def get_host_list(
     total = 0
     host_list = ()
     current_identity = get_current_identity()
-    is_bootc = filter.get("system_profile", {}).get("bootc_status", {})
+    is_bootc = filter.get("system_profile", {}).get("bootc_status")
 
     try:
         if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:

--- a/api/tag.py
+++ b/api/tag.py
@@ -81,13 +81,14 @@ def get_tags(
 ):
     limit, offset = pagination_params(page, per_page)
     current_identity = get_current_identity()
+    is_bootc = filter.get("system_profile", {}).get("bootc_status")
     escaped_search = None
     if search:
         # Escaped so that the string literals are not interpreted as regex
         escaped_search = f".*{custom_escape(search)}.*"
 
     try:
-        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
             results, total = get_tag_list_db(
                 limit=limit,
                 offset=offset,


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9706](https://issues.redhat.com/browse/RHINENG-9706).
* when a bootc system_profile filter is applied using the tags endpoint use the disable.xjoin flow

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
