### PR TITLE
Added SQL dump facility to aid in testing, debugging and reviewing.

### DIFF
--- a/tests/helpers/sql_dump.py
+++ b/tests/helpers/sql_dump.py
@@ -1,0 +1,29 @@
+from sqlalchemy import event as sqlevent
+import json
+
+try:
+	from sqlparse import format as sql_formatter
+except ModuleNotFoundError:
+	def sql_formatter(sql_str, reindent=True, keyword_case='upper'):
+		return sql_str
+
+from app import db
+
+class SQLDump(object):
+	def __init__(self, dump_method=None, write_method=print):
+		if dump_method is None:
+			self.dump_method = self.dump_sql
+		self.write_method = write_method
+
+	def __enter__(self):
+		sqlevent.listen(db.engine, "before_execute", self.dump_method)
+
+	def __exit__(self, exc_type, exc_value, exc_traceback):
+		sqlevent.remove(db.engine, "before_execute", self.dump_method)
+
+	def dump_sql(self, conn, clauseelement, multiparams, params, execution_options):
+		self.write_method("**** QUERY:\n")
+		self.write_method(sql_formatter(str(clauseelement.compile()), reindent=True, keyword_case='upper'))
+		self.write_method("\n**** PARAMETERS:\n")
+		self.write_method(json.dumps(clauseelement.compile().params, sort_keys=True, indent=4, default=str))
+		self.write_method("\n****************\n")

--- a/tests/helpers/sql_dump.py
+++ b/tests/helpers/sql_dump.py
@@ -1,29 +1,33 @@
-from sqlalchemy import event as sqlevent
 import json
 
+from sqlalchemy import event as sqlevent
+
 try:
-	from sqlparse import format as sql_formatter
+    from sqlparse import format as sql_formatter
 except ModuleNotFoundError:
-	def sql_formatter(sql_str, reindent=True, keyword_case='upper'):
-		return sql_str
+
+    def sql_formatter(sql_str, reindent=True, keyword_case="upper"):
+        return sql_str
+
 
 from app import db
 
-class SQLDump(object):
-	def __init__(self, dump_method=None, write_method=print):
-		if dump_method is None:
-			self.dump_method = self.dump_sql
-		self.write_method = write_method
 
-	def __enter__(self):
-		sqlevent.listen(db.engine, "before_execute", self.dump_method)
+class SQLDump:
+    def __init__(self, dump_method=None, write_method=print):
+        if dump_method is None:
+            self.dump_method = self.dump_sql
+        self.write_method = write_method
 
-	def __exit__(self, exc_type, exc_value, exc_traceback):
-		sqlevent.remove(db.engine, "before_execute", self.dump_method)
+    def __enter__(self):
+        sqlevent.listen(db.engine, "before_execute", self.dump_method)
 
-	def dump_sql(self, conn, clauseelement, multiparams, params, execution_options):
-		self.write_method("**** QUERY:\n")
-		self.write_method(sql_formatter(str(clauseelement.compile()), reindent=True, keyword_case='upper'))
-		self.write_method("\n**** PARAMETERS:\n")
-		self.write_method(json.dumps(clauseelement.compile().params, sort_keys=True, indent=4, default=str))
-		self.write_method("\n****************\n")
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        sqlevent.remove(db.engine, "before_execute", self.dump_method)
+
+    def dump_sql(self, conn, clauseelement, multiparams, params, execution_options):
+        self.write_method("**** QUERY:\n")
+        self.write_method(sql_formatter(str(clauseelement.compile()), reindent=True, keyword_case="upper"))
+        self.write_method("\n**** PARAMETERS:\n")
+        self.write_method(json.dumps(clauseelement.compile().params, sort_keys=True, indent=4, default=str))
+        self.write_method("\n****************\n")

--- a/tests/helpers/sql_dump.py
+++ b/tests/helpers/sql_dump.py
@@ -14,6 +14,25 @@ except ModuleNotFoundError:
 
 from app import db
 
+"""
+Usage:
+    from tests.helpers.sql_dump import SQLDump
+    :
+    :
+    # In the test case "with" statement
+        with SQLDump():
+            assert_host_exists_in_db(created_host.id, subset_canonical_facts)
+
+    ------
+
+    from tests.helpers.sql_dump import dumps_sql
+    :
+    :
+    # Or decorator for whole method
+    @dumps_sql
+    def test_find_host_using_superset_canonical_fact_match(db_create_host):
+"""
+
 
 class SQLDump:
     def __init__(self, dump_method=None, write_method=print):


### PR DESCRIPTION
# Overview

A utility to dump formatted SQL statements within tests. It hooks into SQLAlchemy events, so there's no need to isolate the query in the code so it can be printed.

Simple use case, within your test code:
```python
from tests.helpers.sql_dump import SQLDump
: 
: 
# In the test case
    with SQLDump():
        assert_host_exists_in_db(created_host.id, subset_canonical_facts)
```
All the SQL that is executed as the result of the `assert_host_exists_in_db()` call will be dumped, along with a formatted list of parameters.

There's also a decorator that makes it easy to dump all the SQL executed by a given function:
```python
from tests.helpers.sql_dump import dumps_sql
:
:
@dumps_sql
def test_find_host_using_superset_canonical_fact_match(db_create_host):
```
Will dump all the SQL executed by the `test_find_host_using_superset_canonical_fact_match()` test case.

In either case, you can override the dump or write methods based on your specific needs. For example, if you wanted to write the SQL dump to `stderr` instead of `stdout`:
```python
with SQLDump(write_method=sys.stderr.write):
        assert_host_exists_in_db(created_host.id, subset_canonical_facts)
```
or
```python
@dumps_sql(write_method=sys.stderr.write)
def test_find_host_using_superset_canonical_fact_match(db_create_host):
```
Some sample output:
```
**** QUERY:

SELECT hosts.system_profile_facts[:param_1] AS anon_1,
       hosts.id AS hosts_id,
       hosts.account AS hosts_account,
       hosts.org_id AS hosts_org_id,
       hosts.display_name AS hosts_display_name,
       hosts.ansible_host AS hosts_ansible_host,
       hosts.created_on AS hosts_created_on,
       hosts.modified_on AS hosts_modified_on,
       hosts.facts AS hosts_facts,
       hosts.tags AS hosts_tags,
       hosts.canonical_facts AS hosts_canonical_facts,
       hosts.system_profile_facts AS hosts_system_profile_facts,
       hosts.groups AS hosts_groups,
       hosts.stale_timestamp AS hosts_stale_timestamp,
       hosts.reporter AS hosts_reporter,
       hosts.per_reporter_staleness AS hosts_per_reporter_staleness
FROM hosts
WHERE hosts.org_id = :org_id_1
  AND NOT (hosts.canonical_facts ? :canonical_facts_1
           AND NOT hosts.canonical_facts @> :canonical_facts_2)
  AND hosts.canonical_facts @> :canonical_facts_3
  AND (hosts.modified_on > :modified_on_1
       AND hosts.system_profile_facts[:system_profile_facts_1] = :param_2
       OR hosts.modified_on > :modified_on_2
       AND hosts.modified_on <= :modified_on_3
       AND hosts.system_profile_facts[:system_profile_facts_2] = :param_3
       OR hosts.modified_on > :modified_on_4
       AND hosts.modified_on <= :modified_on_5
       AND hosts.system_profile_facts[:system_profile_facts_3] = :param_4
       OR hosts.modified_on > :modified_on_6
       AND hosts.system_profile_facts[:system_profile_facts_4] IS NULL
       OR hosts.modified_on > :modified_on_7
       AND hosts.modified_on <= :modified_on_8
       AND hosts.system_profile_facts[:system_profile_facts_5] IS NULL
       OR hosts.modified_on > :modified_on_9
       AND hosts.modified_on <= :modified_on_10
       AND hosts.system_profile_facts[:system_profile_facts_6] IS NULL)
ORDER BY hosts.modified_on DESC
LIMIT :param_5

**** PARAMETERS:

{
    "canonical_facts_1": "fqdn",
    "canonical_facts_2": {
        "fqdn": "fred.flintstone.com"
    },
    "canonical_facts_3": {
        "fqdn": "fred.flintstone.com"
    },
    "modified_on_1": "2024-06-24 14:26:48.239896+00:00",
    "modified_on_10": "2024-06-19 14:26:48.240534+00:00",
    "modified_on_2": "2023-12-29 14:26:48.239896+00:00",
    "modified_on_3": "2024-06-24 14:26:48.239896+00:00",
    "modified_on_4": "2022-06-27 14:26:48.239896+00:00",
    "modified_on_5": "2023-12-29 14:26:48.239896+00:00",
    "modified_on_6": "2024-06-25 09:26:48.240534+00:00",
    "modified_on_7": "2024-06-19 14:26:48.240534+00:00",
    "modified_on_8": "2024-06-25 09:26:48.240534+00:00",
    "modified_on_9": "2024-06-12 14:26:48.240534+00:00",
    "org_id_1": "test",
    "param_1": "host_type",
    "param_2": "edge",
    "param_3": "edge",
    "param_4": "edge",
    "param_5": 1,
    "system_profile_facts_1": "host_type",
    "system_profile_facts_2": "host_type",
    "system_profile_facts_3": "host_type",
    "system_profile_facts_4": "host_type",
    "system_profile_facts_5": "host_type",
    "system_profile_facts_6": "host_type"
}

****************
```
NOTE: The above output was formatted with the `sqlparse` package. The use of the `sqlparse` is optional; if the package is installed, it will be used. Otherwise, the unformatted SQL string will be output.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
