### PR TITLE
fix(RHINENG-10790) Fix filtering by multiple operating_system values

### DIFF
--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -182,7 +182,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
         os_filter_list.append(f"({' AND '.join(os_range_filter_list)})")
 
     # The top-level filter list should be joined using "OR"
-    return " OR ".join(os_filter_list)
+    return "(" + " OR ".join(os_filter_list) + ")"
 
 
 # Turns a list into a dict like this:

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -35,6 +35,7 @@ USER_IDENTITY = {
 }
 
 SERVICE_ACCOUNT_IDENTITY = {
+    "account_number": "123",
     "org_id": "456",
     "auth_type": "jwt-auth",
     "internal": {"auth_time": 500, "cross_access": False, "org_id": "456"},


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-10790](https://issues.redhat.com/browse/RHINENG-10790).
The Postgres implementation currently breaks when filtering by multiple operating systems. This was caused by the conditions inside the OS filtering code to not be grouped together. This fixes the issue and adds a test to make sure that other filters (like org_id and host_type) do not get ignored.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
