### PR TITLE
Detect and filter zero mac addresses in canonical facts.

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -71,6 +71,8 @@ OLD_TO_NEW_REPORTER_MAP = {"yupana": ("satellite", "discovery")}
 MIN_CANONICAL_FACTS_VERSION = 0
 MAX_CANONICAL_FACTS_VERSION = 1
 
+ZERO_MAC_ADDRESS = "00:00:00:00:00:00"
+
 
 class ProviderType(str, Enum):
     ALIBABA = "alibaba"
@@ -731,6 +733,14 @@ class CanonicalFactsSchema(MarshmallowSchema):
     @validates_schema
     def validate_schema(self, data, **kwargs):
         schema_version = data.get("canonical_facts_version")
+
+        if "mac_addresses" in data:
+            mac_addresses = data["mac_addresses"]
+            while ZERO_MAC_ADDRESS in mac_addresses:
+                logger.warning(f"Zero MAC address reported by: {data.get('reporter', 'Not Available')}")
+                mac_addresses.remove(ZERO_MAC_ADDRESS)
+            if not mac_addresses:
+                raise MarshmallowValidationError("mac_addresses must contain at least on unique MAC address.")
 
         if schema_version > MIN_CANONICAL_FACTS_VERSION:
             if "is_virtual" not in data:

--- a/app/models.py
+++ b/app/models.py
@@ -735,12 +735,20 @@ class CanonicalFactsSchema(MarshmallowSchema):
         schema_version = data.get("canonical_facts_version")
 
         if "mac_addresses" in data:
+            #
+            # Remove all zero mac addresses from the list.
+            #
             mac_addresses = data["mac_addresses"]
             while ZERO_MAC_ADDRESS in mac_addresses:
                 logger.warning(f"Zero MAC address reported by: {data.get('reporter', 'Not Available')}")
                 mac_addresses.remove(ZERO_MAC_ADDRESS)
             if not mac_addresses:
-                raise MarshmallowValidationError("mac_addresses must contain at least on unique MAC address.")
+                #
+                # If mac_addresses is now empty, we remove the mac_addresses key.
+                # This is so we don't introduce a new failure case for varsion 0, and will
+                # only fail for version 1.
+                #
+                del data["mac_addresses"]
 
         if schema_version > MIN_CANONICAL_FACTS_VERSION:
             if "is_virtual" not in data:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -811,16 +811,32 @@ def test_invalid_ip_addresses(canonical_facts):
     (
         {
             "canonical_facts_version": 0,
-            "mac_addresses": [ZERO_MAC_ADDRESS],
-        },
-        {
-            "canonical_facts_version": 1,
             "is_virtual": False,
             "mac_addresses": [ZERO_MAC_ADDRESS],
         },
         {
             "canonical_facts_version": 0,
+            "is_virtual": False,
             "mac_addresses": [ZERO_MAC_ADDRESS, ZERO_MAC_ADDRESS],
+        },
+    ),
+)
+def test_zero_mac_address_only_v0(canonical_facts):
+    #
+    # For version 0 canonical facts, the zero mac address should be filtered out.
+    # If the list is then empty it should proceed as though mac_addresses weren't provided.
+    #
+    validated_host = CanonicalFactsSchema().load(canonical_facts)
+    assert "mac_addresses" not in validated_host
+
+
+@pytest.mark.parametrize(
+    "canonical_facts",
+    (
+        {
+            "canonical_facts_version": 1,
+            "is_virtual": False,
+            "mac_addresses": [ZERO_MAC_ADDRESS],
         },
         {
             "canonical_facts_version": 1,
@@ -829,9 +845,10 @@ def test_invalid_ip_addresses(canonical_facts):
         },
     ),
 )
-def test_zero_mac_address_only(canonical_facts):
+def test_zero_mac_address_only_v1(canonical_facts):
     #
-    # The zero mac address should be filtered out and it should fail as though it was an empty list.
+    # For version 1 canonical facts, the zero mac address should be filtered out.
+    # If the list is then empty it should fail as though it was an empty list.
     #
     with pytest.raises(MarshmallowValidationError):
         CanonicalFactsSchema().load(canonical_facts)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-11698](https://issues.redhat.com/browse/RHINENG-11698).

It appears that some reporters are sending  00:00:00:00:00:00 as one of the reported mac_addresses in the canonical facts. It also seems there are instances where this value is the only reported mac address. Given this is not a unique value, this can lead to duplication issues.

The CanonicalFactsSchema has been updated to check for this. In all cases, the offending reporter is logged, so it can be identified and fixed. The values are removed when they are received, so they won't be saved to the database.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
