### PR TITLE
feat(rhineng-16293): Enable deployments where host uuid needs to be the subscription manager ID

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -274,6 +274,7 @@ def create_app(runtime_environment):
 
     flask_app.config["INVENTORY_CONFIG"] = app_config
     flask_app.config["SYSTEM_PROFILE_SPEC"] = sp_spec
+    flask_app.config["USE_SUBMAN_ID"] = app_config.use_sub_man_id_for_host_id
 
     init_cache(app_config, app)
 

--- a/app/config.py
+++ b/app/config.py
@@ -313,6 +313,7 @@ class Config:
             "IMMUTABLE_TIME_TO_DELETE_SECONDS", days_to_seconds(730)
         )
 
+        self.use_sub_man_id_for_host_id = os.environ.get("USE_SUBMAN_ID", "false").lower() == "true"
         self.host_delete_chunk_size = int(os.getenv("HOST_DELETE_CHUNK_SIZE", "1000"))
         self.script_chunk_size = int(os.getenv("SCRIPT_CHUNK_SIZE", "500"))
         self.export_svc_batch_size = int(os.getenv("EXPORT_SVC_BATCH_SIZE", "500"))

--- a/app/models.py
+++ b/app/models.py
@@ -10,6 +10,7 @@ from os.path import join
 
 from connexion.utils import coerce_type
 from dateutil.parser import isoparse
+from flask import current_app
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from jsonschema import RefResolver
@@ -215,7 +216,10 @@ class LimitedHost(db.Model):  # type: ignore [name-defined]
         tags_alt=None,
         system_profile_facts=None,
         groups=None,
+        id=None,
     ):
+        if id:
+            self.id = id
         if tags is None:
             tags = {}
             tags_alt = []
@@ -328,6 +332,7 @@ class Host(LimitedHost):
         per_reporter_staleness=None,
         groups=None,
     ):
+        id = None
         if tags is None:
             tags = {}
 
@@ -336,6 +341,9 @@ class Host(LimitedHost):
 
         if not canonical_facts:
             raise ValidationException("At least one of the canonical fact fields must be present.")
+
+        if current_app.config["USE_SUBMAN_ID"] and canonical_facts and "subscription_manager_id" in canonical_facts:
+            id = canonical_facts["subscription_manager_id"]
 
         if not stale_timestamp or not reporter:
             raise ValidationException("Both stale_timestamp and reporter fields must be present.")
@@ -354,6 +362,7 @@ class Host(LimitedHost):
             tags_alt,
             system_profile_facts,
             groups,
+            id,
         )
 
         self._update_last_check_in_date()

--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -184,3 +184,40 @@ def future_mock():
 def event_datetime_mock(mocker):
     mock = mocker.patch("app.queue.events.datetime", **{"now.return_value": now()})
     return mock.now.return_value
+
+
+@pytest.fixture(scope="function")
+def mq_create_or_update_host_subman_id(
+    flask_app,  # noqa: ARG001
+    event_producer_mock,
+    notification_event_producer_mock,
+):
+    config = flask_app.app.config["INVENTORY_CONFIG"]
+    config.use_sub_man_id_for_host_id = True
+    flask_app.app.config["USE_SUBMAN_ID"] = config.use_sub_man_id_for_host_id
+
+    def _mq_create_or_update_host_subman_id(
+        host_data,
+        platform_metadata=None,
+        return_all_data=False,
+        event_producer=event_producer_mock,
+        message_operation=add_host,
+        operation_args=None,
+        notification_event_producer=notification_event_producer_mock,
+    ):
+        if not platform_metadata:
+            platform_metadata = get_platform_metadata()
+
+        message = wrap_message(host_data.data(), platform_metadata=platform_metadata, operation_args=operation_args)
+        result = handle_message(json.dumps(message), notification_event_producer, message_operation)
+        db.session.commit()
+        write_add_update_event_message(event_producer, notification_event_producer_mock, result)
+        event = json.loads(event_producer.event)
+
+        if return_all_data:
+            return event_producer_mock.key, event, event_producer.headers
+
+        # add facts object since it's not returned by event message
+        return HostWrapper({**event["host"], **{"facts": host_data.facts}})
+
+    return _mq_create_or_update_host_subman_id

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -2120,3 +2120,14 @@ def test_log_update_system_profile(mq_create_or_update_host, db_get_host, id_typ
         "number_of_sockets": 8,
     }
     assert caplog.records[0].input_host["system_profile"] == "{}"
+
+
+def test_add_host_subman_id(mq_create_or_update_host_subman_id, db_get_host):
+    subscription_manager_id = generate_uuid()
+    host = minimal_host(account=SYSTEM_IDENTITY["account_number"], subscription_manager_id=subscription_manager_id)
+
+    mq_create_or_update_host_subman_id(host)
+
+    record = db_get_host(subscription_manager_id)
+
+    assert str(record.id) == str(subscription_manager_id)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-16293](https://issues.redhat.com/browse/RHINENG-16293).
* Added a configuration variable controlled by an ENV var; defaults to false
* Added a flow for setting the Host model's id to the subscription manager id if its present and the configuration value is set
* Updated find existing host flow to only use subscription manager id as the elevated id in the case where the USE_SUBMAN_ID variable is True


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
