### PR TITLE
RHINENG-8904: Increase floorist chunksize

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1398,6 +1398,7 @@ objects:
     logLevel: ${FLOORIST_LOGLEVEL}
     queries:
       - prefix: insights/inventory/hosts
+        chunksize: 50000
         query: >-
           SELECT
             "id",
@@ -1432,22 +1433,23 @@ objects:
     suspend: ${{FLOORIST_SUSPEND}}
     logLevel: ${FLOORIST_LOGLEVEL}
     queries:
-      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts
-        query: >-
-          SELECT
-            "id",
-            COALESCE("account", '0') AS "account",
-            "org_id" AS "org_id",
-            "created_on" AS "created_at",
-            "modified_on" AS "updated_at",
-            "reporter" AS "reporter",
-            "canonical_facts"->>'insights_id' AS "insights_id",
-            "canonical_facts"->>'subscription_manager_id' AS "subscription_manager_id",
-            "canonical_facts"->>'bios_uuid' AS "bios_uuid",
-            "canonical_facts"->>'provider_id' AS "provider_id",
-            "canonical_facts"->>'provider_type' AS "provider_type"
-          FROM "hbi"."hosts";
+#      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts
+#        query: >-
+#          SELECT
+#            "id",
+#            COALESCE("account", '0') AS "account",
+#            "org_id" AS "org_id",
+#            "created_on" AS "created_at",
+#            "modified_on" AS "updated_at",
+#            "reporter" AS "reporter",
+#            "canonical_facts"->>'insights_id' AS "insights_id",
+#            "canonical_facts"->>'subscription_manager_id' AS "subscription_manager_id",
+#            "canonical_facts"->>'bios_uuid' AS "bios_uuid",
+#            "canonical_facts"->>'provider_id' AS "provider_id",
+#            "canonical_facts"->>'provider_type' AS "provider_type"
+#          FROM "hbi"."hosts";
       - prefix: hms_analytics/inventory/${ENV_NAME}/groups
+        chunksize: 10000
         query: >-
           SELECT
             "id",
@@ -1498,6 +1500,7 @@ objects:
           WHERE "modified_on" >= NOW() - INTERVAL '1 week'
           GROUP BY "reporter";
       - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/hosts_per_org_id
+        chunksize: 10000
         query: >-
           SELECT
             "org_id" AS "org_id",
@@ -1506,10 +1509,12 @@ objects:
           GROUP BY "org_id"
           ORDER BY "host_count" DESC;
       - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/groups_count
+        chunksize: 10000
         query: >-
           SELECT COUNT(*) AS "group_counts"
           FROM "hbi"."groups";
       - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/groups_count_by_account
+        chunksize: 10000
         query: >-
           SELECT
             DISTINCT "account" AS "account",
@@ -1518,6 +1523,7 @@ objects:
           GROUP BY "account"
           ORDER BY "count" DESC;
       - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/org_ids_with_null_accouns
+        chunksize: 10000
         query: >-
           SELECT
             DISTINCT "org_id" AS "org_id",
@@ -1527,6 +1533,7 @@ objects:
           GROUP BY "org_id"
           ORDER BY count DESC;
       - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/org_ids_with_group_names
+        chunksize: 10000
         query: >-
           SELECT
             DISTINCT "org_id" AS "org_id",
@@ -1535,6 +1542,7 @@ objects:
           GROUP BY "org_id", "name"
           ORDER BY "name" ASC;
       - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/hosts_per_groups
+        chunksize: 10000
         query: >-
           SELECT
             "id" AS "group_id",


### PR DESCRIPTION
This PR increases the chunksize (defaulted to 1000) for the heaviest SQL queries. The purpose of this change is to reduce our floorist job execution time and/or figure out the best configuration.

It also pauses the query gathering hosts.

# Overview

This PR is being created to address [RHINENG-8904](https://issues.redhat.com/browse/RHINENG-8904).

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
