### PR TITLE
perf(RHINENG-12047): Improve host-counting efficiency

### DIFF
--- a/api/filtering/db_filters.py
+++ b/api/filtering/db_filters.py
@@ -329,14 +329,9 @@ def query_filters(
 
     # Determine query_base
     if group_name or order_by == "group_name":
-        query_base = (
-            db.session.query(Host)
-            .join(HostGroupAssoc, isouter=True)
-            .join(Group, isouter=True)
-            .group_by(Host.id, Group.name)
-        )
+        query_base = db.session.query(Host).join(HostGroupAssoc, isouter=True).join(Group, isouter=True)
     elif group_ids or rbac_filter:
-        query_base = db.session.query(Host).join(HostGroupAssoc, isouter=True).group_by(Host.id)
+        query_base = db.session.query(Host).join(HostGroupAssoc, isouter=True)
     else:
         query_base = db.session.query(Host)
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-12047](https://issues.redhat.com/browse/RHINENG-12047).
Turns off counting within `paginate()`, and does the count query separately. This results in a simpler and more efficient query used for counting, which should improve DB performance. This change necessitated the removal of some "GROUP BY" statements, so here are examples of the differences in the queries:

## Basic host query with host filters (count)
### Before
```
SELECT count(*) AS count_1 
FROM (SELECT hosts.canonical_facts AS hosts_canonical_facts, hosts.id AS hosts_id, hosts.account AS hosts_account, hosts.org_id AS hosts_org_id, hosts.display_name AS hosts_display_name, hosts.ansible_host AS hosts_ansible_host, hosts.facts AS hosts_facts, hosts.reporter AS hosts_reporter, hosts.per_reporter_staleness AS hosts_per_reporter_staleness, hosts.stale_timestamp AS hosts_stale_timestamp, hosts.created_on AS hosts_created_on, hosts.modified_on AS hosts_modified_on, hosts.groups AS hosts_groups, hosts.system_profile_facts -> %(system_profile_facts_1)s AS host_type 
  FROM hosts 
  WHERE hosts.org_id = %(org_id_1)s AND ((hosts.system_profile_facts ->> %(system_profile_facts_2)s) = %(param_1)s AND (hosts.modified_on > %(modified_on_1)s OR hosts.modified_on > %(modified_on_2)s AND hosts.modified_on <= %(modified_on_3)s OR hosts.modified_on > %(modified_on_4)s AND hosts.modified_on <= %(modified_on_5)s) OR (hosts.system_profile_facts ->> %(system_profile_facts_3)s) IS NULL AND (hosts.modified_on > %(modified_on_6)s OR hosts.modified_on > %(modified_on_7)s AND hosts.modified_on <= %(modified_on_8)s OR hosts.modified_on > %(modified_on_9)s AND hosts.modified_on <= %(modified_on_10)s))) AS anon_1
```
### After
```
SELECT count(*) AS count_1 
FROM hosts 
WHERE hosts.org_id = %(org_id_1)s AND ((hosts.system_profile_facts ->> %(system_profile_facts_1)s) = %(param_1)s AND (hosts.modified_on > %(modified_on_1)s OR hosts.modified_on > %(modified_on_2)s AND hosts.modified_on <= %(modified_on_3)s OR hosts.modified_on > %(modified_on_4)s AND hosts.modified_on <= %(modified_on_5)s) OR (hosts.system_profile_facts ->> %(system_profile_facts_2)s) IS NULL AND (hosts.modified_on > %(modified_on_6)s OR hosts.modified_on > %(modified_on_7)s AND hosts.modified_on <= %(modified_on_8)s OR hosts.modified_on > %(modified_on_9)s AND hosts.modified_on <= %(modified_on_10)s))
```
## Host query filtered on group name (count)
### Before
```
SELECT count(*) AS count_1 
FROM (SELECT hosts.canonical_facts AS hosts_canonical_facts, hosts.id AS hosts_id, hosts.account AS hosts_account, hosts.org_id AS hosts_org_id, hosts.display_name AS hosts_display_name, hosts.ansible_host AS hosts_ansible_host, hosts.facts AS hosts_facts, hosts.reporter AS hosts_reporter, hosts.per_reporter_staleness AS hosts_per_reporter_staleness, hosts.stale_timestamp AS hosts_stale_timestamp, hosts.created_on AS hosts_created_on, hosts.modified_on AS hosts_modified_on, hosts.groups AS hosts_groups, hosts.system_profile_facts -> %(system_profile_facts_1)s AS host_type 
  FROM hosts LEFT OUTER JOIN hosts_groups ON hosts.id = hosts_groups.host_id LEFT OUTER JOIN groups ON groups.id = hosts_groups.group_id 
  WHERE hosts.org_id = %(org_id_1)s AND lower(groups.name) IN (%(lower_1_1)s, %(lower_1_2)s, %(lower_1_3)s, %(lower_1_4)s, %(lower_1_5)s) AND ((hosts.system_profile_facts ->> %(system_profile_facts_2)s) IS NULL AND (hosts.modified_on > %(modified_on_1)s OR hosts.modified_on > %(modified_on_2)s AND hosts.modified_on <= %(modified_on_3)s OR hosts.modified_on > %(modified_on_4)s AND hosts.modified_on <= %(modified_on_5)s) OR (hosts.system_profile_facts ->> %(system_profile_facts_3)s) = %(param_1)s AND (hosts.modified_on > %(modified_on_6)s OR hosts.modified_on > %(modified_on_7)s AND hosts.modified_on <= %(modified_on_8)s OR hosts.modified_on > %(modified_on_9)s AND hosts.modified_on <= %(modified_on_10)s)) GROUP BY hosts.id, groups.name) AS anon_1
```
### After
```
SELECT count(*) AS count_1 
FROM hosts LEFT OUTER JOIN hosts_groups ON hosts.id = hosts_groups.host_id LEFT OUTER JOIN groups ON groups.id = hosts_groups.group_id 
WHERE hosts.org_id = %(org_id_1)s AND lower(groups.name) IN (%(lower_1_1)s, %(lower_1_2)s, %(lower_1_3)s, %(lower_1_4)s, %(lower_1_5)s) AND ((hosts.system_profile_facts ->> %(system_profile_facts_1)s) = %(param_1)s AND (hosts.modified_on > %(modified_on_1)s OR hosts.modified_on > %(modified_on_2)s AND hosts.modified_on <= %(modified_on_3)s OR hosts.modified_on > %(modified_on_4)s AND hosts.modified_on <= %(modified_on_5)s) OR (hosts.system_profile_facts ->> %(system_profile_facts_2)s) IS NULL AND (hosts.modified_on > %(modified_on_6)s OR hosts.modified_on > %(modified_on_7)s AND hosts.modified_on <= %(modified_on_8)s OR hosts.modified_on > %(modified_on_9)s AND hosts.modified_on <= %(modified_on_10)s))
```

## Host query filtered on group name (paginated data)
### Before
```
SELECT hosts.canonical_facts AS hosts_canonical_facts, hosts.id AS hosts_id, hosts.account AS hosts_account, hosts.org_id AS hosts_org_id, hosts.display_name AS hosts_display_name, hosts.ansible_host AS hosts_ansible_host, hosts.facts AS hosts_facts, hosts.reporter AS hosts_reporter, hosts.per_reporter_staleness AS hosts_per_reporter_staleness, hosts.stale_timestamp AS hosts_stale_timestamp, hosts.created_on AS hosts_created_on, hosts.modified_on AS hosts_modified_on, hosts.groups AS hosts_groups, hosts.system_profile_facts -> %(system_profile_facts_1)s AS host_type 
FROM hosts LEFT OUTER JOIN hosts_groups ON hosts.id = hosts_groups.host_id LEFT OUTER JOIN groups ON groups.id = hosts_groups.group_id 
WHERE hosts.org_id = %(org_id_1)s AND lower(groups.name) IN (%(lower_1_1)s, %(lower_1_2)s, %(lower_1_3)s, %(lower_1_4)s, %(lower_1_5)s) AND ((hosts.system_profile_facts ->> %(system_profile_facts_2)s) IS NULL AND (hosts.modified_on > %(modified_on_1)s OR hosts.modified_on > %(modified_on_2)s AND hosts.modified_on <= %(modified_on_3)s OR hosts.modified_on > %(modified_on_4)s AND hosts.modified_on <= %(modified_on_5)s) OR (hosts.system_profile_facts ->> %(system_profile_facts_3)s) = %(param_1)s AND (hosts.modified_on > %(modified_on_6)s OR hosts.modified_on > %(modified_on_7)s AND hosts.modified_on <= %(modified_on_8)s OR hosts.modified_on > %(modified_on_9)s AND hosts.modified_on <= %(modified_on_10)s)) GROUP BY hosts.id, groups.name ORDER BY hosts.modified_on DESC, hosts.id DESC 
 LIMIT %(param_2)s OFFSET %(param_3)s
```
### After
```
SELECT hosts.canonical_facts AS hosts_canonical_facts, hosts.id AS hosts_id, hosts.account AS hosts_account, hosts.org_id AS hosts_org_id, hosts.display_name AS hosts_display_name, hosts.ansible_host AS hosts_ansible_host, hosts.facts AS hosts_facts, hosts.reporter AS hosts_reporter, hosts.per_reporter_staleness AS hosts_per_reporter_staleness, hosts.stale_timestamp AS hosts_stale_timestamp, hosts.created_on AS hosts_created_on, hosts.modified_on AS hosts_modified_on, hosts.groups AS hosts_groups, hosts.system_profile_facts -> %(system_profile_facts_1)s AS host_type 
FROM hosts LEFT OUTER JOIN hosts_groups ON hosts.id = hosts_groups.host_id LEFT OUTER JOIN groups ON groups.id = hosts_groups.group_id 
WHERE hosts.org_id = %(org_id_1)s AND lower(groups.name) IN (%(lower_1_1)s, %(lower_1_2)s, %(lower_1_3)s, %(lower_1_4)s, %(lower_1_5)s) AND ((hosts.system_profile_facts ->> %(system_profile_facts_2)s) = %(param_1)s AND (hosts.modified_on > %(modified_on_1)s OR hosts.modified_on > %(modified_on_2)s AND hosts.modified_on <= %(modified_on_3)s OR hosts.modified_on > %(modified_on_4)s AND hosts.modified_on <= %(modified_on_5)s) OR (hosts.system_profile_facts ->> %(system_profile_facts_3)s) IS NULL AND (hosts.modified_on > %(modified_on_6)s OR hosts.modified_on > %(modified_on_7)s AND hosts.modified_on <= %(modified_on_8)s OR hosts.modified_on > %(modified_on_9)s AND hosts.modified_on <= %(modified_on_10)s)) ORDER BY hosts.modified_on DESC, hosts.id DESC 
 LIMIT %(param_2)s OFFSET %(param_3)s
```


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
