### PR TITLE
Fix redocly by using relative paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
 
 - repo: local
   hooks:
-  - id: redocly-merge # here for reference - currently renames and breaks clien gen
+  - id: redocly-merge # here for reference - currently renames and breaks client gen
     name: redoc merge
     language: node
     additional_dependencies:
@@ -49,14 +49,14 @@ repos:
     pass_filenames: false
     # always_run: true
     stages: [manual]
-  # - id: redocly-filter
-  #   name: redoc filter
-  #   language: node
-  #   additional_dependencies:
-  #   - "@redocly/cli"
-  #   entry: redocly bundle --config=swagger/redocly.yml filter_generated -o swagger/openapi.json
-  #   pass_filenames: false
-  #   always_run: true
+  - id: redocly-filter
+    name: redoc filter
+    language: node
+    additional_dependencies:
+    - "@redocly/cli"
+    entry: redocly bundle --config=swagger/redocly.yml filter_generated -o swagger/openapi.json
+    pass_filenames: false
+    always_run: true
   - id: redocly-validate
     name: redoc validate
     language: node

--- a/swagger/redocly.yml
+++ b/swagger/redocly.yml
@@ -1,8 +1,8 @@
 apis:
   full: # dont use yet, it renames elements
-    root: swagger/api.spec.yaml
+    root: ./api.spec.yaml
   cleaned: #dito
-    root: swagger/api.spec.yaml
+    root: ./api.spec.yaml
     decorators: &remove-assignment-config
       filter-out:
         property: operationId
@@ -12,5 +12,5 @@ apis:
         - api.assignment_rule.get_assignment_rules_by_id
       remove-unused-components: on
   filter_generated:
-    root: swagger/openapi.dev.json
+    root: ./openapi.dev.json
     decorators: *remove-assignment-config


### PR DESCRIPTION
# Overview

This PR is being created to address a pre-commit redocly issue. For some reason redocly started interpreting the paths in the redocly.yml config as relative paths (I guess it's the right way, but it probably interpreted them as full paths from the project root in the past), so when we had `swagger/openapi.dev.json` there it was trying to find `swagger/swagger/openapi.dev.json` file, which didn't exist. This PR should fix the issue.

I verified that the paths are correct now by commenting out `- api.assignment_rule.get_assignment_rules_by_id` from the redocly config and running pre-commit. It correctly recognized the change and copied the endpoint from the `openapi.dev.json` to the `openapi.json`. When I uncommented that line, it correctly removed it from the `openapi.json` again.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
