### PR TITLE
fix(RHINENG-17657): prevent editing and deletion of ungrouped group

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -216,11 +216,11 @@ def delete_groups(group_id_list, rbac_filter=None):
         ungrouped_group_id = str(ungrouped_group.id) if ungrouped_group else None
 
         for group_id in group_id_list:
-            if not ungrouped_group_id or ungrouped_group_id != group_id:
-                delete_rbac_workspace(group_id)
+            if ungrouped_group_id and ungrouped_group_id == group_id:
+                abort(HTTPStatus.BAD_REQUEST, f"Workspace {group_id} can not be deleted.")
 
-        if ungrouped_group_id in group_id_list:
-            abort(HTTPStatus.BAD_REQUEST, "Ungrouped workspace can not be deleted.")
+        for group_id in group_id_list:
+            delete_rbac_workspace(group_id)
 
         return Response(None, HTTPStatus.NO_CONTENT)
     else:

--- a/api/group.py
+++ b/api/group.py
@@ -213,9 +213,14 @@ def delete_groups(group_id_list, rbac_filter=None):
     if get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION):
         # Write is not allowed for the ungrouped through API requests
         ungrouped_group = get_ungrouped_group(get_current_identity())
+        ungrouped_group_id = str(ungrouped_group.id) if ungrouped_group else None
+
         for group_id in group_id_list:
-            if not getattr(ungrouped_group, "id", None) or ungrouped_group.id is not group_id:
+            if not ungrouped_group_id or ungrouped_group_id != group_id:
                 delete_rbac_workspace(group_id)
+
+        if ungrouped_group_id in group_id_list:
+            abort(HTTPStatus.BAD_REQUEST, "Ungrouped workspace can not be deleted.")
 
         return Response(None, HTTPStatus.NO_CONTENT)
     else:

--- a/app/models.py
+++ b/app/models.py
@@ -668,6 +668,8 @@ class Group(db.Model):  # type: ignore [name-defined]
 
     def patch(self, patch_data):
         logger.debug("patching group (id=%s) with data: %s", self.id, patch_data)
+        if self.ungrouped is True:
+            raise InventoryException(title="Bad Request", detail="Group information can not be edited.")
         if not patch_data:
             raise InventoryException(title="Bad Request", detail="Patch json document cannot be empty.")
 

--- a/app/models.py
+++ b/app/models.py
@@ -669,7 +669,7 @@ class Group(db.Model):  # type: ignore [name-defined]
     def patch(self, patch_data):
         logger.debug("patching group (id=%s) with data: %s", self.id, patch_data)
         if self.ungrouped is True:
-            raise InventoryException(title="Bad Request", detail="Group information can not be edited.")
+            raise InventoryException(title="Bad Request", detail="The 'ungrouped' group can not be modified.")
         if not patch_data:
             raise InventoryException(title="Bad Request", detail="Patch json document cannot be empty.")
 

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -300,6 +300,7 @@ def delete_group_list(group_id_list: list[str], identity: Identity, event_produc
     deletion_count = 0
     deleted_host_ids = []
     staleness = get_staleness_obj(identity.org_id)
+
     with session_guard(db.session):
         query = (
             select(HostGroupAssoc)

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -465,5 +465,5 @@ def get_or_create_ungrouped_hosts_group_for_identity(identity: Identity) -> Grou
 
 
 def get_ungrouped_group(identity: Identity) -> Group:
-    group = Group.query.filter(Group.org_id == identity.org_id, Group.ungrouped.is_(True)).one_or_none()
-    return group
+    ungrouped_group = Group.query.filter(Group.org_id == identity.org_id, Group.ungrouped.is_(True)).one_or_none()
+    return ungrouped_group

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -444,7 +444,7 @@ def get_group_using_host_id(host_id: str, org_id: str):
 
 
 def get_or_create_ungrouped_hosts_group_for_identity(identity: Identity) -> Group:
-    group = Group.query.filter(Group.org_id == identity.org_id, Group.ungrouped.is_(True)).one_or_none()
+    group = get_ungrouped_group(identity)
 
     # If the "ungrouped" Group exists, return it.
     if group is not None:
@@ -461,3 +461,8 @@ def get_or_create_ungrouped_hosts_group_for_identity(identity: Identity) -> Grou
         group_id=workspace_id,
         ungrouped=True,
     )
+
+
+def get_ungrouped_group(identity: Identity) -> Group:
+    group = Group.query.filter(Group.org_id == identity.org_id, Group.ungrouped.is_(True)).one_or_none()
+    return group

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -327,12 +327,12 @@ def test_attempt_delete_group_read_only(api_delete_groups, mocker):
 
 @pytest.mark.usefixtures("event_producer")
 def test_delete_non_empty_group_workspace_enabled(api_delete_groups, db_create_group_with_hosts, mocker):
-    with mocker.patch("api.group.get_flag_value", return_value=True):
-        group = db_create_group_with_hosts("non_empty_group", 3)
+    mocker.patch("api.group.get_flag_value", return_value=True)
 
-        response_status, rd = api_delete_groups([group.id])
-        print(">>>>>>>>>>>>>>>>>>>>>", rd)
-        assert_response_status(response_status, expected_status=204)
+    group = db_create_group_with_hosts("non_empty_group", 3)
+
+    response_status, rd = api_delete_groups([group.id])
+    assert_response_status(response_status, expected_status=204)
 
 
 @pytest.mark.usefixtures("event_producer")
@@ -417,16 +417,17 @@ def test_delete_hosts_from_diff_groups_post_kessel_migration(
 
     ungrouped_group_id = str(db_create_group("ungrouped", ungrouped=True).id)
 
-    with mocker.patch("lib.host_repository.get_flag_value", return_value=True):
-        hosts_to_delete = [str(group1.hosts[0].id), str(group2.hosts[0].id), str(group3.hosts[0].id)]
-        response_status, _ = api_remove_hosts_from_diff_groups(hosts_to_delete)
+    mocker.patch("lib.host_repository.get_flag_value", return_value=True)
 
-        assert_response_status(response_status, 204)
-        assert event_producer.write_event.call_count == 3
+    hosts_to_delete = [str(group1.hosts[0].id), str(group2.hosts[0].id), str(group3.hosts[0].id)]
+    response_status, _ = api_remove_hosts_from_diff_groups(hosts_to_delete)
 
-        # Check that the removed hosts were assigned to the ungrouped group
-        for host in db_get_hosts_for_group(ungrouped_group_id):
-            assert str(host.id) in hosts_to_delete
+    assert_response_status(response_status, 204)
+    assert event_producer.write_event.call_count == 3
+
+    # Check that the removed hosts were assigned to the ungrouped group
+    for host in db_get_hosts_for_group(ungrouped_group_id):
+        assert str(host.id) in hosts_to_delete
 
 
 @pytest.mark.usefixtures("enable_rbac")
@@ -448,17 +449,17 @@ def test_delete_ungrouped_group_post_kessel_migration(
     group_id = str(group.id)
     group_name = group.name
 
-    with mocker.patch("api.group.get_flag_value", return_value=True):
-        response_status, _ = api_delete_groups([group_id])
+    mocker.patch("api.group.get_flag_value", return_value=True)
+    response_status, _ = api_delete_groups([group_id])
 
-        # No group should be deleted
-        assert_response_status(response_status, 400)
+    # No group should be deleted
+    assert_response_status(response_status, 400)
 
-        # Confirm that ungrouped group was not deleted
-        retrieved_group = db_get_group_by_id(group_id)
+    # Confirm that ungrouped group was not deleted
+    retrieved_group = db_get_group_by_id(group_id)
 
-        assert retrieved_group.name == group_name
-        assert retrieved_group.ungrouped is True
+    assert retrieved_group.name == group_name
+    assert retrieved_group.ungrouped is True
 
 
 @pytest.mark.usefixtures("event_producer")

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -330,7 +330,8 @@ def test_delete_non_empty_group_workspace_enabled(api_delete_groups, db_create_g
     with mocker.patch("api.group.get_flag_value", return_value=True):
         group = db_create_group_with_hosts("non_empty_group", 3)
 
-        response_status, _ = api_delete_groups([group.id])
+        response_status, rd = api_delete_groups([group.id])
+        print(">>>>>>>>>>>>>>>>>>>>>", rd)
         assert_response_status(response_status, expected_status=204)
 
 
@@ -451,7 +452,7 @@ def test_delete_ungrouped_group_post_kessel_migration(
         response_status, _ = api_delete_groups([group_id])
 
         # No group should be deleted
-        assert_response_status(response_status, 204)
+        assert_response_status(response_status, 400)
 
         # Confirm that ungrouped group was not deleted
         retrieved_group = db_get_group_by_id(group_id)

--- a/tests/test_api_groups_update.py
+++ b/tests/test_api_groups_update.py
@@ -413,3 +413,30 @@ def test_patch_group_RBAC_post_kessel_migration(
             assert str(host.id) in original_host_id_list
 
         assert str(db_get_hosts_for_group(group_id)[0].id) == new_host_id_list[0]
+
+
+@pytest.mark.usefixtures("enable_rbac")
+def test_patch_ungrouped_name_is_denied(db_create_group, db_get_group_by_id, api_patch_group, event_producer, mocker):
+    mocker.patch.object(event_producer, "write_event")
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+    mock_rbac_response = create_mock_rbac_response(
+        "tests/helpers/rbac-mock-data/inv-groups-write-resource-defs-template.json"
+    )
+    get_rbac_permissions_mock.return_value = mock_rbac_response
+
+    # Create ungrouped group
+    group = db_create_group("ungrouped", ungrouped=True)
+    group_id = str(group.id)
+    orig_modified_on = group.modified_on
+    patch_doc = {"name": "modified_group"}
+
+    with mocker.patch("lib.host_repository.get_flag_value", return_value=True):
+        # Try to edit name of ungrouped group
+        response_status, _ = api_patch_group(group_id, patch_doc)
+        assert_response_status(response_status, 400)
+        retrieved_group = db_get_group_by_id(group_id)
+
+        assert retrieved_group.name == "ungrouped"
+        assert retrieved_group.modified_on == orig_modified_on
+
+        assert event_producer.write_event.call_count == 0

--- a/tests/test_api_groups_update.py
+++ b/tests/test_api_groups_update.py
@@ -394,25 +394,25 @@ def test_patch_group_RBAC_post_kessel_migration(
     if update_name:
         new_group_data["name"] = "new_name"
 
-    with mocker.patch("api.group.get_flag_value", return_value=True):
-        response_status, _ = api_patch_group(group_id, new_group_data)
+    mocker.patch("api.group.get_flag_value", return_value=True)
+    response_status, _ = api_patch_group(group_id, new_group_data)
 
-        # If group name was updated, it should have made a request to RBAC
-        if update_name:
-            assert patch_rbac_workspace_mock.call_args_list[0][0][0] == group_id
-            assert patch_rbac_workspace_mock.call_args_list[0][1]["name"] == "new_name"
-        else:
-            assert len(patch_rbac_workspace_mock.call_args_list) == 0
+    # If group name was updated, it should have made a request to RBAC
+    if update_name:
+        assert patch_rbac_workspace_mock.call_args_list[0][0][0] == group_id
+        assert patch_rbac_workspace_mock.call_args_list[0][1]["name"] == "new_name"
+    else:
+        assert len(patch_rbac_workspace_mock.call_args_list) == 0
 
-        assert_response_status(response_status, 200)
-        # 1 for each host (2 originals + 1 new)
-        assert event_producer.write_event.call_count == 3
+    assert_response_status(response_status, 200)
+    # 1 for each host (2 originals + 1 new)
+    assert event_producer.write_event.call_count == 3
 
-        # Check that the removed hosts were assigned to the ungrouped group
-        for host in db_get_hosts_for_group(ungrouped_group_id):
-            assert str(host.id) in original_host_id_list
+    # Check that the removed hosts were assigned to the ungrouped group
+    for host in db_get_hosts_for_group(ungrouped_group_id):
+        assert str(host.id) in original_host_id_list
 
-        assert str(db_get_hosts_for_group(group_id)[0].id) == new_host_id_list[0]
+    assert str(db_get_hosts_for_group(group_id)[0].id) == new_host_id_list[0]
 
 
 @pytest.mark.usefixtures("enable_rbac")
@@ -430,13 +430,14 @@ def test_patch_ungrouped_name_is_denied(db_create_group, db_get_group_by_id, api
     orig_modified_on = group.modified_on
     patch_doc = {"name": "modified_group"}
 
-    with mocker.patch("lib.host_repository.get_flag_value", return_value=True):
-        # Try to edit name of ungrouped group
-        response_status, _ = api_patch_group(group_id, patch_doc)
-        assert_response_status(response_status, 400)
-        retrieved_group = db_get_group_by_id(group_id)
+    mocker.patch("lib.host_repository.get_flag_value", return_value=True)
 
-        assert retrieved_group.name == "ungrouped"
-        assert retrieved_group.modified_on == orig_modified_on
+    # Try to edit name of ungrouped group
+    response_status, _ = api_patch_group(group_id, patch_doc)
+    assert_response_status(response_status, 400)
+    retrieved_group = db_get_group_by_id(group_id)
 
-        assert event_producer.write_event.call_count == 0
+    assert retrieved_group.name == "ungrouped"
+    assert retrieved_group.modified_on == orig_modified_on
+
+    assert event_producer.write_event.call_count == 0


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17657](https://issues.redhat.com/browse/RHINENG-17657).

- prevent the ungrouped group from being edited/deleted from the API
- add tests to confirm correct behavior

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Prevent editing and deletion of the ungrouped group in the inventory system

New Features:
- Add protection mechanism to prevent modifications to the ungrouped group

Bug Fixes:
- Prevent unauthorized changes to the system's default ungrouped group

Tests:
- Add test cases to verify that ungrouped group cannot be deleted
- Add test cases to verify that ungrouped group cannot be renamed or modified