### PR TITLE
fix: sonarqube scanner execution

### DIFF
--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -8,7 +8,7 @@ fi
 COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 
 docker run \
-  -v ${PWD}:/usr/src \
+  -v "$(pwd)":/usr/src \
   -e SONAR_HOST_URL=https://sonarqube.corp.redhat.com/ \
   -e SONAR_SCANNER_HOME=/opt/sonar-scanner \
   -e SONAR_USER_HOME=/opt/sonar-scanner/.sonar \

--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -7,7 +7,9 @@ fi
 
 COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 
-sudo chown -R 1000:1000 .
+id
+
+chmod -R 755 .
 
 docker run \
   -v "$(pwd)":/usr/src \

--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -1,47 +1,21 @@
 #!/bin/bash
 
-mkdir $PWD/sonarqube/
-mkdir $PWD/sonarqube/download/
-mkdir $PWD/sonarqube/extract/
-mkdir $PWD/sonarqube/certs/
-mkdir $PWD/sonarqube/store/
-
-curl -o $PWD/sonarqube/certs/RH-IT-Root-CA.crt --insecure $ROOT_CA_CERT_URL
-
-$JAVA_HOME/bin/keytool \
-  -keystore /$PWD/sonarqube/store/RH-IT-Root-CA.keystore \
-  -import \
-  -alias RH-IT-Root-CA \
-  -file /$PWD/sonarqube/certs/RH-IT-Root-CA.crt \
-  -storepass redhat \
-  -noprompt
-
-export SONAR_SCANNER_OPTS="-Djavax.net.ssl.trustStore=$PWD/sonarqube/store/RH-IT-Root-CA.keystore -Djavax.net.ssl.trustStorePassword=redhat"
-
-
 export SONAR_SCANNER_OS="linux"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     export SONAR_SCANNER_OS="macosx"
 fi
 
-export SONAR_SCANNER_CLI_VERSION="4.7.0.2747"
-export SONAR_SCANNER_DOWNLOAD_NAME="sonar-scanner-cli-$SONAR_SCANNER_CLI_VERSION-$SONAR_SCANNER_OS"
-export SONAR_SCANNER_NAME="sonar-scanner-$SONAR_SCANNER_CLI_VERSION-$SONAR_SCANNER_OS"
-
-curl -o $PWD/sonarqube/download/$SONAR_SCANNER_DOWNLOAD_NAME.zip --insecure $SONARQUBE_CLI_URL
-
-unzip -d $PWD/sonarqube/extract/ $PWD/sonarqube/download/$SONAR_SCANNER_DOWNLOAD_NAME.zip
-
-export PATH="$PWD/sonarqube/extract/$SONAR_SCANNER_NAME/bin:$PATH"
-
 COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 
-sonar-scanner \
-  -Dsonar.projectKey=console.redhat.com:insights-host-inventory \
-  -Dsonar.sources=$PWD \
-  -Dsonar.host.url=$SONARQUBE_REPORT_URL \
-  -Dsonar.projectVersion=$COMMIT_SHORT \
-  -Dsonar.login=$SONARQUBE_TOKEN
+docker run \
+  -v ${PWD}:/usr/src \
+  -e SONAR_HOST_URL=https://sonarqube.corp.redhat.com/ \
+  -e SONAR_SCANNER_HOME=/opt/sonar-scanner \
+  -e SONAR_USER_HOME=/opt/sonar-scanner/.sonar \
+  -e SONAR_SCANNER_OPTS="-Xmx512m -Dsonar.projectKey=console.redhat.com:insights-host-inventory -Dsonar.projectVersion=${COMMIT_SHORT} -Dsonar.sources=/usr/src" \
+  -e SONAR_TOKEN=$SONARQUBE_TOKEN \
+  images.paas.redhat.com/alm/sonar-scanner-alpine \
+  sonar-scanner
 
 mkdir -p $WORKSPACE/artifacts
 cat << EOF > ${WORKSPACE}/artifacts/junit-dummy.xml

--- a/sonarqube.sh
+++ b/sonarqube.sh
@@ -7,6 +7,8 @@ fi
 
 COMMIT_SHORT=$(git rev-parse --short=7 HEAD)
 
+sudo chown -R 1000:1000 .
+
 docker run \
   -v "$(pwd)":/usr/src \
   -e SONAR_HOST_URL=https://sonarqube.corp.redhat.com/ \


### PR DESCRIPTION
# Overview

This PR is an attempt to fix the sonarqube scanner script as part of the PR check job.

Currently the script fails to execute because sonar is not available on the node that runs the PR check job.

`18:18:41 ./sonarqube.sh: line 40: sonar-scanner: command not found`

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Update the SonarQube scanner script to execute within a Docker container, resolving issues where the scanner command was previously unavailable on the CI node.

CI:
- Modify `sonarqube.sh` to run the SonarQube scanner using a pre-built Docker image.
- Remove manual download, extraction, and path configuration for the Sonar Scanner CLI.
- Remove manual download and configuration of the CA certificate for SonarQube.