### PR TITLE
Remove "Host message consumed" log

### DIFF
--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -234,12 +234,6 @@ def log_add_host_attempt(logger, input_host):
     )
 
 
-def log_message_consumed(logger, message, request_id):
-    partition = message.partition()
-    offset = message.offset()
-    logger.info(f"Host message consumed, partition={partition}, offset={offset}, request_id={request_id}")
-
-
 def log_add_update_host_succeeded(logger, add_result, output_host):
     metrics.add_host_success.labels(add_result.name, output_host.get("reporter", "null")).inc()  # created vs updated
     # log all the incoming host data except facts and system_profile b/c they can be quite large

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -28,7 +28,6 @@ from app.instrumentation import log_add_host_attempt
 from app.instrumentation import log_add_host_failure
 from app.instrumentation import log_add_update_host_succeeded
 from app.instrumentation import log_db_access_failure
-from app.instrumentation import log_message_consumed
 from app.instrumentation import log_update_system_profile_failure
 from app.instrumentation import log_update_system_profile_success
 from app.logging import get_logger
@@ -436,12 +435,6 @@ def event_loop(consumer, flask_app, event_producer, notification_event_producer,
                         metrics.ingress_message_handler_failure.inc()
                     else:
                         logger.debug("Message received")
-                        try:
-                            request_id = json.loads(msg.value())["platform_metadata"]["request_id"]
-                            initialize_thread_local_storage(request_id)
-                            log_message_consumed(logger, msg, request_id)
-                        except KeyError as ke:
-                            logger.debug("Error retrieving request_id for log", exc_info=ke)
 
                         try:
                             processed_rows.append(


### PR DESCRIPTION
# Overview

This PR is being created to remove the "Host message consumed" log. This log was useful in one specific instance, but has also misled some folks and guided them to the wrong conclusion. So, unless we really need this log, I think we should remove it.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
