### PR TITLE
feat(RHINENG-16842) Include hosts in "ungrouped" group when filtering on group=None

### DIFF
--- a/api/filtering/db_filters.py
+++ b/api/filtering/db_filters.py
@@ -70,7 +70,7 @@ def _group_names_filter(group_name_list: list) -> list:
     if len(group_name_list) > 0:
         group_filters = [func.lower(Group.name).in_(group_name_list_lower)]
         if "" in group_name_list:
-            group_filters += [HostGroupAssoc.group_id.is_(None)]
+            group_filters += [or_(HostGroupAssoc.group_id.is_(None), Group.ungrouped.is_(True))]
 
         _query_filter += (or_(*group_filters),)
 
@@ -82,7 +82,7 @@ def _group_ids_filter(group_id_list: list) -> list:
     if len(group_id_list) > 0:
         group_filters = [HostGroupAssoc.group_id.in_(group_id_list)]
         if None in group_id_list:
-            group_filters += [HostGroupAssoc.group_id.is_(None)]
+            group_filters += [or_(HostGroupAssoc.group_id.is_(None), Group.ungrouped.is_(True))]
 
         _query_filter += [or_(*group_filters)]
 
@@ -366,9 +366,9 @@ def query_filters(
         filters += rbac_permissions_filter(rbac_filter)
 
     # Determine query_base
-    if group_name or order_by == "group_name":
+    if group_name or group_ids or rbac_filter or order_by == "group_name":
         query_base = db.session.query(Host).join(HostGroupAssoc, isouter=True).join(Group, isouter=True)
-    elif group_ids or rbac_filter:
+    elif group_ids:
         query_base = db.session.query(Host).join(HostGroupAssoc, isouter=True)
     else:
         query_base = db.session.query(Host)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -376,7 +376,6 @@ def get_host_list_by_id_list_from_db(host_id_list, identity, rbac_filter=None, c
     )
     if rbac_filter and "groups" in rbac_filter:
         rbac_group_filters = (HostGroupAssoc.group_id.in_(rbac_filter["groups"]),)
-        # Special handling for "None" rbac attributeFilter, no longer needed after Kessel migration
         if None in rbac_filter["groups"]:
             rbac_group_filters += (
                 HostGroupAssoc.group_id.is_(None),

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -18,12 +18,12 @@ from app.config import ALL_STALENESS_STATES
 from app.config import HOST_TYPES
 from app.exceptions import InventoryException
 from app.logging import get_logger
+from app.models import Group
 from app.models import Host
 from app.models import HostGroupAssoc
 from app.serialization import serialize_staleness_to_dict
 from lib import metrics
 from lib.feature_flags import FLAG_INVENTORY_DEDUPLICATION_ELEVATE_SUBMAN_ID
-from lib.feature_flags import FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION
 from lib.feature_flags import get_flag_value
 
 __all__ = (
@@ -377,12 +377,15 @@ def get_host_list_by_id_list_from_db(host_id_list, identity, rbac_filter=None, c
     if rbac_filter and "groups" in rbac_filter:
         rbac_group_filters = (HostGroupAssoc.group_id.in_(rbac_filter["groups"]),)
         # Special handling for "None" rbac attributeFilter, no longer needed after Kessel migration
-        if None in rbac_filter["groups"] and not get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION):
-            rbac_group_filters += (HostGroupAssoc.group_id.is_(None),)
+        if None in rbac_filter["groups"]:
+            rbac_group_filters += (
+                HostGroupAssoc.group_id.is_(None),
+                Group.ungrouped.is_(True),
+            )
 
         filters += (or_(*rbac_group_filters),)
 
-    query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.id)
+    query = Host.query.join(HostGroupAssoc, isouter=True).join(Group, isouter=True).filter(*filters).group_by(Host.id)
     if columns:
         query = query.with_entities(*columns)
     return find_non_culled_hosts(update_query_for_owner_id(identity, query), identity)

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -27,7 +27,6 @@ from app.instrumentation import rbac_group_permission_denied
 from app.instrumentation import rbac_permission_denied
 from app.logging import get_logger
 from lib.feature_flags import FLAG_INVENTORY_API_READ_ONLY
-from lib.feature_flags import FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION
 from lib.feature_flags import get_flag_value
 
 logger = get_logger(__name__)
@@ -114,11 +113,8 @@ def _get_group_list_from_resource_definition(resource_definition: dict) -> list[
             # Validate that all values in the filter are UUIDs.
             group_list = resource_definition["attributeFilter"]["value"]
             try:
-                kessel_migration = get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION)
                 for gid in group_list:
-                    # Special handling for "None" rbac attributeFilter, no longer needed after Kessel migration
-                    # We need to handle None before the migration, but not after
-                    if kessel_migration or gid is not None:
+                    if gid is not None:
                         UUID(gid)
             except (ValueError, TypeError):
                 abort(

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -478,25 +478,6 @@ def test_patch_host_with_RBAC_allowed(subtests, mocker, api_patch, db_create_hos
 
 
 @pytest.mark.usefixtures("enable_rbac", "event_producer_mock")
-def test_patch_host_RBAC_post_kessel_migration(mocker, api_patch, db_create_host):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-    mock_rbac_response = create_mock_rbac_response(
-        "tests/helpers/rbac-mock-data/inv-hosts-write-resource-defs-template.json"
-    )
-    mock_rbac_response[0]["resourceDefinitions"][0]["attributeFilter"]["value"] = [None]
-    get_rbac_permissions_mock.return_value = mock_rbac_response
-
-    host = db_create_host()
-    url = build_hosts_url(host_list_or_id=host.id)
-
-    with mocker.patch("lib.host_repository.get_flag_value", return_value=True):
-        response_status, _ = api_patch(url, {"display_name": "fred_flintstone"})
-        # Post-Kessel migration, there is no special handling for None in the attributeFilter
-        # This means that the host should not be found
-        assert_response_status(response_status, 404)
-
-
-@pytest.mark.usefixtures("enable_rbac", "event_producer_mock")
 def test_patch_host_with_RBAC_denied(subtests, mocker, api_patch, db_create_host, db_get_host):
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
 

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -82,21 +82,6 @@ def test_RBAC_invalid_UUIDs(mocker, api_get):
 
 
 @pytest.mark.usefixtures("enable_rbac")
-def test_RBAC_none_values_not_allowed_post_kessel_migration(mocker, api_get):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-
-    mock_rbac_response = create_mock_rbac_response(
-        "tests/helpers/rbac-mock-data/inv-hosts-read-resource-defs-template.json"
-    )
-    mock_rbac_response[0]["resourceDefinitions"][0]["attributeFilter"]["value"] = [None]
-    get_rbac_permissions_mock.return_value = mock_rbac_response
-
-    with mocker.patch("lib.middleware.get_flag_value", return_value=True):
-        response_status, _ = api_get(build_hosts_url())
-        assert_response_status(response_status, 503)
-
-
-@pytest.mark.usefixtures("enable_rbac")
 @pytest.mark.parametrize(
     "url_builder",
     [build_staleness_url, build_groups_url],


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-16842](https://issues.redhat.com/browse/RHINENG-16842).
In order for HBI to work in read-only mode during the Kessel Phase 0 migration, we need to allow the None attributeFilter value from RBAC to not only allow access to ungrouped hosts, but also hosts that are in the "ungrouped" group. This will allow the API to continue working as expected in-between HBI's data migration and RBAC's data migration.

Also, mgmt-fabric doesn't necessarily need to remove the None attributeFilter values during migration, and it may exist afterwards. Because of this, I'm removing the code that restricted the None value post-migration.


## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
