### PR TITLE
bugfix(rhineng-11882): Add guard to check that host_list is a list

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -176,7 +176,7 @@ def get_host_list(
     json_data = build_paginated_host_list_response(
         total, page, per_page, host_list, additional_fields, system_profile_fields
     )
-    if is_cached_insights_client_system_query and len(host_list) == 1:
+    if is_cached_insights_client_system_query and isinstance(host_list, list) and len(host_list) == 1:
         system_key = make_system_cache_key(insights_id, current_identity.org_id, owner_id)
         output_host = serialize_host_with_params(host_list[0])
         timeout = inventory_config().cache_insights_client_system_timeout_sec


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-11882](https://issues.redhat.com/browse/RHINENG-11882).
* xjoin apis return a map object which caused a 500

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
