### PR TITLE
Add IQE_IMAGE_TAG parameter to integration testing image

### DIFF
--- a/deploy/testing-integration.yml
+++ b/deploy/testing-integration.yml
@@ -29,7 +29,7 @@ objects:
             optional: true
         containers:
         - name: host-inventory-e2e-iqe-${IMAGE_TAG}-${UID}
-          image: ${IQE_IMAGE}
+          image: ${IQE_IMAGE}:${IQE_IMAGE_TAG}
           imagePullPolicy: Always
           args:
           - ${IQE_CONTAINER_ARGS}


### PR DESCRIPTION
# Overview

After the plugin rename I did in https://github.com/RedHatInsights/insights-host-inventory/pull/1923 the integration test pipeline is failing. After asking around looks like I was missing a argument for the container. In this PR I add that parameter.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
