### PR TITLE
fix(RHINENG-15822) Fix context issue for host-mq RBAC call

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -39,7 +39,7 @@ from lib.group_repository import get_group_by_id_from_db
 from lib.group_repository import get_group_using_host_id
 from lib.group_repository import patch_group
 from lib.group_repository import remove_hosts_from_group
-from lib.group_repository import validate_add_host_list_to_group
+from lib.group_repository import validate_add_host_list_to_group_for_group_create
 from lib.group_repository import wait_for_workspace_creation
 from lib.metrics import create_group_count
 from lib.middleware import delete_rbac_workspace
@@ -98,19 +98,19 @@ def create_group(body, rbac_filter=None):
         if get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION):
             group_name = validated_create_group_data.get("name")
 
+            # Before waiting and workspace creation in RBAC validate whether the hosts can be added to the group
+            if len(host_id_list := validated_create_group_data.get("host_ids", [])) > 0:
+                validate_add_host_list_to_group_for_group_create(
+                    host_id_list,
+                    group_name,
+                    get_current_identity().org_id,
+                )
+
             workspace_id = post_rbac_workspace(group_name, f"{group_name} group")
             if not workspace_id and not inventory_config().bypass_rbac:
                 message = f"Error while creating workspace for {group_name}"
                 logger.exception(message)
                 return json_error_response("Workspace creation failure", message, HTTPStatus.BAD_REQUEST)
-
-            # Before waiting, validate whether the hosts can be added to the group
-            if len(host_id_list := validated_create_group_data.get("host_ids", [])) > 0:
-                validate_add_host_list_to_group(
-                    host_id_list,
-                    workspace_id,
-                    get_current_identity().org_id,
-                )
 
             # Wait for the MQ to notify us of the workspace creation
             try:

--- a/api/group.py
+++ b/api/group.py
@@ -115,7 +115,11 @@ def create_group(body, rbac_filter=None):
                 )
 
             # Wait for the MQ to notify us of the workspace creation
-            wait_for_workspace_creation(workspace_id, inventory_config().rbac_timeout)
+            try:
+                wait_for_workspace_creation(workspace_id, inventory_config().rbac_timeout)
+            except TimeoutError:
+                abort(HTTPStatus.SERVICE_UNAVAILABLE, "Timed out waiting for a message from RBAC v2.")
+
             add_hosts_to_group(
                 workspace_id,
                 host_id_list,

--- a/api/group.py
+++ b/api/group.py
@@ -43,7 +43,6 @@ from lib.group_repository import validate_add_host_list_to_group
 from lib.group_repository import wait_for_workspace_creation
 from lib.metrics import create_group_count
 from lib.middleware import delete_rbac_workspace
-from lib.middleware import get_rbac_default_workspace
 from lib.middleware import post_rbac_workspace
 from lib.middleware import put_rbac_workspace
 from lib.middleware import rbac
@@ -97,10 +96,9 @@ def create_group(body, rbac_filter=None):
     try:
         # Create group with validated data
         if get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION):
-            default_parent_id = get_rbac_default_workspace()
             group_name = validated_create_group_data.get("name")
 
-            workspace_id = post_rbac_workspace(group_name, str(default_parent_id), f"{group_name} group")
+            workspace_id = post_rbac_workspace(group_name, f"{group_name} group")
             if not workspace_id and not inventory_config().bypass_rbac:
                 message = f"Error while creating workspace for {group_name}"
                 logger.exception(message)

--- a/api/group.py
+++ b/api/group.py
@@ -107,11 +107,12 @@ def create_group(body, rbac_filter=None):
                 return json_error_response("Workspace creation failure", message, HTTPStatus.BAD_REQUEST)
 
             # Before waiting, validate whether the hosts can be added to the group
-            validate_add_host_list_to_group(
-                host_id_list := validated_create_group_data.get("host_ids"),
-                workspace_id,
-                get_current_identity().org_id,
-            )
+            if len(host_id_list := validated_create_group_data.get("host_ids", [])) > 0:
+                validate_add_host_list_to_group(
+                    host_id_list,
+                    workspace_id,
+                    get_current_identity().org_id,
+                )
 
             # Wait for the MQ to notify us of the workspace creation
             wait_for_workspace_creation(workspace_id, inventory_config().rbac_timeout)

--- a/app/config.py
+++ b/app/config.py
@@ -97,7 +97,7 @@ class Config:
 
         self.bootstrap_servers = ",".join(app_common_python.KafkaServers)
         if custom_broker := os.getenv("CONSUMER_MQ_BROKER"):
-            self.bootstrap_servers += f",{custom_broker}"
+            self.bootstrap_servers = custom_broker
 
         broker_cfg = cfg.kafka.brokers[0]
 

--- a/app/config.py
+++ b/app/config.py
@@ -96,6 +96,9 @@ class Config:
         self.workspaces_topic = topic(os.environ.get("KAFKA_WORKSPACES_TOPIC"))
 
         self.bootstrap_servers = ",".join(app_common_python.KafkaServers)
+        if custom_broker := os.getenv("CONSUMER_MQ_BROKER"):
+            self.bootstrap_servers += f",{custom_broker}"
+
         broker_cfg = cfg.kafka.brokers[0]
 
         # certificates are required in fedramp, but not in managed kafka

--- a/app/config.py
+++ b/app/config.py
@@ -316,6 +316,7 @@ class Config:
             "IMMUTABLE_TIME_TO_DELETE_SECONDS", days_to_seconds(730)
         )
 
+        self.rbac_v2_force_org_admin = os.getenv("RBAC_V2_FORCE_ORG_ADMIN", "false").lower() == "true"
         self.use_sub_man_id_for_host_id = os.environ.get("USE_SUBMAN_ID", "false").lower() == "true"
         self.host_delete_chunk_size = int(os.getenv("HOST_DELETE_CHUNK_SIZE", "1000"))
         self.script_chunk_size = int(os.getenv("SCRIPT_CHUNK_SIZE", "500"))

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2106,6 +2106,9 @@ parameters:
 - name: S3_AWS_SECRET
   description: The AWS secret for S3
   value: 'hbi-kessel-s3'
+- name: RBAC_V2_FORCE_ORG_ADMIN
+  description: Whether to force User Identities to use is_org_admin=True for RBAC v2 calls
+  value: 'false'
 
 # NGINX
 - displayName: Minimum replicas

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -169,6 +169,8 @@ objects:
           value: ${BYPASS_UNLEASH}
         - name: UNLEASH_REFRESH_INTERVAL
           value: ${UNLEASH_REFRESH_INTERVAL}
+        - name: RBAC_V2_FORCE_ORG_ADMIN
+          value: ${RBAC_V2_FORCE_ORG_ADMIN}
         - name: SEGMENTIO_WRITE_KEY
           valueFrom:
             secretKeyRef:
@@ -479,6 +481,8 @@ objects:
           value: ${BYPASS_UNLEASH}
         - name: UNLEASH_REFRESH_INTERVAL
           value: ${UNLEASH_REFRESH_INTERVAL}
+        - name: RBAC_V2_FORCE_ORG_ADMIN
+          value: ${RBAC_V2_FORCE_ORG_ADMIN}
         - name: SEGMENTIO_WRITE_KEY
           valueFrom:
             secretKeyRef:
@@ -596,6 +600,8 @@ objects:
           value: ${MQ_DB_BATCH_MAX_MESSAGES}
         - name: MQ_DB_BATCH_MAX_SECONDS
           value: ${MQ_DB_BATCH_MAX_SECONDS}
+        - name: RBAC_V2_FORCE_ORG_ADMIN
+          value: ${RBAC_V2_FORCE_ORG_ADMIN}
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3
@@ -695,6 +701,8 @@ objects:
           value: ${MQ_DB_BATCH_MAX_MESSAGES}
         - name: MQ_DB_BATCH_MAX_SECONDS
           value: ${MQ_DB_BATCH_MAX_SECONDS}
+        - name: RBAC_V2_FORCE_ORG_ADMIN
+          value: ${RBAC_V2_FORCE_ORG_ADMIN}
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3
@@ -875,6 +883,8 @@ objects:
           value: ${MQ_DB_BATCH_MAX_MESSAGES}
         - name: MQ_DB_BATCH_MAX_SECONDS
           value: ${MQ_DB_BATCH_MAX_SECONDS}
+        - name: RBAC_V2_FORCE_ORG_ADMIN
+          value: ${RBAC_V2_FORCE_ORG_ADMIN}
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -883,6 +883,8 @@ objects:
           value: ${MQ_DB_BATCH_MAX_MESSAGES}
         - name: MQ_DB_BATCH_MAX_SECONDS
           value: ${MQ_DB_BATCH_MAX_SECONDS}
+        - name: CONSUMER_MQ_BROKER
+          value: ${CONSUMER_MQ_BROKER}
         - name: RBAC_V2_FORCE_ORG_ADMIN
           value: ${RBAC_V2_FORCE_ORG_ADMIN}
         image: ${IMAGE}:${IMAGE_TAG}
@@ -2021,6 +2023,8 @@ parameters:
   value: PLAINTEXT
 - name: KAFKA_SASL_MECHANISM
   value: 'PLAIN'
+- name: CONSUMER_MQ_BROKER
+  value: ''
 - name: PROMETHEUS_PUSHGATEWAY
   value: 'localhost:9091'
 - name: KAFKA_BOOTSTRAP_HOST

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -412,7 +412,7 @@ def get_or_create_ungrouped_hosts_group_for_identity(identity: Identity) -> Grou
         return group
 
     # Otherwise, create the workspace
-    workspace_id = rbac_create_ungrouped_hosts_workspace()
+    workspace_id = rbac_create_ungrouped_hosts_workspace(identity)
 
     # Create "ungrouped" group for this org using group ID == workspace ID
     return add_group(

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -412,7 +412,7 @@ def get_or_create_ungrouped_hosts_group_for_identity(identity: Identity) -> Grou
         return group
 
     # Otherwise, create the workspace
-    workspace_id = rbac_create_ungrouped_hosts_workspace(identity)
+    workspace_id = rbac_create_ungrouped_hosts_workspace()
 
     # Create "ungrouped" group for this org using group ID == workspace ID
     return add_group(

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -89,6 +89,28 @@ def _invalidate_system_cache(host_list: list[Host], identity: Identity):
             delete_cached_system_keys(insights_id=insights_id, org_id=identity.org_id, owner_id=owner_id)
 
 
+def validate_add_host_list_to_group_for_group_create(host_id_list: list[str], group_name: str, org_id: str):
+    # Check if the hosts exist in Inventory and have correct org_id
+    host_query = Host.query.filter((Host.org_id == org_id) & Host.id.in_(host_id_list)).all()
+    found_ids_set = {str(host.id) for host in host_query}
+    if found_ids_set != set(host_id_list):
+        nonexistent_hosts = set(host_id_list) - found_ids_set
+        log_host_group_add_failed(logger, host_id_list, group_name)
+        raise InventoryException(
+            title="Invalid request", detail=f"Could not find existing host(s) with ID {nonexistent_hosts}."
+        )
+
+    # Check if the hosts are already associated with another group
+    assoc_query = HostGroupAssoc.query.filter(HostGroupAssoc.host_id.in_(host_id_list)).all()
+    if assoc_query:
+        taken_hosts = [str(assoc.host_id) for assoc in assoc_query]
+        log_host_group_add_failed(logger, host_id_list, group_name)
+        raise InventoryException(
+            title="Invalid request",
+            detail=f"The following subset of hosts are already associated with another group: {taken_hosts}.",
+        )
+
+
 def validate_add_host_list_to_group(host_id_list: list[str], group_id: str, org_id: str):
     # Check if the hosts exist in Inventory and have correct org_id
     host_query = Host.query.filter((Host.org_id == org_id) & Host.id.in_(host_id_list)).all()

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -232,14 +232,13 @@ def rbac_group_id_check(rbac_filter: dict, requested_ids: set) -> None:
             abort(HTTPStatus.FORBIDDEN, f"You do not have access to the the following groups: {joined_ids}")
 
 
-# TODO: Remove this once no longer testing
 def _temp_add_org_admin_user_identity(identity_header: str) -> str:
     identity = from_auth_header(identity_header)
-    if not hasattr(identity, "user"):
-        return identity_header
-    else:
-        identity.user["is_org_id"] = True
+    if inventory_config().rbac_v2_force_org_admin and hasattr(identity, "user"):
+        identity.user["is_org_admin"] = True
         return to_auth_header(identity)
+
+    return identity_header
 
 
 def get_rbac_default_workspace_using_headers(identity_header: str) -> UUID | None:

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -28,7 +28,6 @@ from app.instrumentation import rbac_failure
 from app.instrumentation import rbac_group_permission_denied
 from app.instrumentation import rbac_permission_denied
 from app.logging import get_logger
-from app.logging import threadctx
 from lib.feature_flags import FLAG_INVENTORY_API_READ_ONLY
 from lib.feature_flags import get_flag_value
 
@@ -244,58 +243,7 @@ def _temp_add_org_admin_user_identity(identity_header: str) -> str:
     return identity_header
 
 
-def get_rbac_default_workspace_using_headers(identity_header: str) -> UUID | None:
-    if inventory_config().bypass_rbac:
-        return None
-
-    # Temporarily set is_org_admin to True if using a user-type identity
-    identity_header = _temp_add_org_admin_user_identity(identity_header)
-
-    workspace_endpoint = "workspaces/?type=default"
-    request_session = Session()
-    retry_config = Retry(total=inventory_config().rbac_retries, backoff_factor=1, status_forcelist=RETRY_STATUSES)
-    request_session.mount(get_rbac_v2_url(endpoint=workspace_endpoint), HTTPAdapter(max_retries=retry_config))
-    request_header = {
-        IDENTITY_HEADER: identity_header,
-        REQUEST_ID_HEADER: threadctx.request_id,
-    }
-
-    logger.info(f"Identity header (get default workspace): {identity_header}")  # TODO: remove after testing
-
-    try:
-        with outbound_http_response_time.labels("rbac").time():
-            rbac_response = request_session.get(
-                url=get_rbac_v2_url(endpoint=workspace_endpoint),
-                headers=request_header,
-                timeout=inventory_config().rbac_timeout,
-                verify=LoadedConfig.tlsCAPath,
-            )
-    except Exception as e:
-        rbac_failure(logger, e)
-        abort(503, "Failed to reach RBAC endpoint, request cannot be fulfilled")
-    finally:
-        request_session.close()
-
-    resp_data = rbac_response.json()
-    logger.debug("Fetched RBAC Data", extra=resp_data)
-
-    if len(resp_data["data"]) == 0:
-        message = "Error while retrieving default workspace: No default workspace in RBAC"
-        logger.exception(message)
-        return None
-    else:
-        return UUID(resp_data["data"][0]["id"])
-
-
-# Only works within an API context. Passes the headers from the current request
-# to the RBAC v2 request.
-def get_rbac_default_workspace() -> UUID | None:
-    return get_rbac_default_workspace_using_headers(
-        request.headers[IDENTITY_HEADER],
-    )
-
-
-def post_rbac_workspace(name, parent_id, description) -> UUID | None:
+def post_rbac_workspace(name, description) -> UUID | None:
     if inventory_config().bypass_rbac:
         return None
 
@@ -303,11 +251,12 @@ def post_rbac_workspace(name, parent_id, description) -> UUID | None:
     request_session = Session()
     retry_config = Retry(total=inventory_config().rbac_retries, backoff_factor=1, status_forcelist=RETRY_STATUSES)
     request_session.mount(get_rbac_v2_url(endpoint=workspace_endpoint), HTTPAdapter(max_retries=retry_config))
+    identity_header = _temp_add_org_admin_user_identity(request.headers[IDENTITY_HEADER])
     request_header = {
-        IDENTITY_HEADER: request.headers[IDENTITY_HEADER],
+        IDENTITY_HEADER: identity_header,
         REQUEST_ID_HEADER: request.headers.get(REQUEST_ID_HEADER),
     }
-    request_data = {"name": name, "description": description, "parent_id": str(parent_id)}
+    request_data = {"name": name, "description": description}
     logger.info(
         f"Identity header (post rbac workspace): {request.headers[IDENTITY_HEADER]}"
     )  # TODO: remove after testing
@@ -333,14 +282,13 @@ def post_rbac_workspace(name, parent_id, description) -> UUID | None:
     return UUID(resp_data["id"])
 
 
-def rbac_create_ungrouped_hosts_workspace(identity: Identity) -> UUID | None:
+def rbac_create_ungrouped_hosts_workspace() -> UUID | None:
     # Creates a new "ungrouped" workspace via the RBAC API, and returns its ID.
     # If not using RBAC, returns None, so the DB will automatically generate the group ID.
     if inventory_config().bypass_rbac:
         return None
     else:
-        parent_id = get_rbac_default_workspace_using_headers(to_auth_header(identity))
-        ungrouped_id = post_rbac_workspace("ungrouped", parent_id, "ungrouped workspace")
+        ungrouped_id = post_rbac_workspace("ungrouped", "ungrouped workspace")
 
         return ungrouped_id
 

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -234,8 +234,11 @@ def rbac_group_id_check(rbac_filter: dict, requested_ids: set) -> None:
 
 def _temp_add_org_admin_user_identity(identity_header: str) -> str:
     identity = from_auth_header(identity_header)
-    if inventory_config().rbac_v2_force_org_admin and hasattr(identity, "user"):
-        identity.user["is_org_admin"] = True
+    if inventory_config().rbac_v2_force_org_admin and identity.identity_type == IdentityType.USER:
+        if hasattr(identity, "user"):
+            identity.user["is_org_admin"] = True
+        else:
+            identity.user = {"is_org_admin": True}
         return to_auth_header(identity)
 
     return identity_header

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -256,15 +256,13 @@ def post_rbac_workspace_using_header(name: str, description: str, identity_heade
     request_session = Session()
     retry_config = Retry(total=inventory_config().rbac_retries, backoff_factor=1, status_forcelist=RETRY_STATUSES)
     request_session.mount(get_rbac_v2_url(endpoint=workspace_endpoint), HTTPAdapter(max_retries=retry_config))
-    identity_header = _temp_add_org_admin_user_identity(request.headers[IDENTITY_HEADER])
+    identity_header = _temp_add_org_admin_user_identity(identity_header)
     request_header = {
         IDENTITY_HEADER: identity_header,
-        REQUEST_ID_HEADER: request.headers.get(REQUEST_ID_HEADER),
+        REQUEST_ID_HEADER: threadctx.request_id,
     }
     request_data = {"name": name, "description": description}
-    logger.info(
-        f"Identity header (post rbac workspace): {request.headers[IDENTITY_HEADER]}"
-    )  # TODO: remove after testing
+    logger.info(f"Identity header (post rbac workspace): {identity_header}")  # TODO: remove after testing
 
     try:
         with outbound_http_response_time.labels("rbac").time():
@@ -306,7 +304,7 @@ def delete_rbac_workspace(workspace_id):
     request_session.mount(get_rbac_v2_url(endpoint=workspace_endpoint), HTTPAdapter(max_retries=retry_config))
     request_header = {
         IDENTITY_HEADER: request.headers[IDENTITY_HEADER],
-        REQUEST_ID_HEADER: threadctx.request_id,
+        REQUEST_ID_HEADER: request.headers.get(REQUEST_ID_HEADER),
     }
 
     try:

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -257,6 +257,8 @@ def get_rbac_default_workspace_using_headers(identity_header: str) -> UUID | Non
         REQUEST_ID_HEADER: threadctx.request_id,
     }
 
+    logger.info(f"Identity header (get default workspace): {identity_header}")  # TODO: remove after testing
+
     try:
         with outbound_http_response_time.labels("rbac").time():
             rbac_response = request_session.get(
@@ -303,6 +305,9 @@ def post_rbac_workspace(name, parent_id, description) -> UUID | None:
         REQUEST_ID_HEADER: request.headers.get(REQUEST_ID_HEADER),
     }
     request_data = {"name": name, "description": description, "parent_id": str(parent_id)}
+    logger.info(
+        f"Identity header (post rbac workspace): {request.headers[IDENTITY_HEADER]}"
+    )  # TODO: remove after testing
 
     try:
         with outbound_http_response_time.labels("rbac").time():

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -235,7 +235,7 @@ def rbac_group_id_check(rbac_filter: dict, requested_ids: set) -> None:
 # TODO: Remove this once no longer testing
 def _temp_add_org_admin_user_identity(identity_header: str) -> str:
     identity = from_auth_header(identity_header)
-    if identity.identity_type != IdentityType.USER:
+    if not hasattr(identity, "user"):
         return identity_header
     else:
         identity.user["is_org_id"] = True

--- a/logconfig.yaml
+++ b/logconfig.yaml
@@ -24,6 +24,12 @@ loggers:
   urllib3:
     level: WARNING
     propagate: true
+  UnleashClient:
+    level: WARNING
+    propagate: true
+  apscheduler.executors.default:
+    level: WARNING
+    propagate: true
 
 handlers:
   logstash:

--- a/logconfig.yaml
+++ b/logconfig.yaml
@@ -29,7 +29,7 @@ loggers:
     propagate: true
   apscheduler:
     level: WARNING
-    propagate: false
+    propagate: true
 
 handlers:
   logstash:

--- a/logconfig.yaml
+++ b/logconfig.yaml
@@ -27,9 +27,9 @@ loggers:
   UnleashClient:
     level: WARNING
     propagate: true
-  apscheduler.executors.default:
+  apscheduler:
     level: WARNING
-    propagate: true
+    propagate: false
 
 handlers:
   logstash:

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -82,8 +82,6 @@ def api_delete_all_hosts(flask_client):
 @pytest.fixture(scope="function")
 def api_create_group(flask_client, mocker):
     def _api_create_group(group_data, identity=USER_IDENTITY, query_parameters=None, extra_headers=None):
-        get_rbac_default_group_mock = mocker.patch("api.group.get_rbac_default_workspace")
-        get_rbac_default_group_mock.return_value = generate_uuid()
         create_rbac_group_mock = mocker.patch("api.group.post_rbac_workspace")
         create_rbac_group_mock.return_value = generate_uuid()
         get_rbac_ungrouped_group_mock = mocker.patch("lib.group_repository.rbac_create_ungrouped_hosts_workspace")
@@ -96,8 +94,6 @@ def api_create_group(flask_client, mocker):
 @pytest.fixture(scope="function")
 def api_create_group_kessel(flask_client, mocker):
     def _api_create_group_kessel(group_data, identity=USER_IDENTITY, query_parameters=None, extra_headers=None):
-        get_rbac_default_group_mock = mocker.patch("api.group.get_rbac_default_workspace")
-        get_rbac_default_group_mock.return_value = generate_uuid()
         get_rbac_ungrouped_group_mock = mocker.patch("lib.group_repository.rbac_create_ungrouped_hosts_workspace")
         get_rbac_ungrouped_group_mock.return_value = generate_uuid()
         return do_request(flask_client.post, GROUP_URL, identity, group_data, query_parameters, extra_headers)

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -132,6 +132,7 @@ def test_handle_message_happy_path(identity, kessel_migration, mocker, ingress_m
         assert result.host_row.canonical_facts["insights_id"] == expected_insights_id
         if kessel_migration:
             assert len(result.host_row.groups) == 1
+            assert result.host_row.groups[0]["name"] == "ungrouped"
         else:
             assert result.host_row.groups == []
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-15822](https://issues.redhat.com/browse/RHINENG-15822).
An issue arose with the original approach because it attempted to pass in the existing request headers to the RBAC call. This would not work when called from an MQ context. This PR addresses this by making it so the original headers are only used when coming from an API context; when coming from MQ, it uses the identity from the payload for the outgoing header.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
