### PR TITLE
[RHCLOUD-39208] Return 202 status error code in group creation

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -11,6 +11,7 @@ from api import flask_json_response
 from api import json_error_response
 from api import metrics
 from api.group_query import build_group_response
+from api.group_query import build_incomplete_response
 from api.group_query import build_paginated_group_list_response
 from api.group_query import get_filtered_group_list_db
 from api.group_query import get_group_list_by_id_list_db
@@ -103,6 +104,7 @@ def create_group(body, rbac_filter=None):
                 logger.exception(message)
                 return json_error_response("Workspace creation failure", message, HTTPStatus.BAD_REQUEST)
 
+            return flask_json_response(build_incomplete_response(workspace_id), HTTPStatus.ACCEPTED)
         else:
             created_group = create_group_from_payload(validated_create_group_data, current_app.event_producer, None)
             create_group_count.inc()

--- a/api/group_query.py
+++ b/api/group_query.py
@@ -8,6 +8,7 @@ from app.models import Group
 from app.models import HostGroupAssoc
 from app.models import db
 from app.serialization import serialize_group
+from app.serialization import serialize_incomplete_group
 
 logger = get_logger(__name__)
 
@@ -122,3 +123,8 @@ def build_paginated_group_list_response(total, page, per_page, group_list):
 def build_group_response(group):
     identity = get_current_identity()
     return serialize_group(group, identity.org_id)
+
+
+def build_incomplete_response(group_id):
+    identity = get_current_identity()
+    return serialize_incomplete_group(group_id, identity.org_id)

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -242,7 +242,7 @@ def _get_unculled_hosts(group, org_id):
 
 
 def serialize_incomplete_group(group_id, org_id):
-    return {"id": _serialize_uuid(group_id), "org_id": org_id, "status": "creation_in_progress"}
+    return {"id": _serialize_uuid(group_id), "org_id": org_id, "status": "accepted", "message": "The requested group is being created asynchronously."}
 
 
 def serialize_group(group, org_id):

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -241,6 +241,10 @@ def _get_unculled_hosts(group, org_id):
     return hosts
 
 
+def serialize_incomplete_group(group_id, org_id):
+    return {"id": _serialize_uuid(group_id), "org_id": org_id, "status": "creation_in_progress"}
+
+
 def serialize_group(group, org_id):
     unculled_hosts = _get_unculled_hosts(group, org_id)
     return {


### PR DESCRIPTION
# Overview

Ticket: https://issues.redhat.com/browse/RHCLOUD-39208

With kessel integration enabled, this request fails:

```
POST localhost:8080/api/inventory/v1/groups
x-rh-identity: eyJpZGVudGl0eSI6eyJ0eXBlIjoiVXNlciIsICJvcmdfaWQiOiIwMDAwMDEiLCJhdXRoX3R5cGUiOiJiYXNpYy1hdXRoIiwgImFjY291bnRfbnVtYmVyIjoiNjA4OTcxOSIsInVzZXIiOnsiaXNfYWN0aXZlIjogdHJ1ZSwibG9jYWxlIjoiZW5fVVMiLCJpc19vcmdfYWRtaW4iOiB0cnVlLCJ1c2VybmFtZSI6IlRlc3QiLCJlbWFpbCI6ICJ0ZXN0QHRlc3QuY29tIiwiZmlyc3RfbmFtZSI6IlRlc3QiLCJ1c2VyX2lkIjoiNTU1NTU1NTUiLCJsYXN0X25hbWUiOiJVc2VyIiwiaXNfaW50ZXJuYWwiOnRydWV9LCAiaW50ZXJuYWwiOiB7Im9yZ19pZCI6ICIwMDAwMDEifX19Cg==
Content-Type: application/json

{
    "name": "sre-group",
    "host_ids": [
        "f0e5add5-0187-4e56-97a2-7d549efad505"
    ]
}
```

response:
```
{
  "type": "about:blank",
  "title": "Internal Server Error",
  "detail": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.",
  "status": 500
}
```

Error message in server:

```
 File "/Users/liborpichler/.local/share/virtualenvs/insights-host-inventory-WrvH8oWp/lib/python3.9/site-packages/connexion/decorators/response.py", line 172, in wrapper
    handler_response = function(*args, **kwargs)
  File "/Users/liborpichler/.local/share/virtualenvs/insights-host-inventory-WrvH8oWp/lib/python3.9/site-packages/connexion/decorators/parameter.py", line 87, in wrapper
    return function(**kwargs)
  File "/Users/liborpichler/.local/share/virtualenvs/insights-host-inventory-WrvH8oWp/lib/python3.9/site-packages/connexion/decorators/main.py", line 123, in wrapper
    return function(*args, **kwargs)
  File "/Users/liborpichler/Projects/insights-host-inventory/api/__init__.py", line 40, in new_func
    results = old_func(*args, **kwargs)
  File "/Users/liborpichler/Projects/insights-host-inventory/lib/middleware.py", line 211, in modified_func
    return func(*args, **kwargs)
  File "<decorator-gen-23>", line 2, in create_group
  File "/Users/liborpichler/.local/share/virtualenvs/insights-host-inventory-WrvH8oWp/lib/python3.9/site-packages/prometheus_client/context_managers.py", line 80, in wrapped
    return func(*args, **kwargs)
  File "/Users/liborpichler/Projects/insights-host-inventory/api/group.py", line 110, in create_group
    log_create_group_succeeded(logger, created_group.id)
UnboundLocalError: local variable 'created_group' referenced before assignment
```

### Solution 
In this case inventory group is being create asynchronously, so status code 202 Accepted might be more relevant:

```
{
  "id": "0195f125-7fee-7340-b388-cc73d6318655",
  "org_id": "000001",
  "status": "creation_in_progress"
}
```




## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
