### PR TITLE
fix: Fix sort with invalid param when FF in enabled

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -208,9 +208,10 @@ def params_to_order_by(order_by: str | None = None, order_how: str | None = None
     elif order_by == "operating_system":
         ordering = (_order_how(Host.operating_system, order_how),) if order_how else (Host.operating_system.desc(),)  # type: ignore [attr-defined]
 
-    elif get_flag_value(FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS):
-        if order_by == "last_check_in":
-            ordering = (_order_how(Host.last_check_in, order_how),) if order_how else (Host.last_check_in.desc(),)
+    elif order_by == "last_check_in" and get_flag_value(
+        FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS
+    ):
+        ordering = (_order_how(Host.last_check_in, order_how),) if order_how else (Host.last_check_in.desc(),)
 
     elif order_by:
         if get_flag_value(FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS):

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -184,19 +184,21 @@ def test_only_order_how(mq_create_three_specific_hosts, api_get, subtests):
             assert response_status == 400
 
 
-def test_invalid_fields(mq_create_three_specific_hosts, api_get, subtests):
-    created_hosts = mq_create_three_specific_hosts
+@pytest.mark.parametrize("feature_flag", (True, False))
+def test_invalid_fields(mq_create_three_specific_hosts, api_get, subtests, feature_flag):
+    with patch("api.host_query_db.get_flag_value", return_value=feature_flag):
+        created_hosts = mq_create_three_specific_hosts
 
-    urls = (
-        HOST_URL,
-        build_hosts_url(host_list_or_id=created_hosts),
-        build_system_profile_url(host_list_or_id=created_hosts),
-    )
-    for url in urls:
-        with subtests.test(url=url):
-            fields_query_parameters = build_fields_query_parameters(fields="i_love_ketchup")
-            response_status, _ = api_get(url, query_parameters=fields_query_parameters)
-            assert response_status == 400
+        urls = (
+            HOST_URL,
+            build_hosts_url(host_list_or_id=created_hosts),
+            build_system_profile_url(host_list_or_id=created_hosts),
+        )
+        for url in urls:
+            with subtests.test(url=url):
+                fields_query_parameters = build_fields_query_parameters(fields="i_love_ketchup")
+                response_status, _ = api_get(url, query_parameters=fields_query_parameters)
+                assert response_status == 400
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17040](https://issues.redhat.com/browse/RHINENG-17040).

Fix sorting response when `hbi.create_last_check_in_update_per_reporter_staleness` feature flag is enabled.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Fix sorting logic for last check-in when the specific feature flag is enabled

Bug Fixes:
- Corrected the conditional logic for sorting hosts by last check-in when the feature flag is active

Enhancements:
- Improved the order_by parameter handling in the host query logic