### PR TITLE
fix(RHINENG-10660): Turn off autoflush during MQ batch operation

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -383,7 +383,7 @@ def event_loop(consumer, flask_app, event_producer, notification_event_producer,
         while not interrupt():
             processed_rows = []
             start_time = datetime.now()
-            with session_guard(db.session):
+            with session_guard(db.session), db.session.no_autoflush:
                 while (
                     not interrupt()
                     and (len(processed_rows) < inventory_config().mq_db_batch_max_messages)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-10660](https://issues.redhat.com/browse/RHINENG-10660).
It turns off auto-flush during the MQ batch operation.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
