### PR TITLE
feat(api): Ensure org_id checking including cached responses

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -37,7 +37,6 @@ from lib.group_repository import get_group_using_host_id
 from lib.group_repository import patch_group
 from lib.group_repository import remove_hosts_from_group
 from lib.metrics import create_group_count
-from lib.middleware import ensure_org_data_integrity
 from lib.middleware import rbac
 from lib.middleware import rbac_group_id_check
 
@@ -46,7 +45,6 @@ logger = get_logger(__name__)
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.READ)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_group_list(
     name=None,
@@ -69,7 +67,6 @@ def get_group_list(
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def create_group(body, rbac_filter=None):
     # If there is an attribute filter on the RBAC permissions,
@@ -119,7 +116,6 @@ def create_group(body, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def patch_group_by_id(group_id, body, rbac_filter=None):
     rbac_group_id_check(rbac_filter, {group_id})
@@ -161,7 +157,6 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_groups(group_id_list, rbac_filter=None):
     rbac_group_id_check(rbac_filter, set(group_id_list))
@@ -180,7 +175,6 @@ def delete_groups(group_id_list, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.READ)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_groups_by_id(
     group_id_list,
@@ -207,7 +201,6 @@ def get_groups_by_id(
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
     rbac_group_id_check(rbac_filter, {group_id})
@@ -226,7 +219,6 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_hosts_from_different_groups(host_id_list, rbac_filter=None):
     hosts_per_group = {}

--- a/api/host.py
+++ b/api/host.py
@@ -65,7 +65,6 @@ from lib.host_repository import find_existing_host
 from lib.host_repository import find_non_culled_hosts
 from lib.host_repository import get_host_list_by_id_list_from_db
 from lib.host_repository import update_query_for_owner_id
-from lib.middleware import ensure_org_data_integrity
 from lib.middleware import rbac
 
 
@@ -78,7 +77,6 @@ logger = get_logger(__name__)
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @CACHE.cached(key_prefix=make_key)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_host_list(
     display_name=None,
@@ -189,7 +187,6 @@ def get_host_list(
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_hosts_by_filter(
     display_name=None,
@@ -351,7 +348,6 @@ def delete_all_hosts(confirm_delete_all=None, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_host_by_id(host_id_list, rbac_filter=None):
     delete_count = _delete_host_list(host_id_list, rbac_filter)
@@ -364,7 +360,6 @@ def delete_host_by_id(host_id_list, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_host_by_id(host_id_list, page=1, per_page=100, order_by=None, order_how=None, fields=None, rbac_filter=None):
     current_identity = get_current_identity()
@@ -393,7 +388,6 @@ def get_host_by_id(host_id_list, page=1, per_page=100, order_by=None, order_how=
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @CACHE.cached(key_prefix=make_key)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_host_system_profile_by_id(
     host_id_list, page=1, per_page=100, order_by=None, order_how=None, fields=None, rbac_filter=None
@@ -433,7 +427,6 @@ def _emit_patch_event(serialized_host, host):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def patch_host_by_id(host_id_list, body, rbac_filter=None):
     try:
@@ -470,7 +463,6 @@ def patch_host_by_id(host_id_list, body, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def replace_facts(host_id_list, namespace, body, rbac_filter=None):
     return update_facts_by_namespace(FactOperations.replace, host_id_list, namespace, body, rbac_filter)
@@ -478,7 +470,6 @@ def replace_facts(host_id_list, namespace, body, rbac_filter=None):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def merge_facts(host_id_list, namespace, body, rbac_filter=None):
     if not body:
@@ -593,7 +584,6 @@ def _build_paginated_host_tags_response(total, page, per_page, tags_list):
 
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def host_checkin(body, rbac_filter=None):
     current_identity = get_current_identity()

--- a/api/staleness.py
+++ b/api/staleness.py
@@ -26,7 +26,6 @@ from app.serialization import serialize_staleness_response
 from app.serialization import serialize_staleness_to_dict
 from lib.feature_flags import FLAG_INVENTORY_CUSTOM_STALENESS
 from lib.feature_flags import get_flag_value
-from lib.middleware import ensure_org_data_integrity
 from lib.middleware import rbac
 from lib.staleness import add_staleness
 from lib.staleness import patch_staleness
@@ -52,7 +51,6 @@ def _validate_input_data(body):
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.READ, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_staleness(rbac_filter=None):
     try:
@@ -67,7 +65,6 @@ def get_staleness(rbac_filter=None):
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.READ, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def get_default_staleness(rbac_filter=None):
     try:
@@ -83,7 +80,6 @@ def get_default_staleness(rbac_filter=None):
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def create_staleness(body):
     if not get_flag_value(FLAG_INVENTORY_CUSTOM_STALENESS):
@@ -116,7 +112,6 @@ def create_staleness(body):
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def delete_staleness():
     if not get_flag_value(FLAG_INVENTORY_CUSTOM_STALENESS):
@@ -138,7 +133,6 @@ def delete_staleness():
 @api_operation
 @rbac(RbacResourceType.STALENESS, RbacPermission.WRITE, permission_base="staleness")
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
-@ensure_org_data_integrity()
 @metrics.api_request_time.time()
 def update_staleness(body):
     if not get_flag_value(FLAG_INVENTORY_CUSTOM_STALENESS):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,6 +36,7 @@ from app.queue.metrics import notification_event_producer_failure
 from app.queue.metrics import notification_event_producer_success
 from app.queue.metrics import rbac_access_denied
 from app.queue.notifications import NotificationType
+from lib.check_org import check_org_id
 from lib.feature_flags import init_unleash_app
 from lib.feature_flags import SchemaStrategy
 from lib.handlers import register_shutdown
@@ -55,6 +56,30 @@ SYSTEM_PROFILE_BLOCK_LIST_FILE = join(SPECIFICATION_DIR, "system_profile_block_l
 SPEC_TYPES_LOOKUP = {"string": str, "integer": int, "boolean": bool, "array": list, "object": dict}
 
 custom_filter_fields = ["operating_system"]
+
+ORG_ID_CHECK_ENDPOINTS = [
+    "api_host_get_host_list",
+    "api_host_delete_hosts_by_filter",
+    "api_host_delete_host_by_id",
+    "api_host_get_host_by_id",
+    "api_host_get_host_system_profile_by_id",
+    "api_host_patch_host_by_id",
+    "api_host_replace_facts",
+    "api_host_merge_facts",
+    "api_host_host_checkin",
+    "api_staleness_get_staleness",
+    "api_staleness_get_default_staleness",
+    "api_staleness_create_staleness",
+    "api_staleness_delete_staleness",
+    "api_staleness_update_staleness",
+    "api_group_get_group_list",
+    "api_group_create_group",
+    "api_group_patch_group_by_id",
+    "api_group_delete_groups",
+    "api_group_get_groups_by_id",
+    "api_group_delete_hosts_from_group",
+    "api_group_delete_hosts_from_different_groups",
+]
 
 
 class RbacPermission(Enum):
@@ -287,6 +312,12 @@ def create_app(runtime_environment):
     @flask_app.before_request
     def set_request_id():
         threadctx.request_id = request.headers.get(REQUEST_ID_HEADER)
+
+    @flask_app.after_request
+    def after_request_org_check(response):
+        if any(endpoint in request.endpoint for endpoint in ORG_ID_CHECK_ENDPOINTS):
+            response = check_org_id(response)
+        return response
 
     if runtime_environment.event_producer_enabled:
         flask_app.event_producer = EventProducer(app_config, app_config.event_topic)

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -52,6 +52,8 @@ from app.serialization import deserialize_host
 from app.serialization import serialize_host
 from lib import host_repository
 from lib.db import session_guard
+from lib.feature_flags import FLAG_INVENTORY_USE_CACHED_INSIGHTS_CLIENT_SYSTEM
+from lib.feature_flags import get_flag_value
 
 logger = get_logger(__name__)
 
@@ -428,17 +430,18 @@ def write_add_update_event_message(event_producer: EventProducer, result: Operat
     org_id = output_host.get("org_id")
     delete_keys(org_id)
     result.success_logger(output_host)
-    try:
-        owner_id = output_host.get("system_profile", {}).get("owner_id")
-        if owner_id and insights_id and org_id:
-            system_key = make_system_cache_key(insights_id, org_id, owner_id)
-            if "tags" in output_host:
-                del output_host["tags"]
-            if "system_profile" in output_host:
-                del output_host["system_profile"]
-            set_cached_system(system_key, output_host, inventory_config())
-    except Exception as ex:
-        logger.error("Error during set cache", ex)
+    if get_flag_value(FLAG_INVENTORY_USE_CACHED_INSIGHTS_CLIENT_SYSTEM):
+        try:
+            owner_id = output_host.get("system_profile", {}).get("owner_id")
+            if owner_id and insights_id and org_id:
+                system_key = make_system_cache_key(insights_id, org_id, owner_id)
+                if "tags" in output_host:
+                    del output_host["tags"]
+                if "system_profile" in output_host:
+                    del output_host["system_profile"]
+                set_cached_system(system_key, output_host, inventory_config())
+        except Exception as ex:
+            logger.error("Error during set cache", ex)
 
 
 def write_message_batch(event_producer, processed_rows):

--- a/lib/check_org.py
+++ b/lib/check_org.py
@@ -1,0 +1,35 @@
+from http import HTTPStatus
+
+from flask import abort
+from flask import request
+from flask import Response
+
+from app.auth import get_current_identity
+from app.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def check_org_id(result):
+    current_identity = get_current_identity()
+    if isinstance(result, Response):
+        data = result.get_json()
+    elif isinstance(result, tuple):
+        data = result[0]
+    else:
+        data = result
+    if isinstance(data, dict):
+        message = f"Response contained data for another org_id. Path={request.path}, parameters={request.args}."
+        if "org_id" in data:
+            if data.get("org_id") and (data.get("org_id") != current_identity.org_id):
+                logger.error(message)
+                abort(HTTPStatus.FORBIDDEN)
+        if "results" in data:
+            results_array = data.get("results", [])
+            for system in results_array:
+                org_id = system.get("org_id")
+                if org_id and (org_id != current_identity.org_id):
+                    logger.error(message)
+                    abort(HTTPStatus.FORBIDDEN)
+    return result


### PR DESCRIPTION
# Overview

* Use Flask's after_request feature to perform the check_org_id check on defined endpoints
* Remove decorator that didn't execute when caching was performed

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
