### PR TITLE
fix(RHINENG-12407) Add org_id and account to threadctx, if available

### DIFF
--- a/app/queue/queue.py
+++ b/app/queue/queue.py
@@ -407,7 +407,7 @@ def write_delete_event_message(event_producer: EventProducer, result: OperationR
 def write_add_update_event_message(event_producer: EventProducer, result: OperationResult):
     # The request ID in the headers is fetched from threadctx.request_id
     request_id = result.platform_metadata.get("request_id")
-    initialize_thread_local_storage(request_id)
+    initialize_thread_local_storage(request_id, result.host_row.org_id, result.host_row.account)
 
     payload_tracker = get_payload_tracker(request_id=request_id)
 
@@ -585,5 +585,9 @@ def event_loop(consumer, flask_app, event_producer, notification_event_producer,
                     db.session.rollback()
 
 
-def initialize_thread_local_storage(request_id):
+def initialize_thread_local_storage(request_id: str, org_id: str = None, account: str = None):
     threadctx.request_id = request_id
+    if org_id:
+        threadctx.org_id = org_id
+    if account:
+        threadctx.account = account


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-12407](https://issues.redhat.com/browse/RHINENG-12407).
It fixes the batch MQ logging issue. The logger automatically pulls its org_id and account from threadctx, so even though these fields were correct on the logged host, they weren't correct on the top level of the log. This is fixed by setting the org_id and account on threadctx each time we produce an add/update message.

The reason I don't pass org_id and account to `initialize_thread_local_storage` during `handle_message` is that the incoming message hasn't been loaded in yet.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
