### PR TITLE
Add arbitrary username to identity when not provided (in override)

### DIFF
--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -238,7 +238,7 @@ def _temp_add_org_admin_user_identity(identity_header: str) -> str:
         if hasattr(identity, "user"):
             identity.user["is_org_admin"] = True
         else:
-            identity.user = {"is_org_admin": True}
+            identity.user = {"username": "hbi-override", "is_org_admin": True}
         return to_auth_header(identity)
 
     return identity_header


### PR DESCRIPTION
# Overview

This PR is being created to address an issue with the HBI-Kessel integration. RBAC requires that user identities provide a username. So, this code updates the is_org_admin override to add an arbitrary username to the identity header.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Update the organization admin identity override to include an arbitrary username when no user identity is present

Bug Fixes:
- Ensure RBAC requirements are met by providing a username in the identity header when not originally present

Enhancements:
- Add a default username 'hbi-override' to the user identity when creating an org admin override