### PR TITLE
fix(RHINENG-10816) Handle nil/not_nil values for operating_system filter

### DIFF
--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 
 # Utility class to facilitate OS filter comparison
 class OsComparison:
-    def __init__(self, name, comparator, major, minor):
+    def __init__(self, name="", comparator="", major=0, minor=0):
         self.name = name
         self.comparator = comparator
         self.major = major
@@ -99,6 +99,15 @@ def _get_valid_os_names() -> list:
 # Has a similar purpose to _unique_paths, but the OS filter works a bit differently.
 def separate_operating_system_filters(filter_param: dict) -> list[OsComparison]:
     os_filter_list = []
+
+    # Handle filter_param if a list is passed in
+    if isinstance(filter_param, list):
+        return [OsComparison(comparator=param) for param in filter_param]
+
+    # Handle filter_param if a str is passed in
+    if isinstance(filter_param, str):
+        return [OsComparison(comparator=filter_param)]
+
     for os_name in filter_param.keys():
         if os_name not in (os_names := _get_valid_os_names()):
             raise ValidationException(f"operating_system filter only supports these OS names: {os_names}.")
@@ -160,7 +169,9 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
         comparator = POSTGRES_COMPARATOR_LOOKUP.get(os_comparison.comparator)
         comparator_no_eq = comparator[:1]
 
-        if os_comparison.comparator == "eq":
+        if os_comparison.comparator in ["nil", "not_nil"]:
+            os_filter_list.append(f"(system_profile_facts->>'operating_system' {comparator})")
+        elif os_comparison.comparator == "eq":
             os_filter_text = (
                 f"(system_profile_facts->'operating_system'->>'name' = '{os_comparison.name}' AND "
                 f"(system_profile_facts->'operating_system'->>'major')::int = {os_comparison.major} AND "

--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -106,7 +106,7 @@ def separate_operating_system_filters(filter_param) -> list[OsComparison]:
         return [OsComparison(comparator=param) for param in filter_param]
 
     # Handle filter_param if a str is passed in
-    if isinstance(filter_param, str):
+    elif isinstance(filter_param, str):
         return [OsComparison(comparator=filter_param)]
 
     # filter_param is a dict

--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -14,6 +14,7 @@ logger = get_logger(__name__)
 
 
 # Utility class to facilitate OS filter comparison
+# The list of comparators can be seen in POSTGRES_COMPARATOR_LOOKUP
 class OsComparison:
     def __init__(self, name="", comparator="", major=0, minor=0):
         self.name = name
@@ -97,7 +98,7 @@ def _get_valid_os_names() -> list:
 #   OsComparison{name: 'RHEL', comparator: 'gt', major: '8', minor: '5'}
 # ]
 # Has a similar purpose to _unique_paths, but the OS filter works a bit differently.
-def separate_operating_system_filters(filter_param: dict) -> list[OsComparison]:
+def separate_operating_system_filters(filter_param) -> list[OsComparison]:
     os_filter_list = []
 
     # Handle filter_param if a list is passed in
@@ -108,6 +109,7 @@ def separate_operating_system_filters(filter_param: dict) -> list[OsComparison]:
     if isinstance(filter_param, str):
         return [OsComparison(comparator=filter_param)]
 
+    # filter_param is a dict
     for os_name in filter_param.keys():
         if os_name not in (os_names := _get_valid_os_names()):
             raise ValidationException(f"operating_system filter only supports these OS names: {os_names}.")

--- a/api/filtering/filtering_common.py
+++ b/api/filtering/filtering_common.py
@@ -49,6 +49,8 @@ POSTGRES_COMPARATOR_LOOKUP = {
     "neq": "<>",
     "is": "IS",
     "contains": "?",
+    "nil": "IS NULL",
+    "not_nil": "IS NOT NULL",
 }
 
 # These are the default SQL comparison operators to use for each data type.

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1578,7 +1578,10 @@ def test_query_all_sp_filters_operating_system(db_create_host, api_get, sp_filte
                     },
                 }
             ],
-            ["[operating_system][]=nil", "[operating_system]=nil"],
+            [
+                "[operating_system][]=nil",
+                "[operating_system]=nil",
+            ],
         ),
         (
             [
@@ -1591,7 +1594,10 @@ def test_query_all_sp_filters_operating_system(db_create_host, api_get, sp_filte
                 }
             ],
             [None],
-            ["[operating_system][]=not_nil", "[operating_system]=not_nil"],
+            [
+                "[operating_system][]=not_nil",
+                "[operating_system]=not_nil",
+            ],
         ),
         (
             [

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1565,6 +1565,86 @@ def test_query_all_sp_filters_operating_system(db_create_host, api_get, sp_filte
 
 
 @pytest.mark.parametrize(
+    "os_match_data_list,os_nomatch_data_list,sp_filter_param_list",
+    (
+        (
+            [None],
+            [
+                {
+                    "operating_system": {
+                        "name": "RHEL",
+                        "major": "8",
+                        "minor": "1",
+                    },
+                }
+            ],
+            ["[operating_system][]=nil", "[operating_system]=nil"],
+        ),
+        (
+            [
+                {
+                    "operating_system": {
+                        "name": "RHEL",
+                        "major": "8",
+                        "minor": "1",
+                    },
+                }
+            ],
+            [None],
+            ["[operating_system][]=not_nil", "[operating_system]=not_nil"],
+        ),
+        (
+            [
+                None,
+                {
+                    "operating_system": {
+                        "name": "RHEL",
+                        "major": "8",
+                        "minor": "1",
+                    },
+                },
+            ],
+            None,
+            [
+                "[operating_system][]=nil&filter[system_profile][operating_system][]=not_nil",
+            ],
+        ),
+    ),
+)
+def test_query_all_operating_system_nil(
+    db_create_host, api_get, os_match_data_list, os_nomatch_data_list, sp_filter_param_list, subtests
+):
+    # Create host with this system profile
+    match_host_id_list = [
+        str(db_create_host(extra_data={"system_profile_facts": {"operating_system": os_data}}).id)
+        for os_data in os_match_data_list
+    ]
+    if os_nomatch_data_list:
+        nomatch_host_id_list = [
+            str(db_create_host(extra_data={"system_profile_facts": {"operating_system": os_data}}).id)
+            for os_data in os_nomatch_data_list
+        ]
+
+    for sp_filter_param in sp_filter_param_list:
+        with subtests.test(query_param=sp_filter_param):
+            url = build_hosts_url(query=f"?filter[system_profile]{sp_filter_param}")
+
+            with patch("api.host.get_flag_value", return_value=True):
+                response_status, response_data = api_get(url)
+
+            assert response_status == 200
+
+            # Assert that only the matching hosts are returned
+            response_ids = [result["id"] for result in response_data["results"]]
+            for match_host_id in match_host_id_list:
+                assert match_host_id in response_ids
+
+            if os_nomatch_data_list:
+                for nomatch_host_id in nomatch_host_id_list:
+                    assert nomatch_host_id not in response_ids
+
+
+@pytest.mark.parametrize(
     "sp_filter_param_list",
     (
         ["[arch][eq][]=x86_64", "[arch][eq][]=ARM"],  # Uses OR (same comparator)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-10816](https://issues.redhat.com/browse/RHINENG-10816).
It enables the use of "nil" and "not_nil" values on the operating_system system profile filter. For instance, these work:

- `?filter[system_profile][operating_system]=nil`
- `?filter[system_profile][operating_system][]=nil`
- `?filter[system_profile][operating_system][]=nil&filter[system_profile][operating_system][]=not_nil`

Note that you cannot combine a nil/not_nil filter with a filter on a specific OS version due to a technical limitation (the deep-object query param structure). So queries like this will not work:

- `?filter[system_profile][operating_system][]=nil&filter[system_profile][operating_system][RHEL][version][gt][]=8`


## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
