### PR TITLE
Put the host_exists endpoint in the "hosts" APIdocs group

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -352,6 +352,8 @@ paths:
           description: Invalid request.
   '/host_exists':
     get:
+      tags:
+        - hosts
       summary: Find one host by insights_id, if it exists
       description: >-
         Find one host by insights_id, if it exists.

--- a/swagger/openapi.dev.json
+++ b/swagger/openapi.dev.json
@@ -606,6 +606,9 @@
     },
     "/host_exists": {
       "get": {
+        "tags": [
+          "hosts"
+        ],
         "summary": "Find one host by insights_id, if it exists",
         "description": "Find one host by insights_id, if it exists. <br /><br /> Required permissions: inventory:hosts:read",
         "operationId": "api.host.get_host_exists",

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -606,6 +606,9 @@
     },
     "/host_exists": {
       "get": {
+        "tags": [
+          "hosts"
+        ],
         "summary": "Find one host by insights_id, if it exists",
         "description": "Find one host by insights_id, if it exists. <br /><br /> Required permissions: inventory:hosts:read",
         "operationId": "api.host.get_host_exists",


### PR DESCRIPTION
# Overview

This PR is being created to put the GET /host_exists endpoint inside the `hosts` group in the API docs.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
