### PR TITLE
fix: Fix SQL query to make job to work properly

### DIFF
--- a/jobs/update_hosts_last_check_in.py
+++ b/jobs/update_hosts_last_check_in.py
@@ -24,15 +24,15 @@ LIMIT = int(os.getenv("HOST_UPDATE_LIMIT", 50000))
 def run(logger: Logger, session: Session, application: FlaskApp):
     with application.app.app_context():
         logger.info("Starting update host last_check_in field job")
-        num_hosts_null_last_check_in = session.query(Host).filter(Host.last_check_in is None).count()
+        num_hosts_null_last_check_in = session.query(Host).filter(Host.last_check_in.is_(None)).count()
 
         if num_hosts_null_last_check_in > 0:
             logger.info(f"There are still {num_hosts_null_last_check_in} to be updated")
             logger.info(f"Updating {LIMIT} hosts' last_check_in field")
             session.execute(
                 text(
-                    "UPDATE hbi.hosts h SET last_check_in  = modified_on ",
-                    f"WHERE h.id IN (SELECT id FROM hbi.hosts sub WHERE sub.last_check_in is NULL LIMIT {LIMIT});",
+                    "UPDATE hbi.hosts h SET last_check_in  = modified_on "
+                    f"WHERE h.id IN (SELECT id FROM hbi.hosts sub WHERE sub.last_check_in is NULL LIMIT {LIMIT});"
                 )
             )
             session.commit()


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-15654](https://issues.redhat.com/browse/RHINENG-15654).

Linter complained about `Host.last_check_in == None` and suggested `Host.last_check_in is None`, but this won't with SQLAlchemy. 
`text()` method was receiving 2 parameters, and it only expect one (a string).

This is now fixed.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
