### PR TITLE
fix(RHINENG-11200): Handle filtering on [host_type][eq]=

### DIFF
--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -318,7 +318,7 @@ def get_host_types_from_filter(host_type_filter: dict) -> Set[str]:
             for val in value:
                 if val == "not_nil":
                     val = HOST_TYPES[0]
-                elif val == "nil":
+                elif val == "nil" or val == "":
                     val = HOST_TYPES[1]
 
                 if comparator == "eq":

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1268,6 +1268,7 @@ def test_query_host_fuzzy_match(db_create_host, api_get, query_filter_param, mat
         "[system_memory_bytes]=8292048963606259",
         "[arch]=x86",  # EQ field, no wildcard
         "[host_type]=",  # Valid bc it's a string field, but no match
+        "[host_type][eq]=",  # Same for this one
         "[sap][sids][contains][]=ABC&filter[system_profile][sap][sids][contains][]=GHI",
     ),
 )


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-11200](https://issues.redhat.com/browse/RHINENG-11200).
Prior to this change, we adequately handled `?filter[system_profile][host_type]=` (with no value), but `?filter[system_profile][host_type][eq]=` resulted in HTTP 500. This PR adds handling for that scenario so it works the same way; it also adds a test case to validate.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
