### PR TITLE
fix(RHINENG-11895): Build rhel_version in notifications for uppercase…

### DIFF
--- a/app/serialization.py
+++ b/app/serialization.py
@@ -517,10 +517,10 @@ def _serialize_per_reporter_staleness(host, staleness, staleness_timestamps):
 def build_rhel_version_str(system_profile: dict) -> str:
     os = system_profile.get("operating_system")
     if os:
-        if os.get("name") == "rhel":
+        if os.get("name", "").lower() == "rhel":
             major = os.get("major")
             minor = os.get("minor")
-            return f"{major:03}.{minor:03}"
+            return f"{major}.{minor}"
     return ""
 
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-11895](https://issues.redhat.com/browse/RHINENG-11895).

If I have a RHEL machine, I don't see `rhel_version` in the notifications. This is because the allowed value for OS name is `RHEL` (uppercase), but the serialization function only creates the `rhel_version` string if the OS name is equal to `rhel` (lowercase)

Also, I updated the `rhel_version` format to not include zeros at the beginning. For example, previously we would have `007.010`, now we have `7.10`. Slack discussion about this [here](https://redhat-internal.slack.com/archives/CQFKM031T/p1723131327386949).

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
