### PR TITLE
fix(RHINENG-15447): improve replace_tags_alt logic

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -313,15 +313,6 @@ class Tag:
         return {self.namespace: {self.key: []}}
 
     @staticmethod
-    def to_structured(tags_dict_list):
-        structured_tags = []
-        for tag_dict in tags_dict_list:
-            tag = Tag(namespace=tag_dict.get("namespace"), key=tag_dict.get("key"), value=tag_dict.get("value"))
-
-            structured_tags.append(tag)
-        return structured_tags
-
-    @staticmethod
     def create_nested_from_tags(tags):
         """
         accepts an array of structured tags and makes a combined nested version

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -1130,7 +1130,10 @@ def test_replace_tags_of_host_by_list(mq_create_or_update_host, db_get_host_by_i
             ]
 
             assert expected_tags == record.tags
-            assert Tag.create_flat_tags_from_structured(structured_tags) == record.tags_alt
+            # The more concise way of replacing tags changes the list order
+            assert sorted(
+                Tag.create_flat_tags_from_structured(structured_tags), key=lambda t: t["namespace"]
+            ) == sorted(record.tags_alt, key=lambda t: t["namespace"])
 
 
 def test_replace_host_tags_by_dict(mq_create_or_update_host, db_get_host_by_insights_id, subtests):
@@ -1176,7 +1179,10 @@ def test_replace_host_tags_by_dict(mq_create_or_update_host, db_get_host_by_insi
             structured_tags = [Tag.from_nested({ns: ns_item}) for ns, ns_item in expected_tags.items()]
 
             assert expected_tags == record.tags
-            assert Tag.create_flat_tags_from_structured(structured_tags) == record.tags_alt
+            # The more concise way of replacing tags changes the list order
+            assert sorted(
+                Tag.create_flat_tags_from_structured(structured_tags), key=lambda t: t["namespace"]
+            ) == sorted(record.tags_alt, key=lambda t: t["namespace"])
 
 
 def test_keep_host_tags_by_empty(mq_create_or_update_host, db_get_host_by_insights_id, subtests):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -291,7 +291,9 @@ def test_update_host_with_tags(db_create_host):
     existing_host.update(input_host)
 
     assert existing_host.tags == new_tags
-    assert existing_host.tags_alt == new_tags_alt
+    assert sorted(existing_host.tags_alt, key=lambda t: t["namespace"]) == sorted(
+        new_tags_alt, key=lambda t: t["namespace"]
+    )
 
 
 def test_update_host_with_no_tags(db_create_host):


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-15447](https://issues.redhat.com/browse/RHINENG-15447).

- Changes the logic of `_replace_tags_in_namespace()` to account for different numbers of items to update

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
