### PR TITLE
feat(RHINENG-15829) Restrict write/delete endpoints in read-only mode

### DIFF
--- a/tests/test_api_groups_create.py
+++ b/tests/test_api_groups_create.py
@@ -96,6 +96,13 @@ def test_create_group_null_name(api_create_group):
     assert "Group name cannot be null" in response_data["detail"]
 
 
+def test_create_group_read_only(api_create_group, mocker):
+    group_data = {"name": "test", "host_ids": []}
+    with mocker.patch("lib.middleware.get_flag_value", return_value=True):
+        response_status, _ = api_create_group(group_data)
+        assert_response_status(response_status, expected_status=503)
+
+
 @pytest.mark.parametrize(
     "new_name",
     ["test_group", " test_group", "test_group ", " test_group "],

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -316,3 +316,10 @@ def test_delete_non_empty_group(api_delete_groups, db_create_group_with_hosts):
 
     response_status, _ = api_delete_groups([group.id])
     assert_response_status(response_status, expected_status=204)
+
+
+@pytest.mark.usefixtures("event_producer_mock", "notification_event_producer_mock")
+def test_attempt_delete_group_read_only(api_delete_groups, mocker):
+    with mocker.patch("lib.middleware.get_flag_value", return_value=True):
+        response_status, _ = api_delete_groups([generate_uuid()])
+        assert_response_status(response_status, expected_status=503)

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -687,6 +687,13 @@ class DeleteHostsMock:
         return iterator
 
 
+@pytest.mark.usefixtures("event_producer_mock", "notification_event_producer_mock")
+def test_attempt_delete_host_read_only(api_delete_host):
+    with patch("lib.middleware.get_flag_value", return_value=True):
+        response_status, _ = api_delete_host(generate_uuid())
+        assert_response_status(response_status, expected_status=503)
+
+
 class DeleteQueryWrapper:
     def __init__(self, mocker):
         self.query = None


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-15829](https://issues.redhat.com/browse/RHINENG-15829).
Restricts write/delete endpoints when API is in read-only mode (i.e. when hbi.api.read-only feature flag is True).

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
