### PR TITLE
bugfix(rhineng-12085): Enable variable alteration of probe timeouts on API pods

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -185,18 +185,18 @@ objects:
             path: /health
             port: 8000
             scheme: HTTP
-          periodSeconds: 30
+          periodSeconds: ${{INVENTORY_API_READS_LIVENESS_PROBE_PERIOD_SECONDS}}
           successThreshold: 1
-          timeoutSeconds: 60
+          timeoutSeconds: ${{INVENTORY_API_READS_LIVENESS_PROBE_TIMEOUT_SECONDS}}
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /health
             port: 8000
             scheme: HTTP
-          periodSeconds: 30
+          periodSeconds: ${{INVENTORY_API_READS_READINESS_PROBE_PERIOD_SECONDS}}
           successThreshold: 1
-          timeoutSeconds: 60
+          timeoutSeconds: ${{INVENTORY_API_READS_READINESS_PROBE_TIMEOUT_SECONDS}}
         volumeMounts:
         - mountPath: /tmp/inventory/prometheus
           name: prometheus-volume
@@ -337,18 +337,18 @@ objects:
             path: /health
             port: 8000
             scheme: HTTP
-          periodSeconds: 30
+          periodSeconds: ${{INVENTORY_API_READS_LIVENESS_PROBE_PERIOD_SECONDS}}
           successThreshold: 1
-          timeoutSeconds: 60
+          timeoutSeconds: ${{INVENTORY_API_READS_LIVENESS_PROBE_TIMEOUT_SECONDS}}
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /health
             port: 8000
             scheme: HTTP
-          periodSeconds: 30
+          periodSeconds: ${{INVENTORY_API_READS_READINESS_PROBE_PERIOD_SECONDS}}
           successThreshold: 1
-          timeoutSeconds: 60
+          timeoutSeconds: ${{INVENTORY_API_READS_READINESS_PROBE_TIMEOUT_SECONDS}}
         volumeMounts:
         - mountPath: /tmp/inventory/prometheus
           name: prometheus-volume
@@ -487,18 +487,18 @@ objects:
             path: /health
             port: 8000
             scheme: HTTP
-          periodSeconds: 30
+          periodSeconds: ${{INVENTORY_API_WRITES_LIVENESS_PROBE_PERIOD_SECONDS}}
           successThreshold: 1
-          timeoutSeconds: 60
+          timeoutSeconds: ${{INVENTORY_API_WRITES_LIVENESS_PROBE_TIMEOUT_SECONDS}}
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /health
             port: 8000
             scheme: HTTP
-          periodSeconds: 30
+          periodSeconds: ${{INVENTORY_API_WRITES_READINESS_PROBE_PERIOD_SECONDS}}
           successThreshold: 1
-          timeoutSeconds: 60
+          timeoutSeconds: ${{INVENTORY_API_WRITES_READINESS_PROBE_TIMEOUT_SECONDS}}
         volumeMounts:
         - mountPath: /tmp/inventory/prometheus
           name: prometheus-volume
@@ -1523,6 +1523,22 @@ parameters:
   value: '10000'
 - name: KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS
   value: '3000'
+- name: INVENTORY_API_WRITES_LIVENESS_PROBE_PERIOD_SECONDS
+  value: '30'
+- name: INVENTORY_API_WRITES_LIVENESS_PROBE_TIMEOUT_SECONDS
+  value: '60'
+- name: INVENTORY_API_READS_LIVENESS_PROBE_PERIOD_SECONDS
+  value: '30'
+- name: INVENTORY_API_READS_LIVENESS_PROBE_TIMEOUT_SECONDS
+  value: '60'
+- name: INVENTORY_API_WRITES_READINESS_PROBE_PERIOD_SECONDS
+  value: '30'
+- name: INVENTORY_API_WRITES_READINESS_PROBE_TIMEOUT_SECONDS
+  value: '60'
+- name: INVENTORY_API_READS_READINESS_PROBE_PERIOD_SECONDS
+  value: '30'
+- name: INVENTORY_API_READS_READINESS_PROBE_TIMEOUT_SECONDS
+  value: '60'
 
 # NGINX
 - displayName: Minimum replicas


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-12085](https://issues.redhat.com/browse/RHINENG-12085).
* Add environment variables to allow tweaking of probe timeouts

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
