### PR TITLE
perf(RHINENG-9788) Only perform the joins that are required by the query

### DIFF
--- a/api/filtering/db_filters.py
+++ b/api/filtering/db_filters.py
@@ -299,12 +299,6 @@ def query_filters(
         filters += _system_profile_filter(filter)
     if rbac_filter:
         filters += rbac_permissions_filter(rbac_filter)
-        query_base = (
-            db.session.query(Host)
-            .join(HostGroupAssoc, isouter=True)
-            .join(Group, isouter=True)
-            .group_by(Host.id, Group.name)
-        )
 
     # Determine query_base
     if group_name or order_by == "group_name":

--- a/api/filtering/db_filters.py
+++ b/api/filtering/db_filters.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from functools import partial
 from typing import List
+from typing import Tuple
 from uuid import UUID
 
 from dateutil import parser
@@ -13,6 +14,7 @@ from sqlalchemy.dialects.postgresql import JSON
 
 from api.filtering.db_custom_filters import build_system_profile_filter
 from api.staleness_query import get_staleness_obj
+from app import db
 from app.config import HOST_TYPES
 from app.culling import staleness_to_conditions
 from app.exceptions import ValidationException
@@ -255,7 +257,8 @@ def query_filters(
     registered_with: List[str] = None,
     filter: dict = None,
     rbac_filter: dict = None,
-) -> List:
+    order_by: str = None,
+) -> Tuple[List, bool]:
     num_ids = 0
     for id_param in [fqdn, display_name, hostname_or_id, insights_id]:
         if id_param:
@@ -282,10 +285,10 @@ def query_filters(
         filters += _canonical_fact_filter("provider_type", provider_type)
     if updated_start or updated_end:
         filters += _modified_on_filter(updated_start, updated_end)
-    if group_name:
-        filters += _group_names_filter(group_name)
     if group_ids:
         filters += _group_ids_filter(group_ids)
+    if group_name:
+        filters += _group_names_filter(group_name)
     if tags:
         filters += _tags_filter(tags)
     if staleness:
@@ -296,5 +299,24 @@ def query_filters(
         filters += _system_profile_filter(filter)
     if rbac_filter:
         filters += rbac_permissions_filter(rbac_filter)
+        query_base = (
+            db.session.query(Host)
+            .join(HostGroupAssoc, isouter=True)
+            .join(Group, isouter=True)
+            .group_by(Host.id, Group.name)
+        )
 
-    return filters
+    # Determine query_base
+    if group_name or order_by == "group_name":
+        query_base = (
+            db.session.query(Host)
+            .join(HostGroupAssoc, isouter=True)
+            .join(Group, isouter=True)
+            .group_by(Host.id, Group.name)
+        )
+    elif group_ids or rbac_filter:
+        query_base = db.session.query(Host).join(HostGroupAssoc, isouter=True).group_by(Host.id)
+    else:
+        query_base = db.session.query(Host)
+
+    return filters, query_base


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9788](https://issues.redhat.com/browse/RHINENG-9788).
It changes our queries so that they join on HostGroupAssoc and Group only when required by the query. Joining on HostGroupAssoc is required when filtering on group ID or applying an RBAC filter; joining on Group is only required when filtering on, or ordering by, group ID.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
