### PR TITLE
[RHINENG-9943] Allow to disable xjoin by configuration

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -98,7 +98,14 @@ def get_host_list(
     is_bootc = filter.get("system_profile", {}).get("bootc_status")
 
     try:
-        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
+        if (
+            get_flag_value(
+                FLAG_INVENTORY_DISABLE_XJOIN,
+                context={"schema": current_identity.org_id},
+                overriden_flag_by_config=inventory_config().bypass_xjoin,
+            )
+            or is_bootc
+        ):
             logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
             host_list, total, additional_fields, system_profile_fields = get_host_list_postgres(
                 display_name,
@@ -195,7 +202,14 @@ def delete_hosts_by_filter(
     try:
         current_identity = get_current_identity()
         is_bootc = filter.get("system_profile", {}).get("bootc_status")
-        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
+        if (
+            get_flag_value(
+                FLAG_INVENTORY_DISABLE_XJOIN,
+                context={"schema": current_identity.org_id},
+                overriden_flag_by_config=inventory_config().bypass_xjoin,
+            )
+            or is_bootc
+        ):
             logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
             ids_list = get_host_ids_list_postgres(
                 display_name,
@@ -327,7 +341,11 @@ def delete_host_by_id(host_id_list, rbac_filter=None):
 def get_host_by_id(host_id_list, page=1, per_page=100, order_by=None, order_how=None, fields=None, rbac_filter=None):
     current_identity = get_current_identity()
     try:
-        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+        if get_flag_value(
+            FLAG_INVENTORY_DISABLE_XJOIN,
+            context={"schema": current_identity.org_id},
+            overriden_flag_by_config=inventory_config().bypass_xjoin,
+        ):
             logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
             host_list, total, additional_fields, system_profile_fields = get_host_list_by_id_list_postgres(
                 host_id_list, page, per_page, order_by, order_how, fields, rbac_filter
@@ -356,7 +374,11 @@ def get_host_system_profile_by_id(
 ):
     current_identity = get_current_identity()
     try:
-        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+        if get_flag_value(
+            FLAG_INVENTORY_DISABLE_XJOIN,
+            context={"schema": current_identity.org_id},
+            overriden_flag_by_config=inventory_config().bypass_xjoin,
+        ):
             logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
             total, host_list = get_sparse_system_profile_postgres(
                 host_id_list, page, per_page, order_by, order_how, fields, rbac_filter
@@ -493,7 +515,11 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict, rba
 @metrics.api_request_time.time()
 def get_host_tag_count(host_id_list, page=1, per_page=100, order_by=None, order_how=None, rbac_filter=None):
     current_identity = get_current_identity()
-    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+    if get_flag_value(
+        FLAG_INVENTORY_DISABLE_XJOIN,
+        context={"schema": current_identity.org_id},
+        overriden_flag_by_config=inventory_config().bypass_xjoin,
+    ):
         logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
         limit, offset = pagination_params(page, per_page)
         host_list, total = get_host_tags_list_by_id_list_postgres(
@@ -513,7 +539,11 @@ def get_host_tag_count(host_id_list, page=1, per_page=100, order_by=None, order_
 @metrics.api_request_time.time()
 def get_host_tags(host_id_list, page=1, per_page=100, order_by=None, order_how=None, search=None, rbac_filter=None):
     current_identity = get_current_identity()
-    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}):
+    if get_flag_value(
+        FLAG_INVENTORY_DISABLE_XJOIN,
+        context={"schema": current_identity.org_id},
+        overriden_flag_by_config=inventory_config().bypass_xjoin,
+    ):
         logger.info(f"{FLAG_INVENTORY_DISABLE_XJOIN} is applied to {current_identity.org_id}")
         limit, offset = pagination_params(page, per_page)
         host_list, total = get_host_tags_list_by_id_list_postgres(

--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -15,6 +15,7 @@ from api.host_query_db import get_sap_system_info as get_sap_system_info_db
 from app import RbacPermission
 from app import RbacResourceType
 from app.auth import get_current_identity
+from app.common import inventory_config
 from app.config import Config
 from app.environment import RuntimeEnvironment
 from app.instrumentation import log_get_operating_system_failed
@@ -132,7 +133,14 @@ def get_sap_system(
 ):
     current_identity = get_current_identity()
     is_bootc = filter.get("system_profile", {}).get("bootc_status")
-    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
+    if (
+        get_flag_value(
+            FLAG_INVENTORY_DISABLE_XJOIN,
+            context={"schema": current_identity.org_id},
+            overriden_flag_by_config=inventory_config().bypass_xjoin,
+        )
+        or is_bootc
+    ):
         results, total = get_sap_system_info_db(
             page,
             per_page,
@@ -190,7 +198,14 @@ def get_sap_sids(
     if search:
         # Escaped so that the string literals are not interpreted as regex
         escaped_search = f".*{custom_escape(search)}.*"
-    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
+    if (
+        get_flag_value(
+            FLAG_INVENTORY_DISABLE_XJOIN,
+            context={"schema": current_identity.org_id},
+            overriden_flag_by_config=inventory_config().bypass_xjoin,
+        )
+        or is_bootc
+    ):
         results, total = get_sap_sids_info_db(
             limit,
             offset,
@@ -246,7 +261,14 @@ def get_operating_system(
     limit, offset = pagination_params(page, per_page)
     current_identity = get_current_identity()
     is_bootc = filter.get("system_profile", {}).get("bootc_status")
-    if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
+    if (
+        get_flag_value(
+            FLAG_INVENTORY_DISABLE_XJOIN,
+            context={"schema": current_identity.org_id},
+            overriden_flag_by_config=inventory_config().bypass_xjoin,
+        )
+        or is_bootc
+    ):
         results, total = get_os_info_db(
             limit,
             offset,

--- a/api/tag.py
+++ b/api/tag.py
@@ -10,6 +10,7 @@ from api.host_query_db import get_tag_list as get_tag_list_db
 from app import RbacPermission
 from app import RbacResourceType
 from app.auth import get_current_identity
+from app.common import inventory_config
 from app.instrumentation import log_get_tags_failed
 from app.instrumentation import log_get_tags_succeeded
 from app.logging import get_logger
@@ -88,7 +89,14 @@ def get_tags(
         escaped_search = f".*{custom_escape(search)}.*"
 
     try:
-        if get_flag_value(FLAG_INVENTORY_DISABLE_XJOIN, context={"schema": current_identity.org_id}) or is_bootc:
+        if (
+            get_flag_value(
+                FLAG_INVENTORY_DISABLE_XJOIN,
+                context={"schema": current_identity.org_id},
+                overriden_flag_by_config=inventory_config().bypass_xjoin,
+            )
+            or is_bootc
+        ):
             results, total = get_tag_list_db(
                 limit=limit,
                 offset=offset,

--- a/app/config.py
+++ b/app/config.py
@@ -147,6 +147,7 @@ class Config:
         self.rbac_timeout = os.environ.get("RBAC_TIMEOUT", 10)
 
         self.bypass_unleash = os.environ.get("BYPASS_UNLEASH", "false").lower() == "true"
+        self.bypass_xjoin = os.environ.get("BYPASS_XJOIN", "false").lower() == "true"
 
         self.bypass_tenant_translation = os.environ.get("BYPASS_TENANT_TRANSLATION", "false").lower() == "true"
         self.tenant_translator_url = os.environ.get("TENANT_TRANSLATOR_URL", "http://localhost:8892/internal/orgIds")
@@ -344,6 +345,8 @@ class Config:
             self.logger.info("RBAC Endpoint: %s", self.rbac_endpoint)
             self.logger.info("RBAC Retry Times: %s", self.rbac_retries)
             self.logger.info("RBAC Timeout Seconds: %s", self.rbac_timeout)
+
+            self.logger.info("Xjoin Bypassed by config: %s", self.bypass_xjoin)
 
             self.logger.info("Unleash (feature flags) Bypassed by config: %s", self.bypass_unleash)
             self.logger.info("Unleash (feature flags) Bypassed by missing token: %s", self.unleash_token is None)

--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -45,9 +45,14 @@ def custom_fallback(feature_name: str, context: dict) -> bool:
 # Gets a feature flag's value from Unleash, if available.
 # Accepts a string with the name of the feature flag.
 # Returns a tuple containing the flag's value and whether or not the fallback value was used.
-def get_flag_value_and_fallback(flag_name: str, context: dict = {}) -> Tuple[bool, bool]:
+def get_flag_value_and_fallback(
+    flag_name: str, context: dict = {}, overriden_flag_by_config: bool = False
+) -> Tuple[bool, bool]:
     # Get flag name and default to fallback value
-    flag_value = FLAG_FALLBACK_VALUES[flag_name]
+    if overriden_flag_by_config:
+        flag_value = True
+    else:
+        flag_value = FLAG_FALLBACK_VALUES[flag_name]
     using_fallback = True
 
     # Attempt to get the feature flag via Unleash
@@ -69,5 +74,5 @@ def get_flag_value_and_fallback(flag_name: str, context: dict = {}) -> Tuple[boo
 # Gets a feature flag's value from Unleash, if available.
 # Accepts a string with the name of the feature flag.
 # Returns the value of the feature flag, whether it's the fallback or real value.
-def get_flag_value(flag_name: str, context: dict = {}) -> bool:
-    return get_flag_value_and_fallback(flag_name, context)[0]
+def get_flag_value(flag_name: str, context: dict = {}, overriden_flag_by_config: bool = False) -> bool:
+    return get_flag_value_and_fallback(flag_name, context, overriden_flag_by_config)[0]


### PR DESCRIPTION
This PR allows to disable `xjoin` by using a new environment variable. Using the new variable `BYPASS_XJOIN=true` and `BYPASS_UNLEASH=true`, forces the use of DB queries to get hosts. Using BYPASS_UNLEASH=true by itself makes host-inventory to fallback to pre-unleash settings that required xjoin, which is not easy to setup in a dev environment.

With this fix in place, unleash container is not even needed. If this change is acceptable and is merged, the README will be updated.

Related-Bug: RHINENG-9943
Co-Authored-By: Muhammad Arif <aarif@redhat.com>
Signed-off-by: Gaël Chamoulaud <gchamoul@redhat.com>

# Overview

This PR is being created to address [RHINENG-xxxx](https://issues.redhat.com/browse/RHINENG-xxxx).
(A description of your PR's changes, along with why/context to the PR, goes here.)

## PR Checklist

- [X] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
