### PR TITLE
Add auth_type to add_host_attempt log

### DIFF
--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -2,6 +2,7 @@ import json
 
 from flask import g
 
+from app.auth.identity import Identity
 from app.queue import metrics
 from app.queue.metrics import event_producer_failure
 from app.queue.metrics import event_producer_success
@@ -211,7 +212,7 @@ def log_get_sparse_system_profile_succeeded(logger, data):
 
 
 # add host
-def log_add_host_attempt(logger, input_host, sp_fields_to_log):
+def log_add_host_attempt(logger, input_host, sp_fields_to_log, identity: Identity):
     logger.info(
         "Attempting to add host",
         extra={
@@ -226,6 +227,7 @@ def log_add_host_attempt(logger, input_host, sp_fields_to_log):
                 "system_profile": json.dumps(sp_fields_to_log),
             },
             "access_rule": get_control_rule(),
+            "auth_type": identity.auth_type,
         },
     )
 

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -94,7 +94,7 @@ def _formatted_uuid(uuid_string):
     return str(UUID(uuid_string))
 
 
-def _get_identity(host, metadata):
+def _get_identity(host, metadata) -> Identity:
     # rhsm reporter does not provide identity.  Set identity type to system for access the host in future.
     if metadata and "b64_identity" in metadata:
         identity = _decode_id(metadata["b64_identity"])
@@ -262,7 +262,7 @@ def add_host(host_data, platform_metadata, operation_args=None):
         if identity.identity_type == IdentityType.SYSTEM:
             input_host = _set_owner(input_host, identity)
 
-        log_add_host_attempt(logger, input_host, sp_fields_to_log)
+        log_add_host_attempt(logger, input_host, sp_fields_to_log, identity)
         host_row, add_result = host_repository.add_host(input_host, identity, operation_args=operation_args)
         success_logger = partial(log_add_update_host_succeeded, logger, add_result, sp_fields_to_log)
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-16229](https://issues.redhat.com/browse/RHINENG-16229).

This will help me to identify how many (if any) payloads without subscription_manager_id use basic-auth.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
