### PR TITLE
bugfix(rhineng-17575): Correct ungrouped default value and migrate existing entries

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -664,7 +664,7 @@ class Group(db.Model):  # type: ignore [name-defined]
     account = db.Column(db.String(10))
     org_id = db.Column(db.String(36), nullable=False)
     name = db.Column(db.String(255), nullable=False)
-    ungrouped = db.Column(db.Boolean, default=False)
+    ungrouped = db.Column(db.Boolean, default=False, nullable=False)
     created_on = db.Column(db.DateTime(timezone=True), default=_time_now)
     modified_on = db.Column(db.DateTime(timezone=True), default=_time_now, onupdate=_time_now)
     hosts = orm.relationship("Host", secondary=f"{INVENTORY_SCHEMA}.hosts_groups")

--- a/migrations/versions/84ef628a2a99_fix_groups_ungrouped_column_default.py
+++ b/migrations/versions/84ef628a2a99_fix_groups_ungrouped_column_default.py
@@ -1,0 +1,42 @@
+"""fix groups ungrouped column default
+
+Revision ID: 84ef628a2a99
+Revises: f94ada908824
+Create Date: 2025-04-17 13:20:24.685754
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "84ef628a2a99"
+down_revision = "f94ada908824"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Update existing NULL values to False
+    op.execute("UPDATE hbi.groups SET ungrouped = FALSE WHERE ungrouped IS NULL")
+
+    # Alter column to set default and make non-nullable
+    op.alter_column(
+        table_name="groups",
+        column_name="ungrouped",
+        schema="hbi",
+        existing_type=sa.Boolean,
+        nullable=False,
+        server_default=sa.text("FALSE"),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        table_name="groups",
+        column_name="ungrouped",
+        schema="hbi",
+        existing_type=sa.Boolean,
+        nullable=True,
+        server_default=None,
+    )


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17575](https://issues.redhat.com/browse/RHINENG-17575).

* This migration updates any existing group that has a NULL for its ungrouped column to FALSE
* This migration alters the ungrouped column to default the value to FALSE and not allow NULL

# Test instructions

1. Locally create some groups in your database
2. Manually edit some of the `hbi.groups` rows to place `NULL` in the ungrouped column value
3. Use psql to get the current schema setup for the `hbi.groups` table

```
insights=# \d+ hbi.groups
                                                      Table "hbi.groups"
   Column    |           Type           | Collation | Nullable | Default | Storage  | Compression | Stats target | Description
-------------+--------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
 id          | uuid                     |           | not null |         | plain    |             |              |
 org_id      | character varying(36)    |           | not null |         | extended |             |              |
 account     | character varying(10)    |           |          |         | extended |             |              |
 name        | character varying(255)   |           | not null |         | extended |             |              |
 created_on  | timestamp with time zone |           | not null |         | plain    |             |              |
 modified_on | timestamp with time zone |           | not null |         | plain    |             |              |
 ungrouped   | boolean                  |           |          |         | plain    |             |              |
Indexes:
    "groups_pkey" PRIMARY KEY, btree (id) REPLICA IDENTITY
    "idx_groups_org_id_name_nocase" UNIQUE, btree (org_id, lower(name::text))
    "idxgrouporgid" btree (org_id)
    "idxorgidungrouped" btree (org_id, ungrouped)
Referenced by:
    TABLE "hbi.hosts_groups" CONSTRAINT "hosts_groups_group_id_fkey" FOREIGN KEY (group_id) REFERENCES hbi.groups(id)
Access method: heap
```

4. Run the migration `make upgrade_db`
5. Verify that all `NULL` values for the `ungrouped` column in `hbi.groups` have been set to `FALSE`
6. Verify that the schema has been updated to default to `FALSE` and not allow `NULL`

```
insights=# \d+ hbi.groups
                                                      Table "hbi.groups"
   Column    |           Type           | Collation | Nullable | Default | Storage  | Compression | Stats target | Description
-------------+--------------------------+-----------+----------+---------+----------+-------------+--------------+-------------
 id          | uuid                     |           | not null |         | plain    |             |              |
 org_id      | character varying(36)    |           | not null |         | extended |             |              |
 account     | character varying(10)    |           |          |         | extended |             |              |
 name        | character varying(255)   |           | not null |         | extended |             |              |
 created_on  | timestamp with time zone |           | not null |         | plain    |             |              |
 modified_on | timestamp with time zone |           | not null |         | plain    |             |              |
 ungrouped   | boolean                  |           | not null | false   | plain    |             |              |
Indexes:
    "groups_pkey" PRIMARY KEY, btree (id) REPLICA IDENTITY
    "idx_groups_org_id_name_nocase" UNIQUE, btree (org_id, lower(name::text))
    "idxgrouporgid" btree (org_id)
    "idxorgidungrouped" btree (org_id, ungrouped)
Referenced by:
    TABLE "hbi.hosts_groups" CONSTRAINT "hosts_groups_group_id_fkey" FOREIGN KEY (group_id) REFERENCES hbi.groups(id)
Access method: heap
```


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Correct the 'ungrouped' column in the groups table by setting existing NULL values to FALSE and modifying the column to have a non-nullable default of FALSE