### PR TITLE
Test: Revert "chore(deps): update pre-commit hook astral-sh/ruff-pre-commit to v0.8.3"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     files: swagger/openapi.json$
     exclude: swagger/inventory-schemas/
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.3
+  rev: v0.8.2
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
Reverts RedHatInsights/insights-host-inventory#2129
Test PR. Seeing if reverting this would fix the PR check issue.