### PR TITLE
fix(RHINENG-9245): Fix API doc permissions for staleness

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -792,7 +792,7 @@ paths:
       summary: Read the entire list of account staleness
       description: >-
         Read the entire list of all accounts staleness available.
-        Required permissions: inventory:TODO:read
+        Required permissions: staleness:staleness:read
       security:
         - ApiKeyAuth: []
         - BearerAuth: []
@@ -812,7 +812,7 @@ paths:
       summary: Create account staleness record
       description: >-
         Create account staleness record.
-        Required permissions: inventory:TODO:write
+        Required permissions: staleness:staleness:write
       security:
         - ApiKeyAuth: []
         - BearerAuth: []
@@ -839,7 +839,7 @@ paths:
       summary: Update account staleness record
       description: >-
         Update account staleness record.
-        Required permissions: inventory:staleness:write
+        Required permissions: staleness:staleness:write
       security:
         - ApiKeyAuth: []
         - BearerAuth: []
@@ -869,7 +869,7 @@ paths:
       description: >-
         Delete an account staleness
         <br /><br />
-        Required permissions: inventory:staleness:write
+        Required permissions: staleness:staleness:write
       security:
         - ApiKeyAuth: []
         - BearerAuth: []
@@ -889,7 +889,7 @@ paths:
       summary: Read the entire list of account staleness
       description: >-
         Read the entire list of all accounts staleness available.
-        Required permissions: inventory:TODO:read
+        Required permissions: staleness:staleness:read
       security:
         - ApiKeyAuth: []
         - BearerAuth: []

--- a/swagger/openapi.dev.json
+++ b/swagger/openapi.dev.json
@@ -1330,7 +1330,7 @@
           "accounts_staleness"
         ],
         "summary": "Read the entire list of account staleness",
-        "description": "Read the entire list of all accounts staleness available. Required permissions: inventory:TODO:read",
+        "description": "Read the entire list of all accounts staleness available. Required permissions: staleness:staleness:read",
         "security": [
           {
             "ApiKeyAuth": []
@@ -1361,7 +1361,7 @@
           "accounts_staleness"
         ],
         "summary": "Create account staleness record",
-        "description": "Create account staleness record. Required permissions: inventory:TODO:write",
+        "description": "Create account staleness record. Required permissions: staleness:staleness:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -1403,7 +1403,7 @@
           "accounts_staleness"
         ],
         "summary": "Update account staleness record",
-        "description": "Update account staleness record. Required permissions: inventory:staleness:write",
+        "description": "Update account staleness record. Required permissions: staleness:staleness:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -1448,7 +1448,7 @@
           "accounts_staleness"
         ],
         "summary": "Delete an account staleness",
-        "description": "Delete an account staleness <br /><br /> Required permissions: inventory:staleness:write",
+        "description": "Delete an account staleness <br /><br /> Required permissions: staleness:staleness:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -1477,7 +1477,7 @@
           "accounts_staleness"
         ],
         "summary": "Read the entire list of account staleness",
-        "description": "Read the entire list of all accounts staleness available. Required permissions: inventory:TODO:read",
+        "description": "Read the entire list of all accounts staleness available. Required permissions: staleness:staleness:read",
         "security": [
           {
             "ApiKeyAuth": []

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1330,7 +1330,7 @@
           "accounts_staleness"
         ],
         "summary": "Read the entire list of account staleness",
-        "description": "Read the entire list of all accounts staleness available. Required permissions: inventory:TODO:read",
+        "description": "Read the entire list of all accounts staleness available. Required permissions: staleness:staleness:read",
         "security": [
           {
             "ApiKeyAuth": []
@@ -1361,7 +1361,7 @@
           "accounts_staleness"
         ],
         "summary": "Create account staleness record",
-        "description": "Create account staleness record. Required permissions: inventory:TODO:write",
+        "description": "Create account staleness record. Required permissions: staleness:staleness:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -1403,7 +1403,7 @@
           "accounts_staleness"
         ],
         "summary": "Update account staleness record",
-        "description": "Update account staleness record. Required permissions: inventory:staleness:write",
+        "description": "Update account staleness record. Required permissions: staleness:staleness:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -1448,7 +1448,7 @@
           "accounts_staleness"
         ],
         "summary": "Delete an account staleness",
-        "description": "Delete an account staleness <br /><br /> Required permissions: inventory:staleness:write",
+        "description": "Delete an account staleness <br /><br /> Required permissions: staleness:staleness:write",
         "security": [
           {
             "ApiKeyAuth": []
@@ -1477,7 +1477,7 @@
           "accounts_staleness"
         ],
         "summary": "Read the entire list of account staleness",
-        "description": "Read the entire list of all accounts staleness available. Required permissions: inventory:TODO:read",
+        "description": "Read the entire list of all accounts staleness available. Required permissions: staleness:staleness:read",
         "security": [
           {
             "ApiKeyAuth": []


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-9245](https://issues.redhat.com/browse/RHINENG-9245).

Fix API doc with correct permissions for the staleness resources


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
