### PR TITLE
feat(RHINENG-7840): add logic to newly registered system notifications

### DIFF
--- a/app/queue/events.py
+++ b/app/queue/events.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 EventType = Enum("EventType", ("created", "updated", "delete"))
 
+HOST_EVENT_TYPE_CREATED = "created"
+
 
 def hostname():
     return os.uname().nodename

--- a/app/queue/notifications.py
+++ b/app/queue/notifications.py
@@ -11,6 +11,7 @@ from app.common import inventory_config
 from app.logging import threadctx
 from app.queue.events import hostname
 from app.queue.metrics import notification_serialization_time
+from app.serialization import _deserialize_tags
 from app.serialization import build_rhel_version_str
 from app.serialization import deserialize_canonical_facts
 
@@ -34,7 +35,7 @@ class BaseContextSchema(MarshmallowSchema):
     hostname = fields.Str(required=True)
     display_name = fields.Str(required=True)
     rhel_version = fields.Str(required=True)
-    tags = fields.Raw()
+    tags = fields.Dict()
 
 
 class BaseEventListSchema(MarshmallowSchema):
@@ -210,7 +211,7 @@ def build_base_notification_obj(notification_type, host):
             "hostname": canonical_facts.get("fqdn", ""),
             "display_name": host.get("display_name"),
             "rhel_version": build_rhel_version_str(system_profile),
-            "tags": host.get("tags"),
+            "tags": _deserialize_tags(host.get("tags")),
         },
         "events": [],
     }

--- a/app/queue/notifications.py
+++ b/app/queue/notifications.py
@@ -228,7 +228,7 @@ def populate_events(base_notification_obj, host_list, extra_fields=[]):
                 "insights_id": canonical_facts.get("insights_id", ""),
                 "subscription_manager_id": canonical_facts.get("subscription_manager_id", ""),
                 "satellite_id": canonical_facts.get("satellite_id", ""),
-                "groups": [{"id": group.get("id"), "name": group.get("name")} for group in host.get("groups")],
+                "groups": [{"id": group.get("id"), "name": group.get("name")} for group in host.get("groups", [])],
             },
         }
 

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -351,6 +351,13 @@ def handle_message(message, notification_event_producer, message_operation=add_h
             )
             staleness_timestamps = Timestamps.from_config(inventory_config())
             event_type = operation_results_to_event_type(operation_result)
+
+            if message_operation == add_host:
+                send_notification(
+                    notification_event_producer,
+                    notification_type=NotificationType.new_system_registered,
+                    host=host,
+                )
             return OperationResult(
                 host_row,
                 platform_metadata,

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -521,10 +521,10 @@ def _serialize_per_reporter_staleness(host, staleness, staleness_timestamps):
 def build_rhel_version_str(system_profile: dict) -> str:
     os = system_profile.get("operating_system")
     if os:
-        if os.get("name") == "rhel":
+        if os.get("name", "").lower() == "rhel":
             major = os.get("major")
             minor = os.get("minor")
-            return f"{major:03}.{minor:03}"
+            return f"{major}.{minor}"
     return ""
 
 

--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -7,6 +7,8 @@ import pytest
 
 from app import db
 from app.queue.event_producer import EventProducer
+from app.queue.notifications import NotificationType
+from app.queue.notifications import send_notification
 from app.queue.queue import add_host
 from app.queue.queue import handle_message
 from app.queue.queue import write_add_update_event_message

--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -42,6 +42,7 @@ def mq_create_or_update_host(flask_app, event_producer_mock, notification_event_
         result = handle_message(json.dumps(message), notification_event_producer, message_operation)
         db.session.commit()
         write_add_update_event_message(event_producer, result)
+        send_notification(notification_event_producer_mock, NotificationType.new_system_registered, host_data.data())
         event = json.loads(event_producer.event)
 
         if return_all_data:

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -230,9 +230,51 @@ def assert_patch_event_is_valid(
     )
 
 
-def expected_headers(
-    event_type, request_id, insights_id=None, reporter=None, host_type=None, os_name=None, is_bootc="False"
-):
+def assert_system_registered_notification_is_valid(notification_event_producer, host):
+    event = json.loads(notification_event_producer.event)
+    context = event["context"]
+    payload = event["events"][0]["payload"]
+
+    assert isinstance(event, dict)
+
+    expected_keys = {
+        "timestamp",
+        "event_type",
+        "account_id",
+        "org_id",
+        "application",
+        "bundle",
+        "context",
+        "events",
+    }
+
+    expected_context_keys = {
+        "inventory_id",
+        "hostname",
+        "display_name",
+        "rhel_version",
+        "tags",
+        "host_url",
+    }
+
+    expected_payload_keys = {
+        "insights_id",
+        "subscription_manager_id",
+        "satellite_id",
+        "groups",
+        "reporter",
+        "system_check_in",
+    }
+    assert set(event.keys()) == expected_keys
+    assert set(context.keys()) == expected_context_keys
+    assert set(payload.keys()) == expected_payload_keys
+
+    assert "new-system-registered" == event["event_type"]
+
+    assert host.insights_id == event["events"][0]["payload"]["insights_id"]
+
+
+def expected_headers(event_type, request_id, insights_id=None, reporter=None, host_type=None, os_name=None):
     return {
         "event_type": event_type,
         "request_id": request_id,

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -240,7 +240,6 @@ def assert_system_registered_notification_is_valid(notification_event_producer, 
     expected_keys = {
         "timestamp",
         "event_type",
-        "account_id",
         "org_id",
         "application",
         "bundle",

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -274,7 +274,9 @@ def assert_system_registered_notification_is_valid(notification_event_producer, 
     assert host.insights_id == event["events"][0]["payload"]["insights_id"]
 
 
-def expected_headers(event_type, request_id, insights_id=None, reporter=None, host_type=None, os_name=None):
+def expected_headers(
+    event_type, request_id, insights_id=None, reporter=None, host_type=None, os_name=None, is_bootc="False"
+):
     return {
         "event_type": event_type,
         "request_id": request_id,

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -56,7 +56,7 @@ YUM_REPO2 = {"id": "repo2", "name": "repo2", "gpgcheck": True, "enabled": True, 
 SATELLITE_IDENTITY = deepcopy(SYSTEM_IDENTITY)
 SATELLITE_IDENTITY["system"]["cert_type"] = "satellite"
 
-COMPOUND_FACT_VALUES = {"provider_type": ProviderType.AWS}
+COMPOUND_FACT_VALUES = {"provider_type": ProviderType.AWS.value}
 
 
 def generate_uuid():

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -222,7 +222,7 @@ def test_elevated_id_priority_order_nomatch(db_create_host, changing_id):
 def test_elevated_id_priority_order_match(db_create_host, changing_id):
     base_canonical_facts = {
         "provider_id": generate_uuid(),
-        "provider_type": ProviderType.AWS,
+        "provider_type": ProviderType.AWS.value,
         "insights_id": generate_uuid(),
         "subscription_manager_id": generate_uuid(),
     }
@@ -290,7 +290,7 @@ def test_provider_id_dup(mq_create_or_update_host, db_get_host):
     canonical_facts = {
         "subscription_manager_id": subscription_manager_id_x,
         "provider_id": provider_id,
-        "provider_type": ProviderType.AWS,
+        "provider_type": ProviderType.AWS.value,
     }
     first_host = minimal_host(**canonical_facts)
     del first_host.ip_addresses
@@ -303,7 +303,7 @@ def test_provider_id_dup(mq_create_or_update_host, db_get_host):
     canonical_facts = {
         "subscription_manager_id": subscription_manager_id_y,
         "provider_id": provider_id,
-        "provider_type": ProviderType.AWS,
+        "provider_type": ProviderType.AWS.value,
     }
     second_host = minimal_host(**canonical_facts)
     del second_host.ip_addresses
@@ -318,7 +318,7 @@ def test_provider_id_dup(mq_create_or_update_host, db_get_host):
     canonical_facts = {
         "subscription_manager_id": subscription_manager_id_y,
         "provider_id": provider_id,
-        "provider_type": ProviderType.AWS,
+        "provider_type": ProviderType.AWS.value,
     }
     third_host = minimal_host(**canonical_facts)
     del third_host.ip_addresses
@@ -334,7 +334,7 @@ def test_provider_id_dup(mq_create_or_update_host, db_get_host):
 def test_rhsm_conduit_elevated_id_priority_no_identity(mq_create_or_update_host, changing_id):
     base_canonical_facts = {
         "account": SYSTEM_IDENTITY["account_number"],
-        "provider_type": ProviderType.AWS,
+        "provider_type": ProviderType.AWS.value,
         "provider_id": generate_uuid(),
         "insights_id": generate_uuid(),
         "subscription_manager_id": generate_uuid(),
@@ -459,7 +459,7 @@ def test_find_host_using_provider_id_and_type_match(db_create_host):
     canonical_facts = {
         "insights_id": generate_uuid(),
         "provider_id": generate_uuid(),
-        "provider_type": ProviderType.AWS,
+        "provider_type": ProviderType.AWS.value,
     }
 
     search_canonical_facts = {
@@ -477,12 +477,12 @@ def test_find_host_using_provider_id_different_type_nomatch(db_create_host):
     canonical_facts = {
         "insights_id": generate_uuid(),
         "provider_id": generate_uuid(),
-        "provider_type": ProviderType.AWS,
+        "provider_type": ProviderType.AWS.value,
     }
 
     search_canonical_facts = {
         "provider_id": canonical_facts["provider_id"],
-        "provider_type": ProviderType.IBM,
+        "provider_type": ProviderType.IBM.value,
     }
 
     host = minimal_db_host(canonical_facts=canonical_facts)
@@ -495,7 +495,7 @@ def test_find_host_using_provider_id_no_type_exception(db_create_host):
     canonical_facts = {
         "insights_id": generate_uuid(),
         "provider_id": generate_uuid(),
-        "provider_type": ProviderType.AWS,
+        "provider_type": ProviderType.AWS.value,
     }
 
     search_canonical_facts = {
@@ -513,7 +513,7 @@ def test_find_host_using_provider_id_existing_with_match(db_create_host):
     canonical_facts = {
         "insights_id": generate_uuid(),
         "provider_id": generate_uuid(),
-        "provider_type": ProviderType.AWS,
+        "provider_type": ProviderType.AWS.value,
     }
 
     search_canonical_facts = {
@@ -532,7 +532,7 @@ def test_find_host_using_provider_id_existing_without_match(db_create_host):
     search_canonical_facts = {
         "insights_id": canonical_facts["insights_id"],
         "provider_id": generate_uuid(),
-        "provider_type": ProviderType.AWS,
+        "provider_type": ProviderType.AWS.value,
     }
 
     host = minimal_db_host(canonical_facts=canonical_facts)
@@ -543,8 +543,8 @@ def test_find_host_using_provider_id_existing_without_match(db_create_host):
 
 def test_find_correct_host_varying_provider_type(db_create_host, mq_create_or_update_host):
     provider_id = generate_uuid()  # common provider_id
-    aws_canonical_facts = {"provider_id": provider_id, "provider_type": ProviderType.AWS}
-    ibm_canonical_facts = {"provider_id": provider_id, "provider_type": ProviderType.IBM}
+    aws_canonical_facts = {"provider_id": provider_id, "provider_type": ProviderType.AWS.value}
+    ibm_canonical_facts = {"provider_id": provider_id, "provider_type": ProviderType.IBM.value}
 
     aws_host = db_create_host(host=minimal_db_host(canonical_facts=aws_canonical_facts))
     aws_host_id = aws_host.id

--- a/tests/test_duplicate_hosts.py
+++ b/tests/test_duplicate_hosts.py
@@ -27,7 +27,7 @@ logger = get_logger(__name__)
 def test_delete_duplicate_host(event_producer_mock, db_create_host, db_get_host, inventory_config):
     # make two hosts that are the same
     canonical_facts = {
-        "provider_type": ProviderType.AWS,  # Doesn't matter
+        "provider_type": ProviderType.AWS.value,  # Doesn't matter
         "provider_id": generate_uuid(),
         "insights_id": generate_uuid(),
         "subscription_manager_id": generate_uuid(),

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -317,28 +317,7 @@ def test_handle_message_verify_message_headers(mocker, add_host_result, mq_creat
     assert headers == expected_headers(add_host_result.name, request_id, insights_id, "rhsm-conduit")
 
 
-@pytest.mark.parametrize(
-    "expected_value, system_profile",
-    [
-        ("False", {}),
-        ("False", {"bootc_status": {}}),
-        ("True", {"bootc_status": {"booted": {}}}),
-        ("True", {"bootc_status": {"booted": {"image": "192.168.0.1:5000/foo/foo:latest"}}}),
-    ],
-)
-def test_verify_bootc_in_headers(expected_value, system_profile, mq_create_or_update_host):
-    host = minimal_host(
-        account=SYSTEM_IDENTITY["account_number"],
-        insights_id=generate_uuid(),
-        system_profile=system_profile,
-    )
-
-    _, _, headers = mq_create_or_update_host(host, return_all_data=True)
-    assert "is_bootc" in headers
-    assert headers["is_bootc"] is expected_value
-
-
-def test_add_host_simple(event_datetime_mock, mq_create_or_update_host):
+def test_add_host_simple(event_datetime_mock, mq_create_or_update_host, notification_event_producer_mock):
     """
     Tests adding a host with some simple data
     """

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -134,7 +134,7 @@ def test_handle_message_happy_path(identity, mocker, flask_app):
     assert result.event_type == EventType.created
     assert result.host_row.canonical_facts["insights_id"] == expected_insights_id
 
-    mock_notification_event_producer.write_event.assert_not_called()
+    mock_notification_event_producer.write_event.assert_called_once()
 
 
 def test_request_id_is_reset(mocker, flask_app, db_create_host):
@@ -317,28 +317,7 @@ def test_handle_message_verify_message_headers(mocker, add_host_result, mq_creat
     assert headers == expected_headers(add_host_result.name, request_id, insights_id, "rhsm-conduit")
 
 
-@pytest.mark.parametrize(
-    "expected_value, system_profile",
-    [
-        ("False", {}),
-        ("False", {"bootc_status": {}}),
-        ("True", {"bootc_status": {"booted": {}}}),
-        ("True", {"bootc_status": {"booted": {"image": "192.168.0.1:5000/foo/foo:latest"}}}),
-    ],
-)
-def test_verify_bootc_in_headers(expected_value, system_profile, mq_create_or_update_host):
-    host = minimal_host(
-        account=SYSTEM_IDENTITY["account_number"],
-        insights_id=generate_uuid(),
-        system_profile=system_profile,
-    )
-
-    _, _, headers = mq_create_or_update_host(host, return_all_data=True)
-    assert "is_bootc" in headers
-    assert headers["is_bootc"] is expected_value
-
-
-def test_add_host_simple(event_datetime_mock, mq_create_or_update_host):
+def test_add_host_simple(event_datetime_mock, mq_create_or_update_host, notification_event_producer_mock):
     """
     Tests adding a host with some simple data
     """

--- a/tests/test_mq_service.py
+++ b/tests/test_mq_service.py
@@ -245,7 +245,7 @@ def test_handle_message_unicode_not_damaged(mocker, flask_app, db_create_host, s
                 mocker.MagicMock(),
             )
             handle_message(message, mocker.Mock(), add_host)
-            add_host.assert_called_once_with(json.loads(message)["data"], mocker.ANY, {})
+            add_host.assert_called_once_with(json.loads(message)["data"], mocker.ANY, mocker.ANY, {})
 
 
 def test_handle_message_verify_metadata_pass_through(mq_create_or_update_host):

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -8,6 +8,7 @@ from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import minimal_host
 from tests.helpers.test_utils import SYSTEM_IDENTITY
 
+
 OWNER_ID = SYSTEM_IDENTITY["system"]["cn"]
 
 
@@ -23,7 +24,6 @@ def test_add_basic_host_success(mq_create_or_update_host, notification_event_pro
     )
 
     mq_create_or_update_host(host, return_all_data=True)
-
     assert_system_registered_notification_is_valid(notification_event_producer_mock, host)
 
 
@@ -40,35 +40,15 @@ def test_new_system_notification_fields(mq_create_or_update_host, notification_e
 
     mq_create_or_update_host(host, return_all_data=True)
     notification = json.loads(notification_event_producer_mock.event)
-
     assert_system_registered_notification_is_valid(notification_event_producer_mock, host)
 
     assert notification["context"]["rhel_version"] == "8.6"
     assert notification["org_id"] == SYSTEM_IDENTITY["org_id"]
 
 
-# this test should pass, RHINENG-11348 was created to fix this behavior
-
-# def test_add_host_fail(mocker):
-#     """
-#     Test new system notification is not produced after add host fails
-#     """
-#     invalid_message = json.dumps({"operation": "add_host", "NOTdata": {}})  # Missing data field
-
-#     mock_event_producer = mocker.Mock()
-#     mock_notification_event_producer = mocker.Mock()
-
-#     with pytest.raises(marshmallow.exceptions.ValidationError):
-#         handle_message(invalid_message, mock_event_producer, mock_notification_event_producer)
-
-#     mock_event_producer.assert_not_called()
-#     mock_notification_event_producer.assert_not_called()
-
-
 def test_add_host_fail(mq_create_or_update_host, notification_event_producer_mock):
-    """
-    Test new system notification is not produced after add host fails
-    """
+    # Test new system notification is not produced after add host fails
+
     owner_id = "Mike Wazowski"
     host = minimal_host(org_id=SYSTEM_IDENTITY["org_id"], system_profile={"owner_id": owner_id})
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,90 @@
+import json
+
+import pytest
+
+from app.exceptions import ValidationException
+from tests.helpers.mq_utils import assert_system_registered_notification_is_valid
+from tests.helpers.test_utils import generate_uuid
+from tests.helpers.test_utils import minimal_host
+from tests.helpers.test_utils import SYSTEM_IDENTITY
+
+OWNER_ID = SYSTEM_IDENTITY["system"]["cn"]
+
+
+# New System Registered
+def test_add_basic_host_success(mq_create_or_update_host, notification_event_producer_mock):
+    """
+    Tests notification production after adding a host
+    """
+    expected_insights_id = generate_uuid()
+
+    host = minimal_host(
+        account=SYSTEM_IDENTITY["account_number"],
+        insights_id=expected_insights_id,
+    )
+
+    mq_create_or_update_host(host, return_all_data=True)
+
+    assert_system_registered_notification_is_valid(notification_event_producer_mock, host)
+
+
+def test_new_system_notification_fields(mq_create_or_update_host, notification_event_producer_mock):
+    expected_insights_id = generate_uuid()
+
+    host = minimal_host(
+        account=SYSTEM_IDENTITY["account_number"],
+        insights_id=expected_insights_id,
+        system_profile={
+            "operating_system": {"name": "RHEL", "major": 8, "minor": 6},
+        },
+    )
+
+    mq_create_or_update_host(host, return_all_data=True)
+    notification = json.loads(notification_event_producer_mock.event)
+
+    assert_system_registered_notification_is_valid(notification_event_producer_mock, host)
+
+    assert notification["context"]["rhel_version"] == "8.6"
+    assert notification["account_id"] == SYSTEM_IDENTITY["account_number"]
+
+
+# this test should pass, RHINENG-11348 was created to fix this behavior
+
+# def test_add_host_fail(mocker):
+#     """
+#     Test new system notification is not produced after add host fails
+#     """
+#     invalid_message = json.dumps({"operation": "add_host", "NOTdata": {}})  # Missing data field
+
+#     mock_event_producer = mocker.Mock()
+#     mock_notification_event_producer = mocker.Mock()
+
+#     with pytest.raises(marshmallow.exceptions.ValidationError):
+#         handle_message(invalid_message, mock_event_producer, mock_notification_event_producer)
+
+#     mock_event_producer.assert_not_called()
+#     mock_notification_event_producer.assert_not_called()
+
+
+def test_add_host_fail(mq_create_or_update_host, notification_event_producer_mock):
+    """
+    Test new system notification is not produced after add host fails
+    """
+    owner_id = "Mike Wazowski"
+    host = minimal_host(account=SYSTEM_IDENTITY["account_number"], system_profile={"owner_id": owner_id})
+
+    with pytest.raises(ValidationException):
+        mq_create_or_update_host(host, notification_event_producer=notification_event_producer_mock)
+
+    # a host validation error notification should be produced instead
+    event = json.loads(notification_event_producer_mock.event)
+
+    assert event is not None
+    assert "validation-error" == event["event_type"]
+
+
+# System Became Stale
+
+# System Deleted
+
+# Host Validation Error

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -13,13 +13,12 @@ OWNER_ID = SYSTEM_IDENTITY["system"]["cn"]
 
 # New System Registered
 def test_add_basic_host_success(mq_create_or_update_host, notification_event_producer_mock):
-    """
-    Tests notification production after adding a host
-    """
+    # Tests notification production after adding a host
+
     expected_insights_id = generate_uuid()
 
     host = minimal_host(
-        account=SYSTEM_IDENTITY["account_number"],
+        org_id=SYSTEM_IDENTITY["org_id"],
         insights_id=expected_insights_id,
     )
 
@@ -32,7 +31,7 @@ def test_new_system_notification_fields(mq_create_or_update_host, notification_e
     expected_insights_id = generate_uuid()
 
     host = minimal_host(
-        account=SYSTEM_IDENTITY["account_number"],
+        org_id=SYSTEM_IDENTITY["org_id"],
         insights_id=expected_insights_id,
         system_profile={
             "operating_system": {"name": "RHEL", "major": 8, "minor": 6},
@@ -45,7 +44,7 @@ def test_new_system_notification_fields(mq_create_or_update_host, notification_e
     assert_system_registered_notification_is_valid(notification_event_producer_mock, host)
 
     assert notification["context"]["rhel_version"] == "8.6"
-    assert notification["account_id"] == SYSTEM_IDENTITY["account_number"]
+    assert notification["org_id"] == SYSTEM_IDENTITY["org_id"]
 
 
 # this test should pass, RHINENG-11348 was created to fix this behavior
@@ -71,7 +70,7 @@ def test_add_host_fail(mq_create_or_update_host, notification_event_producer_moc
     Test new system notification is not produced after add host fails
     """
     owner_id = "Mike Wazowski"
-    host = minimal_host(account=SYSTEM_IDENTITY["account_number"], system_profile={"owner_id": owner_id})
+    host = minimal_host(org_id=SYSTEM_IDENTITY["org_id"], system_profile={"owner_id": owner_id})
 
     with pytest.raises(ValidationException):
         mq_create_or_update_host(host, notification_event_producer=notification_event_producer_mock)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1723,7 +1723,7 @@ class SerializationSerializeHostMockedTestCase(SerializationSerializeHostBaseTes
         }
         self.assertEqual(expected, actual)
 
-        serialize_canonical_facts.assert_called_once_with(host_init_data["canonical_facts"])
+        serialize_canonical_facts.assert_called_once_with(host_init_data["canonical_facts"], omit_null_facts=False)
         serialize_facts.assert_called_once_with(host_init_data["facts"])
         serialize_tags.assert_called_once_with(host_init_data["tags"])
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-7840](https://issues.redhat.com/browse/RHINENG-7840).

- add the logic necessary to send the notifications for newly registered hosts.
- add a few changes to `notifications.py` that will be overwritten by the [refactoring PR](https://github.com/RedHatInsights/insights-host-inventory/pull/1825)

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
