### PR TITLE
fix(RHINENG-12591): Fix message for unsupported filter field/operation

### DIFF
--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1523,22 +1523,20 @@ def test_query_all_sp_filters_multiple_of_same_field(db_create_host, api_get, sp
 
 
 @pytest.mark.parametrize(
-    "sp_filter_param",
+    "sp_filter_param,parent,child",
     (
-        "[foo]=val",  # Invalid top-level field
-        "[bootc_status][foo]=val",  # Invalid non-top-level field
-        "[bootc_status][booted][foo]=val",  # Invalid non-top-level field
-        "[arch][gteq]=val",  # Invalid comparator/field
+        ("[foo]=val", "system_profile", "foo"),  # Invalid top-level field
+        ("[bootc_status][foo]=val", "bootc_status", "foo"),  # Invalid non-top-level field
+        ("[bootc_status][booted][foo]=val", "booted", "foo"),  # Invalid non-top-level field
+        ("[arch][gteq]=val", "arch", "gteq"),  # Invalid comparator/field
     ),
 )
-def test_query_all_sp_filters_invalid_field(api_get, sp_filter_param):
+def test_query_all_sp_filters_invalid_field(api_get, sp_filter_param, parent, child):
     url = build_hosts_url(query=f"?filter[system_profile]{sp_filter_param}")
-
-    with patch("api.host.get_flag_value", return_value=True):
-        response_status, response_data = api_get(url)
+    response_status, response_data = api_get(url)
 
     assert response_status == 400
-    assert "invalid filter field" in response_data.get("detail")
+    assert f"Invalid operation or child node for {parent}: {child}" == response_data.get("detail")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-12591](https://issues.redhat.com/browse/RHINENG-12591).
It improves the "invalid filter field" error message by making it clearer and adding more context. 
For the example request "GET /hosts?filter[system_profile][owner_id][not_eq]=123"...

- Before: "invalid filter field: not_eq"
- After: "Invalid operation or child node for owner_id: not_eq"

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
