### PR TITLE
Add a default statement timeout for API server queries

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,6 +18,7 @@ from api.spec import spec_blueprint
 from app import payload_tracker
 from app.config import Config
 from app.custom_validator import build_validator_map
+from app.environment import RuntimeEnvironment
 from app.exceptions import InventoryException
 from app.logging import configure_logging
 from app.logging import get_logger
@@ -228,6 +229,10 @@ def create_app(runtime_environment):
     flask_app.config["SQLALCHEMY_ENGINE_OPTIONS['pool_size']"] = app_config.db_pool_size
     flask_app.config["SQLALCHEMY_ENGINE_OPTIONS['pool_timeout']"] = app_config.db_pool_timeout
     flask_app.config["SQLALCHEMY_ENGINE_OPTIONS['pool_pre_ping']"] = True
+    if runtime_environment == RuntimeEnvironment.SERVER and app_config.db_statement_timeout > 0:
+        flask_app.config["SQLALCHEMY_ENGINE_OPTIONS['connect_args']"] = {
+            "options": f"-c statement_timeout={app_config.db_statement_timeout}"
+        }
 
     flask_app.config["INVENTORY_CONFIG"] = app_config
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,7 +18,6 @@ from api.spec import spec_blueprint
 from app import payload_tracker
 from app.config import Config
 from app.custom_validator import build_validator_map
-from app.environment import RuntimeEnvironment
 from app.exceptions import InventoryException
 from app.logging import configure_logging
 from app.logging import get_logger
@@ -229,10 +228,9 @@ def create_app(runtime_environment):
     flask_app.config["SQLALCHEMY_ENGINE_OPTIONS['pool_size']"] = app_config.db_pool_size
     flask_app.config["SQLALCHEMY_ENGINE_OPTIONS['pool_timeout']"] = app_config.db_pool_timeout
     flask_app.config["SQLALCHEMY_ENGINE_OPTIONS['pool_pre_ping']"] = True
-    if runtime_environment == RuntimeEnvironment.SERVER and app_config.db_statement_timeout > 0:
-        flask_app.config["SQLALCHEMY_ENGINE_OPTIONS['connect_args']"] = {
-            "options": f"-c statement_timeout={app_config.db_statement_timeout}"
-        }
+    flask_app.config["SQLALCHEMY_ENGINE_OPTIONS['connect_args']"] = {
+        "options": f"-c statement_timeout={app_config.db_statement_timeout}"
+    }
 
     flask_app.config["INVENTORY_CONFIG"] = app_config
 

--- a/app/config.py
+++ b/app/config.py
@@ -128,6 +128,8 @@ class Config:
         self._db_ssl_mode = os.getenv("INVENTORY_DB_SSL_MODE", "")
         self.db_pool_timeout = int(os.getenv("INVENTORY_DB_POOL_TIMEOUT", "5"))
         self.db_pool_size = int(os.getenv("INVENTORY_DB_POOL_SIZE", "5"))
+        # Allow configuring a statement timeout on engine connection
+        self.db_statement_timeout = int(os.getenv("INVENTORY_DB_STATEMENT_TIMEOUT", "30000"))
 
         self.db_uri = self._build_db_uri(self._db_ssl_mode)
 

--- a/app/config.py
+++ b/app/config.py
@@ -128,8 +128,10 @@ class Config:
         self._db_ssl_mode = os.getenv("INVENTORY_DB_SSL_MODE", "")
         self.db_pool_timeout = int(os.getenv("INVENTORY_DB_POOL_TIMEOUT", "5"))
         self.db_pool_size = int(os.getenv("INVENTORY_DB_POOL_SIZE", "5"))
+        self.db_statement_timeout = 0
         # Allow configuring a statement timeout on engine connection
-        self.db_statement_timeout = int(os.getenv("INVENTORY_DB_STATEMENT_TIMEOUT", "30000"))
+        if runtime_environment == RuntimeEnvironment.SERVER:
+            self.db_statement_timeout = int(os.getenv("INVENTORY_DB_STATEMENT_TIMEOUT", "30000"))
 
         self.db_uri = self._build_db_uri(self._db_ssl_mode)
 

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -83,6 +83,8 @@ objects:
           value: ${BYPASS_TENANT_TRANSLATION}
         - name: CLOWDER_ENABLED
           value: "true"
+        - name: INVENTORY_DB_STATEMENT_TIMEOUT
+          value: "${INVENTORY_DB_STATEMENT_TIMEOUT}"
         - name: UNLEASH_URL
           value: ${UNLEASH_URL}
         - name: UNLEASH_TOKEN
@@ -915,6 +917,8 @@ parameters:
   value: '500'
 - name: REBUILD_EVENTS_TIME_LIMIT
   value: '3600'
+- name: INVENTORY_DB_STATEMENT_TIMEOUT
+  value: '30000'
 
 # Feature flags
 - description: Unleash secret name


### PR DESCRIPTION
# Overview

* Introduce a connection option for the flask API app that sets a statement timeout for the engine
* The default will be 30 seconds as any API request over 30 seconds will receive a gateway timeout
* This value can be set to a negative value to avoid the setting being applied altogether

https://docs.sqlalchemy.org/en/20/core/engines.html#use-the-connect-args-dictionary-parameter

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
