### PR TITLE
feat(api): Add weighting to reads API server so writes db can take variable traffic

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1032,7 +1032,8 @@ objects:
         server_tokens       off;
 
         upstream host-inventory-service-reads {
-          server host-inventory-service-reads:8000;
+          server host-inventory-service-reads:8000 weight=${ROUND_ROBIN_READS_WEIGHT};
+          server host-inventory-service-writes:8000;
         }
         upstream host-inventory-service-writes {
           server host-inventory-service-writes:8000;
@@ -1339,6 +1340,10 @@ parameters:
   name: NGINX_CPU_LIMIT
   required: true
   value: 200m
+- displayName: Round robin weight to send traffic to the reads API
+  name: ROUND_ROBIN_READS_WEIGHT
+  required: true
+  value: '8'
 
 # Feature flags
 - description: Unleash secret name


### PR DESCRIPTION
# Overview

* Add a weight to the reads API service that is configurable by parameter
* Include writes service in reads location; default weight of 1
* Add a parameter, default to 8, for the weight of the reads service

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
