### PR TITLE
bugfix(api): Add cache invalidation on create group

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -89,6 +89,8 @@ def create_group(body, rbac_filter=None):
         created_group = add_group(validated_create_group_data, current_app.event_producer)
         create_group_count.inc()
 
+        current_identity = get_current_identity()
+        delete_keys(current_identity.org_id)
         log_create_group_succeeded(logger, created_group.id)
     except IntegrityError as inte:
         group_name = validated_create_group_data.get("name")


### PR DESCRIPTION
# Overview

* Need to invalidate cache on create group API call
 
## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
