### PR TITLE
feat(RHINENG-10853): creates structure for the stale host notification

### DIFF
--- a/app/queue/notifications.py
+++ b/app/queue/notifications.py
@@ -92,7 +92,7 @@ class SystemDeletedSchema(NotificationSchema):
     events = fields.List(fields.Nested(SystemDeletedEventListSchema()))
 
 
-# Stale became stale notification
+# System became stale notification
 class SystemStaleContextSchema(MarshmallowSchema):
     inventory_id = fields.Str(required=True)
     hostname = fields.Str(required=True)
@@ -155,7 +155,7 @@ def system_deleted_notification(notification_type, host):
     notification = {
         "context": {
             "inventory_id": host.get("id"),
-            "hostname": canonical_facts.get("fqdn", ""),
+            "fqnd": canonical_facts.get("fqdn", ""),
             "display_name": host.get("display_name"),
             "rhel_version": build_rhel_version_str(system_profile),
             "tags": host.get("tags"),
@@ -181,16 +181,16 @@ def system_deleted_notification(notification_type, host):
 def system_stale_notification(notification_type, host):
     base_notification_obj = build_base_notification_obj(notification_type, host)
 
+    host_id = host.get("id")
     canonical_facts = host.get("canonical_facts")
     system_profile = host.get("system_profile_facts")
     notification = {
         "context": {
-            "inventory_id": host.get("id"),
-            "hostname": canonical_facts.get("fqdn", ""),
+            "inventory_id": host_id,
+            "fqnd": canonical_facts.get("fqdn", ""),
             "display_name": host.get("display_name"),
             "rhel_version": build_rhel_version_str(system_profile),
-            # get host url
-            "host_url": "",
+            "host_url": f"https://console.redhat.com/insights/inventory/{host_id}",
             "tags": host.get("tags"),
         },
         "events": [
@@ -207,8 +207,7 @@ def system_stale_notification(notification_type, host):
     }
 
     notification.update(base_notification_obj)
-    result = SystemStaleSchema().dumps(notification)
-    return result
+    return SystemStaleSchema().dumps(notification)
 
 
 def notification_headers(event_type: NotificationType):

--- a/app/queue/notifications.py
+++ b/app/queue/notifications.py
@@ -13,7 +13,7 @@ from app.queue.metrics import notification_serialization_time
 from app.serialization import build_rhel_version_str
 from app.serialization import deserialize_canonical_facts
 
-NotificationType = Enum("NotificationType", ("validation_error", "system_deleted"))
+NotificationType = Enum("NotificationType", ("validation_error", "system_deleted", "system_became_stale"))
 EventSeverity = Enum("EventSeverity", ("warning", "error", "critical"))
 
 
@@ -92,6 +92,32 @@ class SystemDeletedSchema(NotificationSchema):
     events = fields.List(fields.Nested(SystemDeletedEventListSchema()))
 
 
+# Stale became stale notification
+class SystemStaleContextSchema(MarshmallowSchema):
+    inventory_id = fields.Str(required=True)
+    hostname = fields.Str(required=True)
+    display_name = fields.Str(required=True)
+    rhel_version = fields.Str(required=True)
+    host_url = fields.Str(required=True)
+    tags = fields.Dict()
+
+
+class SystemStalePayloadSchema(MarshmallowSchema):
+    groups = fields.List(fields.Dict())
+    insights_id = fields.Str(required=True)
+    subscription_manager_id = fields.Str(required=True)
+    satellite_id = fields.Str(required=True)
+
+
+class SystemStaleEventListSchema(EventListSchema):
+    payload = fields.Nested(SystemStalePayloadSchema())
+
+
+class SystemStaleSchema(NotificationSchema):
+    context = fields.Nested(SystemStaleContextSchema())
+    events = fields.List(fields.Nested(SystemStaleEventListSchema()))
+
+
 def host_validation_error_notification(notification_type, host, detail, stack_trace=None):
     base_notification_obj = build_base_notification_obj(notification_type, host)
     notification = {
@@ -152,6 +178,39 @@ def system_deleted_notification(notification_type, host):
     return result
 
 
+def system_stale_notification(notification_type, host):
+    base_notification_obj = build_base_notification_obj(notification_type, host)
+
+    canonical_facts = host.get("canonical_facts")
+    system_profile = host.get("system_profile_facts")
+    notification = {
+        "context": {
+            "inventory_id": host.get("id"),
+            "hostname": canonical_facts.get("fqdn", ""),
+            "display_name": host.get("display_name"),
+            "rhel_version": build_rhel_version_str(system_profile),
+            # get host url
+            "host_url": "",
+            "tags": host.get("tags"),
+        },
+        "events": [
+            {
+                "metadata": {},
+                "payload": {
+                    "insights_id": canonical_facts.get("insights_id", ""),
+                    "subscription_manager_id": canonical_facts.get("subscription_manager_id", ""),
+                    "satellite_id": canonical_facts.get("satellite_id", ""),
+                    "groups": [{"id": group.get("id"), "name": group.get("name")} for group in host.get("groups")],
+                },
+            },
+        ],
+    }
+
+    notification.update(base_notification_obj)
+    result = SystemStaleSchema().dumps(notification)
+    return result
+
+
 def notification_headers(event_type: NotificationType):
     return {
         "event_type": event_type.name,
@@ -189,4 +248,5 @@ def send_notification(notification_event_producer, notification_type, host, **kw
 NOTIFICATION_TYPE_MAP = {
     NotificationType.validation_error: host_validation_error_notification,
     NotificationType.system_deleted: system_deleted_notification,
+    NotificationType.system_became_stale: system_stale_notification,
 }

--- a/app/queue/notifications.py
+++ b/app/queue/notifications.py
@@ -95,7 +95,7 @@ class SystemDeletedSchema(NotificationSchema):
 # System became stale notification
 class SystemStaleContextSchema(MarshmallowSchema):
     inventory_id = fields.Str(required=True)
-    hostname = fields.Str(required=True)
+    fqdn = fields.Str(required=True)
     display_name = fields.Str(required=True)
     rhel_version = fields.Str(required=True)
     host_url = fields.Str(required=True)
@@ -155,7 +155,7 @@ def system_deleted_notification(notification_type, host):
     notification = {
         "context": {
             "inventory_id": host.get("id"),
-            "fqnd": canonical_facts.get("fqdn", ""),
+            "fqdn": canonical_facts.get("fqdn", ""),
             "display_name": host.get("display_name"),
             "rhel_version": build_rhel_version_str(system_profile),
             "tags": host.get("tags"),
@@ -187,7 +187,7 @@ def system_stale_notification(notification_type, host):
     notification = {
         "context": {
             "inventory_id": host_id,
-            "fqnd": canonical_facts.get("fqdn", ""),
+            "fqdn": canonical_facts.get("fqdn", ""),
             "display_name": host.get("display_name"),
             "rhel_version": build_rhel_version_str(system_profile),
             "host_url": f"https://console.redhat.com/insights/inventory/{host_id}",

--- a/app/queue/notifications.py
+++ b/app/queue/notifications.py
@@ -95,7 +95,8 @@ class SystemDeletedSchema(NotificationSchema):
 # System became stale notification
 class SystemStaleContextSchema(MarshmallowSchema):
     inventory_id = fields.Str(required=True)
-    fqdn = fields.Str(required=True)
+    # hostname is used for consistency with other notifications; corresponds to fqnd on our model
+    hostname = fields.Str(required=True)
     display_name = fields.Str(required=True)
     rhel_version = fields.Str(required=True)
     host_url = fields.Str(required=True)
@@ -155,7 +156,7 @@ def system_deleted_notification(notification_type, host):
     notification = {
         "context": {
             "inventory_id": host.get("id"),
-            "fqdn": canonical_facts.get("fqdn", ""),
+            "hostname": canonical_facts.get("fqdn", ""),
             "display_name": host.get("display_name"),
             "rhel_version": build_rhel_version_str(system_profile),
             "tags": host.get("tags"),
@@ -187,7 +188,7 @@ def system_stale_notification(notification_type, host):
     notification = {
         "context": {
             "inventory_id": host_id,
-            "fqdn": canonical_facts.get("fqdn", ""),
+            "hostname": canonical_facts.get("fqdn", ""),
             "display_name": host.get("display_name"),
             "rhel_version": build_rhel_version_str(system_profile),
             "host_url": f"https://console.redhat.com/insights/inventory/{host_id}",


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-10853](https://issues.redhat.com/browse/RHINENG-10853).
I broke down [RHINENG-7833](https://issues.redhat.com/browse/RHINENG-7833) into 2 sub-tasks to make everyone's life easier, so this is the first one, addressing just the creation of the notification without the code to send it.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
