### PR TITLE
perf(RHINENG-9788) Remove duplicate host-type WHERE clauses

### DIFF
--- a/api/filtering/db_filters.py
+++ b/api/filtering/db_filters.py
@@ -131,19 +131,24 @@ def per_reporter_staleness_filter(staleness, reporter, host_type_filter):
     staleness_obj = serialize_staleness_to_dict(get_staleness_obj())
     staleness_conditions = []
     for host_type in host_type_filter:
-        staleness_conditions.append(
-            and_(
-                Host.system_profile_facts["host_type"].astext == host_type,
-                or_(
-                    *staleness_to_conditions(
-                        staleness_obj,
-                        staleness,
-                        host_type,
-                        partial(_stale_timestamp_per_reporter_filter, reporter=reporter),
-                    )
-                ),
+        conditions = or_(
+            *staleness_to_conditions(
+                staleness_obj,
+                staleness,
+                host_type,
+                partial(_stale_timestamp_per_reporter_filter, reporter=reporter),
             )
         )
+        if len(host_type_filter) > 1:
+            staleness_conditions.append(
+                and_(
+                    Host.system_profile_facts["host_type"].astext == host_type,
+                    conditions,
+                )
+            )
+        else:
+            staleness_conditions.append(conditions)
+
     return staleness_conditions
 
 
@@ -151,12 +156,17 @@ def _staleness_filter(staleness: List[str], host_type_filter: Set[str]) -> List:
     staleness_obj = serialize_staleness_to_dict(get_staleness_obj())
     staleness_conditions = []
     for host_type in host_type_filter:
-        staleness_conditions.append(
-            and_(
-                Host.system_profile_facts["host_type"].astext == host_type,
-                or_(*staleness_to_conditions(staleness_obj, staleness, host_type, _stale_timestamp_filter)),
+        conditions = or_(*staleness_to_conditions(staleness_obj, staleness, host_type, _stale_timestamp_filter))
+        if len(host_type_filter) > 1:
+            staleness_conditions.append(
+                and_(
+                    Host.system_profile_facts["host_type"].astext == host_type,
+                    conditions,
+                )
             )
-        )
+        else:
+            staleness_conditions.append(conditions)
+
     return [or_(*staleness_conditions)]
 
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9788](https://issues.redhat.com/browse/RHINENG-9788).
The `staleness` and `per_reporter_staleness` generate a group of WHERE clauses for each host type (one for "edge", one for None) even if the user is filtering hosts by a specific host type. This PR makes it so that if you're filtering on host_type, it only adds the staleness filters specific to that host_type.

Additionally, when filtering on only one host_type, it gets rid of the redundant `host_type` filters added in the `staleness` and `per_reporter_staleness` filters.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
