### PR TITLE
perf(RHINENG-9788): Remove unused indexes

### DIFF
--- a/migrations/versions/90879eb18c66_remove_unused_indexes.py
+++ b/migrations/versions/90879eb18c66_remove_unused_indexes.py
@@ -35,8 +35,8 @@ def downgrade():
             if_not_exists=True,
         )
         op.create_index(
-            "idx_reporter", 
-            "hosts", 
+            "idx_reporter",
+            "hosts",
             ["reporter"],
             postgresql_concurrently=True,
             if_not_exists=True,

--- a/migrations/versions/90879eb18c66_remove_unused_indexes.py
+++ b/migrations/versions/90879eb18c66_remove_unused_indexes.py
@@ -1,0 +1,51 @@
+"""Remove unused indexes
+
+Revision ID: 90879eb18c66
+Revises: 091e613af3d9
+Create Date: 2024-05-01 11:18:49.909380
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "90879eb18c66"
+down_revision = "091e613af3d9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "hosts_subscription_manager_id_index", table_name="hosts", postgresql_concurrently=True, if_exists=True
+        )
+        op.drop_index("idx_reporter", table_name="hosts", postgresql_concurrently=True, if_exists=True)
+        op.drop_index("idxdisplay_name", table_name="hosts", postgresql_concurrently=True, if_exists=True)
+        op.drop_index("idxsap_sids", table_name="hosts", postgresql_concurrently=True, if_exists=True)
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "hosts_subscription_manager_id_index",
+            "hosts",
+            [sa.text("(canonical_facts ->> 'subscription_manager_id')")],
+        )
+        op.create_index("idx_reporter", "hosts", ["reporter"])
+        op.create_index(
+            "idxdisplay_name",
+            "hosts",
+            ["display_name"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "idxsap_sids",
+            "hosts",
+            [sa.text("(system_profile_facts->'sap_sids') jsonb_path_ops")],
+            postgresql_using="gin",
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )

--- a/migrations/versions/90879eb18c66_remove_unused_indexes.py
+++ b/migrations/versions/90879eb18c66_remove_unused_indexes.py
@@ -31,8 +31,16 @@ def downgrade():
             "hosts_subscription_manager_id_index",
             "hosts",
             [sa.text("(canonical_facts ->> 'subscription_manager_id')")],
+            postgresql_concurrently=True,
+            if_not_exists=True,
         )
-        op.create_index("idx_reporter", "hosts", ["reporter"])
+        op.create_index(
+            "idx_reporter", 
+            "hosts", 
+            ["reporter"],
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
         op.create_index(
             "idxdisplay_name",
             "hosts",


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9788](https://issues.redhat.com/browse/RHINENG-9788). Removes 4 unused indexes (hosts_subscription_manager_id_index, idx_reporter, idxdisplay_name, idxsap_sids).

There were 2 more considered for deletion that I'm not removing yet:
- idxinsightsid: Unused in Stage, but is used in Prod.
- idx_operating_system: This isn't used in either env, but we still need an index for this. I'll work with David Halasz to figure out why it's not used and determine whether we can update a WHERE or if we have to replace the index.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
