### PR TITLE
chore: add python path

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1339,6 +1339,8 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         args: ["./jobs/create_ungrouped_host_groups.py"]
         env:
+          - name: PYTHONPATH
+            value: '/opt/app-root/src'
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -1402,6 +1404,8 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         args: ["./jobs/export_group_data_s3.py"]
         env:
+          - name: PYTHONPATH
+            value: '/opt/app-root/src'
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -1448,6 +1452,8 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         args: ["./jobs/update_hosts_last_check_in.py"]
         env:
+          - name: PYTHONPATH
+            value: '/opt/app-root/src'
           - name: HOST_UPDATE_LIMIT
             value: ${HOST_UPDATE_LIMIT}
           - name: INVENTORY_LOG_LEVEL

--- a/jobs/update_hosts_last_check_in.py
+++ b/jobs/update_hosts_last_check_in.py
@@ -23,6 +23,7 @@ LIMIT = int(os.getenv("HOST_UPDATE_LIMIT", 50000))
 
 def run(logger: Logger, session: Session, application: FlaskApp):
     with application.app.app_context():
+        logger.info("Starting update host last_check_in field job")
         num_hosts_null_last_check_in = session.query(Host).filter(Host.last_check_in is None).count()
 
         if num_hosts_null_last_check_in > 0:


### PR DESCRIPTION
# Overview

It addes `PYTHONPATH` ENV var to all jobs that are under `jobs/*` folder.
This is required because `PYTHONPATH` is not being initialized for the Clowdapp jobs.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
