### PR TITLE
bug(rhineng-9706): Enable bootc workaround for addl endpoints

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -194,7 +194,8 @@ def delete_hosts_by_filter(
 
     try:
         current_identity = get_current_identity()
-        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+        is_bootc = filter.get("system_profile", {}).get("bootc_status")
+        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
             logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
             ids_list = get_host_ids_list_postgres(
                 display_name,

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -131,7 +131,8 @@ def get_sap_system(
     tags=None, page=None, per_page=None, staleness=None, registered_with=None, filter=None, rbac_filter=None
 ):
     current_identity = get_current_identity()
-    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+    is_bootc = filter.get("system_profile", {}).get("bootc_status")
+    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
         results, total = get_sap_system_info_db(
             page,
             per_page,
@@ -184,11 +185,12 @@ def get_sap_sids(
 ):
     limit, offset = pagination_params(page, per_page)
     current_identity = get_current_identity()
+    is_bootc = filter.get("system_profile", {}).get("bootc_status")
     escaped_search = None
     if search:
         # Escaped so that the string literals are not interpreted as regex
         escaped_search = f".*{custom_escape(search)}.*"
-    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
         results, total = get_sap_sids_info_db(
             limit,
             offset,
@@ -243,7 +245,8 @@ def get_operating_system(
 ):
     limit, offset = pagination_params(page, per_page)
     current_identity = get_current_identity()
-    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+    is_bootc = filter.get("system_profile", {}).get("bootc_status")
+    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
         results, total = get_os_info_db(
             limit,
             offset,


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9706](https://issues.redhat.com/browse/RHINENG-9706).
Enable bootc to use disable xjoin flow for:
* DELETE /hosts
* GET /system_profile/sap_sids
* GET /system_profile/sap_system
* GET /system_profile/operating_system

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
