### PR TITLE
fix(RHINENG-17628): Abort when group name in use; handle unexpected kessel responses

### DIFF
--- a/api/group_query.py
+++ b/api/group_query.py
@@ -111,7 +111,9 @@ def does_group_with_name_exist(group_name: str, org_id: str):
     Returns:
     bool: True if a group with the given name exists, False otherwise.
     """
-    return Group.query.filter(func.lower(Group.name) == func.lower(group_name), Group.org_id == org_id).count() > 0
+    return db.session.query(
+        db.exists().where(func.lower(Group.name) == func.lower(group_name), Group.org_id == org_id)
+    ).scalar()
 
 
 def get_filtered_group_list_db(group_name, page, per_page, order_by, order_how, rbac_filter, exclude_ungrouped=False):

--- a/api/group_query.py
+++ b/api/group_query.py
@@ -100,6 +100,20 @@ def get_group_list_by_id_list_db(group_id_list, page, per_page, order_by, order_
     return get_group_list_from_db(filters, page, per_page, order_by, order_how, rbac_filter)
 
 
+def does_group_with_name_exist(group_name: str, org_id: str):
+    """
+    Check if a group with the given name exists in the database.
+
+    Parameters:
+    - group_name (str): The name of the group to check.
+    - org_id (str): The ID of the organization to filter by.
+
+    Returns:
+    bool: True if a group with the given name exists, False otherwise.
+    """
+    return Group.query.filter(func.lower(Group.name) == func.lower(group_name), Group.org_id == org_id).count() > 0
+
+
 def get_filtered_group_list_db(group_name, page, per_page, order_by, order_how, rbac_filter, exclude_ungrouped=False):
     filters = (Group.org_id == get_current_identity().org_id,)
     if exclude_ungrouped:

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import partial
 from functools import wraps
 from http import HTTPStatus
+from json import JSONDecodeError
 from uuid import UUID
 
 from app_common_python import LoadedConfig
@@ -279,16 +280,18 @@ def post_rbac_workspace_using_header(name: str, description: str, identity_heade
     finally:
         request_session.close()
 
+    workspace_id = None
     try:
         resp_data = rbac_response.json()
+        workspace_id = resp_data["id"]
         logger.debug("POSTED RBAC Data", extra=resp_data)
-    except Exception as e:
+    except (JSONDecodeError, KeyError) as e:
         rbac_failure(logger, e)
         abort(503, "Failed to parse RBAC response, request cannot be fulfilled")
     finally:
         request_session.close()
 
-    return UUID(resp_data["id"])
+    return workspace_id
 
 
 def rbac_create_ungrouped_hosts_workspace(identity: Identity) -> UUID | None:

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -279,9 +279,15 @@ def post_rbac_workspace_using_header(name: str, description: str, identity_heade
     finally:
         request_session.close()
 
-    resp_data = rbac_response.json()
+    try:
+        resp_data = rbac_response.json()
+        logger.debug("POSTED RBAC Data", extra=resp_data)
+    except Exception as e:
+        rbac_failure(logger, e)
+        abort(503, "Failed to parse RBAC response, request cannot be fulfilled")
+    finally:
+        request_session.close()
 
-    logger.debug("POSTED RBAC Data", extra=resp_data)
     return UUID(resp_data["id"])
 
 

--- a/tests/test_api_groups_create.py
+++ b/tests/test_api_groups_create.py
@@ -118,6 +118,23 @@ def test_create_group_taken_name(api_create_group, new_name):
     assert group_data["name"] in response_data["detail"]
 
 
+@pytest.mark.usefixtures("event_producer")
+@pytest.mark.parametrize(
+    "new_name",
+    ["test_group", " test_group", "test_group ", " test_group "],
+)
+def test_create_group_taken_name_kessel(api_create_group, new_name, mocker):
+    group_data = {"name": "test_group", "host_ids": []}
+
+    api_create_group(group_data)
+    group_data["name"] = new_name
+    with mocker.patch("api.group.get_flag_value", return_value=True):
+        response_status, response_data = api_create_group(group_data)
+
+    assert_response_status(response_status, expected_status=400)
+    assert group_data["name"] in response_data["detail"]
+
+
 @pytest.mark.parametrize(
     "host_ids",
     [["", "3578"], ["notauuid"]],

--- a/tests/test_api_groups_create.py
+++ b/tests/test_api_groups_create.py
@@ -105,7 +105,7 @@ def test_create_group_read_only(api_create_group, mocker):
 
 @pytest.mark.parametrize(
     "new_name",
-    ["test_group", " test_group", "test_group ", " test_group "],
+    ["test_Group", " Test_Group", "test_group ", " test_group "],
 )
 def test_create_group_taken_name(api_create_group, new_name):
     group_data = {"name": "test_group", "host_ids": []}
@@ -121,7 +121,7 @@ def test_create_group_taken_name(api_create_group, new_name):
 @pytest.mark.usefixtures("event_producer")
 @pytest.mark.parametrize(
     "new_name",
-    ["test_group", " test_group", "test_group ", " test_group "],
+    ["test_Group", " Test_Group", "test_group ", " test_group "],
 )
 def test_create_group_taken_name_kessel(api_create_group, new_name, mocker):
     group_data = {"name": "test_group", "host_ids": []}


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17628](https://issues.redhat.com/browse/RHINENG-17628).

- Before attempting to create a group, checks whether a group with that name already exists (in Kessel logic path)
- Better error handling when Kessel gives us an unexpected response format

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Improve group creation process by adding name collision checks and enhancing error handling for Kessel workspace creation

Bug Fixes:
- Prevent creating groups with duplicate names by checking name existence before creation
- Add robust error handling for unexpected RBAC response formats

Enhancements:
- Implement case-insensitive group name existence check
- Add more comprehensive error logging for RBAC interactions

Tests:
- Add test cases for group creation with existing names, including variations with whitespace
- Validate error responses for group name conflicts