### PR TITLE
fix(RHINENG-11457): Correct legacy API path

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -179,7 +179,7 @@ class Config:
 
         self.base_url_path = self._build_base_url_path()
         self.api_url_path_prefix = self._build_api_path()
-        self.legacy_api_url_path_prefix = os.getenv("INVENTORY_LEGACY_API_URL", "")
+        self.legacy_api_url_path_prefix = os.getenv("INVENTORY_LEGACY_API_URL", "/r/insights/platform/inventory/v1")
         self.mgmt_url_path_prefix = os.getenv("INVENTORY_MANAGEMENT_URL_PATH_PREFIX", "/")
 
         self.api_urls = [self.api_url_path_prefix, self.legacy_api_url_path_prefix]

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -103,7 +103,7 @@ objects:
         - name: PATH_PREFIX
           value: ${PATH_PREFIX}
         - name: INVENTORY_LEGACY_API_URL
-          value: /r/insights/platform/inventory/v1/
+          value: /r/insights/platform/inventory/v1
         - name: prometheus_multiproc_dir
           value: /tmp/inventory/prometheus
         - name: INVENTORY_LOG_LEVEL
@@ -249,7 +249,7 @@ objects:
         - name: PATH_PREFIX
           value: ${PATH_PREFIX}
         - name: INVENTORY_LEGACY_API_URL
-          value: /r/insights/platform/inventory/v1/
+          value: /r/insights/platform/inventory/v1
         - name: prometheus_multiproc_dir
           value: /tmp/inventory/prometheus
         - name: INVENTORY_LOG_LEVEL
@@ -395,7 +395,7 @@ objects:
         - name: PATH_PREFIX
           value: ${PATH_PREFIX}
         - name: INVENTORY_LEGACY_API_URL
-          value: /r/insights/platform/inventory/v1/
+          value: /r/insights/platform/inventory/v1
         - name: prometheus_multiproc_dir
           value: /tmp/inventory/prometheus
         - name: INVENTORY_LOG_LEVEL

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -16,8 +16,10 @@ from app.auth.identity import IdentityType
 from tests.helpers.test_utils import now
 
 BASE_URL = "/api/inventory/v1"
+LEGACY_BASE_URL = "/r/insights/platform/inventory/v1"
 ASSIGNMENT_RULE_URL = f"{BASE_URL}/assignment-rules"
 HOST_URL = f"{BASE_URL}/hosts"
+LEGACY_HOST_URL = f"{LEGACY_BASE_URL}/hosts"
 GROUP_URL = f"{BASE_URL}/groups"
 TAGS_URL = f"{BASE_URL}/tags"
 SYSTEM_PROFILE_URL = f"{BASE_URL}/system_profile"

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -25,6 +25,7 @@ from tests.helpers.api_utils import create_mock_rbac_response
 from tests.helpers.api_utils import HOST_READ_ALLOWED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import HOST_READ_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import HOST_URL
+from tests.helpers.api_utils import LEGACY_HOST_URL
 from tests.helpers.api_utils import quote
 from tests.helpers.api_utils import quote_everything
 from tests.helpers.graphql_utils import XJOIN_HOSTS_RESPONSE
@@ -496,13 +497,17 @@ def test_get_hosts_timestamp_invalid_value_graceful_rejection(patch_xjoin_post, 
     assert 400 == api_get(build_hosts_url(query="?filter[system_profile][last_boot_time][eq]=foo"))[0]
 
 
-def test_query_all(mq_create_three_specific_hosts, api_get, subtests):
+@pytest.mark.parametrize(
+    "host_url",
+    (HOST_URL, LEGACY_HOST_URL),
+)
+def test_query_all(mq_create_three_specific_hosts, api_get, subtests, host_url):
     created_hosts = mq_create_three_specific_hosts
     expected_host_list = build_expected_host_list(created_hosts)
 
     with patch("api.host.get_flag_value", return_value=True):
-        response_status, response_data = api_get(HOST_URL)
-        api_base_pagination_test(api_get, subtests, HOST_URL, expected_total=len(expected_host_list))
+        response_status, response_data = api_get(host_url)
+        api_base_pagination_test(api_get, subtests, host_url, expected_total=len(expected_host_list))
 
     assert response_status == 200
     assert_host_lists_equal(expected_host_list, response_data["results"])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -472,14 +472,14 @@ class CreateAppConnexionAppInitTestCase(TestCase):
         translating_parser.assert_called_once_with(SPECIFICATION_FILE)
         assert "lazy" not in translating_parser.mock_calls[0].kwargs
 
-        app.return_value.add_api.assert_called_once()
+        assert app.return_value.add_api.call_count == 2
         args = app.return_value.add_api.mock_calls[0].args
         assert len(args) == 1
         assert args[0] is translating_parser.return_value.specification
 
     def test_specification_is_parsed(self, init_app, app):
         create_app(RuntimeEnvironment.TEST)
-        app.return_value.add_api.assert_called_once()
+        assert app.return_value.add_api.call_count == 2
         args = app.return_value.add_api.mock_calls[0].args
         assert len(args) == 1
         assert args[0] is not None


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-11457](https://issues.redhat.com/browse/RHINENG-11457).
The Connexion & Flask upgrade in PR #1822 broke the legacy API. It turns out this was due to how trailing slashes are handled in the framework; removing the trailing slash from the API path fixed the issue.

I also added a test to make sure the basic `GET /hosts` request works on both the new and legacy endpoints.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
