### PR TITLE
fix: Define RBAC metric inside RBAC call

### DIFF
--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -33,8 +33,6 @@ RBAC_ROUTE = "/api/rbac/v1/access/?application="
 CHECKED_TYPES = [IdentityType.USER, IdentityType.SERVICE_ACCOUNT]
 RETRY_STATUSES = [500, 502, 503, 504]
 
-outbound_http_metric = outbound_http_response_time.labels("rbac")
-
 
 def get_rbac_url(app: str) -> str:
     return inventory_config().rbac_endpoint + RBAC_ROUTE + app
@@ -50,7 +48,7 @@ def get_rbac_permissions(app: str, request_header: dict):
     request_session.mount(get_rbac_url(app), HTTPAdapter(max_retries=retry_config))
 
     try:
-        with outbound_http_metric.time():
+        with outbound_http_response_time.labels("rbac").time():
             rbac_response = request_session.get(
                 url=get_rbac_url(app),
                 headers=request_header,


### PR DESCRIPTION
# Overview

Currently, if you try to run the unit tests for one specific file or test suite, it will fail due to an initialization failure of a Prometheus metric within `middleware.py`. This PR moves the metric definition within the RBAC function, which gets bypassed during tests.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
