### PR TITLE
chore: Remove OS index, set replica identity for tables

### DIFF
--- a/migrations/versions/3d4efbc9da4f_remove_os_index.py
+++ b/migrations/versions/3d4efbc9da4f_remove_os_index.py
@@ -1,4 +1,4 @@
-"""Remove OS index
+"""Remove OS index, set replica identity for groups and hosts_groups
 
 Revision ID: 3d4efbc9da4f
 Revises: 90879eb18c66
@@ -18,10 +18,14 @@ depends_on = None
 def upgrade():
     with op.get_context().autocommit_block():
         op.drop_index("idx_operating_system", table_name="hosts", postgresql_concurrently=True, if_exists=True)
+        op.execute('ALTER TABLE "groups" REPLICA IDENTITY FULL')
+        op.execute('ALTER TABLE "hosts_groups" REPLICA IDENTITY FULL')
 
 
 def downgrade():
     with op.get_context().autocommit_block():
+        op.execute('ALTER TABLE "groups" REPLICA IDENTITY DEFAULT')
+        op.execute('ALTER TABLE "hosts_groups" REPLICA IDENTITY DEFAULT')
         op.create_index(
             "idx_operating_system",
             "hosts",

--- a/migrations/versions/3d4efbc9da4f_remove_os_index.py
+++ b/migrations/versions/3d4efbc9da4f_remove_os_index.py
@@ -1,4 +1,4 @@
-"""Remove OS index, set replica identity for groups and hosts_groups
+"""Remove OS index, set replica identity for tables
 
 Revision ID: 3d4efbc9da4f
 Revises: 90879eb18c66
@@ -20,12 +20,14 @@ def upgrade():
         op.drop_index("idx_operating_system", table_name="hosts", postgresql_concurrently=True, if_exists=True)
         op.execute('ALTER TABLE "groups" REPLICA IDENTITY FULL')
         op.execute('ALTER TABLE "hosts_groups" REPLICA IDENTITY FULL')
+        op.execute('ALTER TABLE "staleness" REPLICA IDENTITY FULL')
 
 
 def downgrade():
     with op.get_context().autocommit_block():
         op.execute('ALTER TABLE "groups" REPLICA IDENTITY DEFAULT')
         op.execute('ALTER TABLE "hosts_groups" REPLICA IDENTITY DEFAULT')
+        op.execute('ALTER TABLE "staleness" REPLICA IDENTITY DEFAULT')
         op.create_index(
             "idx_operating_system",
             "hosts",

--- a/migrations/versions/3d4efbc9da4f_remove_os_index.py
+++ b/migrations/versions/3d4efbc9da4f_remove_os_index.py
@@ -1,0 +1,32 @@
+"""Remove OS index
+
+Revision ID: 3d4efbc9da4f
+Revises: 90879eb18c66
+Create Date: 2024-05-03 09:01:46.316467
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3d4efbc9da4f"
+down_revision = "90879eb18c66"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index("idx_operating_system", table_name="hosts", postgresql_concurrently=True, if_exists=True)
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "idx_operating_system",
+            "hosts",
+            [sa.text("(COALESCE(system_profile_facts -> 'operating_system' ->> 'name', '')) gin_trgm_ops")],
+            postgresql_using="gin",
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )

--- a/migrations/versions/3d4efbc9da4f_remove_os_index.py
+++ b/migrations/versions/3d4efbc9da4f_remove_os_index.py
@@ -18,9 +18,9 @@ depends_on = None
 def upgrade():
     with op.get_context().autocommit_block():
         op.drop_index("idx_operating_system", table_name="hosts", postgresql_concurrently=True, if_exists=True)
-        op.execute('ALTER TABLE "groups" REPLICA IDENTITY FULL')
-        op.execute('ALTER TABLE "hosts_groups" REPLICA IDENTITY FULL')
-        op.execute('ALTER TABLE "staleness" REPLICA IDENTITY FULL')
+        op.execute('ALTER TABLE "groups" REPLICA IDENTITY USING INDEX groups_pkey')
+        op.execute('ALTER TABLE "hosts_groups" REPLICA IDENTITY USING INDEX hosts_groups_pkey')
+        op.execute('ALTER TABLE "staleness" REPLICA IDENTITY USING INDEX staleness_pkey')
 
 
 def downgrade():

--- a/run_pg_repack.py
+++ b/run_pg_repack.py
@@ -48,6 +48,8 @@ def main(logger):
             "groups",
             "-t",
             "hosts_groups",
+            "-t",
+            "staleness",
         ],
         stdout=PIPE,
         stderr=STDOUT,


### PR DESCRIPTION
# Overview

This PR is being created to remove the OS index, because our stats in both Stage and Prod show that it has never been used. It also sets the replica identity to "FULL" for the groups and hosts_groups tables, which is required for pg_repack to work correctly.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
