### PR TITLE
feat(api): split read traffic to read replica db using nginx proxy

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -30,6 +30,26 @@ class Config:
         if cfg.database.rdsCa:
             self._db_ssl_cert = cfg.rds_ca()
 
+        use_read_replica = os.getenv("INVENTORY_API_USE_READREPLICA", "false").lower() == "true"
+        read_replica_file_list = [
+            "/etc/db/readreplica/db_host",
+            "/etc/db/readreplica/db_port",
+            "/etc/db/readreplica/db_name",
+            "/etc/db/readreplica/db_user",
+            "/etc/db/readreplica/db_password",
+        ]
+        if use_read_replica and all(list(map(os.path.isfile, read_replica_file_list))):
+            self.logger.info("Read replica files exist.")
+            with open("/etc/db/readreplica/db_host") as file:
+                self._db_host = file.read().rstrip()
+            with open("/etc/db/readreplica/db_port") as file:
+                self._db_port = file.read().rstrip()
+            with open("/etc/db/readreplica/db_name") as file:
+                self._db_name = file.read().rstrip()
+            with open("/etc/db/readreplica/db_user") as file:
+                self._db_user = file.read().rstrip()
+            with open("/etc/db/readreplica/db_password") as file:
+                self._db_password = file.read().rstrip()
         self._cache_host = None
         self._cache_port = None
         if cfg.inMemoryDb:

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -20,11 +20,210 @@ objects:
       - export-service
     deployments:
     - name: service
-      replicas: ${{REPLICAS_SVC}}
+      podSpec:
+        command:
+        - nginx
+        - -g
+        - daemon off;
+        env:
+        - name: CLOWDER_ENABLED
+          value: ${CLOWDER_ENABLED}
+        - name: APP_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/cloudservices/ubi8-nginx-124
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: ${NGINX_CPU_LIMIT}
+            memory: ${NGINX_MEMORY_LIMIT}
+          requests:
+            cpu: ${NGINX_CPU_REQUEST}
+            memory: ${NGINX_MEMORY_REQUEST}
+        volumeMounts:
+        - mountPath: /etc/nginx
+          name: api-nginx-conf
+        volumes:
+        - configMap:
+            name: nginx-conf
+          name: api-nginx-conf
+      replicas: ${{NGINX_REPLICAS}}
+      webServices:
+        private:
+          enabled: false
+        public:
+          apiPath: inventory
+          enabled: true
+    - name: service-reads
+      replicas: ${{REPLICAS_SVC_READS}}
       webServices:
         public:
           enabled: true
-          apiPath: inventory
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        args: [
+          "gunicorn",
+          "--workers=${GUNICORN_WORKERS}",
+          "--threads=${GUNICORN_THREADS}",
+          "--limit-request-field_size=${GUNICORN_REQUEST_FIELD_LIMIT}",
+          "--limit-request-line=${GUNICORN_REQUEST_LINE_LIMIT}",
+          "--worker-tmp-dir=/gunicorn",
+          "-c",
+          "gunicorn.conf.py",
+          "-b",
+          "0.0.0.0:8000",
+          "-t",
+          "60",
+          "run"
+        ]
+        env:
+        - name: APP_NAME
+          value: ${APP_NAME}
+        - name: PATH_PREFIX
+          value: ${PATH_PREFIX}
+        - name: INVENTORY_LEGACY_API_URL
+          value: /r/insights/platform/inventory/v1/
+        - name: prometheus_multiproc_dir
+          value: /tmp/inventory/prometheus
+        - name: INVENTORY_LOG_LEVEL
+          value: ${LOG_LEVEL}
+        - name: URLLIB3_LOG_LEVEL
+          value: ${URLLIB3_LOG_LEVEL}
+        - name: INVENTORY_DB_SSL_MODE
+          value: ${INVENTORY_DB_SSL_MODE}
+        - name: PAYLOAD_TRACKER_SERVICE_NAME
+          value: inventory
+        - name: PAYLOAD_TRACKER_ENABLED
+          value: 'true'
+        - name: XJOIN_GRAPHQL_URL
+          value: http://${XJOIN_SEARCH_HOST}:${XJOIN_SEARCH_PORT}/graphql
+        - name: BYPASS_RBAC
+          value: ${BYPASS_RBAC}
+        - name: KAFKA_PRODUCER_ACKS
+          value: ${KAFKA_PRODUCER_ACKS}
+        - name: KAFKA_PRODUCER_RETRIES
+          value: ${KAFKA_PRODUCER_RETRIES}
+        - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
+          value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
+        - name: KAFKA_SECURITY_PROTOCOL
+          value: ${KAFKA_SECURITY_PROTOCOL}
+        - name: KAFKA_SASL_MECHANISM
+          value: ${KAFKA_SASL_MECHANISM}
+        - name: KAFKA_EVENT_TOPIC
+          value: ${KAFKA_EVENT_TOPIC}
+        - name: KAFKA_NOTIFICATION_TOPIC
+          value: ${KAFKA_NOTIFICATION_TOPIC}
+        - name: TENANT_TRANSLATOR_URL
+          value: http://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}/internal/orgIds
+        - name: BYPASS_TENANT_TRANSLATION
+          value: ${BYPASS_TENANT_TRANSLATION}
+        - name: CLOWDER_ENABLED
+          value: "true"
+        - name: INVENTORY_DB_STATEMENT_TIMEOUT
+          value: "${INVENTORY_DB_STATEMENT_TIMEOUT}"
+        - name: INVENTORY_DB_LOCK_TIMEOUT
+          value: "${INVENTORY_DB_LOCK_TIMEOUT}"
+        - name: INVENTORY_API_CACHE_TIMEOUT_SECONDS
+          value: "${INVENTORY_API_CACHE_TIMEOUT_SECONDS}"
+        - name: INVENTORY_API_CACHE_TYPE
+          value: "${INVENTORY_API_CACHE_TYPE}"
+        - name: INVENTORY_API_USE_READREPLICA
+          value: "${INVENTORY_API_USE_READREPLICA}"
+        - name: UNLEASH_URL
+          value: ${UNLEASH_URL}
+        - name: UNLEASH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ${UNLEASH_SECRET_NAME}
+              key: CLIENT_ACCESS_TOKEN
+              optional: true
+        - name: BYPASS_UNLEASH
+          value: ${BYPASS_UNLEASH}
+        - name: SEGMENTIO_WRITE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: segmentio
+              key: WRITE_KEY
+              optional: true
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_SERVICE}
+            memory: ${MEMORY_LIMIT_SERVICE}
+          requests:
+            cpu: ${CPU_REQUEST_SERVICE}
+            memory: ${MEMORY_REQUEST_SERVICE}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTP
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 60
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTP
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 60
+        volumeMounts:
+        - mountPath: /tmp/inventory/prometheus
+          name: prometheus-volume
+        - mountPath: /gunicorn
+          name: gunicorn-worker-dir
+        - mountPath: /etc/db/readreplica
+          name: host-inventory-read-only-db
+          readOnly: true
+        volumes:
+        - emptyDir: {}
+          name: prometheus-volume
+        - emptyDir:
+            medium: Memory
+          name: gunicorn-worker-dir
+        - name: host-inventory-read-only-db
+          secret:
+            items:
+            - key: db.host
+              path: db_host
+            - key: db.name
+              path: db_name
+            - key: db.password
+              path: db_password
+            - key: db.port
+              path: db_port
+            - key: db.user
+              path: db_user
+            secretName: host-inventory-read-only-db
+            optional: true
+    - name: service-writes
+      replicas: ${{REPLICAS_SVC_WRITES}}
+      webServices:
+        public:
+          enabled: true
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         args: [
@@ -808,6 +1007,76 @@ objects:
             "system_profile_facts"->'sap' AS "sap_workload",
             "system_profile_facts"->'rhc_client_id' AS "rhc_client_id"
           FROM "hosts"
+
+- apiVersion: v1
+  data:
+    nginx.conf: |-
+      worker_processes  1;
+      error_log  /dev/stderr warn;
+      pid        /run/nginx.pid;
+
+      events {
+        worker_connections  1024;
+      }
+      http {
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_proto" "$http_x_forwarded_for"';
+
+        access_log  /dev/stdout  main;
+
+        sendfile            on;
+        tcp_nopush          on;
+        tcp_nodelay         on;
+        keepalive_timeout   65;
+        server_tokens       off;
+
+        upstream host-inventory-service-reads {
+          server host-inventory-service-reads:8000;
+        }
+        upstream host-inventory-service-writes {
+          server host-inventory-service-writes:8000;
+        }
+        map $request_method $upstream_location {
+                    GET     host-inventory-service-reads;
+                    HEAD    host-inventory-service-reads;
+                    POST    host-inventory-service-writes;
+                    PUT     host-inventory-service-writes;
+                    DELETE  host-inventory-service-writes;
+                    default host-inventory-service-writes;
+        }
+        server {
+          error_log  stderr;
+          listen 8000;
+          listen 9000;
+
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+          proxy_set_header Host $http_host;
+          proxy_redirect off;
+
+          client_max_body_size 500M;
+          client_header_buffer_size 46k;
+          location /healthz {
+              auth_basic          off;
+              allow               all;
+              return              200;
+          }
+          location /metrics {
+              auth_basic          off;
+              allow               all;
+              return              200;
+          }
+          location / {
+            proxy_pass http://$upstream_location;
+            proxy_read_timeout 600s;
+          }
+        }
+      }
+  kind: ConfigMap
+  metadata:
+    name: nginx-conf
+
 parameters:
 - name: LOG_LEVEL
   value: INFO
@@ -912,8 +1181,11 @@ parameters:
   name: REPLICAS_SP
   value: "2"
 - description: Replica count for webservice
-  name: REPLICAS_SVC
-  value: "10"
+  name: REPLICAS_SVC_READS
+  value: "7"
+- description: Replica count for webservice
+  name: REPLICAS_SVC_WRITES
+  value: "3"
 - description: Replica count for export-service
   name: REPLICAS_EXPORT_SVC
   value: "2"
@@ -1043,6 +1315,30 @@ parameters:
   value: '1'
 - name: MQ_DB_BATCH_MAX_SECONDS
   value: '1'
+- name: INVENTORY_API_USE_READREPLICA
+  value: 'false'
+
+# NGINX
+- displayName: Minimum replicas
+  name: NGINX_REPLICAS
+  required: true
+  value: "1"
+- displayName: Memory Request
+  name: NGINX_MEMORY_REQUEST
+  required: true
+  value: 100Mi
+- displayName: Memory Limit
+  name: NGINX_MEMORY_LIMIT
+  required: true
+  value: 200Mi
+- displayName: CPU Request
+  name: NGINX_CPU_REQUEST
+  required: true
+  value: 100m
+- displayName: CPU Limit
+  name: NGINX_CPU_LIMIT
+  required: true
+  value: 200m
 
 # Feature flags
 - description: Unleash secret name


### PR DESCRIPTION
# Overview

* Define nginx config file and proxy in clowdapp.yml
* Define a reads and writes API service
* Mount the read only db connection secret to the reads service
* Update the clowder config flow to connect to the read replica DB if enabled and connection data is present

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
