### PR TITLE
fix(RHINENG-11882): Convert map to list in xjoin implementation

### DIFF
--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -147,7 +147,13 @@ def get_host_list_using_filters(all_filters, page, per_page, param_order_by, par
     total = response["meta"]["total"]
     check_pagination(offset, total)
 
-    return list(map(deserialize_host, response["data"])), total, additional_fields, system_profile_fields
+    try:
+        host_list = list(map(deserialize_host, response["data"]))
+    except ValueError as ve:
+        logger.exception("xjoin-search responded with invalid value", exc_info=ve)
+        flask.abort(503)
+
+    return host_list, total, additional_fields, system_profile_fields
 
 
 def get_host_tags_list_using_filters(all_filters, page, per_page, param_order_by, param_order_how):

--- a/api/host_query_xjoin.py
+++ b/api/host_query_xjoin.py
@@ -147,7 +147,7 @@ def get_host_list_using_filters(all_filters, page, per_page, param_order_by, par
     total = response["meta"]["total"]
     check_pagination(offset, total)
 
-    return map(deserialize_host, response["data"]), total, additional_fields, system_profile_fields
+    return list(map(deserialize_host, response["data"])), total, additional_fields, system_profile_fields
 
 
 def get_host_tags_list_using_filters(all_filters, page, per_page, param_order_by, param_order_how):

--- a/tests/test_xjoin.py
+++ b/tests/test_xjoin.py
@@ -1130,7 +1130,7 @@ def test_invalid_without_timezone(graphql_query, api_get):
     graphql_query(return_value=response)
     response_status, response_data = api_get(HOST_URL)
 
-    assert response_status == 500
+    assert response_status == 503
 
 
 def test_tags_headers_forwarded(mocker, patch_xjoin_post, api_get):


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-11882](https://issues.redhat.com/browse/RHINENG-11882).
It coerces a map to type `list`, which is needed in python 3. It also updates exception handling and a unit test.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
