### PR TITLE
bugfix(rhineng-12147): Handle systems without owner_id to avoid spurious wildcard deletion

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -449,7 +449,8 @@ def patch_host_by_id(host_id_list, body, rbac_filter=None):
             _emit_patch_event(serialized_host, host)
             insights_id = host.canonical_facts.get("insights_id")
             owner_id = host.system_profile_facts.get("owner_id")
-            delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id)
+            if insights_id and owner_id:
+                delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id)
 
     log_patch_host_success(logger, host_id_list)
     return 200
@@ -521,7 +522,8 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict, rba
             _emit_patch_event(serialized_host, host)
             insights_id = host.canonical_facts.get("insights_id")
             owner_id = host.system_profile_facts.get("owner_id")
-            delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id)
+            if insights_id and owner_id:
+                delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id)
 
     logger.debug("hosts_to_update:%s", hosts_to_update)
 
@@ -589,7 +591,8 @@ def host_checkin(body, rbac_filter=None):
         _emit_patch_event(serialized_host, existing_host)
         insights_id = existing_host.canonical_facts.get("insights_id")
         owner_id = existing_host.system_profile_facts.get("owner_id")
-        delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id)
+        if insights_id and owner_id:
+            delete_cached_system_keys(insights_id=insights_id, org_id=current_identity.org_id, owner_id=owner_id)
         return flask_json_response(serialized_host, 201)
     else:
         flask.abort(404, "No hosts match the provided canonical facts.")

--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -397,7 +397,10 @@ def write_delete_event_message(event_producer: EventProducer, result: OperationR
     event_producer.write_event(event, str(result.host_row.id), headers, wait=True)
     insights_id = result.host_row.canonical_facts.get("insights_id")
     owner_id = result.host_row.system_profile_facts.get("owner_id")
-    delete_cached_system_keys(insights_id=insights_id, org_id=result.host_row.org_id, owner_id=owner_id, spawn=True)
+    if insights_id and owner_id:
+        delete_cached_system_keys(
+            insights_id=insights_id, org_id=result.host_row.org_id, owner_id=owner_id, spawn=True
+        )
     result.success_logger()
 
 

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -36,14 +36,17 @@ from lib.metrics import delete_host_group_processing_time
 logger = get_logger(__name__)
 
 
-def _produce_host_update_events(event_producer, host_id_list, group_id_list=[], staleness=None):
-    identity = get_current_identity()  # Note: This should be moved to an API file
+def _update_hosts_for_group_changes(host_id_list, group_id_list=[]):
+    identity = get_current_identity()
     serialized_groups = [serialize_group(get_group_by_id_from_db(group_id), identity) for group_id in group_id_list]
 
     # Update groups data on each host record
     Host.query.filter(Host.id.in_(host_id_list)).update({"groups": serialized_groups}, synchronize_session="fetch")
     db.session.commit()
-    host_list = get_host_list_by_id_list_from_db(host_id_list)
+    return serialized_groups, get_host_list_by_id_list_from_db(host_id_list)
+
+
+def _produce_host_update_events(event_producer, serialized_groups, host_list, staleness=None):
     metadata = {"b64_identity": to_auth_header(get_current_identity())}  # Note: This should be moved to an API file
 
     # Send messages
@@ -60,7 +63,6 @@ def _produce_host_update_events(event_producer, host_id_list, group_id_list=[], 
         )
         event = build_event(EventType.updated, serialized_host, platform_metadata=metadata)
         event_producer.write_event(event, serialized_host["id"], headers, wait=True)
-    return host_list
 
 
 def _invalidate_system_cache(host_list):
@@ -121,9 +123,8 @@ def add_hosts_to_group(group_id: str, host_id_list: List[str], event_producer: E
         _add_hosts_to_group(group_id, host_id_list)
 
     # Produce update messages once the DB session has been closed
-    host_list = _produce_host_update_events(
-        event_producer, host_id_list, group_id_list=[group_id], staleness=staleness
-    )
+    serialized_groups, host_list = _update_hosts_for_group_changes(host_id_list, group_id_list=[group_id])
+    _produce_host_update_events(event_producer, serialized_groups, host_list, staleness=staleness)
     _invalidate_system_cache(host_list)
 
 
@@ -150,9 +151,8 @@ def add_group(group_data, event_producer) -> Group:
     created_group = Group.query.filter((Group.name == group_name) & (Group.org_id == org_id)).one_or_none()
 
     # Produce update messages once the DB session has been closed
-    host_list = _produce_host_update_events(
-        event_producer, host_id_list, group_id_list=[created_group.id], staleness=staleness
-    )
+    serialized_groups, host_list = _update_hosts_for_group_changes(host_id_list, group_id_list=[created_group.id])
+    _produce_host_update_events(event_producer, serialized_groups, host_list, staleness=staleness)
     _invalidate_system_cache(host_list)
 
     return created_group
@@ -209,7 +209,8 @@ def delete_group_list(group_id_list: List[str], event_producer: EventProducer) -
                 else:
                     log_group_delete_failed(logger, group_id, get_control_rule())
 
-    host_list = _produce_host_update_events(event_producer, deleted_host_ids, [], staleness=staleness)
+    serialized_groups, host_list = _update_hosts_for_group_changes(deleted_host_ids, [])
+    _produce_host_update_events(event_producer, serialized_groups, host_list, staleness=staleness)
     _invalidate_system_cache(host_list)
     return deletion_count
 
@@ -220,7 +221,8 @@ def remove_hosts_from_group(group_id, host_id_list, event_producer):
     with session_guard(db.session):
         removed_host_ids = _remove_hosts_from_group(group_id, host_id_list)
 
-    host_list = _produce_host_update_events(event_producer, removed_host_ids, [], staleness=staleness)
+    serialized_groups, host_list = _update_hosts_for_group_changes(removed_host_ids, [])
+    _produce_host_update_events(event_producer, serialized_groups, host_list, staleness=staleness)
     _invalidate_system_cache(host_list)
     return len(removed_host_ids)
 
@@ -281,7 +283,8 @@ def patch_group(group: Group, patch_data: dict, event_producer: EventProducer):
         # If anything was updated, and the host list is not being replaced,
         # send update messages to existing hosts. Otherwise, wait until the host list is replaced
         # so we don't produce messages that will be instantly obsoleted.
-        host_list = _produce_host_update_events(event_producer, existing_host_ids, [group_id], staleness=staleness)
+        serialized_groups, host_list = _update_hosts_for_group_changes(existing_host_ids, [group_id])
+        _produce_host_update_events(event_producer, serialized_groups, host_list, staleness=staleness)
         _invalidate_system_cache(host_list)
     elif new_host_ids is not None:
         # If host IDs were provided, we need to update the host list.
@@ -290,11 +293,13 @@ def patch_group(group: Group, patch_data: dict, event_producer: EventProducer):
         db.session.add(group)
 
         deleted_host_uuids = [str(host_id) for host_id in (existing_host_ids - new_host_ids)]
-        host_list = _produce_host_update_events(event_producer, deleted_host_uuids, [], staleness=staleness)
+        serialized_groups, host_list = _update_hosts_for_group_changes(deleted_host_uuids, [])
+        _produce_host_update_events(event_producer, deleted_host_uuids, [], staleness=staleness)
         _invalidate_system_cache(host_list)
 
         added_host_uuids = [str(host_id) for host_id in new_host_ids]
-        host_list = _produce_host_update_events(event_producer, added_host_uuids, [group_id], staleness=staleness)
+        serialized_groups, host_list = _update_hosts_for_group_changes(added_host_uuids, [group_id])
+        _produce_host_update_events(event_producer, serialized_groups, host_list, staleness=staleness)
         _invalidate_system_cache(host_list)
 
 

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -43,7 +43,8 @@ def _update_hosts_for_group_changes(host_id_list, group_id_list=[]):
     # Update groups data on each host record
     Host.query.filter(Host.id.in_(host_id_list)).update({"groups": serialized_groups}, synchronize_session="fetch")
     db.session.commit()
-    return serialized_groups, get_host_list_by_id_list_from_db(host_id_list)
+    host_list = get_host_list_by_id_list_from_db(host_id_list)
+    return serialized_groups, host_list
 
 
 def _produce_host_update_events(event_producer, serialized_groups, host_list, staleness=None):
@@ -294,7 +295,7 @@ def patch_group(group: Group, patch_data: dict, event_producer: EventProducer):
 
         deleted_host_uuids = [str(host_id) for host_id in (existing_host_ids - new_host_ids)]
         serialized_groups, host_list = _update_hosts_for_group_changes(deleted_host_uuids, [])
-        _produce_host_update_events(event_producer, deleted_host_uuids, [], staleness=staleness)
+        _produce_host_update_events(event_producer, serialized_groups, host_list, staleness=staleness)
         _invalidate_system_cache(host_list)
 
         added_host_uuids = [str(host_id) for host_id in new_host_ids]


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-12147](https://issues.redhat.com/browse/RHINENG-12147).
* Add guards for systems without owner_id
* Move code from the produce events code as requested

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
