### PR TITLE
update synchronously stale_warning_timestamp and culled_timestamp when host checks-in

### DIFF
--- a/api/staleness_query.py
+++ b/api/staleness_query.py
@@ -1,9 +1,10 @@
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.auth import get_current_identity
-from app.common import inventory_config
 from app.logging import get_logger
 from app.models import Staleness
+from app.staleness_serialization import build_serialized_acc_staleness_obj
+from app.staleness_serialization import build_staleness_sys_default
 
 logger = get_logger(__name__)
 
@@ -13,65 +14,19 @@ def get_staleness_obj(identity=None):
     try:
         staleness = Staleness.query.filter(Staleness.org_id == org_id).one()
         logger.info("Using custom account staleness")
-        staleness = _build_serialized_acc_staleness_obj(staleness)
+        staleness = build_serialized_acc_staleness_obj(staleness)
     except NoResultFound:
         logger.debug(f"No data found for user {org_id}, using system default values")
-        staleness = _build_staleness_sys_default(org_id)
+        staleness = build_staleness_sys_default(org_id)
         return staleness
 
     return staleness
 
 
 def get_sys_default_staleness(config=None):
-    return _build_staleness_sys_default("000000", config)
+    return build_staleness_sys_default("000000", config)
 
 
 def get_sys_default_staleness_api(identity, config=None):
     org_id = identity.org_id or "00000"
-    return _build_staleness_sys_default(org_id, config)
-
-
-def _build_staleness_sys_default(org_id, config=None):
-    if not config:
-        config = inventory_config()
-
-    return AttrDict(
-        {
-            "id": "system_default",
-            "org_id": org_id,
-            "conventional_time_to_stale": config.conventional_time_to_stale_seconds,
-            "conventional_time_to_stale_warning": config.conventional_time_to_stale_warning_seconds,
-            "conventional_time_to_delete": config.conventional_time_to_delete_seconds,
-            "immutable_time_to_stale": config.immutable_time_to_stale_seconds,
-            "immutable_time_to_stale_warning": config.immutable_time_to_stale_warning_seconds,
-            "immutable_time_to_delete": config.immutable_time_to_delete_seconds,
-            "created_on": None,
-            "modified_on": None,
-        }
-    )
-
-
-# This is required because we do not keep a ORM object that is attached to a session
-# leaving in the global scope. Before this serialization,
-# it was causing sqlalchemy.orm.exc.DetachedInstanceError
-def _build_serialized_acc_staleness_obj(staleness):
-    return AttrDict(
-        {
-            "id": str(staleness.id),
-            "org_id": staleness.org_id,
-            "conventional_time_to_stale": staleness.conventional_time_to_stale,
-            "conventional_time_to_stale_warning": staleness.conventional_time_to_stale_warning,
-            "conventional_time_to_delete": staleness.conventional_time_to_delete,
-            "immutable_time_to_stale": staleness.immutable_time_to_stale,
-            "immutable_time_to_stale_warning": staleness.immutable_time_to_stale_warning,
-            "immutable_time_to_delete": staleness.immutable_time_to_delete,
-            "created_on": staleness.created_on,
-            "modified_on": staleness.modified_on,
-        }
-    )
-
-
-class AttrDict(dict):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__dict__ = self
+    return build_staleness_sys_default(org_id, config)

--- a/app/staleness_serialization.py
+++ b/app/staleness_serialization.py
@@ -1,0 +1,74 @@
+from app.common import inventory_config
+
+# This file is being created to reuse the function
+# and avoid circular imports
+
+
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__dict__ = self
+
+def build_staleness_sys_default(org_id, config=None):
+    if not config:
+        config = inventory_config()
+
+    return AttrDict(
+        {
+            "id": "system_default",
+            "org_id": org_id,
+            "conventional_time_to_stale": config.conventional_time_to_stale_seconds,
+            "conventional_time_to_stale_warning": config.conventional_time_to_stale_warning_seconds,
+            "conventional_time_to_delete": config.conventional_time_to_delete_seconds,
+            "immutable_time_to_stale": config.immutable_time_to_stale_seconds,
+            "immutable_time_to_stale_warning": config.immutable_time_to_stale_warning_seconds,
+            "immutable_time_to_delete": config.immutable_time_to_delete_seconds,
+            "created_on": None,
+            "modified_on": None,
+        }
+    )
+
+
+# This is required because we do not keep a ORM object that is attached to a session
+# leaving in the global scope. Before this serialization,
+# it was causing sqlalchemy.orm.exc.DetachedInstanceError
+def build_serialized_acc_staleness_obj(staleness):
+    return AttrDict(
+        {
+            "id": str(staleness.id),
+            "org_id": staleness.org_id,
+            "conventional_time_to_stale": staleness.conventional_time_to_stale,
+            "conventional_time_to_stale_warning": staleness.conventional_time_to_stale_warning,
+            "conventional_time_to_delete": staleness.conventional_time_to_delete,
+            "immutable_time_to_stale": staleness.immutable_time_to_stale,
+            "immutable_time_to_stale_warning": staleness.immutable_time_to_stale_warning,
+            "immutable_time_to_delete": staleness.immutable_time_to_delete,
+            "created_on": staleness.created_on,
+            "modified_on": staleness.modified_on,
+        }
+    )
+
+
+def get_staleness_timestamps_from_dict(host, staleness_timestamps, staleness) -> dict:
+    """Helper function to calculate staleness timestamps based on host type."""
+    staleness_type = (
+        "immutable"
+        if (
+            hasattr(host, "system_profile_facts")
+            and host.system_profile_facts
+            and host.system_profile_facts.get("host_type") == "edge"
+        )
+        else "conventional"
+    )
+
+    return {
+        "stale_timestamp": staleness_timestamps.stale_timestamp(
+            host.modified_on, staleness[f"{staleness_type}_time_to_stale"]
+        ),
+        "stale_warning_timestamp": staleness_timestamps.stale_warning_timestamp(
+            host.modified_on, staleness[f"{staleness_type}_time_to_stale_warning"]
+        ),
+        "culled_timestamp": staleness_timestamps.culled_timestamp(
+            host.modified_on, staleness[f"{staleness_type}_time_to_delete"]
+        ),
+    }

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -596,7 +596,7 @@ def build_host_chunk():
 
         if add_provider_id:
             payload["provider_id"] = random_uuid()
-            payload["provider_type"] = random.choice(["aws", "azure", "google", "ibm"])
+            payload["provider_type"] = random.choice(["aws", "azure", "gcp", "ibm"])
 
         payload["reporter"] = random.choice(
             ["cloud-connector", "puptoo", "rhsm-conduit", "rhsm-system-profile-bridge", "yuptoo"]


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-xxxx](https://issues.redhat.com/browse/RHINENG-xxxx).
(A description of your PR's changes, along with why/context to the PR, goes here.)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
