### PR TITLE
fix(RHINENG-8070): Don't allow empty strings for Service Account fields

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -167,8 +167,8 @@ class SystemIdentitySchema(IdentityBaseSchema):
 
 
 class ServiceAccountInfoIdentitySchema(IdentityBaseSchema):
-    client_id = m.fields.Str(required=True)
-    username = m.fields.Str(required=True)
+    client_id = m.fields.Str(required=True, validate=m.validate.Length(min=1))
+    username = m.fields.Str(required=True, validate=m.validate.Length(min=1))
 
 
 class ServiceAccountIdentitySchema(IdentityBaseSchema):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -231,7 +231,15 @@ class AuthIdentityValidateTestCase(TestCase):
 
     def test_invalid_service_account_obj(self):
         test_identity = deepcopy(SERVICE_ACCOUNT_IDENTITY)
-        service_account_objects = [None, ""]
+        service_account_objects = [
+            None,
+            "",
+            {
+                "client_id": SERVICE_ACCOUNT_IDENTITY["service_account"]["client_id"],
+                "username": "",
+            },
+            {"client_id": "", "username": SERVICE_ACCOUNT_IDENTITY["service_account"]["username"]},
+        ]
         for service_account_object in service_account_objects:
             with self.subTest(service_account_object=service_account_object):
                 test_identity["service_account"] = service_account_object


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-8070](https://issues.redhat.com/browse/RHINENG-8070).
Makes it so the Identity fields specific to Service Account can't be set to empty strings. Also adds a couple test cases to validate this.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
