### PR TITLE
fix(RHINENG-13858): Fix request_id in "host message consumed" log

### DIFF
--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -234,14 +234,10 @@ def log_add_host_attempt(logger, input_host):
     )
 
 
-def log_message_consumed(logger, message):
-    try:
-        request_id = json.loads(message.value())["platform_metadata"]["request_id"]
-        partition = message.partition()
-        offset = message.offset()
-        logger.info(f"Host message consumed, partition={partition}, offset={offset}, request_id={request_id}")
-    except KeyError as ke:
-        logger.debug("Error retrieving request_id for log", exc_info=ke)
+def log_message_consumed(logger, message, request_id):
+    partition = message.partition()
+    offset = message.offset()
+    logger.info(f"Host message consumed, partition={partition}, offset={offset}, request_id={request_id}")
 
 
 def log_add_update_host_succeeded(logger, add_result, output_host):

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -281,6 +281,7 @@ def handle_message(message, notification_event_producer, message_operation=add_h
         payload_tracker, received_status_message="message received", current_operation="handle_message"
     ):
         try:
+            log_message_consumed(logger, message)
             host = validated_operation_msg["data"]
             host_row, operation_result, identity, success_logger = message_operation(
                 host, platform_metadata, notification_event_producer, validated_operation_msg.get("operation_args", {})
@@ -430,8 +431,6 @@ def event_loop(consumer, flask_app, event_producer, notification_event_producer,
                         metrics.ingress_message_handler_failure.inc()
                     else:
                         logger.debug("Message received")
-                        log_message_consumed(logger, msg)
-
                         try:
                             processed_rows.append(
                                 handler(


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-13858](https://issues.redhat.com/browse/RHINENG-13858).
It moves some things around so that we can have the request ID along with the message partition & offset in the same log. In order to do this, we unfortunately need to decode the message twice; the alternative would be to restructure `handle_message` to accept a raw MQ message rather than its value.

If you all think it's worth changing all that for the sake of this log, let me know and I can do so.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
