### PR TITLE
bugfix(rhineng-10815): Fix make_key to avoid args being flattened causing cache collisions

### DIFF
--- a/api/cache_key.py
+++ b/api/cache_key.py
@@ -4,9 +4,16 @@ from app import IDENTITY_HEADER
 from app import process_identity_header
 
 
+def _encode_params(args):
+    arg_key = ""
+    for key, val in args.to_dict(flat=False).items():
+        arg_key += f"{key}={val}"
+    return arg_key
+
+
 def make_key():
     request = flask.request
-    args = str(hash(frozenset(request.args.items())))
+    args = str(hash(_encode_params(request.args)))
     encoded_id_header = request.headers.get(IDENTITY_HEADER)
     org_id, access_id = process_identity_header(encoded_id_header)
     if org_id is None or access_id is None:


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-10815](https://issues.redhat.com/browse/RHINENG-10815).

* Add a fix to collect and hash all request args avoiding them being flatten if a key has multiple values

I found the following [blog](https://www.geeksforgeeks.org/multi-value-query-parameters-with-flask/) that lead me to the fix, which called out the following that the original code didn't do:
```
request.args.to_dict(flat=False)
```

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
