### PR TITLE
feat(RHINENG-15648): Async update per_reporter_staleness

### DIFF
--- a/api/staleness.py
+++ b/api/staleness.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from threading import Thread
 
 from flask import abort
 from marshmallow import ValidationError
@@ -18,14 +19,18 @@ from app.instrumentation import log_create_staleness_failed
 from app.instrumentation import log_create_staleness_succeeded
 from app.instrumentation import log_patch_staleness_succeeded
 from app.logging import get_logger
+from app.models import Host
 from app.models import StalenessSchema
 from app.serialization import serialize_staleness_response
 from app.serialization import serialize_staleness_to_dict
 from app.staleness_serialization import get_sys_default_staleness_api
+from lib.feature_flags import FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS
+from lib.feature_flags import get_flag_value
 from lib.middleware import rbac
 from lib.staleness import add_staleness
 from lib.staleness import patch_staleness
 from lib.staleness import remove_staleness
+from run import app as application
 
 logger = get_logger(__name__)
 
@@ -42,6 +47,25 @@ def _validate_input_data(body):
     except ValidationError as e:
         logger.exception(f'Input validation error, "{str(e.messages)}", while creating account staleness: {body}')
         abort(HTTPStatus.BAD_REQUEST, f"Validation Error: {str(e.messages)}")
+
+
+def _update_hosts_staleness_async(org_id):
+    with application.app.app_context():
+        logger.debug("Starting host staleness update thread")
+        try:
+            logger.debug(f"Querying hosts for org_id: {org_id}")
+            hosts_query = Host.query.filter(Host.org_id == org_id)
+            num_hosts = hosts_query.count()
+            if num_hosts > 0:
+                logger.debug(f"Found {num_hosts} hosts for org_id: {org_id}")
+                for host in hosts_query.yield_per(500):
+                    host._update_all_per_reporter_staleness()
+                hosts_query.session.commit()
+
+                delete_cached_system_keys(org_id=org_id, spawn=True)
+            logger.debug("Leaving host staleness update thread")
+        except Exception as e:
+            raise e
 
 
 @api_operation
@@ -89,7 +113,11 @@ def create_staleness(body):
     try:
         # Create account staleness with validated data
         created_staleness = add_staleness(validated_data)
-        delete_cached_system_keys(org_id=org_id, spawn=True)
+        if get_flag_value(FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS):
+            update_hosts_thread = Thread(target=_update_hosts_staleness_async, daemon=True, args=(org_id,))
+            update_hosts_thread.start()
+        else:
+            delete_cached_system_keys(org_id=org_id, spawn=True)
         log_create_staleness_succeeded(logger, created_staleness.id)
     except IntegrityError:
         error_message = f"Staleness record for org_id {org_id} already exists."
@@ -109,7 +137,11 @@ def delete_staleness():
     org_id = get_current_identity().org_id
     try:
         remove_staleness()
-        delete_cached_system_keys(org_id=org_id, spawn=True)
+        if get_flag_value(FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS):
+            update_hosts_thread = Thread(target=_update_hosts_staleness_async, daemon=True, args=(org_id,))
+            update_hosts_thread.start()
+        else:
+            delete_cached_system_keys(org_id=org_id, spawn=True)
         return flask_json_response(None, HTTPStatus.NO_CONTENT)
     except NoResultFound:
         abort(
@@ -137,7 +169,12 @@ def update_staleness(body):
             # since update only return None with no record instead of exception.
             raise NoResultFound
 
-        delete_cached_system_keys(org_id=org_id, spawn=True)
+        if get_flag_value(FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS):
+            update_hosts_thread = Thread(target=_update_hosts_staleness_async, daemon=True, args=(org_id,))
+            update_hosts_thread.start()
+        else:
+            delete_cached_system_keys(org_id=org_id, spawn=True)
+
         log_patch_staleness_succeeded(logger, updated_staleness.id)
 
         return flask_json_response(serialize_staleness_response(updated_staleness), HTTPStatus.OK)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-15648](https://issues.redhat.com/browse/RHINENG-15648).

It updates PRS asynchronously when user CREATE/UPDATE/DELETE its custom staleness.

A Thread is created every time a user perform the mentioned interactions with our API.

This feature is behind the `hbi.create_last_check_in_update_per_reporter_staleness` feature flag.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
