### PR TITLE
bugfix(api): Correct delete_keys flow using CACHE_CONFIG type

### DIFF
--- a/api/cache.py
+++ b/api/cache.py
@@ -36,6 +36,9 @@ def init_cache(app_config, flask_app):
 
 
 def _delete_keys_simple(prefix):
+    global CACHE
+    if not CACHE:
+        return
     cache_dict = CACHE.cache._cache
     for cache_key in list(cache_dict.keys()):
         if cache_key.startswith(f"flask_cache_{prefix}"):
@@ -54,8 +57,9 @@ def _delete_keys_redis(prefix):
 
 
 def delete_keys(prefix):
-    if CACHE and CACHE.config["CACHE_TYPE"] == "SimpleCache":
+    global CACHE_CONFIG
+    if CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == "SimpleCache":
         _delete_keys_simple(prefix)
 
-    if CACHE and CACHE.config["CACHE_TYPE"] == "RedisCache":
+    if CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == "RedisCache":
         _delete_keys_redis(prefix)


### PR DESCRIPTION
# Overview

* Key off the cache config cache type value to call the correct deletion mechanism.

# Testing
Used local flow to test MQ deletes that caused previous issue.

Added the following the the compose file:
```
    redis:
      image: redis:latest
      restart: always
      ports:
        - "6379:6379"
      volumes:
        - ./cache:/root/redis
      environment:
        - REDIS_PORT=6379
        - REDIS_DATABASES=2
```
Added the following to the environment:
```
INVENTORY_API_CACHE_TIMEOUT_SECONDS=30
INVENTORY_API_CACHE_TYPE="RedisCache"
```

Run the following to populate the Cache:
```
make run_inv_web_service reload=--reload
```
And hit a cached endpoint with curl or Postman
```
curl --location 'http://localhost:8080/api/inventory/v1/hosts/' \
--header 'x-rh-identity: eyJpZGVudGl0eSI6eyJvcmdfaWQiOiI1ODk0MzAwIiwidHlwZSI6IlVzZXIiLCJhdXRoX3R5cGUiOiJiYXNpYy1hdXRoIiwidXNlciI6eyJ1c2VyX2lkIjogNzE0LCAidXNlcm5hbWUiOiJ0dXNlckByZWRoYXQuY29tIiwiZW1haWwiOiJ0dXNlckByZWRoYXQuY29tIiwiZmlyc3RfbmFtZSI6InRlc3QiLCJsYXN0X25hbWUiOiJ1c2VyIiwiaXNfYWN0aXZlIjp0cnVlLCJpc19vcmdfYWRtaW4iOmZhbHNlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW5fVVMifX19'
```

Review the existing redis keys:
```
docker exec -it insights-host-inventory-redis-1 redis-cli keys "*"
```


Before the timeout hit the checkin endpoint to trigger cache deletion via curl or Postman (update the `bios_uuid` to a valid value for an existing system):
```
curl --location 'http://localhost:8080/api/inventory/v1/hosts/checkin' \
--header 'x-rh-identity: eyJpZGVudGl0eSI6eyJvcmdfaWQiOiI1ODk0MzAwIiwidHlwZSI6IlVzZXIiLCJhdXRoX3R5cGUiOiJiYXNpYy1hdXRoIiwidXNlciI6eyJ1c2VyX2lkIjogNzE0LCAidXNlcm5hbWUiOiJ0dXNlckByZWRoYXQuY29tIiwiZW1haWwiOiJ0dXNlckByZWRoYXQuY29tIiwiZmlyc3RfbmFtZSI6InRlc3QiLCJsYXN0X25hbWUiOiJ1c2VyIiwiaXNfYWN0aXZlIjp0cnVlLCJpc19vcmdfYWRtaW4iOmZhbHNlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW5fVVMifX19' \
--header 'Content-Type: application/json' \
--data '{"bios_uuid": "58563b5f-5004-4e0a-a8cb-1bc757c60eb4"}'
```
Review the existing redis keys:
```
docker exec -it insights-host-inventory-redis-1 redis-cli keys "*"
```
The key should have been deleted.


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
