### PR TITLE
[RHINENG-11403] Create a new Makefile entry to run the inv_export_service.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ run_inv_web_service:
 run_inv_mq_service:
 	KAFKA_EVENT_TOPIC=platform.inventory.events PAYLOAD_TRACKER_SERVICE_NAME=inventory-mq-service INVENTORY_LOG_LEVEL=DEBUG BYPASS_TENANT_TRANSLATION=true python3 inv_mq_service.py
 
+run_inv_export_service:
+	KAFKA_EXPORT_SERVICE_TOPIC=platform.export.requests EXPORT_SERVICE_TOKEN=testing-a-psk python3 inv_export_service.py
+
 run_inv_mq_service_test_producer:
 	NUM_HOSTS=${NUM_HOSTS} python3 utils/kafka_producer.py
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ In one terminal, run the following command:
 
 ```bash
 pipenv shell
-python3 inv_export_service.py
+make run_inv_export_service
 ```
 
 In one other terminal, generate event towards the export service with the following command:


### PR DESCRIPTION
This PR adds a new Makefile entry to run the `inv_export_service.py` script.

# Overview

This PR is being created to address [RHINENG-11403](https://issues.redhat.com/browse/RHINENG-11403).

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
