### PR TITLE
fix(RHINENG-5450): Change intent of grafana dashboard

### DIFF
--- a/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
@@ -2902,7 +2902,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(increase(inventory_produce_large_message_failures_total[$__range])) / sum(increase(inventory_event_producer_successes_total[$__range]))",
+              "expr": "sum(increase(inventory_produce_large_message_failures_total[$__range])) / sum(increase(inventory_event_producer_failures[$__range]))",
               "instant": true,
               "interval": "5m",
               "refId": "A"
@@ -2975,13 +2975,13 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(inventory_consumed_message_size_sum[$__rate_interval]))",
+              "expr": "max(rate(inventory_consumed_message_size_sum[$__rate_interval]))",
               "interval": "1m",
               "legendFormat": "Consumed",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(inventory_produced_message_size_sum[$__rate_interval]))",
+              "expr": "max(rate(inventory_produced_message_size_sum[$__rate_interval]))",
               "interval": "1m",
               "legendFormat": "Produced",
               "refId": "B"
@@ -2991,7 +2991,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Message sizes",
+          "title": "Maximum message sizes",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-5450](https://issues.redhat.com/browse/RHINENG-5450).
The intent of the Message size panel was to see the the maximum size of the consumed/produced messages, so one more change was made to the query.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
