### PR TITLE
Move restartPolicy to correct location

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -845,9 +845,9 @@ objects:
       schedule: '@hourly'
       concurrencyPolicy: "Forbid"
       suspend: ${{REAPER_SUSPEND}}
+      restartPolicy: Never
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
-        restartPolicy: Never
         args: ["./host_reaper.py"]
         env:
           - name: INVENTORY_LOG_LEVEL
@@ -914,9 +914,9 @@ objects:
     - name: sp-validator
       schedule: '@hourly'
       suspend: ${{SP_VALIDATOR_SUSPEND}}
+      restartPolicy: Never
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
-        restartPolicy: Never
         args: ["./system_profile_validator.py"]
         env:
           - name: INVENTORY_LOG_LEVEL
@@ -995,9 +995,9 @@ objects:
     - name: pendo-syncher
       schedule: ${PENDO_CRON_SCHEDULE}
       suspend: ${{PENDO_SYNCHER_SUSPEND}}
+      restartPolicy: Never
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
-        restartPolicy: Never
         args: ["./pendo_syncher.py"]
         env:
           - name: INVENTORY_LOG_LEVEL
@@ -1039,9 +1039,9 @@ objects:
             cpu: ${CPU_REQUEST_PENDO_SYNCHER}
             memory: ${MEMORY_REQUEST_PENDO_SYNCHER}
     - name: synchronizer
+      restartPolicy: OnFailure
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
-        restartPolicy: OnFailure
         args: ["./rebuild_events_topic.py", "&&", "./host_synchronizer.py"]
         env:
           - name: INVENTORY_LOG_LEVEL
@@ -1105,9 +1105,9 @@ objects:
       schedule: ${PG_REPACK_SCHEDULE}
       concurrencyPolicy: "Forbid"
       suspend: ${{PG_REPACK_SUSPEND}}
+      restartPolicy: Never
       podSpec:
         image: ${PG_REPACK_IMAGE}:${IMAGE_TAG}
-        restartPolicy: Never
         args: ["./run_pg_repack.py"]
         env:
           - name: INVENTORY_LOG_LEVEL


### PR DESCRIPTION
The `restartPolicy` is currently placed under the `podSpec` but it should be under the job at the same level as `podSpec`, see here: 

https://github.com/RedHatInsights/clowder/blob/master/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go#L108

The `restartPolicy` was added 2 years ago but @thearifismail was running into an issue deploying this template to minikube:
```
error: error validating "host-inventory.yaml": error validating data: [
    ValidationError(ClowdApp.spec.jobs[0].podSpec): unknown field "restartPolicy" in com.redhat.cloud.v1alpha1.ClowdApp.spec.jobs.podSpec, 
    ValidationError(ClowdApp.spec.jobs[1].podSpec): unknown field "restartPolicy" in com.redhat.cloud.v1alpha1.ClowdApp.spec.jobs.podSpec, 
    ValidationError(ClowdApp.spec.jobs[2].podSpec): unknown field "restartPolicy" in com.redhat.cloud.v1alpha1.ClowdApp.spec.jobs.podSpec, 
    ValidationError(ClowdApp.spec.jobs[3].podSpec): unknown field "restartPolicy" in com.redhat.cloud.v1alpha1.ClowdApp.spec.jobs.podSpec, 
    ValidationError(ClowdApp.spec.jobs[4].podSpec): unknown field "restartPolicy" in com.redhat.cloud.v1alpha1.ClowdApp.spec.jobs.podSpec
]; if you choose to ignore these errors, turn validation off with --validate=false
```

The above error is due to restartPolicy being in the wrong place.