### PR TITLE
feat(RHINENG-15654): Add last_check_in timestamp to the hosts response

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -207,19 +207,32 @@ def params_to_order_by(order_by: str | None = None, order_how: str | None = None
         ordering = (base_ordering.nulls_last(),) if order_how == "DESC" else (base_ordering.nulls_first(),)
     elif order_by == "operating_system":
         ordering = (_order_how(Host.operating_system, order_how),) if order_how else (Host.operating_system.desc(),)  # type: ignore [attr-defined]
-    elif order_by == "last_check_in":
-        ordering = (_order_how(Host.last_check_in, order_how),) if order_how else (Host.last_check_in.desc(),)
-    elif order_by:
-        raise ValueError(
-            'Unsupported ordering column: use "updated", "display_name",'
-            ' "group_name", "operating_system" or "last_check_in"'
-        )
-    elif order_how:
-        raise ValueError(
-            "Providing ordering direction without a column is not supported."
-            " Provide order_by={updated,display_name,group_name,operating_system,last_check_in}."
-        )
 
+    elif get_flag_value(FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS):
+        if order_by == "last_check_in":
+            ordering = (_order_how(Host.last_check_in, order_how),) if order_how else (Host.last_check_in.desc(),)
+
+    elif order_by:
+        if get_flag_value(FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS):
+            raise ValueError(
+                'Unsupported ordering column: use "updated", "display_name",'
+                ' "group_name", "operating_system" or "last_check_in"'
+            )
+        else:
+            raise ValueError(
+                'Unsupported ordering column: use "updated", "display_name", "group_name", "operating_system"'
+            )
+    elif order_how:
+        if get_flag_value(FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS):
+            raise ValueError(
+                "Providing ordering direction without a column is not supported."
+                " Provide order_by={updated,display_name,group_name,operating_system,last_check_in}."
+            )
+        else:
+            raise ValueError(
+                "Providing ordering direction without a column is not supported."
+                " Provide order_by={updated,display_name,group_name,operating_system}."
+            )
     return ordering + modified_on_ordering + (Host.id.desc(),)
 
 

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -207,13 +207,17 @@ def params_to_order_by(order_by: str | None = None, order_how: str | None = None
         ordering = (base_ordering.nulls_last(),) if order_how == "DESC" else (base_ordering.nulls_first(),)
     elif order_by == "operating_system":
         ordering = (_order_how(Host.operating_system, order_how),) if order_how else (Host.operating_system.desc(),)  # type: ignore [attr-defined]
+    elif order_by == "last_check_in":
+        ordering = (_order_how(Host.last_check_in, order_how),) if order_how else (Host.last_check_in.desc(),)
     elif order_by:
         raise ValueError(
-            'Unsupported ordering column: use "updated", "display_name", "group_name", or "operating_system".'
+            'Unsupported ordering column: use "updated", "display_name",'
+            ' "group_name", "operating_system" or "last_check_in"'
         )
     elif order_how:
         raise ValueError(
-            "Providing ordering direction without a column is not supported. Provide order_by={updated,display_name}."
+            "Providing ordering direction without a column is not supported."
+            " Provide order_by={updated,display_name,group_name,operating_system,last_check_in}."
         )
 
     return ordering + modified_on_ordering + (Host.id.desc(),)

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1056,6 +1056,7 @@ components:
           - group_name
           - updated
           - operating_system
+          - last_check_in
       description: Ordering field name
     groupOrderByParam:
       name: order_by
@@ -1629,6 +1630,9 @@ components:
                 $ref: '#/components/schemas/GroupOut'
             system_profile:
               $ref: '#/components/schemas/SystemProfile'
+            last_check_in:
+              type: string
+              format: date-time
           required:
             - org_id
     HostIdOut:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1726,7 +1726,8 @@
             "display_name",
             "group_name",
             "updated",
-            "operating_system"
+            "operating_system",
+            "last_check_in"
           ]
         },
         "description": "Ordering field name"
@@ -2460,6 +2461,10 @@
               },
               "system_profile": {
                 "$ref": "#/components/schemas/SystemProfile"
+              },
+              "last_check_in": {
+                "type": "string",
+                "format": "date-time"
               }
             },
             "required": [

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -804,6 +804,30 @@ def test_get_hosts_order_by_group_name(db_create_group_with_hosts, db_create_mul
             )
 
 
+@pytest.mark.parametrize("order_how", ("ASC", "DESC"))
+def test_get_hosts_order_by_last_check_in(mocker, db_create_host, api_get, order_how):
+    host0 = str(db_create_host().id)
+    host1 = str(db_create_host().id)
+
+    with (
+        mocker.patch("app.serialization.get_flag_value", return_value=True),
+        mocker.patch("api.host_query_db.get_flag_value", return_value=True),
+    ):
+        url = build_hosts_url(query=f"?order_by=last_check_in&order_how={order_how}")
+
+        response_status, response_data = api_get(url)
+
+        assert response_status == 200
+        assert len(response_data["results"]) == 2
+        hosts = response_data["results"]
+        if order_how == "DESC":
+            assert host1 == hosts[0]["id"]
+            assert host0 == hosts[1]["id"]
+        else:
+            assert host0 == hosts[0]["id"]
+            assert host1 == hosts[1]["id"]
+
+
 @pytest.mark.parametrize("order_how", ("", "ASC", "DESC"))
 def test_get_hosts_order_by_operating_system(mq_create_or_update_host, api_get, order_how):
     # Create some operating systems in ASC sort order


### PR DESCRIPTION
# Overview

OBS: PR #2310 must be merged first.

This PR is being created to address [RHINENG-15654](https://issues.redhat.com/browse/RHINENG-15654).

- Update OpenAPI spec
- Add sorting by `last_check_in` 

Functionality is enabled when using feature flag: `hbi.create_last_check_in_update_per_reporter_staleness` 

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
