### PR TITLE
refact(RHINENG-10672): Refact app/queue/queue.py

### DIFF
--- a/app/queue/export_service_mq.py
+++ b/app/queue/export_service_mq.py
@@ -1,0 +1,121 @@
+import sys
+
+from marshmallow import fields
+from marshmallow import Schema
+from marshmallow import ValidationError
+from sqlalchemy.exc import OperationalError
+
+from app.logging import get_logger
+from app.queue import metrics
+from app.queue.export_service import create_export
+from app.queue.mq_common import common_message_parser
+
+
+logger = get_logger(__name__)
+
+CONSUMER_POLL_TIMEOUT_SECONDS = 1
+EXPORT_EVENT_SOURCE = "urn:redhat:source:console:app:export-service"
+EXPORT_SERVICE_APPLICATION = "urn:redhat:application:inventory"
+
+
+class ExportResourceRequest(Schema):
+    application = fields.Str(required=True)
+    export_request_uuid = fields.UUID(required=True)
+    filters = fields.Dict()
+    format = fields.Str(required=True)
+    resource = fields.Str(required=True)
+    uuid = fields.Str(required=True)
+    x_rh_identity = fields.Str(required=True, data_key="x-rh-identity")
+
+
+class ExportDataSchema(Schema):
+    resource_request = fields.Nested(ExportResourceRequest)
+
+
+class ExportEventSchema(Schema):
+    id = fields.UUID(required=True)
+    schema = fields.Str(data_key="$schema")
+    source = fields.Str(required=True)
+    subject = fields.Str(required=True)
+    specversion = fields.Str(required=True)
+    type = fields.Str(required=True)
+    time = fields.DateTime(required=True)
+    redhatorgid = fields.Str(required=True)
+    dataschema = fields.Str(required=True)
+    data = fields.Nested(ExportDataSchema, required=True)
+
+
+@metrics.export_service_message_parsing_time.time()
+def parse_export_service_message(message):
+    parsed_message = common_message_parser(message)
+    try:
+        parsed_export_msg = ExportEventSchema().load(parsed_message)
+        return parsed_export_msg
+    except ValidationError as e:
+        logger.error(
+            "Input validation error while parsing export event message:%s", e, extra={"operation": parsed_message}
+        )  # logger.error is used to avoid printing out the same traceback twice
+
+        metrics.export_service_message_parsing_failure.labels("invalid").inc()
+        raise
+    except Exception:
+        logger.exception("Error parsing export event message", extra={"operation": parsed_message})
+
+        metrics.export_service_message_parsing_failure.labels("error").inc()
+        raise
+
+
+@metrics.export_service_message_handler_time.time()
+def handle_export_message(message, inventory_config):
+    validated_msg = parse_export_service_message(message)
+    message_handled = False
+    try:
+        if (
+            validated_msg["source"] == EXPORT_EVENT_SOURCE
+            and validated_msg["data"]["resource_request"]["application"] == EXPORT_SERVICE_APPLICATION
+        ):
+            logger.info("Found host-inventory application export message")
+            logger.debug("parsed_message: %s", validated_msg)
+            base64_x_rh_identity = validated_msg["data"]["resource_request"]["x_rh_identity"]
+
+            if create_export(validated_msg, base64_x_rh_identity, inventory_config):
+                metrics.export_service_message_handler_success.inc()
+                message_handled = True
+            else:
+                metrics.export_service_message_handler_failure.inc()
+                message_handled = False
+        else:
+            logger.debug("Found export message not related to host-inventory")
+            message_handled = False
+    except Exception as e:
+        logger.error(e)
+        metrics.export_service_message_handler_failure.inc()
+        message_handled = False
+    finally:
+        return message_handled
+
+
+def export_service_event_loop(consumer, flask_app, interrupt):
+    with flask_app.app_context():
+        inventory_config = flask_app.config.get("INVENTORY_CONFIG")
+        while not interrupt():
+            messages = consumer.consume(timeout=CONSUMER_POLL_TIMEOUT_SECONDS)
+            for msg in messages:
+                if msg is None:
+                    continue
+                elif msg.error():
+                    logger.error(f"Message received but has an error, which is {str(msg.error())}")
+                    metrics.ingress_message_handler_failure.inc()
+                else:
+                    logger.debug("Export Service message received")
+                    try:
+                        handle_export_message(msg.value(), inventory_config)
+                    except OperationalError as oe:
+                        """sqlalchemy.exc.OperationalError: This error occurs when an
+                        authentication failure occurs or the DB is not accessible.
+                        Exit the process to restart the pod
+                        """
+                        logger.error(f"Could not access DB {str(oe)}")
+                        sys.exit(3)
+                    except Exception:
+                        logger.exception("Unable to process message", extra={"incoming_message": msg.value()})

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -46,7 +46,7 @@ from app.queue.events import EventType
 from app.queue.events import HOST_EVENT_TYPE_CREATED
 from app.queue.events import message_headers
 from app.queue.events import operation_results_to_event_type
-from app.queue.export_service import create_export
+from app.queue.mq_common import common_message_parser
 from app.queue.notifications import NotificationType
 from app.queue.notifications import send_notification
 from app.serialization import deserialize_host
@@ -60,8 +60,6 @@ logger = get_logger(__name__)
 
 CONSUMER_POLL_TIMEOUT_SECONDS = 1
 SYSTEM_IDENTITY = {"auth_type": "cert-auth", "system": {"cert_type": "system"}, "type": "System"}
-EXPORT_EVENT_SOURCE = "urn:redhat:source:console:app:export-service"
-EXPORT_SERVICE_APPLICATION = "urn:redhat:application:inventory"
 
 
 class OperationSchema(Schema):
@@ -80,33 +78,6 @@ class OperationResult:
         self.staleness_object = so
         self.event_type = et
         self.success_logger = sl
-
-
-class ExportResourceRequest(Schema):
-    application = fields.Str(required=True)
-    export_request_uuid = fields.UUID(required=True)
-    filters = fields.Dict()
-    format = fields.Str(required=True)
-    resource = fields.Str(required=True)
-    uuid = fields.Str(required=True)
-    x_rh_identity = fields.Str(required=True, data_key="x-rh-identity")
-
-
-class ExportDataSchema(Schema):
-    resource_request = fields.Nested(ExportResourceRequest)
-
-
-class ExportEventSchema(Schema):
-    id = fields.UUID(required=True)
-    schema = fields.Str(data_key="$schema")
-    source = fields.Str(required=True)
-    subject = fields.Str(required=True)
-    specversion = fields.Str(required=True)
-    type = fields.Str(required=True)
-    time = fields.DateTime(required=True)
-    redhatorgid = fields.Str(required=True)
-    dataschema = fields.Str(required=True)
-    data = fields.Nested(ExportDataSchema, required=True)
 
 
 # input is a base64 encoded utf-8 string. b64decode returns bytes, which
@@ -194,22 +165,6 @@ def _validate_json_object_for_utf8(json_object):
         pass
 
 
-@metrics.common_message_parsing_time.time()
-def common_message_parser(message):
-    try:
-        # Due to RHCLOUD-3610 we're receiving messages with invalid unicode code points (invalid surrogate pairs)
-        # Python pretty much ignores that but it is not possible to store such strings in the database (db INSERTS
-        # blow up)
-        parsed_message = json.loads(message)
-        return parsed_message
-    except json.decoder.JSONDecodeError:
-        # The "extra" dict cannot have a key named "msg" or "message"
-        # otherwise an exception in thrown in the logging code
-        logger.exception("Unable to parse json message from message queue", extra={"incoming_message": message})
-        metrics.common_message_parsing_failure.labels("invalid").inc()
-        raise
-
-
 @metrics.ingress_message_parsing_time.time()
 def parse_operation_message(message):
     parsed_message = common_message_parser(message)
@@ -236,26 +191,6 @@ def parse_operation_message(message):
 
     logger.debug("parsed_message: %s", parsed_operation)
     return parsed_operation
-
-
-@metrics.export_service_message_parsing_time.time()
-def parse_export_service_message(message):
-    parsed_message = common_message_parser(message)
-    try:
-        parsed_export_msg = ExportEventSchema().load(parsed_message)
-        return parsed_export_msg
-    except ValidationError as e:
-        logger.error(
-            "Input validation error while parsing export event message:%s", e, extra={"operation": parsed_message}
-        )  # logger.error is used to avoid printing out the same traceback twice
-
-        metrics.export_service_message_parsing_failure.labels("invalid").inc()
-        raise
-    except Exception:
-        logger.exception("Error parsing export event message", extra={"operation": parsed_message})
-
-        metrics.export_service_message_parsing_failure.labels("error").inc()
-        raise
 
 
 def sync_event_message(message, session, event_producer):
@@ -456,62 +391,6 @@ def write_message_batch(event_producer, processed_rows):
             except Exception as exc:
                 metrics.ingress_message_handler_failure.inc()
                 logger.exception("Error while producing message", exc_info=exc)
-
-
-@metrics.export_service_message_handler_time.time()
-def handle_export_message(message, inventory_config):
-    validated_msg = parse_export_service_message(message)
-    message_handled = False
-    try:
-        if (
-            validated_msg["source"] == EXPORT_EVENT_SOURCE
-            and validated_msg["data"]["resource_request"]["application"] == EXPORT_SERVICE_APPLICATION
-        ):
-            logger.info("Found host-inventory application export message")
-            logger.debug("parsed_message: %s", validated_msg)
-            base64_x_rh_identity = validated_msg["data"]["resource_request"]["x_rh_identity"]
-
-            if create_export(validated_msg, base64_x_rh_identity, inventory_config):
-                metrics.export_service_message_handler_success.inc()
-                message_handled = True
-            else:
-                metrics.export_service_message_handler_failure.inc()
-                message_handled = False
-        else:
-            logger.debug("Found export message not related to host-inventory")
-            message_handled = False
-    except Exception as e:
-        logger.error(e)
-        metrics.export_service_message_handler_failure.inc()
-        message_handled = False
-    finally:
-        return message_handled
-
-
-def export_service_event_loop(consumer, flask_app, interrupt):
-    with flask_app.app_context():
-        inventory_config = flask_app.config.get("INVENTORY_CONFIG")
-        while not interrupt():
-            messages = consumer.consume(timeout=CONSUMER_POLL_TIMEOUT_SECONDS)
-            for msg in messages:
-                if msg is None:
-                    continue
-                elif msg.error():
-                    logger.error(f"Message received but has an error, which is {str(msg.error())}")
-                    metrics.ingress_message_handler_failure.inc()
-                else:
-                    logger.debug("Export Service message received")
-                    try:
-                        handle_export_message(msg.value(), inventory_config)
-                    except OperationalError as oe:
-                        """sqlalchemy.exc.OperationalError: This error occurs when an
-                        authentication failure occurs or the DB is not accessible.
-                        Exit the process to restart the pod
-                        """
-                        logger.error(f"Could not access DB {str(oe)}")
-                        sys.exit(3)
-                    except Exception:
-                        logger.exception("Unable to process message", extra={"incoming_message": msg.value()})
 
 
 def event_loop(consumer, flask_app, event_producer, notification_event_producer, handler, interrupt):

--- a/app/queue/mq_common.py
+++ b/app/queue/mq_common.py
@@ -1,0 +1,23 @@
+import json
+
+from app.logging import get_logger
+from app.queue import metrics
+
+
+logger = get_logger(__name__)
+
+
+@metrics.common_message_parsing_time.time()
+def common_message_parser(message):
+    try:
+        # Due to RHCLOUD-3610 we're receiving messages with invalid unicode code points (invalid surrogate pairs)
+        # Python pretty much ignores that but it is not possible to store such strings in the database (db INSERTS
+        # blow up)
+        parsed_message = json.loads(message)
+        return parsed_message
+    except json.decoder.JSONDecodeError:
+        # The "extra" dict cannot have a key named "msg" or "message"
+        # otherwise an exception in thrown in the logging code
+        logger.exception("Unable to parse json message from message queue", extra={"incoming_message": message})
+        metrics.common_message_parsing_failure.labels("invalid").inc()
+        raise

--- a/inv_export_service.py
+++ b/inv_export_service.py
@@ -7,11 +7,11 @@ from prometheus_client import start_http_server
 from app import create_app
 from app.environment import RuntimeEnvironment
 from app.logging import get_logger
-from app.queue.queue import export_service_event_loop
+from app.queue.export_service_mq import export_service_event_loop
 from lib.handlers import register_shutdown
 from lib.handlers import ShutdownHandler
 
-logger = get_logger("mq_service")
+logger = get_logger("export_sevice_mq")
 
 
 def main():

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -9,14 +9,14 @@ from app import create_app
 from app.environment import RuntimeEnvironment
 from app.logging import get_logger
 from app.queue.event_producer import EventProducer
-from app.queue.queue import add_host
-from app.queue.queue import event_loop
-from app.queue.queue import handle_message
-from app.queue.queue import update_system_profile
+from app.queue.host_mq import add_host
+from app.queue.host_mq import event_loop
+from app.queue.host_mq import handle_message
+from app.queue.host_mq import update_system_profile
 from lib.handlers import register_shutdown
 from lib.handlers import ShutdownHandler
 
-logger = get_logger("mq_service")
+logger = get_logger("host_mq_service")
 
 
 def main():

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -10,10 +10,10 @@ from app.models import Host
 from app.models import HostGroupAssoc
 from app.queue.event_producer import EventProducer
 from app.queue.events import EventType
+from app.queue.host_mq import OperationResult
+from app.queue.host_mq import write_delete_event_message
 from app.queue.notifications import NotificationType
 from app.queue.notifications import send_notification
-from app.queue.queue import OperationResult
-from app.queue.queue import write_delete_event_message
 from lib.db import session_guard
 from lib.host_kafka import kafka_available
 from lib.metrics import delete_host_count

--- a/lib/system_profile_validate.py
+++ b/lib/system_profile_validate.py
@@ -9,7 +9,7 @@ from yaml import safe_load
 
 from app.exceptions import InventoryException
 from app.logging import get_logger
-from app.queue.queue import OperationSchema
+from app.queue.host_mq import OperationSchema
 from app.serialization import deserialize_host
 
 __all__ = ("validate_sp_for_branch",)

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -18,7 +18,7 @@ from app.logging import configure_logging
 from app.logging import get_logger
 from app.logging import threadctx
 from app.queue.event_producer import EventProducer
-from app.queue.queue import sync_event_message
+from app.queue.host_mq import sync_event_message
 from lib.db import session_guard
 from lib.handlers import register_shutdown
 from lib.handlers import ShutdownHandler

--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -7,11 +7,11 @@ import pytest
 
 from app import db
 from app.queue.event_producer import EventProducer
+from app.queue.host_mq import add_host
+from app.queue.host_mq import handle_message
+from app.queue.host_mq import write_add_update_event_message
 from app.queue.notifications import NotificationType
 from app.queue.notifications import send_notification
-from app.queue.queue import add_host
-from app.queue.queue import handle_message
-from app.queue.queue import write_add_update_event_message
 from app.utils import HostWrapper
 from tests.helpers.api_utils import FACTS
 from tests.helpers.api_utils import TAGS

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -13,7 +13,7 @@ from app.culling import _Config as CullingConfig
 from app.culling import Timestamps
 from app.queue.export_service import _format_export_data
 from app.queue.export_service import get_host_list
-from app.queue.queue import handle_export_message
+from app.queue.export_service_mq import handle_export_message
 from app.serialization import _EXPORT_SERVICE_FIELDS
 from app.serialization import serialize_host_for_export_svc
 from tests.helpers import export_service_utils as es_utils


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-10672](https://issues.redhat.com/browse/RHINENG-10672).
It split the export service MQ and host MQ services into their files. Also create a common mq file to hold the common code used between both services. It also updates the tests required tests.

Creates the following files:
- host_mq.py
- export_service_mq.py
- mq_common.py

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
