### PR TITLE
fix(RHINENG-16421) Fix bulk delete endpoint

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -226,6 +226,7 @@ def delete_hosts_by_filter(
             tags,
             filter,
             rbac_filter,
+            get_current_identity(),
         )
     except ValueError as err:
         log_get_host_list_failed(logger)

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -592,6 +592,7 @@ def get_host_ids_list(
     tags: list[str],
     filter: dict,
     rbac_filter: dict,
+    identity: Identity,
 ) -> list[str]:
     all_filters, base_query = query_filters(
         fqdn,
@@ -609,6 +610,7 @@ def get_host_ids_list(
         registered_with,
         filter,
         rbac_filter,
+        identity=identity,
     )
     host_list = [str(res[0]) for res in _find_hosts_entities_query(base_query, [Host.id]).filter(*all_filters).all()]
     db.session.close()


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-16421](https://issues.redhat.com/browse/RHINENG-16421).
Fixes the bulk delete endpoint with respect to the changes to the staleness functions. Passes the current identity through the endpoint, and uses its org_id in the staleness functions. Also adds a test to make sure that scenario is covered.

Fixes an issue introduced in #2332.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
