### PR TITLE
fix(RHINENG-17656): Fix kessel PUT call; update test

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -182,10 +182,9 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
         if get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION):
             # Update group on Kessel
             new_group_name = validated_patch_group_data.get("name")
-            new_group_description = validated_patch_group_data.get("description")
 
-            if new_group_name or new_group_description:
-                put_rbac_workspace(group_id, name=new_group_name, description=new_group_description)
+            if new_group_name:
+                put_rbac_workspace(group_id, name=new_group_name)
 
         # Separate out the host IDs because they're not stored on the Group
         patch_group(group_to_update, validated_patch_group_data, identity, current_app.event_producer)

--- a/api/group.py
+++ b/api/group.py
@@ -185,7 +185,7 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
             new_group_description = validated_patch_group_data.get("description")
 
             if new_group_name or new_group_description:
-                put_rbac_workspace(new_group_name, new_group_description)
+                put_rbac_workspace(group_id, name=new_group_name, description=new_group_description)
 
         # Separate out the host IDs because they're not stored on the Group
         patch_group(group_to_update, validated_patch_group_data, identity, current_app.event_producer)

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -331,7 +331,7 @@ def delete_rbac_workspace(workspace_id):
         request_session.close()
 
 
-def put_rbac_workspace(workspace_id, name=None, description=None) -> None:
+def put_rbac_workspace(workspace_id: str, name: str | None = None) -> None:
     if inventory_config().bypass_rbac:
         return None
 
@@ -347,8 +347,6 @@ def put_rbac_workspace(workspace_id, name=None, description=None) -> None:
     request_data = {}
     if name is not None:
         request_data.update({"name": name})
-    if description is not None:
-        request_data.update({"description": description})
 
     try:
         with outbound_http_response_time.labels("rbac").time():

--- a/tests/test_api_groups_update.py
+++ b/tests/test_api_groups_update.py
@@ -364,7 +364,9 @@ def test_patch_group_both_add_and_remove_hosts(
 
 
 @pytest.mark.usefixtures("enable_rbac")
+@pytest.mark.parametrize("update_name", [True, False])
 def test_patch_group_RBAC_post_kessel_migration(
+    update_name,
     mocker,
     api_patch_group,
     db_create_group_with_hosts,
@@ -380,14 +382,26 @@ def test_patch_group_RBAC_post_kessel_migration(
     )
     get_rbac_permissions_mock.return_value = mock_rbac_response
 
-    group = db_create_group_with_hosts("test_group", 2)
+    put_rbac_workspace_mock = mocker.patch("api.group.put_rbac_workspace")
+
+    group = db_create_group_with_hosts("old_name", 2)
     group_id = str(group.id)
     original_host_id_list = [str(host.id) for host in group.hosts]
     new_host_id_list = [str(db_create_host().id)]
     ungrouped_group_id = str(db_create_group("ungrouped_group", ungrouped=True).id)
 
-    with mocker.patch("lib.host_repository.get_flag_value", return_value=True):
-        response_status, _ = api_patch_group(group_id, {"host_ids": new_host_id_list})
+    with mocker.patch("api.group.get_flag_value", return_value=True):
+        new_group_data = {"host_ids": new_host_id_list}
+        if update_name:
+            new_group_data["name"] = "new_name"
+        response_status, _ = api_patch_group(group_id, new_group_data)
+
+        # If new_name != old group name, it should have made a request to RBAC
+        if update_name:
+            assert put_rbac_workspace_mock.call_args_list[0][0][0] == group_id
+            assert put_rbac_workspace_mock.call_args_list[0][1]["name"] == "new_name"
+        else:
+            assert len(put_rbac_workspace_mock.call_args_list) == 0
 
         assert_response_status(response_status, 200)
         # 1 for each host (2 originals + 1 new)

--- a/tests/test_api_groups_update.py
+++ b/tests/test_api_groups_update.py
@@ -390,13 +390,14 @@ def test_patch_group_RBAC_post_kessel_migration(
     new_host_id_list = [str(db_create_host().id)]
     ungrouped_group_id = str(db_create_group("ungrouped_group", ungrouped=True).id)
 
+    new_group_data = {"host_ids": new_host_id_list}
+    if update_name:
+        new_group_data["name"] = "new_name"
+
     with mocker.patch("api.group.get_flag_value", return_value=True):
-        new_group_data = {"host_ids": new_host_id_list}
-        if update_name:
-            new_group_data["name"] = "new_name"
         response_status, _ = api_patch_group(group_id, new_group_data)
 
-        # If new_name != old group name, it should have made a request to RBAC
+        # If group name was updated, it should have made a request to RBAC
         if update_name:
             assert put_rbac_workspace_mock.call_args_list[0][0][0] == group_id
             assert put_rbac_workspace_mock.call_args_list[0][1]["name"] == "new_name"


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17656](https://issues.redhat.com/browse/RHINENG-17656).
Fixes the call to `put_rbac_workspace`, and updates the test to validate the parameters sent.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Fix and update the RBAC workspace update mechanism for group patches, ensuring correct parameters are passed when updating group names

Bug Fixes:
- Corrected the `put_rbac_workspace` call to include the group ID as the first parameter and support optional name and description updates

Enhancements:
- Added parametrized testing to cover different group update scenarios

Tests:
- Enhanced the test for group RBAC updates to validate RBAC workspace update scenarios with and without name changes