### PR TITLE
bugfix(api): spawn cache invalidation to avoid timeouts

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -90,7 +90,7 @@ def create_group(body, rbac_filter=None):
         create_group_count.inc()
 
         current_identity = get_current_identity()
-        delete_cached_system_keys(org_id=current_identity.org_id)
+        delete_cached_system_keys(org_id=current_identity.org_id, spawn=True)
         log_create_group_succeeded(logger, created_group.id)
     except IntegrityError as inte:
         group_name = validated_create_group_data.get("name")
@@ -147,7 +147,7 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
 
     updated_group = get_group_by_id_from_db(group_id)
     current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
+    delete_cached_system_keys(org_id=current_identity.org_id, spawn=True)
     log_patch_group_success(logger, group_id)
     return flask_json_response(build_group_response(updated_group), HTTPStatus.OK)
 
@@ -165,7 +165,7 @@ def delete_groups(group_id_list, rbac_filter=None):
         abort(HTTPStatus.NOT_FOUND, "No groups found for deletion.")
 
     current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
+    delete_cached_system_keys(org_id=current_identity.org_id, spawn=True)
     return Response(None, HTTPStatus.NO_CONTENT)
 
 
@@ -208,7 +208,7 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
         abort(HTTPStatus.NOT_FOUND, "Group or hosts not found.")
 
     current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
+    delete_cached_system_keys(org_id=current_identity.org_id, spawn=True)
     return Response(None, HTTPStatus.NO_CONTENT)
 
 
@@ -242,5 +242,5 @@ def delete_hosts_from_different_groups(host_id_list, rbac_filter=None):
         abort(HTTPStatus.NOT_FOUND, "The provided hosts were not found.")
 
     current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
+    delete_cached_system_keys(org_id=current_identity.org_id, spawn=True)
     return Response(None, HTTPStatus.NO_CONTENT)

--- a/api/host.py
+++ b/api/host.py
@@ -448,8 +448,14 @@ def patch_host_by_id(host_id_list, body, rbac_filter=None):
             serialized_host = serialize_host(host, staleness_timestamps(), staleness=staleness)
             _emit_patch_event(serialized_host, host)
             insights_id = host.canonical_facts.get("insights_id")
+            owner_id = host.system_profile_facts.get("owner_id")
             if insights_id:
-                delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id)
+                if owner_id:
+                    delete_cached_system_keys(
+                        insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id
+                    )
+                else:
+                    delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, spawn=True)
 
     log_patch_host_success(logger, host_id_list)
     return 200
@@ -520,8 +526,14 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict, rba
             serialized_host = serialize_host(host, staleness_timestamps(), staleness=staleness)
             _emit_patch_event(serialized_host, host)
             insights_id = host.canonical_facts.get("insights_id")
+            owner_id = host.system_profile_facts.get("owner_id")
             if insights_id:
-                delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id)
+                if owner_id:
+                    delete_cached_system_keys(
+                        insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id
+                    )
+                else:
+                    delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, spawn=True)
 
     logger.debug("hosts_to_update:%s", hosts_to_update)
 
@@ -588,8 +600,12 @@ def host_checkin(body, rbac_filter=None):
         serialized_host = serialize_host(existing_host, staleness_timestamps(), staleness=staleness)
         _emit_patch_event(serialized_host, existing_host)
         insights_id = existing_host.canonical_facts.get("insights_id")
+        owner_id = existing_host.system_profile_facts.get("owner_id")
         if insights_id:
-            delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id)
+            if owner_id:
+                delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id)
+            else:
+                delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, spawn=True)
         return flask_json_response(serialized_host, 201)
     else:
         flask.abort(404, "No hosts match the provided canonical facts.")

--- a/api/host_group.py
+++ b/api/host_group.py
@@ -53,7 +53,7 @@ def add_host_list_to_group(group_id, body, rbac_filter=None):
 
     updated_group = get_group_by_id_from_db(group_id)
     current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
+    delete_cached_system_keys(org_id=current_identity.org_id, spawn=True)
     log_host_group_add_succeeded(logger, host_id_list, group_id)
     return flask_json_response(build_group_response(updated_group), HTTPStatus.OK)
 
@@ -70,5 +70,5 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
         abort(HTTPStatus.NOT_FOUND, "Group or hosts not found.")
 
     current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
+    delete_cached_system_keys(org_id=current_identity.org_id, spawn=True)
     return Response(None, HTTPStatus.NO_CONTENT)

--- a/api/staleness.py
+++ b/api/staleness.py
@@ -95,7 +95,7 @@ def create_staleness(body):
     try:
         # Create account staleness with validated data
         created_staleness = add_staleness(validated_data)
-        delete_cached_system_keys(org_id=org_id)
+        delete_cached_system_keys(org_id=org_id, spawn=True)
         log_create_staleness_succeeded(logger, created_staleness.id)
     except IntegrityError:
         error_message = f"Staleness record for org_id {org_id} already exists."
@@ -118,7 +118,7 @@ def delete_staleness():
     org_id = get_current_identity().org_id
     try:
         remove_staleness()
-        delete_cached_system_keys(org_id=org_id)
+        delete_cached_system_keys(org_id=org_id, spawn=True)
         return flask_json_response(None, HTTPStatus.NO_CONTENT)
     except NoResultFound:
         abort(
@@ -149,7 +149,7 @@ def update_staleness(body):
             # since update only return None with no record instead of exception.
             raise NoResultFound
 
-        delete_cached_system_keys(org_id=org_id)
+        delete_cached_system_keys(org_id=org_id, spawn=True)
         log_patch_staleness_succeeded(logger, updated_staleness.id)
 
         return flask_json_response(serialize_staleness_response(updated_staleness), HTTPStatus.OK)


### PR DESCRIPTION
# Overview

* Spawn cache invalidation to avoid timeouts

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
