### PR TITLE
fix(RHINENG-10773) Fix request ID in produced message headers

### DIFF
--- a/app/payload_tracker/__init__.py
+++ b/app/payload_tracker/__init__.py
@@ -219,13 +219,18 @@ class PayloadTrackerContext:
 
 class PayloadTrackerProcessingContext:
     def __init__(
-        self, payload_tracker=None, processing_status_message=None, success_status_message=None, current_operation=None
+        self,
+        payload_tracker=None,
+        processing_status_message=None,
+        success_status_message=None,
+        current_operation=None,
+        inventory_id=None,
     ):
         self._payload_tracker = payload_tracker
         self._processing_status_msg = processing_status_message
         self._success_status_msg = success_status_message
         self._current_operation = current_operation
-        self._inventory_id = None
+        self._inventory_id = inventory_id
 
     def __enter__(self):
         self._payload_tracker.processing(status_message=self._processing_status_msg)

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -291,66 +291,54 @@ def sync_event_message(message, session, event_producer):
 
 
 def update_system_profile(host_data, platform_metadata, operation_args={}):
-    payload_tracker = get_payload_tracker(request_id=threadctx.request_id)
-
-    with PayloadTrackerProcessingContext(
-        payload_tracker,
-        processing_status_message="updating host system profile",
-        current_operation="updating host system profile",
-    ):
-        try:
-            input_host = deserialize_host(host_data, schema=LimitedHostSchema)
-            input_host.id = host_data.get("id")
-            identity = create_mock_identity_with_org_id(input_host.org_id)
-            output_host, update_result = host_repository.update_system_profile(input_host, identity)
-            success_logger = partial(log_update_system_profile_success, logger)
-            return output_host, update_result, identity, success_logger
-        except ValidationException:
-            metrics.update_system_profile_failure.labels("ValidationException").inc()
-            raise
-        except InventoryException:
-            log_update_system_profile_failure(logger, host_data)
-            raise
-        except OperationalError as oe:
-            log_db_access_failure(logger, f"Could not access DB {str(oe)}", host_data)
-            raise oe
-        except Exception:
-            logger.exception("Error while updating host system profile", extra={"host": host_data})
-            metrics.update_system_profile_failure.labels("Exception").inc()
-            raise
+    try:
+        input_host = deserialize_host(host_data, schema=LimitedHostSchema)
+        input_host.id = host_data.get("id")
+        identity = create_mock_identity_with_org_id(input_host.org_id)
+        output_host, update_result = host_repository.update_system_profile(input_host, identity)
+        success_logger = partial(log_update_system_profile_success, logger)
+        return output_host, update_result, identity, success_logger
+    except ValidationException:
+        metrics.update_system_profile_failure.labels("ValidationException").inc()
+        raise
+    except InventoryException:
+        log_update_system_profile_failure(logger, host_data)
+        raise
+    except OperationalError as oe:
+        log_db_access_failure(logger, f"Could not access DB {str(oe)}", host_data)
+        raise oe
+    except Exception:
+        logger.exception("Error while updating host system profile", extra={"host": host_data})
+        metrics.update_system_profile_failure.labels("Exception").inc()
+        raise
 
 
 def add_host(host_data, platform_metadata, operation_args={}):
-    payload_tracker = get_payload_tracker(request_id=threadctx.request_id)
+    try:
+        identity = _get_identity(host_data, platform_metadata)
+        # basic-auth does not need owner_id
+        if identity.identity_type == IdentityType.SYSTEM:
+            host_data = _set_owner(host_data, identity)
 
-    with PayloadTrackerProcessingContext(
-        payload_tracker, processing_status_message="adding/updating host", current_operation="adding/updating host"
-    ):
-        try:
-            identity = _get_identity(host_data, platform_metadata)
-            # basic-auth does not need owner_id
-            if identity.identity_type == IdentityType.SYSTEM:
-                host_data = _set_owner(host_data, identity)
+        input_host = deserialize_host(host_data)
+        log_add_host_attempt(logger, input_host)
+        host_row, add_result = host_repository.add_host(input_host, identity, operation_args=operation_args)
+        success_logger = partial(log_add_update_host_succeeded, logger, add_result)
 
-            input_host = deserialize_host(host_data)
-            log_add_host_attempt(logger, input_host)
-            host_row, add_result = host_repository.add_host(input_host, identity, operation_args=operation_args)
-            success_logger = partial(log_add_update_host_succeeded, logger, add_result)
-
-            return host_row, add_result, identity, success_logger
-        except ValidationException:
-            metrics.add_host_failure.labels("ValidationException", host_data.get("reporter", "null")).inc()
-            raise
-        except InventoryException as ie:
-            log_add_host_failure(logger, str(ie.detail), host_data)
-            raise
-        except OperationalError as oe:
-            log_db_access_failure(logger, f"Could not access DB {str(oe)}", host_data)
-            raise oe
-        except Exception:
-            logger.exception("Error while adding host", extra={"host": host_data})
-            metrics.add_host_failure.labels("Exception", host_data.get("reporter", "null")).inc()
-            raise
+        return host_row, add_result, identity, success_logger
+    except ValidationException:
+        metrics.add_host_failure.labels("ValidationException", host_data.get("reporter", "null")).inc()
+        raise
+    except InventoryException as ie:
+        log_add_host_failure(logger, str(ie.detail), host_data)
+        raise
+    except OperationalError as oe:
+        log_db_access_failure(logger, f"Could not access DB {str(oe)}", host_data)
+        raise oe
+    except Exception:
+        logger.exception("Error while adding host", extra={"host": host_data})
+        metrics.add_host_failure.labels("Exception", host_data.get("reporter", "null")).inc()
+        raise
 
 
 @metrics.ingress_message_handler_time.time()
@@ -406,36 +394,39 @@ def handle_message(message, notification_event_producer, message_operation=add_h
 
 
 def write_add_update_event_message(event_producer: EventProducer, result: OperationResult):
-    output_host = serialize_host(result.host_row, result.staleness_timestamps, staleness=result.staleness_object)
-    insights_id = result.host_row.canonical_facts.get("insights_id")
-    event = build_event(result.event_type, output_host, platform_metadata=result.platform_metadata)
+    # The request ID in the headers is fetched from threadctx.request_id
+    request_id = result.platform_metadata.get("request_id")
+    initialize_thread_local_storage(request_id)
 
-    org_id = output_host["org_id"]
-    headers = message_headers(
-        result.event_type,
-        insights_id,
-        output_host.get("reporter"),
-        output_host.get("system_profile", {}).get("host_type"),
-        output_host.get("system_profile", {}).get("operating_system", {}).get("name"),
-    )
-    event_producer.write_event(event, str(result.host_row.id), headers, wait=True)
-    delete_keys(org_id)
-    result.success_logger(output_host)
+    payload_tracker = get_payload_tracker(request_id=request_id)
+
+    with PayloadTrackerProcessingContext(
+        payload_tracker,
+        processing_status_message="host operation complete",
+        current_operation="write_message_batch",
+        inventory_id=result.host_row.id,
+    ):
+        output_host = serialize_host(result.host_row, result.staleness_timestamps, staleness=result.staleness_object)
+        insights_id = result.host_row.canonical_facts.get("insights_id")
+        event = build_event(result.event_type, output_host, platform_metadata=result.platform_metadata)
+
+        org_id = output_host["org_id"]
+        headers = message_headers(
+            result.event_type,
+            insights_id,
+            output_host.get("reporter"),
+            output_host.get("system_profile", {}).get("host_type"),
+            output_host.get("system_profile", {}).get("operating_system", {}).get("name"),
+        )
+        event_producer.write_event(event, str(result.host_row.id), headers, wait=True)
+        delete_keys(org_id)
+        result.success_logger(output_host)
 
 
 def write_message_batch(event_producer, processed_rows):
     for result in processed_rows:
         if result is not None:
-            request_id = result.platform_metadata.get("request_id")
-            payload_tracker = get_payload_tracker(request_id=request_id)
-
-            with PayloadTrackerContext(
-                payload_tracker,
-                received_status_message="host operation complete",
-                current_operation="write_message_batch",
-            ) as payload_tracker_processing_ctx:
-                payload_tracker_processing_ctx.inventory_id = result.host_row.id
-                write_add_update_event_message(event_producer, result)
+            write_add_update_event_message(event_producer, result)
 
 
 @metrics.export_service_message_handler_time.time()


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-10773](https://issues.redhat.com/browse/RHINENG-10773).
After the MQ batch update, the request ID was effectively being cached in the produced messages within a batch, which was due to `threadctx.request_id` not being set in the correct places. This PR fixes that, and also simplifies our payload tracker usage a bit (which is related).

For reference, [PR 1778](https://github.com/RedHatInsights/insights-host-inventory/pull/1778) is the change that batched our MQ processing.


## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
