### PR TITLE
Fix: Ensure consistent string comparison for workspace ID in notification payload

### DIFF
--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -145,7 +145,7 @@ def wait_for_workspace_creation(workspace_id: str, timeout: int = 5):
         while time.time() < timeout_start + timeout:
             conn.poll()
             for notify in conn.notifies:
-                if notify.payload == workspace_id:
+                if str(notify.payload) == str(workspace_id):
                     return
 
             conn.notifies.clear()


### PR DESCRIPTION
# Overview

- The passed workspace_id is a UUID, so it needs to be cast to a string.
- `notify.payload` is already a string, so both values are cast to strings to ensure a reliable comparison.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
