### PR TITLE
feat(RHINENG-10515): remove custom staleness feature flag

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -36,22 +36,6 @@
             "createdAt": "2024-01-10T20:16:35.042Z"
         },
         {
-            "name": "hbi.custom-staleness",
-            "description": "If active, Custom host staleness/culling features will be enabled in the API and UI",
-            "type": "release",
-            "project": "default",
-            "stale": false,
-            "enabled": true,
-            "strategies": [
-                {
-                    "name": "default",
-                    "parameters": {}
-                }
-            ],
-            "variants": [],
-            "createdAt": "2024-01-10T20:18:18.842Z"
-        },
-        {
             "name": "hbi.api.hide-edge-by-default",
             "description": "If this is toggled, the HBI API will hide Edge hosts by default on all requests. If the request has a host-type filter, that is used instead.",
             "type": "release",

--- a/api/staleness.py
+++ b/api/staleness.py
@@ -1,7 +1,6 @@
 from http import HTTPStatus
 
 from flask import abort
-from flask import Response
 from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
@@ -23,8 +22,6 @@ from app.logging import get_logger
 from app.models import StalenessSchema
 from app.serialization import serialize_staleness_response
 from app.serialization import serialize_staleness_to_dict
-from lib.feature_flags import FLAG_INVENTORY_CUSTOM_STALENESS
-from lib.feature_flags import get_flag_value
 from lib.middleware import rbac
 from lib.staleness import add_staleness
 from lib.staleness import patch_staleness
@@ -81,9 +78,6 @@ def get_default_staleness(rbac_filter=None):
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def create_staleness(body):
-    if not get_flag_value(FLAG_INVENTORY_CUSTOM_STALENESS):
-        return Response(None, HTTPStatus.NOT_IMPLEMENTED)
-
     # Validate account staleness input data
     org_id = get_current_identity().org_id
     try:
@@ -112,9 +106,6 @@ def create_staleness(body):
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_staleness():
-    if not get_flag_value(FLAG_INVENTORY_CUSTOM_STALENESS):
-        return Response(None, HTTPStatus.NOT_IMPLEMENTED)
-
     org_id = get_current_identity().org_id
     try:
         remove_staleness()
@@ -132,9 +123,6 @@ def delete_staleness():
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def update_staleness(body):
-    if not get_flag_value(FLAG_INVENTORY_CUSTOM_STALENESS):
-        return Response(None, HTTPStatus.NOT_IMPLEMENTED)
-
     # Validate account staleness input data
     try:
         validated_data = _validate_input_data(body)

--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -10,14 +10,12 @@ UNLEASH = Unleash()
 logger = get_logger(__name__)
 
 FLAG_INVENTORY_ASSIGNMENT_RULES = "hbi.group-assignment-rules"
-FLAG_INVENTORY_CUSTOM_STALENESS = "hbi.custom-staleness"
 FLAG_HIDE_EDGE_HOSTS = "hbi.api.hide-edge-by-default"
 FLAG_INVENTORY_DISABLE_XJOIN = "hbi.api.disable-xjoin"
 FLAG_INVENTORY_USE_CACHED_INSIGHTS_CLIENT_SYSTEM = "hbi.api.use-cached-insights-client-system"
 
 FLAG_FALLBACK_VALUES = {
     FLAG_INVENTORY_ASSIGNMENT_RULES: True,
-    FLAG_INVENTORY_CUSTOM_STALENESS: True,
     FLAG_HIDE_EDGE_HOSTS: False,
     FLAG_INVENTORY_DISABLE_XJOIN: False,
     FLAG_INVENTORY_USE_CACHED_INSIGHTS_CLIENT_SYSTEM: False,


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-10515](https://issues.redhat.com/browse/RHINENG-10515).

It removes the usage of custom staleness feature flag from HBI backend

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
