### PR TITLE
perf(RHINENG-9788): Remove double-filter on OS query

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -365,7 +365,6 @@ def get_os_info(
     )
     # Only include records that have set an operating_system.name
     filters += (columns[0].isnot(None),)
-    os_query = os_query.filter(*filters)
 
     query_results = os_query.filter(*filters).all()
     db.session.close()


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9788](https://issues.redhat.com/browse/RHINENG-9788).
Removes a duplicate filter, which nearly doubles the length of the operating_system query.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
