### PR TITLE
fix(RHINENG-12070): Fix error logs in unit tests

### DIFF
--- a/app/payload_tracker/__init__.py
+++ b/app/payload_tracker/__init__.py
@@ -192,8 +192,11 @@ class KafkaPayloadTracker(PayloadTracker):
 
 
 class NullProducer:
-    def send(self, topic, msg):
+    def produce(self, topic, msg):
         print(f"sending message: {topic} - {msg}")
+
+    def poll(self, timeout: float = 0.0):
+        pass  # It's not useful to know when the NullProducer polls
 
 
 class PayloadTrackerContext:

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -588,7 +588,7 @@ def test_delete_host_that_belongs_to_group_fail(
 
     # Patch it so the DB deletion fails
     deleted_by_this_query_mock = mocker.patch("lib.host_delete._deleted_by_this_query")
-    deleted_by_this_query_mock.side_effect = False
+    deleted_by_this_query_mock.side_effect = InterruptedError()
 
     # Delete the first host
     api_delete_host(host_id_list[0])


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-12070](https://issues.redhat.com/browse/RHINENG-12070). It addresses a couple of minor issues in our unit tests.

This one was caused by an improper mock, though it didn't affect the functionality or results of the test:
```
TypeError: 'bool' object is not an iterator
```

This one has been occurring for a long time, and appears to have started during the migration to confluent-kafka:
```
Traceback (most recent call last):
File "/opt/app-root/src/app/payload_tracker/_init_.py", line 187, in _send_message
  self._producer.produce(self._topic, message.encode("utf-8"))
AttributeError: 'NullProducer' object has no attribute 'produce'
```

Both of these are resolved by this PR.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
