### PR TITLE
bugfix(api): Invalidate cache on add and remove hosts from groups

### DIFF
--- a/api/host_group.py
+++ b/api/host_group.py
@@ -7,9 +7,11 @@ from flask import Response
 from api import api_operation
 from api import flask_json_response
 from api import metrics
+from api.cache import delete_keys
 from api.group_query import build_group_response
 from app import RbacPermission
 from app import RbacResourceType
+from app.auth import get_current_identity
 from app.instrumentation import log_host_group_add_succeeded
 from app.instrumentation import log_patch_group_failed
 from app.logging import get_logger
@@ -50,6 +52,8 @@ def add_host_list_to_group(group_id, body, rbac_filter=None):
         add_hosts_to_group(group_id, body, current_app.event_producer)
 
     updated_group = get_group_by_id_from_db(group_id)
+    current_identity = get_current_identity()
+    delete_keys(current_identity.org_id)
     log_host_group_add_succeeded(logger, host_id_list, group_id)
     return flask_json_response(build_group_response(updated_group), HTTPStatus.OK)
 
@@ -65,4 +69,6 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
     if delete_count == 0:
         abort(HTTPStatus.NOT_FOUND, "Group or hosts not found.")
 
+    current_identity = get_current_identity()
+    delete_keys(current_identity.org_id)
     return Response(None, HTTPStatus.NO_CONTENT)


### PR DESCRIPTION
# Overview

* Update host_group.py to call delete keys for these two APIs that were missed.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
