### PR TITLE
feat(api): Invalidate cached systems in groups and staleness apis

### DIFF
--- a/api/cache.py
+++ b/api/cache.py
@@ -64,3 +64,10 @@ def delete_keys(prefix):
 
     if CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == "RedisCache" and prefix:
         _delete_keys_redis(prefix)
+
+
+def delete_cached_system_keys(insights_id=None, org_id=None):
+    if insights_id:
+        delete_keys(f"insights_id={insights_id}")
+    if org_id:
+        delete_keys(f"insights_id=*_org={org_id}")

--- a/api/cache_key.py
+++ b/api/cache_key.py
@@ -20,3 +20,7 @@ def make_key():
         return
     key = f"{org_id}_{access_id}_{request.path}_{args}"
     return key
+
+
+def make_system_cache_key(insights_id, org_id, owner_id):
+    return f"insights_id={insights_id}_org={org_id}_user=SYSTEM-{owner_id}"

--- a/api/group.py
+++ b/api/group.py
@@ -10,6 +10,7 @@ from api import api_operation
 from api import flask_json_response
 from api import json_error_response
 from api import metrics
+from api.cache import delete_cached_system_keys
 from api.cache import delete_keys
 from api.group_query import build_group_response
 from api.group_query import build_paginated_group_list_response
@@ -94,6 +95,7 @@ def create_group(body, rbac_filter=None):
 
         current_identity = get_current_identity()
         delete_keys(current_identity.org_id)
+        delete_cached_system_keys(org_id=current_identity.org_id)
         log_create_group_succeeded(logger, created_group.id)
     except IntegrityError as inte:
         group_name = validated_create_group_data.get("name")
@@ -152,6 +154,7 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
     updated_group = get_group_by_id_from_db(group_id)
     current_identity = get_current_identity()
     delete_keys(current_identity.org_id)
+    delete_cached_system_keys(org_id=current_identity.org_id)
     log_patch_group_success(logger, group_id)
     return flask_json_response(build_group_response(updated_group), HTTPStatus.OK)
 
@@ -171,6 +174,7 @@ def delete_groups(group_id_list, rbac_filter=None):
 
     current_identity = get_current_identity()
     delete_keys(current_identity.org_id)
+    delete_cached_system_keys(current_identity.org_id)
     return Response(None, HTTPStatus.NO_CONTENT)
 
 
@@ -216,6 +220,7 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
 
     current_identity = get_current_identity()
     delete_keys(current_identity.org_id)
+    delete_cached_system_keys(org_id=current_identity.org_id)
     return Response(None, HTTPStatus.NO_CONTENT)
 
 
@@ -251,4 +256,5 @@ def delete_hosts_from_different_groups(host_id_list, rbac_filter=None):
 
     current_identity = get_current_identity()
     delete_keys(current_identity.org_id)
+    delete_cached_system_keys(current_identity.org_id)
     return Response(None, HTTPStatus.NO_CONTENT)

--- a/api/host_group.py
+++ b/api/host_group.py
@@ -7,6 +7,7 @@ from flask import Response
 from api import api_operation
 from api import flask_json_response
 from api import metrics
+from api.cache import delete_cached_system_keys
 from api.cache import delete_keys
 from api.group_query import build_group_response
 from app import RbacPermission
@@ -54,6 +55,7 @@ def add_host_list_to_group(group_id, body, rbac_filter=None):
     updated_group = get_group_by_id_from_db(group_id)
     current_identity = get_current_identity()
     delete_keys(current_identity.org_id)
+    delete_cached_system_keys(org_id=current_identity.org_id)
     log_host_group_add_succeeded(logger, host_id_list, group_id)
     return flask_json_response(build_group_response(updated_group), HTTPStatus.OK)
 
@@ -71,4 +73,5 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
 
     current_identity = get_current_identity()
     delete_keys(current_identity.org_id)
+    delete_cached_system_keys(org_id=current_identity.org_id)
     return Response(None, HTTPStatus.NO_CONTENT)

--- a/api/staleness.py
+++ b/api/staleness.py
@@ -10,6 +10,7 @@ from api import api_operation
 from api import flask_json_response
 from api import json_error_response
 from api import metrics
+from api.cache import delete_cached_system_keys
 from api.cache import delete_keys
 from api.staleness_query import get_staleness_obj
 from api.staleness_query import get_sys_default_staleness_api
@@ -100,6 +101,7 @@ def create_staleness(body):
         # Create account staleness with validated data
         created_staleness = add_staleness(validated_data)
         delete_keys(org_id)
+        delete_cached_system_keys(org_id=org_id)
         log_create_staleness_succeeded(logger, created_staleness.id)
     except IntegrityError:
         error_message = f"Staleness record for org_id {org_id} already exists."
@@ -124,6 +126,7 @@ def delete_staleness():
     try:
         remove_staleness()
         delete_keys(org_id)
+        delete_cached_system_keys(org_id=org_id)
         return flask_json_response(None, HTTPStatus.NO_CONTENT)
     except NoResultFound:
         abort(
@@ -156,6 +159,7 @@ def update_staleness(body):
             raise NoResultFound
 
         delete_keys(org_id)
+        delete_cached_system_keys(org_id=org_id)
         log_patch_staleness_succeeded(logger, updated_staleness.id)
 
         return flask_json_response(serialize_staleness_response(updated_staleness), HTTPStatus.OK)

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -5,6 +5,7 @@ from dateutil.parser import isoparse
 from marshmallow import ValidationError
 
 from api.staleness_query import get_staleness_obj
+from app.auth import get_current_identity
 from app.common import inventory_config
 from app.culling import Conditions
 from app.culling import Timestamps
@@ -521,3 +522,10 @@ def build_rhel_version_str(system_profile: dict) -> str:
             minor = os.get("minor")
             return f"{major:03}.{minor:03}"
     return ""
+
+
+def serialize_host_with_params(host, additional_fields=tuple(), system_profile_fields=None):
+    timestamps = Timestamps.from_config(inventory_config())
+    identity = get_current_identity()
+    staleness = get_staleness_obj(identity)
+    return serialize_host(host, timestamps, False, additional_fields, staleness, system_profile_fields)


### PR DESCRIPTION
# Overview

* Define key deletion types and abstract them out
* Add cached system key deletion to group and staleness flows
* Define method for cached system key
* Add cache opportunity on cached system miss

You can reuse testing instructions from here: https://github.com/RedHatInsights/insights-host-inventory/pull/1841
However now if you alter staleness or groups in the org cached systems will be removed. 

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
