### PR TITLE
fix(RHINENG-13652): Add system profile field to HostOut

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1754,11 +1754,7 @@ components:
               items:
                 $ref: '#/components/schemas/GroupOut'
             system_profile:
-              description: >-
-                The host system profile object
-              type: object
-              items:
-                $ref: '#/components/schemas/SystemProfile'
+              $ref: '#/components/schemas/SystemProfile'
           required:
             - org_id
     HostIdOut:

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1753,6 +1753,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/GroupOut'
+            system_profile:
+              description: >-
+                The host system profile object
+              type: object
+              items:
+                $ref: '#/components/schemas/SystemProfile'
           required:
             - org_id
     HostIdOut:

--- a/swagger/openapi.dev.json
+++ b/swagger/openapi.dev.json
@@ -2661,11 +2661,7 @@
                 }
               },
               "system_profile": {
-                "description": "The host system profile object",
-                "type": "object",
-                "items": {
-                  "$ref": "#/components/schemas/SystemProfile"
-                }
+                "$ref": "#/components/schemas/SystemProfile"
               }
             },
             "required": [

--- a/swagger/openapi.dev.json
+++ b/swagger/openapi.dev.json
@@ -2659,6 +2659,13 @@
                 "items": {
                   "$ref": "#/components/schemas/GroupOut"
                 }
+              },
+              "system_profile": {
+                "description": "The host system profile object",
+                "type": "object",
+                "items": {
+                  "$ref": "#/components/schemas/SystemProfile"
+                }
               }
             },
             "required": [

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -2528,11 +2528,7 @@
                 }
               },
               "system_profile": {
-                "description": "The host system profile object",
-                "type": "object",
-                "items": {
-                  "$ref": "#/components/schemas/SystemProfile"
-                }
+                "$ref": "#/components/schemas/SystemProfile"
               }
             },
             "required": [

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -2526,6 +2526,13 @@
                 "items": {
                   "$ref": "#/components/schemas/GroupOut"
                 }
+              },
+              "system_profile": {
+                "description": "The host system profile object",
+                "type": "object",
+                "items": {
+                  "$ref": "#/components/schemas/SystemProfile"
+                }
               }
             },
             "required": [


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-13652](https://issues.redhat.com/browse/RHINENG-13652).

It adds `system_profile` field to `HostOut` object in the OpenAPI spec


## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
