### PR TITLE
feat: Add job to update last_check_in field in the DB

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1440,6 +1440,39 @@ objects:
           requests:
             cpu: ${CPU_REQUEST_GROUPS_S3_EXPORT}
             memory: ${MEMORY_REQUEST_GROUPS_S3_EXPORT}
+    - name: update-hosts-last-check-in
+      schedule: ${{HOSTS_LAST_CHECK_IN_SCHEDULE}}
+      restartPolicy: Never
+      suspend: ${{HOSTS_LAST_CHECK_IN_SUSPEND}}
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        args: ["./jobs/update_hosts_last_check_in.py"]
+        env:
+          - name: HOST_UPDATE_LIMIT
+            value: ${HOST_UPDATE_LIMIT}
+          - name: INVENTORY_LOG_LEVEL
+            value: ${LOG_LEVEL}
+          - name: INVENTORY_DB_SSL_MODE
+            value: ${INVENTORY_DB_SSL_MODE}
+          - name: INVENTORY_DB_SSL_CERT
+            value: ${INVENTORY_DB_SSL_CERT}
+          - name: INVENTORY_DB_SCHEMA
+            value: "${INVENTORY_DB_SCHEMA}"
+          - name: PROMETHEUS_PUSHGATEWAY
+            value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CLOWDER_ENABLED
+            value: "true"
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_HOSTS_LAST_CHECK_IN}
+            memory: ${MEMORY_LIMIT_HOSTS_LAST_CHECK_IN}
+          requests:
+            cpu: ${CPU_REQUEST_HOSTS_LAST_CHECK_IN}
+            memory: ${MEMORY_REQUEST_HOSTS_LAST_CHECK_IN}
     database:
       name: ${DB_NAME}
       version: 16
@@ -1842,6 +1875,17 @@ parameters:
 - name: MEMORY_LIMIT_EXPORT_SVC
   value: 512Mi
 
+- name: CPU_REQUEST_HOSTS_LAST_CHECK_IN
+  value: 250m
+- name: CPU_LIMIT_HOSTS_LAST_CHECK_IN
+  value: 500m
+- name: MEMORY_REQUEST_HOSTS_LAST_CHECK_IN
+  value: 256Mi
+- name: MEMORY_LIMIT_HOSTS_LAST_CHECK_IN
+  value: 512Mi
+- name: HOST_UPDATE_LIMIT
+  value: "50000"
+
 - description: Replica count for p1 consumer
   name: REPLICAS_P1
   value: "5"
@@ -1987,6 +2031,10 @@ parameters:
   value: 'false'
 - name: SYNDICATOR_CRON_SCHEDULE
   value: '*/5 * * * *'
+- name: HOSTS_LAST_CHECK_IN_SCHEDULE
+  value: '@hourly'
+- name: HOSTS_LAST_CHECK_IN_SUSPEND
+  value: 'false'
 - name: KAFKA_SP_VALIDATOR_MAX_MESSAGES
   value: '10000'
 - name: TENANT_TRANSLATOR_HOST

--- a/jobs/update_hosts_last_check_in.py
+++ b/jobs/update_hosts_last_check_in.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+import os
+import sys
+from functools import partial
+from logging import Logger
+
+from connexion import FlaskApp
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.environment import RuntimeEnvironment
+from app.logging import get_logger
+from app.models import Host
+from jobs.common import excepthook
+from jobs.common import job_setup
+
+PROMETHEUS_JOB = "inventory-update-hosts-last-check-in"
+LOGGER_NAME = "update-hosts-last-check-in"
+RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
+
+LIMIT = int(os.getenv("HOST_UPDATE_LIMIT", 50000))
+
+
+def run(logger: Logger, session: Session, application: FlaskApp):
+    with application.app.app_context():
+        num_hosts_null_last_check_in = session.query(Host).filter(Host.last_check_in is None).count()
+
+        if num_hosts_null_last_check_in > 0:
+            logger.info(f"There are still {num_hosts_null_last_check_in} to be updated")
+            logger.info(f"Updating {LIMIT} hosts' last_check_in field")
+            session.execute(
+                text(
+                    "UPDATE hbi.hosts h SET last_check_in  = modified_on ",
+                    f"WHERE h.id IN (SELECT id FROM hbi.hosts sub WHERE sub.last_check_in is NULL LIMIT {LIMIT});",
+                )
+            )
+            session.commit()
+
+
+if __name__ == "__main__":
+    logger = get_logger(LOGGER_NAME)
+    job_type = "Update host last_check_in field"
+    sys.excepthook = partial(excepthook, logger, job_type)
+
+    _, session, event_producer, _, _, application = job_setup(tuple(), PROMETHEUS_JOB)
+    run(logger, session, application)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-15654](https://issues.redhat.com/browse/RHINENG-15654).

It creates a OCP cronjob to update Host last_check_in field.
By default it limits the update size to 50000 hosts each run.
The job runs hourly by default

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
