### PR TITLE
chore(RHINENG-14059) Implement ruff's flake8-unused-arguments

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -509,7 +509,7 @@ def _build_paginated_host_tags_response(total, page, per_page, tags_list):
 @api_operation
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
-def host_checkin(body, rbac_filter=None):
+def host_checkin(body, rbac_filter=None):  # noqa: ARG001, required for all API endpoints, not needed for host checkins
     current_identity = get_current_identity()
     canonical_facts = deserialize_canonical_facts(body)
     existing_host = find_existing_host(current_identity, canonical_facts)

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -120,7 +120,7 @@ class IdentityBaseSchema(m.Schema):
     class Meta:
         unknown = m.INCLUDE
 
-    def handle_error(self, err, data, **kwargs):
+    def handle_error(self, err, data, **kwargs):  # noqa: ARG002, overrides a function from m.Schema
         raise ValueError(err.messages)
 
 

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -218,7 +218,7 @@ def sync_event_message(message, session, event_producer):
     return
 
 
-def update_system_profile(host_data, platform_metadata, notification_event_producer=None, operation_args=None):
+def update_system_profile(host_data, platform_metadata, operation_args=None):  # noqa: ARG001, required by message_operation
     if operation_args is None:
         operation_args = {}
 
@@ -249,7 +249,7 @@ def update_system_profile(host_data, platform_metadata, notification_event_produ
         raise
 
 
-def add_host(host_data, platform_metadata, notification_event_producer, operation_args=None):
+def add_host(host_data, platform_metadata, operation_args=None):
     if operation_args is None:
         operation_args = {}
 
@@ -298,7 +298,7 @@ def handle_message(message, notification_event_producer, message_operation=add_h
         try:
             host = validated_operation_msg["data"]
             host_row, operation_result, identity, success_logger = message_operation(
-                host, platform_metadata, notification_event_producer, validated_operation_msg.get("operation_args", {})
+                host, platform_metadata, validated_operation_msg.get("operation_args", {})
             )
             staleness_timestamps = Timestamps.from_config(inventory_config())
             event_type = operation_results_to_event_type(operation_result)

--- a/check_schemas.py
+++ b/check_schemas.py
@@ -16,12 +16,12 @@ with open(OAPI) as fp:
 def make_diff(specfile, output_filename):
     parser = TranslatingParser(SPECIFICATION_DIR + specfile)
     cdiff = unified_diff(
-        oapi_data.splitlines(True), parser.yaml().splitlines(True), fromfile="oapi", tofile="output_filename"
+        oapi_data.splitlines(True), parser.yaml().splitlines(True), fromfile="oapi", tofile=output_filename
     )
     sys.stdout.writelines(cdiff)
 
 
 if __name__ == "__main__":
-    make_diff("openapi.json", "prace_reads_bundle")
-    # todo: reenable this once the prance bug about inclusion is resolved
+    make_diff("openapi.json", "prance_reads_bundle")
+    # TODO: reenable this once the prance bug about inclusion is resolved
     # make_diff("api.spec.yaml", "prace_reads_spec")

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -4,10 +4,10 @@ from app.config import Config
 from app.environment import RuntimeEnvironment
 
 
-def when_ready(server):
+def when_ready(server):  # noqa: ARG001, needed by gunicorn
     config = Config(RuntimeEnvironment.SERVER)
     GunicornPrometheusMetrics.start_http_server_when_ready(config.metrics_port)
 
 
-def child_exit(server, worker):
+def child_exit(server, worker):  # noqa: ARG001, needed by gunicorn
     GunicornPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)

--- a/host_delete_duplicates.py
+++ b/host_delete_duplicates.py
@@ -41,7 +41,7 @@ def _prometheus_job(namespace):
     return f"{PROMETHEUS_JOB}-{namespace}" if namespace else PROMETHEUS_JOB
 
 
-def _excepthook(logger, type, value, traceback):
+def _excepthook(logger, type, value, traceback):  # noqa: ARG001, needed by sys.excepthook
     logger.exception("Host duplicate remover failed", exc_info=value)
 
 

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -61,7 +61,7 @@ def _prometheus_job(namespace):
     return f"{PROMETHEUS_JOB}-{namespace}" if namespace else PROMETHEUS_JOB
 
 
-def _excepthook(logger, type, value, traceback):
+def _excepthook(logger, type, value, traceback):  # noqa: ARG001, needed by sys.excepthook
     logger.exception("Host reaper failed", exc_info=value)
 
 

--- a/host_synchronizer.py
+++ b/host_synchronizer.py
@@ -58,7 +58,7 @@ def _prometheus_job(namespace):
     return f"{PROMETHEUS_JOB}-{namespace}" if namespace else PROMETHEUS_JOB
 
 
-def _excepthook(logger, type, value, traceback):
+def _excepthook(logger, type, value, traceback):  # noqa: ARG001, needed by sys.excepthook
     logger.exception("Host synchronizer failed", exc_info=value)
 
 

--- a/inv_migration_runner.py
+++ b/inv_migration_runner.py
@@ -32,7 +32,7 @@ def _init_db(config):
     return sessionmaker(bind=engine)
 
 
-def _excepthook(logger, type, value, traceback):
+def _excepthook(logger, type, value, traceback):  # noqa: ARG001, needed by sys.excepthook
     logger.exception("Inventory migration failed", exc_info=value)
 
 

--- a/inv_publish_hosts.py
+++ b/inv_publish_hosts.py
@@ -52,7 +52,7 @@ def _prometheus_job(namespace):
     return f"{PROMETHEUS_JOB}-{namespace}" if namespace else PROMETHEUS_JOB
 
 
-def _excepthook(logger, type, value, traceback):
+def _excepthook(logger, type, value, traceback):  # noqa: ARG001, needed by sys.excepthook
     logger.exception("Inventory migration failed", exc_info=value)
 
 

--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -34,7 +34,7 @@ def init_unleash_app(app):
 
 # Raise an error if the toggle is not found on the configured Unleash server.
 # Without this fallback function, is_enabled just returns False without error.
-def custom_fallback(feature_name: str, context: dict) -> bool:
+def custom_fallback(feature_name: str, context: dict) -> bool:  # noqa: ARG001, required by UnleashClient
     raise ConnectionError(f"Could not contact Unleash server, or feature toggle {feature_name} not found.")
 
 

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -13,7 +13,7 @@ class ShutdownHandler:
     def __init__(self):
         self._shutdown = False
 
-    def _signal_handler(self, signum, frame):
+    def _signal_handler(self, signum, frame):  # noqa: ARG002, required by signal
         signame = Signals(signum).name
         logger.info("Gracefully Shutting Down. Received: %s", signame)
         self._shutdown = True

--- a/lib/host_remove_duplicates.py
+++ b/lib/host_remove_duplicates.py
@@ -151,4 +151,7 @@ def delete_duplicate_hosts(
 
         total_deleted += len(duplicate_list)
 
+        if interrupt:
+            break
+
     return total_deleted

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -65,7 +65,7 @@ def run_migrations_online():
     # this callback is used to prevent an auto-migration from being generated
     # when there are no changes to the schema
     # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
-    def process_revision_directives(context, revision, directives):
+    def process_revision_directives(context, revision, directives):  # noqa: ARG001, required by alembic
         if getattr(config.cmd_opts, "autogenerate", False):
             script = directives[0]
             if script.upgrade_ops.is_empty():

--- a/pendo_syncher.py
+++ b/pendo_syncher.py
@@ -55,7 +55,7 @@ def _prometheus_job(namespace):
     return f"{PROMETHEUS_JOB}-{namespace}" if namespace else PROMETHEUS_JOB
 
 
-def _excepthook(logger, type, value, traceback):
+def _excepthook(logger, type, value, traceback):  # noqa: ARG001, needed by sys.excepthook
     logger.exception("Pendo Syncher failed", exc_info=value)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ lint.select = [
     # isort
     "I",
     # flake8-unused-arguments
-    # "ARG",
+    "ARG",
 ]
 
 lint.ignore = [
@@ -35,7 +35,7 @@ lint.extend-safe-fixes = [
 
 lint.isort.force-single-line = true
 
-# lint.flake8-unused-arguments.ignore-variadic-names = true
+lint.flake8-unused-arguments.ignore-variadic-names = true
 
 [tool.mypy]
 python_version = "3.9"

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -31,7 +31,7 @@ __all__ = "main"
 LOGGER_NAME = "inventory_events_rebuilder"
 
 
-def _excepthook(logger, type, value, traceback):
+def _excepthook(logger, type, value, traceback):  # noqa: ARG001, needed by sys.excepthook
     logger.exception("Events topic rebuilder failed", exc_info=value)
 
 

--- a/system_profile_validator.py
+++ b/system_profile_validator.py
@@ -44,7 +44,7 @@ def _init_config():
     return config
 
 
-def _excepthook(logger, type, value, traceback):
+def _excepthook(logger, type, value, traceback):  # noqa: ARG001, needed by sys.excepthook
     logger.exception("System Profile Validator failed", exc_info=value)
 
 

--- a/tests/fixtures/app_fixtures.py
+++ b/tests/fixtures/app_fixtures.py
@@ -9,7 +9,7 @@ from tests.helpers.db_utils import clean_tables
 
 
 @pytest.fixture(scope="session")
-def new_flask_app(database):
+def new_flask_app(database):  # noqa: ARG001
     application = create_app(RuntimeEnvironment.TEST)
     with application.app.app_context():
         db.session.execute(sa_text("CREATE SCHEMA IF NOT EXISTS hbi"))

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -41,7 +41,7 @@ def database_name():
 
 
 @pytest.fixture(scope="session")
-def database(database_name):
+def database(database_name):  # noqa: ARG001
     config = Config(RuntimeEnvironment.TEST)
     if not database_exists(config.db_uri):
         create_database(config.db_uri)
@@ -52,7 +52,7 @@ def database(database_name):
 
 
 @pytest.fixture(scope="function")
-def db_get_host(flask_app):
+def db_get_host(flask_app):  # noqa: ARG001
     def _db_get_host(host_id):
         return Host.query.filter(Host.id == host_id).one_or_none()
 
@@ -60,7 +60,7 @@ def db_get_host(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_get_hosts(flask_app):
+def db_get_hosts(flask_app):  # noqa: ARG001
     def _db_get_hosts(host_ids):
         return Host.query.filter(Host.id.in_(host_ids))
 
@@ -68,7 +68,7 @@ def db_get_hosts(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_get_host_by_insights_id(flask_app):
+def db_get_host_by_insights_id(flask_app):  # noqa: ARG001
     def _db_get_host_by_insights_id(insights_id):
         return Host.query.filter(Host.canonical_facts["insights_id"].astext == insights_id).one()
 
@@ -76,7 +76,7 @@ def db_get_host_by_insights_id(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_get_group_by_id(flask_app):
+def db_get_group_by_id(flask_app):  # noqa: ARG001
     def _db_get_group_by_id(group_id):
         return db.session.get(Group, group_id)
 
@@ -84,7 +84,7 @@ def db_get_group_by_id(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_get_group_by_name(flask_app):
+def db_get_group_by_name(flask_app):  # noqa: ARG001
     def _db_get_group_by_name(group_name):
         return Group.query.filter(Group.name == group_name).first()
 
@@ -92,7 +92,7 @@ def db_get_group_by_name(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_get_hosts_for_group(flask_app):
+def db_get_hosts_for_group(flask_app):  # noqa: ARG001
     def _db_get_hosts_for_group(group_id):
         return Host.query.join(HostGroupAssoc).filter(HostGroupAssoc.group_id == group_id).all()
 
@@ -100,7 +100,7 @@ def db_get_hosts_for_group(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_get_groups_for_host(flask_app):
+def db_get_groups_for_host(flask_app):  # noqa: ARG001
     def _db_get_groups_for_host(host_id):
         return Group.query.join(HostGroupAssoc).filter(HostGroupAssoc.host_id == host_id).all()
 
@@ -108,7 +108,7 @@ def db_get_groups_for_host(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_get_assignment_rule(flask_app):
+def db_get_assignment_rule(flask_app):  # noqa: ARG001
     def _db_get_assignment_rule(ar_id):
         return db.session.get(AssignmentRule, ar_id)
 
@@ -116,7 +116,7 @@ def db_get_assignment_rule(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_create_host(flask_app):
+def db_create_host(flask_app):  # noqa: ARG001
     def _db_create_host(identity=SYSTEM_IDENTITY, host=None, extra_data=None):
         extra_data = extra_data or {}
         host = host or minimal_db_host(org_id=identity["org_id"], account=identity["account_number"], **extra_data)
@@ -128,7 +128,7 @@ def db_create_host(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_create_multiple_hosts(flask_app):
+def db_create_multiple_hosts(flask_app):  # noqa: ARG001
     def _db_create_multiple_hosts(identity=SYSTEM_IDENTITY, hosts=None, how_many=10, extra_data=None):
         extra_data = extra_data or {}
         created_hosts = []
@@ -150,7 +150,7 @@ def db_create_multiple_hosts(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_create_bulk_hosts(flask_app):
+def db_create_bulk_hosts(flask_app):  # noqa: ARG001
     def _db_create_bulk_hosts(identity=SYSTEM_IDENTITY, how_many=10, extra_data=None):
         extra_data = extra_data or {}
         host_dicts = []
@@ -179,7 +179,7 @@ def models_datetime_mock(mocker):
 
 
 @pytest.fixture(scope="function")
-def db_create_group(flask_app):
+def db_create_group(flask_app):  # noqa: ARG001
     def _db_create_group(name, identity=SYSTEM_IDENTITY):
         group = db_group(org_id=identity["org_id"], account=identity["account_number"], name=name)
         db.session.add(group)
@@ -190,7 +190,7 @@ def db_create_group(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_create_host_group_assoc(flask_app, db_get_group_by_id):
+def db_create_host_group_assoc(flask_app, db_get_group_by_id):  # noqa: ARG001
     def _db_create_host_group_assoc(host_id, group_id):
         host_group = HostGroupAssoc(host_id=host_id, group_id=group_id)
         db.session.add(host_group)
@@ -205,7 +205,7 @@ def db_create_host_group_assoc(flask_app, db_get_group_by_id):
 
 
 @pytest.fixture(scope="function")
-def db_remove_hosts_from_group(flask_app):
+def db_remove_hosts_from_group(flask_app):  # noqa: ARG001
     def _db_remove_hosts_from_group(host_id_list, group_id):
         db.session.query(Host).filter(Host.id.in_(host_id_list)).update({"groups": []}, synchronize_session=False)
         delete_query = db.session.query(HostGroupAssoc).filter(
@@ -218,7 +218,7 @@ def db_remove_hosts_from_group(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_delete_group(flask_app):
+def db_delete_group(flask_app):  # noqa: ARG001
     def _db_delete_group(group_id):
         delete_query = db.session.query(Group).filter(Group.id == group_id)
         delete_query.delete(synchronize_session="fetch")
@@ -241,7 +241,7 @@ def db_create_group_with_hosts(db_create_group, db_create_host, db_create_host_g
 
 
 @pytest.fixture(scope="function")
-def db_create_assignment_rule(flask_app):
+def db_create_assignment_rule(flask_app):  # noqa: ARG001
     def _db_create_assignment_rule(name, group_id, filter, enabled):
         assignment_rule = db_assignment_rule(name=name, group_id=group_id, filter=filter, enabled=enabled)
         db.session.add(assignment_rule)
@@ -252,7 +252,7 @@ def db_create_assignment_rule(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_delete_assignment_rule(flask_app):
+def db_delete_assignment_rule(flask_app):  # noqa: ARG001
     def _db_delete_assignment_rule(ar_id):
         delete_query = db.session.query(AssignmentRule).filter(AssignmentRule.id == ar_id)
         delete_query.delete(synchronize_session="fetch")
@@ -262,7 +262,7 @@ def db_delete_assignment_rule(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_create_staleness_culling(flask_app):
+def db_create_staleness_culling(flask_app):  # noqa: ARG001
     def _db_create_staleness_culling(
         conventional_time_to_stale=None,
         conventional_time_to_stale_warning=None,
@@ -287,7 +287,7 @@ def db_create_staleness_culling(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_delete_staleness_culling(flask_app):
+def db_delete_staleness_culling(flask_app):  # noqa: ARG001
     def _db_delete_staleness_culling(org_id):
         delete_query = db.session.query(Staleness).filter(Staleness.org_id == org_id)
         delete_query.delete(synchronize_session="fetch")
@@ -297,7 +297,7 @@ def db_delete_staleness_culling(flask_app):
 
 
 @pytest.fixture(scope="function")
-def db_get_staleness_culling(flask_app):
+def db_get_staleness_culling(flask_app):  # noqa: ARG001
     def _db_get_staleness_culling(org_id):
         return Staleness.query.filter(Staleness.org_id == org_id).first()
 

--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -25,7 +25,11 @@ from tests.helpers.test_utils import now
 
 
 @pytest.fixture(scope="function")
-def mq_create_or_update_host(flask_app, event_producer_mock, notification_event_producer_mock):
+def mq_create_or_update_host(
+    flask_app,  # noqa: ARG001
+    event_producer_mock,
+    notification_event_producer_mock,
+):
     def _mq_create_or_update_host(
         host_data,
         platform_metadata=None,
@@ -140,7 +144,7 @@ def notification_kafka_producer(mocker):
 
 
 @pytest.fixture(scope="function")
-def event_producer(flask_app, kafka_producer):
+def event_producer(flask_app, kafka_producer):  # noqa: ARG001
     config = flask_app.app.config["INVENTORY_CONFIG"]
     flask_app.app.event_producer = EventProducer(config, config.event_topic)
     yield flask_app.app.event_producer
@@ -148,7 +152,7 @@ def event_producer(flask_app, kafka_producer):
 
 
 @pytest.fixture(scope="function")
-def notification_event_producer(flask_app, notification_kafka_producer):
+def notification_event_producer(flask_app, notification_kafka_producer):  # noqa: ARG001
     config = flask_app.app.config["INVENTORY_CONFIG"]
     flask_app.app.notification_event_producer = EventProducer(config, config.notification_topic)
     yield flask_app.app.notification_event_producer

--- a/tests/helpers/sql_dump.py
+++ b/tests/helpers/sql_dump.py
@@ -8,7 +8,7 @@ try:
     from sqlparse import format as sql_formatter
 except ModuleNotFoundError:
 
-    def sql_formatter(sql_str, reindent=True, keyword_case="upper"):
+    def sql_formatter(sql_str, reindent=True, keyword_case="upper"):  # noqa: ARG001
         return sql_str
 
 
@@ -43,10 +43,10 @@ class SQLDump:
     def __enter__(self):
         sqlevent.listen(db.engine, "before_execute", self.dump_method)
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(self, exc_type, exc_value, exc_traceback):  # noqa: ARG002
         sqlevent.remove(db.engine, "before_execute", self.dump_method)
 
-    def dump_sql(self, conn, clauseelement, multiparams, params, execution_options):
+    def dump_sql(self, conn, clauseelement, multiparams, params, execution_options):  # noqa: ARG002
         self.write_method("**** QUERY:\n")
         self.write_method(sql_formatter(str(clauseelement.compile()), reindent=True, keyword_case="upper"))
         self.write_method("\n**** PARAMETERS:\n")

--- a/tests/test_api_groups_create.py
+++ b/tests/test_api_groups_create.py
@@ -77,11 +77,10 @@ def test_create_group_with_hosts(
     [
         "",
         "  ",
-        "  ",
     ],
 )
 def test_create_group_invalid_name(api_create_group, new_name):
-    group_data = {"name": "", "host_ids": []}
+    group_data = {"name": new_name, "host_ids": []}
 
     response_status, _ = api_create_group(group_data)
 

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -11,10 +11,11 @@ from tests.helpers.test_utils import USER_IDENTITY
 from tests.helpers.test_utils import generate_uuid
 
 
-def test_delete_non_existent_group(api_delete_groups, event_producer):
+@pytest.mark.usefixtures("event_producer")
+def test_delete_non_existent_group(api_delete_groups):
     group_id = generate_uuid()
 
-    response_status, response_data = api_delete_groups([group_id])
+    response_status, _ = api_delete_groups([group_id])
 
     assert_response_status(response_status, expected_status=404)
 
@@ -22,15 +23,16 @@ def test_delete_non_existent_group(api_delete_groups, event_producer):
 def test_delete_with_invalid_group_id(api_delete_groups):
     group_id = "notauuid"
 
-    response_status, response_data = api_delete_groups(group_id)
+    response_status, _ = api_delete_groups(group_id)
 
     assert_response_status(response_status, expected_status=400)
 
 
-def test_delete_group_ids(db_create_group, db_get_group_by_id, api_delete_groups, event_producer):
+@pytest.mark.usefixtures("event_producer")
+def test_delete_group_ids(db_create_group, db_get_group_by_id, api_delete_groups):
     group_id_list = [str(db_create_group(f"test_group{g_index}").id) for g_index in range(3)]
 
-    response_status, response_data = api_delete_groups(group_id_list)
+    response_status, _ = api_delete_groups(group_id_list)
 
     assert_response_status(response_status, expected_status=204)
 
@@ -308,7 +310,8 @@ def test_delete_hosts_no_group(
         assert len(host["groups"]) == 0
 
 
-def test_delete_non_empty_group(api_delete_groups, db_create_group_with_hosts, event_producer):
+@pytest.mark.usefixtures("event_producer")
+def test_delete_non_empty_group(api_delete_groups, db_create_group_with_hosts):
     group = db_create_group_with_hosts("non_empty_group", 3)
 
     response_status, _ = api_delete_groups([group.id])

--- a/tests/test_api_groups_update.py
+++ b/tests/test_api_groups_update.py
@@ -316,9 +316,7 @@ def test_patch_group_name_only(
     assert host["groups"][0]["name"] == "modified_group"
 
 
-def test_patch_group_same_hosts(
-    db_create_group_with_hosts, db_get_group_by_id, api_patch_group, event_producer, mocker
-):
+def test_patch_group_same_hosts(db_create_group_with_hosts, api_patch_group, event_producer, mocker):
     # Create a group with hosts
     mocker.patch.object(event_producer, "write_event")
     group = db_create_group_with_hosts("test_group", 5)
@@ -338,7 +336,7 @@ def test_patch_group_same_hosts(
 
 
 def test_patch_group_both_add_and_remove_hosts(
-    db_create_group_with_hosts, db_get_group_by_id, db_create_host, api_patch_group, event_producer, mocker
+    db_create_group_with_hosts, db_create_host, api_patch_group, event_producer, mocker
 ):
     # Create a group with hosts
     mocker.patch.object(event_producer, "write_event")

--- a/tests/test_api_host_group.py
+++ b/tests/test_api_host_group.py
@@ -13,9 +13,8 @@ from tests.helpers.api_utils import create_mock_rbac_response
 from tests.helpers.test_utils import generate_uuid
 
 
-def test_add_host_to_group(
-    db_create_group, db_create_host, db_get_hosts_for_group, api_add_hosts_to_group, event_producer
-):
+@pytest.mark.usefixtures("event_producer")
+def test_add_host_to_group(db_create_group, db_create_host, db_get_hosts_for_group, api_add_hosts_to_group):
     # Create a group and 3 hosts
     group_id = db_create_group("test_group").id
     host_id_list = [db_create_host().id for _ in range(3)]
@@ -48,14 +47,13 @@ def test_add_host_to_group_RBAC_denied(
             assert_response_status(response_status, 403)
 
 
+@pytest.mark.usefixtures("enable_rbac", "event_producer")
 def test_add_host_to_group_RBAC_allowed_specific_groups(
     mocker,
     db_create_group_with_hosts,
     api_add_hosts_to_group,
     db_create_host,
     db_get_hosts_for_group,
-    enable_rbac,
-    event_producer,
 ):
     # Create a group and 3 hosts
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
@@ -179,13 +177,13 @@ def test_add_associated_host_to_different_group(
     assert event_producer.write_event.call_count == 0
 
 
+@pytest.mark.usefixtures("event_producer")
 def test_add_host_list_with_one_associated_host_to_group(
     db_create_group,
     db_create_host,
     db_get_hosts_for_group,
     db_create_host_group_assoc,
     api_add_hosts_to_group,
-    event_producer,
 ):
     # Create a group and 3 hosts
     group_id = db_create_group("test_group").id
@@ -204,7 +202,8 @@ def test_add_host_list_with_one_associated_host_to_group(
     assert len(hosts_after) == 3
 
 
-def test_add_host_to_missing_group(db_create_host, api_add_hosts_to_group, event_producer):
+@pytest.mark.usefixtures("event_producer")
+def test_add_host_to_missing_group(db_create_host, api_add_hosts_to_group):
     # Create a test group which not exist in database
     missing_group_id = "454dddba-9a4d-42b3-8f16-86a8c1400000"
     host_id_list = [db_create_host().id for _ in range(3)]
@@ -213,7 +212,8 @@ def test_add_host_to_missing_group(db_create_host, api_add_hosts_to_group, event
     assert response_status == 404
 
 
-def test_add_missing_host_to_existing_group(db_create_group, api_add_hosts_to_group, event_producer):
+@pytest.mark.usefixtures("event_producer")
+def test_add_missing_host_to_existing_group(db_create_group, api_add_hosts_to_group):
     group_id = db_create_group("test_group").id
     host_id_list = [str(uuid.uuid4())]
 
@@ -221,7 +221,8 @@ def test_add_missing_host_to_existing_group(db_create_group, api_add_hosts_to_gr
     assert response_status == 400
 
 
-def test_with_empty_data(api_add_hosts_to_group, event_producer):
+@pytest.mark.usefixtures("event_producer")
+def test_with_empty_data(api_add_hosts_to_group):
     response_status, _ = api_add_hosts_to_group(None, None)
     assert response_status == 400
 
@@ -240,12 +241,12 @@ def test_add_empty_array_to_group(db_create_group, api_add_hosts_to_group):
     assert response_status == 400
 
 
+@pytest.mark.usefixtures("event_producer")
 def test_group_with_culled_hosts(
     db_create_group,
     db_create_host,
     db_get_hosts_for_group,
     api_add_hosts_to_group,
-    event_producer,
     db_get_host,
     api_get,
 ):

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -231,9 +231,8 @@ def test_delete_when_all_hosts_are_deleted(
     assert notification_event_producer_mock.event is None
 
 
-def test_delete_when_some_hosts_is_deleted(
-    event_producer_mock, notification_event_producer_mock, db_create_multiple_hosts, api_delete_host, mocker
-):
+@pytest.mark.usefixtures("notification_event_producer_mock")
+def test_delete_when_some_hosts_is_deleted(event_producer_mock, db_create_multiple_hosts, api_delete_host, mocker):
     hosts = db_create_multiple_hosts(how_many=2)
     host_id_list = [str(hosts[0].id), str(hosts[1].id)]
 
@@ -331,9 +330,8 @@ def test_delete_host_with_RBAC_bypassed_as_system(
     assert not db_get_host(host.id)
 
 
+@pytest.mark.usefixtures("event_producer_mock", "notification_event_producer_mock")
 def test_delete_hosts_chunk_size(
-    event_producer_mock,
-    notification_event_producer_mock,
     db_create_multiple_hosts,
     api_delete_host,
     mocker,
@@ -538,9 +536,7 @@ def test_delete_host_RBAC_denied_specific_groups(mocker, db_create_host, db_get_
 
 
 @pytest.mark.usefixtures("notification_event_producer_mock")
-def test_postgres_delete_filtered_hosts(
-    db_create_host, api_get, api_delete_filtered_hosts, event_producer_mock, notification_event_producer_mock
-):
+def test_postgres_delete_filtered_hosts(db_create_host, api_get, api_delete_filtered_hosts, event_producer_mock):
     host_1_id = db_create_host(extra_data={"display_name": "foobar"}).id
     host_2_id = db_create_host(extra_data={"display_name": "foobaz"}).id
 

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -54,7 +54,7 @@ def test_query_invalid_host_id(mq_create_three_specific_hosts, api_get, subtests
     for host_id_list in chain(only_bad_id, with_bad_id):
         with subtests.test(host_id_list=host_id_list):
             url = build_hosts_url(host_list_or_id=host_id_list)
-            response_status, response_data = api_get(url)
+            response_status, _ = api_get(url)
             assert response_status == 400
 
 
@@ -66,7 +66,7 @@ def test_query_host_id_with_incorrect_formats(api_get, subtests):
     for bad_host_id in bad_host_ids:
         with subtests.test():
             url = build_hosts_url(host_list_or_id=bad_host_id)
-            response_status, response_data = api_get(url)
+            response_status, _ = api_get(url)
             assert response_status == 400
 
 
@@ -77,20 +77,20 @@ def test_query_invalid_paging_parameters(mq_create_three_specific_hosts, api_get
     api_pagination_invalid_parameters_test(api_get, subtests, url)
 
 
-def test_query_with_invalid_insights_id(mq_create_three_specific_hosts, api_get, subtests):
+def test_query_with_invalid_insights_id(api_get):
     url = build_hosts_url(query="?insights_id=notauuid")
-    response_status, response_data = api_get(url)
+    response_status, _ = api_get(url)
 
     assert response_status == 400
 
 
-def test_get_host_with_invalid_tag_no_key(mq_create_three_specific_hosts, api_get):
+def test_get_host_with_invalid_tag_no_key(api_get):
     """
     Attempt to find host with an incomplete tag (no key).
     Expects 400 response.
     """
     url = build_hosts_url(query="?tags=namespace/=Value")
-    response_status, response_data = api_get(url)
+    response_status, _ = api_get(url)
 
     assert response_status == 400
 
@@ -103,14 +103,14 @@ def test_get_host_with_invalid_tag_no_key(mq_create_three_specific_hosts, api_ge
         (f"namespace/key={'a' * 256}", "value"),
     ),
 )
-def test_get_host_tag_part_too_long(tag_query, part_name, mq_create_three_specific_hosts, api_get):
+def test_get_host_tag_part_too_long(tag_query, part_name, api_get):
     """
     send a request to find hosts with a string tag where the length
     of the namespace excedes the 255 character limit
     """
 
     url = build_hosts_url(query=f"?tags={tag_query}")
-    response_status, response_data = api_get(url)
+    _, response_data = api_get(url)
 
     assert_error_response(
         response_data, expected_status=400, expected_detail=f"{part_name} is longer than 255 characters"
@@ -128,7 +128,7 @@ def test_invalid_order_by(mq_create_three_specific_hosts, api_get, subtests):
     for url in urls:
         with subtests.test(url=url):
             order_query_parameters = build_order_query_parameters(order_by="fqdn", order_how="ASC")
-            response_status, response_data = api_get(url, query_parameters=order_query_parameters)
+            response_status, _ = api_get(url, query_parameters=order_query_parameters)
             assert response_status == 400
 
 
@@ -143,7 +143,7 @@ def test_invalid_order_how(mq_create_three_specific_hosts, api_get, subtests):
     for url in urls:
         with subtests.test(url=url):
             order_query_parameters = build_order_query_parameters(order_by="display_name", order_how="asc")
-            response_status, response_data = api_get(url, query_parameters=order_query_parameters)
+            response_status, _ = api_get(url, query_parameters=order_query_parameters)
             assert response_status == 400
 
 
@@ -158,7 +158,7 @@ def test_only_order_how(mq_create_three_specific_hosts, api_get, subtests):
     for url in urls:
         with subtests.test(url=url):
             order_query_parameters = build_order_query_parameters(order_by=None, order_how="ASC")
-            response_status, response_data = api_get(url, query_parameters=order_query_parameters)
+            response_status, _ = api_get(url, query_parameters=order_query_parameters)
             assert response_status == 400
 
 
@@ -173,7 +173,7 @@ def test_invalid_fields(mq_create_three_specific_hosts, api_get, subtests):
     for url in urls:
         with subtests.test(url=url):
             fields_query_parameters = build_fields_query_parameters(fields="i_love_ketchup")
-            response_status, response_data = api_get(url, query_parameters=fields_query_parameters)
+            response_status, _ = api_get(url, query_parameters=fields_query_parameters)
             assert response_status == 400
 
 

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -559,7 +559,7 @@ def test_update_delete_race(event_producer, db_create_host, db_get_host, api_pat
     mocker.patch("lib.host_delete.kafka_available")
 
     # slow down the execution of update_display_name so that it's more likely we hit the race condition
-    def sleep(data):
+    def sleep(data):  # noqa: ARG001, required by patch
         time.sleep(1)
 
     mocker.patch("app.models.Host.update_display_name", wraps=sleep)
@@ -602,7 +602,7 @@ def test_patch_updated_timestamp(event_producer, db_create_host, db_get_host, ap
     host = db_create_host()
     patch_doc = {"display_name": "update_test"}
     url = build_hosts_url(host_list_or_id=host.id)
-    patch_response_status, patch_response_data = api_patch(url, patch_doc)
+    patch_response_status, _ = api_patch(url, patch_doc)
 
     assert_response_status(patch_response_status, expected_status=200)
 

--- a/tests/test_culling.py
+++ b/tests/test_culling.py
@@ -21,9 +21,9 @@ from tests.helpers.mq_utils import assert_delete_notification_is_valid
 from tests.helpers.test_utils import get_staleness_timestamps
 
 
-def test_dont_get_only_culled(mq_create_hosts_in_all_states, api_get):
+def test_dont_get_only_culled(api_get):
     url = build_hosts_url(query="?staleness=culled")
-    response_status, response_data = api_get(url)
+    response_status, _ = api_get(url)
 
     assert response_status == 400
 
@@ -32,7 +32,7 @@ def test_fail_patch_culled_host(mq_create_deleted_hosts, api_patch):
     culled_host = mq_create_deleted_hosts["culled"]
 
     url = build_hosts_url(host_list_or_id=[culled_host])
-    response_status, response_data = api_patch(url, {"display_name": "patched"})
+    response_status, _ = api_patch(url, {"display_name": "patched"})
 
     assert response_status == 404
 
@@ -41,7 +41,7 @@ def test_patch_works_on_non_culled(mq_create_hosts_in_all_states, api_patch):
     fresh_host = mq_create_hosts_in_all_states["fresh"]
 
     url = build_hosts_url(host_list_or_id=[fresh_host])
-    response_status, response_data = api_patch(url, {"display_name": "patched"})
+    response_status, _ = api_patch(url, {"display_name": "patched"})
 
     assert response_status == 200
 
@@ -77,7 +77,7 @@ def test_put_facts_works_on_non_culled(mq_create_hosts_in_all_states, api_put):
     fresh_host = mq_create_hosts_in_all_states["fresh"]
 
     url = build_facts_url(host_list_or_id=[fresh_host], namespace="ns1")
-    response_status, response_data = api_put(url, {"ARCHITECTURE": "patched"})
+    response_status, _ = api_put(url, {"ARCHITECTURE": "patched"})
 
     assert response_status == 200
 
@@ -85,7 +85,7 @@ def test_put_facts_works_on_non_culled(mq_create_hosts_in_all_states, api_put):
 def test_delete_ignores_culled(mq_create_deleted_hosts, api_delete_host):
     culled_host = mq_create_deleted_hosts["culled"]
 
-    response_status, response_data = api_delete_host(culled_host.id)
+    response_status, _ = api_delete_host(culled_host.id)
 
     assert response_status == 404
 
@@ -93,7 +93,7 @@ def test_delete_ignores_culled(mq_create_deleted_hosts, api_delete_host):
 def test_delete_works_on_non_culled(mq_create_hosts_in_all_states, api_delete_host):
     fresh_host = mq_create_hosts_in_all_states["fresh"]
 
-    response_status, response_data = api_delete_host(fresh_host.id)
+    response_status, _ = api_delete_host(fresh_host.id)
 
     assert response_status == 200
 
@@ -103,7 +103,7 @@ def test_get_host_by_id_doesnt_use_staleness_parameter(mq_create_hosts_in_all_st
     created_hosts = mq_create_hosts_in_all_states
 
     url = build_hosts_url(host_list_or_id=created_hosts)
-    response_status, response_data = api_get(url, query_parameters={"staleness": "fresh"})
+    response_status, _ = api_get(url, query_parameters={"staleness": "fresh"})
 
     assert response_status == 400
 
@@ -113,7 +113,7 @@ def test_tags_doesnt_use_staleness_parameter(mq_create_hosts_in_all_states, api_
     created_hosts = mq_create_hosts_in_all_states
 
     url = build_host_tags_url(host_list_or_id=created_hosts)
-    response_status, response_data = api_get(url, query_parameters={"staleness": "fresh"})
+    response_status, _ = api_get(url, query_parameters={"staleness": "fresh"})
 
     assert response_status == 400
 
@@ -123,7 +123,7 @@ def test_tags_count_doesnt_use_staleness_parameter(mq_create_hosts_in_all_states
     created_hosts = mq_create_hosts_in_all_states
 
     url = build_tags_count_url(host_list_or_id=created_hosts)
-    response_status, response_data = api_get(url, query_parameters={"staleness": "fresh"})
+    response_status, _ = api_get(url, query_parameters={"staleness": "fresh"})
 
     assert response_status == 400
 
@@ -133,7 +133,7 @@ def test_system_profile_doesnt_use_staleness_parameter(mq_create_hosts_in_all_st
     created_hosts = mq_create_hosts_in_all_states
 
     url = build_system_profile_url(host_list_or_id=created_hosts)
-    response_status, response_data = api_get(url, query_parameters={"staleness": "fresh"})
+    response_status, _ = api_get(url, query_parameters={"staleness": "fresh"})
 
     assert response_status == 400
 

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -281,7 +281,7 @@ def test_find_host_using_subscription_manager_id_match(db_create_host):
 # The test asserts that this sequence of events no longer results
 # in the creation of such duplicates.
 #
-def test_provider_id_dup(mq_create_or_update_host, db_get_host):
+def test_provider_id_dup(mq_create_or_update_host):
     provider_id = generate_uuid()
 
     subscription_manager_id_x = generate_uuid()

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -52,12 +52,12 @@ def test_handle_create_export_unicode(db_create_host, flask_app, inventory_confi
 
 
 @mock.patch("requests.Session.post", autospec=True)
-@mock.patch("app.queue.export_service.get_hosts_to_export", return_value=iter(es_utils.EXPORT_DATA))
-@mock.patch("app.queue.export_service.create_export", return_value=True)
-def test_handle_create_export_request_with_data_to_export(
-    mock_export, mock_rbac, mock_post, flask_app, inventory_config
-):
-    with flask_app.app.app_context():
+def test_handle_create_export_request_with_data_to_export(mock_post, flask_app, inventory_config):
+    with (
+        flask_app.app.app_context(),
+        mock.patch("app.queue.export_service.get_hosts_to_export", return_value=iter(es_utils.EXPORT_DATA)),
+        mock.patch("app.queue.export_service.create_export", return_value=True),
+    ):
         export_message = es_utils.create_export_message_mock()
         mock_post.return_value.status_code = 202
         resp = handle_export_message(message=export_message, inventory_config=inventory_config)
@@ -65,12 +65,12 @@ def test_handle_create_export_request_with_data_to_export(
 
 
 @mock.patch("requests.Session.post", autospec=True)
-@mock.patch("app.queue.export_service.get_hosts_to_export", return_value=[])
-@mock.patch("app.queue.export_service.create_export", return_value=False)
-def test_handle_create_export_request_with_no_data_to_export(
-    mock_export, mock_rbac, mock_post, flask_app, inventory_config
-):
-    with flask_app.app.app_context():
+def test_handle_create_export_request_with_no_data_to_export(mock_post, flask_app, inventory_config):
+    with (
+        flask_app.app.app_context(),
+        mock.patch("app.queue.export_service.get_hosts_to_export", return_value=[]),
+        mock.patch("app.queue.export_service.create_export", return_value=False),
+    ):
         export_message = es_utils.create_export_message_mock()
         mock_post.return_value.status_code = 202
         resp = handle_export_message(message=export_message, inventory_config=inventory_config)

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -247,7 +247,7 @@ def test_handle_message_unicode_not_damaged(mocker, db_create_host, subtests):
                 mocker.MagicMock(),
             )
             handle_message(message, mocker.Mock(), add_host)
-            add_host.assert_called_once_with(json.loads(message)["data"], mocker.ANY, mocker.ANY, {})
+            add_host.assert_called_once_with(json.loads(message)["data"], mocker.ANY, {})
 
 
 def test_handle_message_verify_metadata_pass_through(mq_create_or_update_host):


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-14059](https://issues.redhat.com/browse/RHINENG-14059).
Enables ruff's flake8-unused-arguments tool, and addresses its complaints with fixes and noqa comments.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
