### PR TITLE
feat(api): Enable caching of host APIs with associated cache invalidation

### DIFF
--- a/api/cache.py
+++ b/api/cache.py
@@ -22,3 +22,25 @@ def init_cache(app_config, flask_app):
         CACHE = Cache(config=cache_config)
     if isinstance(flask_app, Flask):
         CACHE = CACHE.init_app(flask_app, config=cache_config)
+
+
+def _delete_keys_simple(prefix):
+    cache_dict = CACHE.cache._cache
+    for cache_key in list(cache_dict.keys()):
+        if cache_key.startswith(prefix):
+            cache_dict.pop(cache_key)
+
+
+def _delete_keys_redis(prefix):
+    redis_client = CACHE.cache._client
+    # Use SCAN to find keys to delete that start with the prefix
+    for key in redis_client.scan_iter(f"{prefix}*"):
+        redis_client.delete(key)
+
+
+def delete_keys(prefix):
+    if CACHE and CACHE.config["CACHE_TYPE"] == "SimpleCache":
+        _delete_keys_simple(prefix)
+
+    if CACHE and CACHE.config["CACHE_TYPE"] == "RedisCache":
+        _delete_keys_redis(prefix)

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -10,6 +10,7 @@ from marshmallow import Schema
 from marshmallow import ValidationError
 from sqlalchemy.exc import OperationalError
 
+from api.cache import delete_keys
 from api.staleness_query import get_staleness_obj
 from app.auth.identity import create_mock_identity_with_org_id
 from app.auth.identity import Identity
@@ -297,10 +298,11 @@ def handle_message(message, event_producer, notification_event_producer, message
     ):
         try:
             host = validated_operation_msg["data"]
-
+            org_id = host["org_id"]
             output_host, host_id, insights_id, operation_result = message_operation(
                 host, platform_metadata, validated_operation_msg.get("operation_args", {})
             )
+            delete_keys(org_id)
             event_type = operation_results_to_event_type(operation_result)
             event = build_event(event_type, output_host, platform_metadata=platform_metadata)
 

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -187,6 +187,10 @@ objects:
           value: ${BYPASS_TENANT_TRANSLATION}
         - name: CLOWDER_ENABLED
           value: "true"
+        - name: INVENTORY_API_CACHE_TIMEOUT_SECONDS
+          value: "${INVENTORY_API_CACHE_TIMEOUT_SECONDS}"
+        - name: INVENTORY_API_CACHE_TYPE
+          value: "${INVENTORY_API_CACHE_TYPE}"
         - name: UNLEASH_URL
           value: ${UNLEASH_URL}
         - name: UNLEASH_TOKEN
@@ -264,6 +268,10 @@ objects:
           value: ${BYPASS_TENANT_TRANSLATION}
         - name: CLOWDER_ENABLED
           value: "true"
+        - name: INVENTORY_API_CACHE_TIMEOUT_SECONDS
+          value: "${INVENTORY_API_CACHE_TIMEOUT_SECONDS}"
+        - name: INVENTORY_API_CACHE_TYPE
+          value: "${INVENTORY_API_CACHE_TYPE}"
         - name: UNLEASH_URL
           value: ${UNLEASH_URL}
         - name: UNLEASH_TOKEN
@@ -338,6 +346,10 @@ objects:
           value: ${BYPASS_TENANT_TRANSLATION}
         - name: CLOWDER_ENABLED
           value: "true"
+        - name: INVENTORY_API_CACHE_TIMEOUT_SECONDS
+          value: "${INVENTORY_API_CACHE_TIMEOUT_SECONDS}"
+        - name: INVENTORY_API_CACHE_TYPE
+          value: "${INVENTORY_API_CACHE_TYPE}"
         - name: UNLEASH_URL
           value: ${UNLEASH_URL}
         - name: UNLEASH_TOKEN
@@ -415,6 +427,10 @@ objects:
             value: ${KAFKA_SASL_MECHANISM}
           - name: CLOWDER_ENABLED
             value: "true"
+          - name: INVENTORY_API_CACHE_TIMEOUT_SECONDS
+            value: "${INVENTORY_API_CACHE_TIMEOUT_SECONDS}"
+          - name: INVENTORY_API_CACHE_TYPE
+            value: "${INVENTORY_API_CACHE_TYPE}"
           - name: UNLEASH_URL
             value: ${UNLEASH_URL}
           - name: UNLEASH_TOKEN

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine
 from sqlalchemy import or_
 from sqlalchemy.orm import sessionmaker
 
+from api.cache import init_cache
 from app import create_app
 from app.auth.identity import create_mock_identity_with_org_id
 from app.config import Config
@@ -131,7 +132,7 @@ def run(config, logger, session, event_producer, shutdown_handler):
 
 def main(logger):
     config = _init_config()
-
+    init_cache(config, application)
     registry = CollectorRegistry()
     for metric in COLLECTED_METRICS:
         registry.register(metric)

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -4,6 +4,7 @@ from functools import partial
 from confluent_kafka import Consumer as KafkaConsumer
 from prometheus_client import start_http_server
 
+from api.cache import init_cache
 from app import create_app
 from app.environment import RuntimeEnvironment
 from app.logging import get_logger
@@ -21,6 +22,7 @@ logger = get_logger("mq_service")
 def main():
     application = create_app(RuntimeEnvironment.SERVICE)
     config = application.app.config["INVENTORY_CONFIG"]
+    init_cache(config, application)
     start_http_server(config.metrics_port)
 
     topic_to_handler = {config.host_ingress_topic: add_host, config.system_profile_topic: update_system_profile}

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -1,6 +1,7 @@
 from confluent_kafka import KafkaException
 from sqlalchemy.orm.base import instance_state
 
+from api.cache import delete_keys
 from app.auth.identity import to_auth_header
 from app.logging import get_logger
 from app.models import Host
@@ -18,10 +19,12 @@ logger = get_logger(__name__)
 
 
 def delete_hosts(select_query, event_producer, chunk_size, interrupt=lambda: False, identity=None):
+    cache_keys_to_invalidate = set()
     with session_guard(select_query.session):
         while select_query.count():
             for host in select_query.limit(chunk_size):
                 host_id = host.id
+                cache_keys_to_invalidate.add(host.org_id)
                 with delete_host_processing_time.time():
                     host_deleted = _delete_host(select_query.session, event_producer, host, identity)
 
@@ -29,6 +32,8 @@ def delete_hosts(select_query, event_producer, chunk_size, interrupt=lambda: Fal
 
                 if interrupt():
                     return
+    for org_id in cache_keys_to_invalidate:
+        delete_keys(org_id)
 
 
 def _delete_host(session, event_producer, host, identity=None):


### PR DESCRIPTION
# Overview

* Add mechanism to remove cached keys by prefix using the org_id prefix
* Add decorator to get/list host APIs
* Add delete keys step to host APIs that alter/delete host data for cache invalidation
* Add delete keys step to MQ processing flow for cache invalidation
* Add delete keys step to host reaper flow for cache invalidation

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
