### PR TITLE
refact(RHINENG-15309): Refactor filtering logic related to custom staleness

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -14,6 +14,7 @@ from api import pagination_params
 from api.cache import CACHE
 from api.cache import delete_cached_system_keys
 from api.cache_key import make_system_cache_key
+from api.filtering.db_filters import update_query_for_owner_id
 from api.host_query import build_paginated_host_list_response
 from api.host_query import staleness_timestamps
 from api.host_query_db import get_all_hosts
@@ -58,7 +59,6 @@ from lib.host_delete import delete_hosts
 from lib.host_repository import find_existing_host
 from lib.host_repository import find_non_culled_hosts
 from lib.host_repository import get_host_list_by_id_list_from_db
-from lib.host_repository import update_query_for_owner_id
 from lib.middleware import rbac
 
 FactOperations = Enum("FactOperations", ("merge", "replace"))

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -18,9 +18,11 @@ from api.filtering.db_filters import canonical_fact_filter
 from api.filtering.db_filters import host_id_list_filter
 from api.filtering.db_filters import query_filters
 from api.filtering.db_filters import rbac_permissions_filter
+from api.filtering.db_filters import update_query_for_owner_id
 from api.host_query import staleness_timestamps
 from api.staleness_query import get_staleness_obj
 from app.auth import get_current_identity
+from app.config import ALL_STALENESS_STATES
 from app.exceptions import InventoryException
 from app.instrumentation import log_get_host_list_succeeded
 from app.logging import get_logger
@@ -29,8 +31,6 @@ from app.models import Host
 from app.models import HostGroupAssoc
 from app.models import db
 from app.serialization import serialize_host_for_export_svc
-from lib.host_repository import ALL_STALENESS_STATES
-from lib.host_repository import update_query_for_owner_id
 
 __all__ = (
     "get_all_hosts",

--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,7 @@ from app.logging import get_logger
 PRODUCER_ACKS = {"0": 0, "1": 1, "all": "all"}
 
 HOST_TYPES = ["edge", None]
+ALL_STALENESS_STATES = ("fresh", "stale", "stale_warning")
 
 
 class Config:

--- a/app/culling.py
+++ b/app/culling.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
-__all__ = ("Conditions", "staleness_to_conditions", "Timestamps", "days_to_seconds")
+__all__ = ("Conditions", "Timestamps", "days_to_seconds")
 
 
 class _Config(namedtuple("_Config", ("stale_warning_offset_delta", "culled_offset_delta"))):
@@ -91,12 +91,6 @@ class Conditions:
             return "stale"
         else:
             return "stale warning"
-
-
-def staleness_to_conditions(staleness, staleness_states, host_type, timestamp_filter_func):
-    condition = Conditions(staleness, host_type)
-    filtered_states = (state for state in staleness_states if state != "unknown")
-    return (timestamp_filter_func(*getattr(condition, state)(), host_type=host_type) for state in filtered_states)
 
 
 def days_to_seconds(n_days: int) -> int:


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-15309](https://issues.redhat.com/browse/RHINENG-15309).
The purpose of this PR is to simplify some things, but it also resolves an inconsistency with staleness_to_conditions, which is needed to unblock #2181.

- Move ALL_STALENESS_STATES to config.py
- Consolidate stale_timestamp filter functions
- Move staleness_to_conditions and update_query_for_owner_id to db_filters.py, as they both generate DB filters
- Resolve the inconsistency in staleness_to_conditions timestamp filtering functions. Some required host_type, and some did not.


## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
