### PR TITLE
feat(rhineng-10859): Add decorator to ensure org_id integrity

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -36,6 +36,7 @@ from lib.group_repository import get_group_using_host_id
 from lib.group_repository import patch_group
 from lib.group_repository import remove_hosts_from_group
 from lib.metrics import create_group_count
+from lib.middleware import ensure_org_data_integrity
 from lib.middleware import rbac
 from lib.middleware import rbac_group_id_check
 
@@ -44,6 +45,7 @@ logger = get_logger(__name__)
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.READ)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_group_list(
     name=None,
@@ -66,6 +68,7 @@ def get_group_list(
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def create_group(body, rbac_filter=None):
     # If there is an attribute filter on the RBAC permissions,
@@ -114,6 +117,7 @@ def create_group(body, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def patch_group_by_id(group_id, body, rbac_filter=None):
     rbac_group_id_check(rbac_filter, {group_id})
@@ -154,6 +158,7 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_groups(group_id_list, rbac_filter=None):
     rbac_group_id_check(rbac_filter, set(group_id_list))
@@ -171,6 +176,7 @@ def delete_groups(group_id_list, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.READ)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_groups_by_id(
     group_id_list,
@@ -197,6 +203,7 @@ def get_groups_by_id(
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
     rbac_group_id_check(rbac_filter, {group_id})
@@ -214,6 +221,7 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_hosts_from_different_groups(host_id_list, rbac_filter=None):
     hosts_per_group = {}

--- a/api/host.py
+++ b/api/host.py
@@ -62,6 +62,7 @@ from lib.host_repository import find_existing_host
 from lib.host_repository import find_non_culled_hosts
 from lib.host_repository import get_host_list_by_id_list_from_db
 from lib.host_repository import update_query_for_owner_id
+from lib.middleware import ensure_org_data_integrity
 from lib.middleware import rbac
 
 
@@ -74,6 +75,7 @@ logger = get_logger(__name__)
 @api_operation
 @CACHE.cached(key_prefix=make_key)
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_host_list(
     display_name=None,
@@ -159,6 +161,7 @@ def get_host_list(
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_hosts_by_filter(
     display_name=None,
@@ -320,6 +323,7 @@ def delete_all_hosts(confirm_delete_all=None, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_host_by_id(host_id_list, rbac_filter=None):
     delete_count = _delete_host_list(host_id_list, rbac_filter)
@@ -332,6 +336,7 @@ def delete_host_by_id(host_id_list, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_host_by_id(host_id_list, page=1, per_page=100, order_by=None, order_how=None, fields=None, rbac_filter=None):
     current_identity = get_current_identity()
@@ -360,6 +365,7 @@ def get_host_by_id(host_id_list, page=1, per_page=100, order_by=None, order_how=
 @api_operation
 @CACHE.cached(key_prefix=make_key)
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_host_system_profile_by_id(
     host_id_list, page=1, per_page=100, order_by=None, order_how=None, fields=None, rbac_filter=None
@@ -398,6 +404,7 @@ def _emit_patch_event(serialized_host, host):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def patch_host_by_id(host_id_list, body, rbac_filter=None):
     try:
@@ -431,6 +438,7 @@ def patch_host_by_id(host_id_list, body, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def replace_facts(host_id_list, namespace, body, rbac_filter=None):
     return update_facts_by_namespace(FactOperations.replace, host_id_list, namespace, body, rbac_filter)
@@ -438,6 +446,7 @@ def replace_facts(host_id_list, namespace, body, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def merge_facts(host_id_list, namespace, body, rbac_filter=None):
     if not body:
@@ -549,6 +558,7 @@ def _build_paginated_host_tags_response(total, page, per_page, tags_list):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def host_checkin(body, rbac_filter=None):
     current_identity = get_current_identity()

--- a/api/staleness.py
+++ b/api/staleness.py
@@ -24,6 +24,7 @@ from app.serialization import serialize_staleness_response
 from app.serialization import serialize_staleness_to_dict
 from lib.feature_flags import FLAG_INVENTORY_CUSTOM_STALENESS
 from lib.feature_flags import get_flag_value
+from lib.middleware import ensure_org_data_integrity
 from lib.middleware import rbac
 from lib.staleness import add_staleness
 from lib.staleness import patch_staleness
@@ -49,6 +50,7 @@ def _validate_input_data(body):
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.READ, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_staleness(rbac_filter=None):
     try:
@@ -63,6 +65,7 @@ def get_staleness(rbac_filter=None):
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.READ, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_default_staleness(rbac_filter=None):
     try:
@@ -78,6 +81,7 @@ def get_default_staleness(rbac_filter=None):
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def create_staleness(body):
     if not get_flag_value(FLAG_INVENTORY_CUSTOM_STALENESS):
@@ -108,6 +112,7 @@ def create_staleness(body):
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_staleness():
     if not get_flag_value(FLAG_INVENTORY_CUSTOM_STALENESS):
@@ -126,6 +131,7 @@ def delete_staleness():
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
+@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def update_staleness(body):
     if not get_flag_value(FLAG_INVENTORY_CUSTOM_STALENESS):

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -188,7 +188,7 @@ def ensure_org_data_integrity():
             if isinstance(result, Response):
                 data = result.get_json()
             elif isinstance(result, tuple):
-                data, _ = result
+                data = result[0]
             else:
                 data = result
             if isinstance(data, dict):

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -7,6 +7,7 @@ from app_common_python import LoadedConfig
 from flask import abort
 from flask import g
 from flask import request
+from flask import Response
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
@@ -175,3 +176,38 @@ def rbac_group_id_check(rbac_filter: dict, requested_ids: set) -> None:
             joined_ids = ", ".join(disallowed_ids)
             rbac_group_permission_denied(logger, joined_ids, required_permission)
             abort(HTTPStatus.FORBIDDEN, f"You do not have access to the the following groups: {joined_ids}")
+
+
+def ensure_org_data_integrity():
+    def decorator(func):
+        @wraps(func)
+        def decorator_method(*args, **kwargs):
+            current_identity = get_current_identity()
+            result = func(*args, **kwargs)
+
+            if isinstance(result, Response):
+                data = result.get_json()
+            elif isinstance(result, tuple):
+                data, _ = result
+            else:
+                data = result
+            if isinstance(data, dict):
+                message = (
+                    f"Response contained data for another org_id. Path={request.path}, parameters={request.args}."
+                )
+                if "org_id" in data:
+                    if data.get("org_id") and (data.get("org_id") != current_identity.org_id):
+                        logger.error(message)
+                        abort(HTTPStatus.FORBIDDEN)
+                if "results" in data:
+                    results_array = data.get("results", [])
+                    for system in results_array:
+                        org_id = system.get("org_id")
+                        if org_id and (org_id != current_identity.org_id):
+                            logger.error(message)
+                            abort(HTTPStatus.FORBIDDEN)
+            return result
+
+        return decorator_method
+
+    return decorator


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-10859](https://issues.redhat.com/browse/RHINENG-10859).
* Create a decorator that process the response of API calls and validates that it only contains data for the current org
* Apply decorator to APIs

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
