### PR TITLE
fix(RHINENG-15180): Fix CSV data export with unicode chars

### DIFF
--- a/app/queue/export_service.py
+++ b/app/queue/export_service.py
@@ -16,6 +16,7 @@ from app import RbacResourceType
 from app.auth.identity import Identity
 from app.auth.identity import from_auth_header
 from app.config import Config
+from app.exceptions import InventoryException
 from app.logging import get_logger
 from lib import metrics
 from lib.middleware import get_rbac_filter
@@ -23,7 +24,7 @@ from utils.json_to_csv import json_arr_to_csv
 
 logger = get_logger(__name__)
 
-HEADER_CONTENT_TYPE = {"json": "application/json", "csv": "text/csv"}
+HEADER_CONTENT_TYPE = {"json": "application/json; charset=utf-8", "csv": "text/csv; charset=utf-8"}
 
 
 def extract_export_svc_data(export_svc_data: dict) -> tuple[str, UUID, str, str, str]:
@@ -133,7 +134,9 @@ def create_export(
                 f"{len(host_data)} hosts will be exported (format: {exportFormat}) for org_id {identity.org_id}"
             )
             response = session.post(
-                url=request_url, headers=request_headers, data=_format_export_data(host_data, exportFormat)
+                url=request_url,
+                headers=request_headers,
+                data=_format_export_data(host_data, exportFormat).encode("utf-8"),
             )
             _handle_export_response(response, exportUUID, exportFormat)
             export_created = True
@@ -149,7 +152,7 @@ def create_export(
             )
             _handle_export_response(response, exportUUID, exportFormat)
             export_created = False
-    except Exception as e:
+    except InventoryException as e:
         request_url = _build_export_request_url(
             export_service_endpoint, exportUUID, applicationName, resourceUUID, "error"
         )
@@ -188,7 +191,7 @@ def _handle_export_error(
 # This function is used by create_export, needs improvement
 def _handle_export_response(response: Response, exportUUID: UUID, exportFormat: str):
     if response.status_code != HTTPStatus.ACCEPTED:
-        raise Exception(response.text)
+        raise InventoryException(response.text)
     elif response.text != "":
         logger.info(f"{response.text} for export ID {str(exportUUID)} in {exportFormat.upper()} format")
 

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -2,8 +2,10 @@ import json
 import math
 from base64 import b64encode
 from datetime import timedelta
+from http import HTTPStatus
 from itertools import product
 from struct import unpack
+from typing import Any
 from urllib.parse import parse_qs
 from urllib.parse import quote_plus as url_quote
 from urllib.parse import urlencode
@@ -11,6 +13,7 @@ from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
 
 import dateutil.parser
+from requests import Response
 
 from app.auth.identity import IdentityType
 from tests.helpers.test_utils import now
@@ -610,3 +613,13 @@ def assert_resource_types_pagination(
         assert links["next"] is None
 
     assert links["last"] == f"{expected_path_base}?per_page={expected_per_page}&page={expected_number_of_pages}"
+
+
+def mocked_export_post(_self: Any, url: str, *, data: bytes, **_: Any) -> Response:
+    # This will raise UnicodeDecodeError if not correctly encoded or AttributeError if data is str
+    data.decode("utf-8")
+    response = Response()
+    response.url = url
+    response.status_code = HTTPStatus.ACCEPTED
+    response._content = b"Export successful"
+    return response

--- a/tests/helpers/export_service_utils.py
+++ b/tests/helpers/export_service_utils.py
@@ -64,7 +64,7 @@ EXPORT_DATA = [
 ]
 
 
-def create_export_message_mock():
+def create_export_message_mock(format: str = "json"):
     return json.dumps(
         {
             "id": "b4228e37-8ae8-4c67-81d5-d03f39bbe309",
@@ -85,7 +85,7 @@ def create_export_message_mock():
                         "productId": "RHEL",
                         "startDate": "2024-01-01T00:00:00Z",
                     },
-                    "format": "json",
+                    "format": format,
                     "resource": "urn:redhat:application:inventory:export:systems",
                     "uuid": "2844f3a1-e047-45b1-b0ce-fb9812ad6a6f",
                     "x-rh-identity": (

--- a/tests/helpers/export_service_utils.py
+++ b/tests/helpers/export_service_utils.py
@@ -64,7 +64,7 @@ EXPORT_DATA = [
 ]
 
 
-def create_export_message_mock(format: str = "json"):
+def create_export_message_mock(format: str = "json") -> str:
     return json.dumps(
         {
             "id": "b4228e37-8ae8-4c67-81d5-d03f39bbe309",


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-15180](https://issues.redhat.com/browse/RHINENG-15180).
Encodes export_service's POST requests in utf-8 and sets the charset header accordingly. Also makes a try/catch more specific so we can more easily detect this kind of error in the future - it used to just broadly catch all Exceptions and handle them the same way, so the UnicodeEncodeError went undetected.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
