### PR TITLE
chore(RHINENG-3408): Replace calls to sleep()

### DIFF
--- a/tests/test_custom_staleness.py
+++ b/tests/test_custom_staleness.py
@@ -1,5 +1,7 @@
-import time
+from datetime import datetime
+from datetime import timedelta
 from unittest import mock
+from unittest.mock import patch
 
 from app.logging import threadctx
 from app.models import db
@@ -53,12 +55,14 @@ def test_delete_only_immutable_hosts(
 ):
     db_create_staleness_culling(**CUSTOM_STALENESS_DELETE_ONLY_IMMUTABLE)
 
-    immutable_hosts = db_create_multiple_hosts(how_many=2, extra_data={"system_profile_facts": {"host_type": "edge"}})
-    immutable_hosts = [host.id for host in immutable_hosts]
-    conventional_hosts = db_create_multiple_hosts(how_many=2)
-    conventional_hosts = [host.id for host in conventional_hosts]
-
-    time.sleep(1)
+    with patch("app.models.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime.now() - timedelta(minutes=1)
+        immutable_hosts = db_create_multiple_hosts(
+            how_many=2, extra_data={"system_profile_facts": {"host_type": "edge"}}
+        )
+        immutable_hosts = [host.id for host in immutable_hosts]
+        conventional_hosts = db_create_multiple_hosts(how_many=2)
+        conventional_hosts = [host.id for host in conventional_hosts]
 
     threadctx.request_id = None
     host_reaper_run(
@@ -85,12 +89,14 @@ def test_delete_only_conventional_hosts(
 ):
     db_create_staleness_culling(**CUSTOM_STALENESS_DELETE_ONLY_CONVENTIONAL)
 
-    immutable_hosts = db_create_multiple_hosts(how_many=2, extra_data={"system_profile_facts": {"host_type": "edge"}})
-    immutable_hosts = [host.id for host in immutable_hosts]
-    conventional_hosts = db_create_multiple_hosts(how_many=2)
-    conventional_hosts = [host.id for host in conventional_hosts]
-
-    time.sleep(1)
+    with patch("app.models.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime.now() - timedelta(minutes=1)
+        immutable_hosts = db_create_multiple_hosts(
+            how_many=2, extra_data={"system_profile_facts": {"host_type": "edge"}}
+        )
+        immutable_hosts = [host.id for host in immutable_hosts]
+        conventional_hosts = db_create_multiple_hosts(how_many=2)
+        conventional_hosts = [host.id for host in conventional_hosts]
 
     threadctx.request_id = None
     host_reaper_run(
@@ -117,12 +123,14 @@ def test_delete_conventional_immutable_hosts(
 ):
     db_create_staleness_culling(**CUSTOM_STALENESS_DELETE_CONVENTIONAL_IMMUTABLE)
 
-    immutable_hosts = db_create_multiple_hosts(how_many=2, extra_data={"system_profile_facts": {"host_type": "edge"}})
-    immutable_hosts = [host.id for host in immutable_hosts]
-    conventional_hosts = db_create_multiple_hosts(how_many=2)
-    conventional_hosts = [host.id for host in conventional_hosts]
-
-    time.sleep(1)
+    with patch("app.models.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime.now() - timedelta(minutes=1)
+        immutable_hosts = db_create_multiple_hosts(
+            how_many=2, extra_data={"system_profile_facts": {"host_type": "edge"}}
+        )
+        immutable_hosts = [host.id for host in immutable_hosts]
+        conventional_hosts = db_create_multiple_hosts(how_many=2)
+        conventional_hosts = [host.id for host in conventional_hosts]
 
     threadctx.request_id = None
     host_reaper_run(
@@ -149,12 +157,14 @@ def test_no_hosts_to_delete(
 ):
     db_create_staleness_culling(**CUSTOM_STALENESS_NO_HOSTS_TO_DELETE)
 
-    immutable_hosts = db_create_multiple_hosts(how_many=2, extra_data={"system_profile_facts": {"host_type": "edge"}})
-    immutable_hosts = [host.id for host in immutable_hosts]
-    conventional_hosts = db_create_multiple_hosts(how_many=2)
-    conventional_hosts = [host.id for host in conventional_hosts]
-
-    time.sleep(1)
+    with patch("app.models.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime.now() - timedelta(minutes=1)
+        immutable_hosts = db_create_multiple_hosts(
+            how_many=2, extra_data={"system_profile_facts": {"host_type": "edge"}}
+        )
+        immutable_hosts = [host.id for host in immutable_hosts]
+        conventional_hosts = db_create_multiple_hosts(how_many=2)
+        conventional_hosts = [host.id for host in conventional_hosts]
 
     threadctx.request_id = None
     host_reaper_run(

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -1,6 +1,6 @@
 import io
 import json
-import time
+from datetime import datetime
 from datetime import timedelta
 from unittest import mock
 
@@ -184,13 +184,11 @@ def test_do_not_export_culled_hosts(flask_app, db_create_host, db_create_stalene
             "immutable_time_to_delete": 1,
         }
 
-        db_create_staleness_culling(**CUSTOM_STALENESS_DELETE_CONVENTIONAL_IMMUTABLE)
-        db_create_host()
+        with mock.patch("app.models.datetime") as mock_datetime:
+            mock_datetime.now.return_value = datetime.now() - timedelta(minutes=1)
+            db_create_staleness_culling(**CUSTOM_STALENESS_DELETE_CONVENTIONAL_IMMUTABLE)
+            db_create_host()
 
-        # This is not ideal, but there no other way that I
-        # found to not use time.sleep
-
-        time.sleep(1)
         identity = Identity(USER_IDENTITY)
         host_list = get_host_list(
             identity=identity, exportFormat="json", rbac_filter=None, inventory_config=inventory_config


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-3408](https://issues.redhat.com/browse/RHINENG-3408).
It removes calls to `sleep()` within our unit tests and replaces them with datetime mocks. This will speed up our unit test runs by at least 5 seconds.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
