### PR TITLE
bugfix(rhineng-12147): Perform finer grain key deletions from cache

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -10,14 +10,12 @@ from api import api_operation
 from api import flask_json_response
 from api import json_error_response
 from api import metrics
-from api.cache import delete_cached_system_keys
 from api.group_query import build_group_response
 from api.group_query import build_paginated_group_list_response
 from api.group_query import get_filtered_group_list_db
 from api.group_query import get_group_list_by_id_list_db
 from app import RbacPermission
 from app import RbacResourceType
-from app.auth import get_current_identity
 from app.exceptions import InventoryException
 from app.instrumentation import log_create_group_failed
 from app.instrumentation import log_create_group_not_allowed
@@ -89,8 +87,6 @@ def create_group(body, rbac_filter=None):
         created_group = add_group(validated_create_group_data, current_app.event_producer)
         create_group_count.inc()
 
-        current_identity = get_current_identity()
-        delete_cached_system_keys(org_id=current_identity.org_id)
         log_create_group_succeeded(logger, created_group.id)
     except IntegrityError as inte:
         group_name = validated_create_group_data.get("name")
@@ -146,8 +142,6 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
         )
 
     updated_group = get_group_by_id_from_db(group_id)
-    current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
     log_patch_group_success(logger, group_id)
     return flask_json_response(build_group_response(updated_group), HTTPStatus.OK)
 
@@ -163,9 +157,6 @@ def delete_groups(group_id_list, rbac_filter=None):
     if delete_count == 0:
         log_get_group_list_failed(logger)
         abort(HTTPStatus.NOT_FOUND, "No groups found for deletion.")
-
-    current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
     return Response(None, HTTPStatus.NO_CONTENT)
 
 
@@ -206,9 +197,6 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
     if delete_count == 0:
         log_delete_hosts_from_group_failed(logger)
         abort(HTTPStatus.NOT_FOUND, "Group or hosts not found.")
-
-    current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
     return Response(None, HTTPStatus.NO_CONTENT)
 
 
@@ -240,7 +228,4 @@ def delete_hosts_from_different_groups(host_id_list, rbac_filter=None):
     if delete_count == 0:
         log_delete_hosts_from_group_failed(logger)
         abort(HTTPStatus.NOT_FOUND, "The provided hosts were not found.")
-
-    current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
     return Response(None, HTTPStatus.NO_CONTENT)

--- a/api/host.py
+++ b/api/host.py
@@ -448,8 +448,8 @@ def patch_host_by_id(host_id_list, body, rbac_filter=None):
             serialized_host = serialize_host(host, staleness_timestamps(), staleness=staleness)
             _emit_patch_event(serialized_host, host)
             insights_id = host.canonical_facts.get("insights_id")
-            if insights_id:
-                delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id)
+            owner_id = host.system_profile_facts.get("owner_id")
+            delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id)
 
     log_patch_host_success(logger, host_id_list)
     return 200
@@ -520,8 +520,8 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict, rba
             serialized_host = serialize_host(host, staleness_timestamps(), staleness=staleness)
             _emit_patch_event(serialized_host, host)
             insights_id = host.canonical_facts.get("insights_id")
-            if insights_id:
-                delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id)
+            owner_id = host.system_profile_facts.get("owner_id")
+            delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id)
 
     logger.debug("hosts_to_update:%s", hosts_to_update)
 
@@ -588,8 +588,8 @@ def host_checkin(body, rbac_filter=None):
         serialized_host = serialize_host(existing_host, staleness_timestamps(), staleness=staleness)
         _emit_patch_event(serialized_host, existing_host)
         insights_id = existing_host.canonical_facts.get("insights_id")
-        if insights_id:
-            delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id)
+        owner_id = existing_host.system_profile_facts.get("owner_id")
+        delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id)
         return flask_json_response(serialized_host, 201)
     else:
         flask.abort(404, "No hosts match the provided canonical facts.")

--- a/api/host_group.py
+++ b/api/host_group.py
@@ -7,11 +7,9 @@ from flask import Response
 from api import api_operation
 from api import flask_json_response
 from api import metrics
-from api.cache import delete_cached_system_keys
 from api.group_query import build_group_response
 from app import RbacPermission
 from app import RbacResourceType
-from app.auth import get_current_identity
 from app.instrumentation import log_host_group_add_succeeded
 from app.instrumentation import log_patch_group_failed
 from app.logging import get_logger
@@ -52,8 +50,6 @@ def add_host_list_to_group(group_id, body, rbac_filter=None):
         add_hosts_to_group(group_id, body, current_app.event_producer)
 
     updated_group = get_group_by_id_from_db(group_id)
-    current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
     log_host_group_add_succeeded(logger, host_id_list, group_id)
     return flask_json_response(build_group_response(updated_group), HTTPStatus.OK)
 
@@ -68,7 +64,4 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
 
     if delete_count == 0:
         abort(HTTPStatus.NOT_FOUND, "Group or hosts not found.")
-
-    current_identity = get_current_identity()
-    delete_cached_system_keys(org_id=current_identity.org_id)
     return Response(None, HTTPStatus.NO_CONTENT)

--- a/api/staleness.py
+++ b/api/staleness.py
@@ -95,7 +95,7 @@ def create_staleness(body):
     try:
         # Create account staleness with validated data
         created_staleness = add_staleness(validated_data)
-        delete_cached_system_keys(org_id=org_id)
+        delete_cached_system_keys(org_id=org_id, spawn=True)
         log_create_staleness_succeeded(logger, created_staleness.id)
     except IntegrityError:
         error_message = f"Staleness record for org_id {org_id} already exists."
@@ -118,7 +118,7 @@ def delete_staleness():
     org_id = get_current_identity().org_id
     try:
         remove_staleness()
-        delete_cached_system_keys(org_id=org_id)
+        delete_cached_system_keys(org_id=org_id, spawn=True)
         return flask_json_response(None, HTTPStatus.NO_CONTENT)
     except NoResultFound:
         abort(
@@ -149,7 +149,7 @@ def update_staleness(body):
             # since update only return None with no record instead of exception.
             raise NoResultFound
 
-        delete_cached_system_keys(org_id=org_id)
+        delete_cached_system_keys(org_id=org_id, spawn=True)
         log_patch_staleness_succeeded(logger, updated_staleness.id)
 
         return flask_json_response(serialize_staleness_response(updated_staleness), HTTPStatus.OK)

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from api.cache import delete_cached_system_keys
 from api.host_query import staleness_timestamps
 from api.staleness_query import get_staleness_obj
 from app.auth import get_current_identity
@@ -59,6 +60,11 @@ def _produce_host_update_events(event_producer, host_id_list, group_id_list=[], 
         )
         event = build_event(EventType.updated, serialized_host, platform_metadata=metadata)
         event_producer.write_event(event, serialized_host["id"], headers, wait=True)
+
+    for host in host_list:
+        insights_id = host.canonical_facts.get("insights_id")
+        owner_id = host.system_profile_facts.get("owner_id")
+        delete_cached_system_keys(insights_id=insights_id, org_id=identity.org_id, owner_id=owner_id)
 
 
 def _add_hosts_to_group(group_id: str, host_id_list: List[str]):


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-12147](https://issues.redhat.com/browse/RHINENG-12147).
* Optimize cache key deletion to avoid search and delete cases
* Allow thread spawning for staleness APIs

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
