### PR TITLE
RHINENG-17234: Remove group name uniqueness restriction

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -632,7 +632,6 @@ class Group(db.Model):  # type: ignore [name-defined]
     __tablename__ = "groups"
     __table_args__ = (
         Index("idxgrouporgid", "org_id"),
-        Index("idx_groups_org_id_name_nocase", "org_id", text("lower(name)"), unique=True),
         Index("idxorgidungrouped", "org_id", "ungrouped"),
         {"schema": INVENTORY_SCHEMA},
     )

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -7,3 +7,4 @@
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
+script_location=./migrations

--- a/migrations/versions/f6c43a920347_remove_name_uniqueness_restrictions.py
+++ b/migrations/versions/f6c43a920347_remove_name_uniqueness_restrictions.py
@@ -20,4 +20,4 @@ def upgrade():
 
 
 def downgrade():
-    pass
+    op.create_index("idx_groups_org_id_name_nocase", "groups", ["name", "org_id"], if_not_exists=True, schema="hbi")

--- a/migrations/versions/f6c43a920347_remove_name_uniqueness_restrictions.py
+++ b/migrations/versions/f6c43a920347_remove_name_uniqueness_restrictions.py
@@ -1,0 +1,23 @@
+"""remove name uniqueness restrictions
+
+Revision ID: f6c43a920347
+Revises: bfc9f9c35c66
+Create Date: 2025-05-01 17:30:29.838183
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f6c43a920347"
+down_revision = "bfc9f9c35c66"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index("idx_groups_org_id_name_nocase", table_name="groups", if_exists=True, schema="hbi")
+
+
+def downgrade():
+    pass

--- a/tests/test_api_groups_create.py
+++ b/tests/test_api_groups_create.py
@@ -105,17 +105,17 @@ def test_create_group_read_only(api_create_group, mocker):
 
 @pytest.mark.parametrize(
     "new_name",
-    ["test_Group", " Test_Group", "test_group ", " test_group "],
+    ["test_Group", "Test_Group", "test_group", "test_group"],
 )
-def test_create_group_taken_name(api_create_group, new_name):
+def test_create_group_reuse_name(api_create_group, new_name):
     group_data = {"name": "test_group", "host_ids": []}
 
     api_create_group(group_data)
     group_data["name"] = new_name
     response_status, response_data = api_create_group(group_data)
 
-    assert_response_status(response_status, expected_status=400)
-    assert group_data["name"] in response_data["detail"]
+    assert_response_status(response_status, expected_status=201)
+    assert group_data["name"] in response_data["name"]
 
 
 @pytest.mark.usefixtures("event_producer")

--- a/tests/test_api_groups_update.py
+++ b/tests/test_api_groups_update.py
@@ -147,10 +147,9 @@ def test_patch_group_existing_name_same_org(db_create_group, api_patch_group, pa
 
     response_status, response_body = api_patch_group(new_id, {"name": patch_name})
 
-    # There's already a group with that name (case-insensitive), so we should get an HTTP 400.
-    # Make sure the group name is mentioned in the response.
-    assert_response_status(response_status, 400)
-    assert patch_name in response_body["detail"]
+    # change the group name to an existing name
+    assert_response_status(response_status, 200)
+    assert patch_name in response_body["name"]
 
 
 def test_patch_group_hosts_from_different_group(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 import pytest
 from marshmallow import ValidationError as MarshmallowValidationError
 from sqlalchemy.exc import DataError
-from sqlalchemy.exc import IntegrityError
 
 from api.host_query import staleness_timestamps
 from app.exceptions import ValidationException
@@ -1223,11 +1222,10 @@ def test_create_group_existing_name_diff_org(db_create_group, db_get_group_by_id
 
 
 def test_create_group_existing_name_same_org(db_create_group):
-    # Make sure we can't create two groups with the same name in the same org
+    # Make sure a duplicate host with the same name can be created
     group_name = "TestGroup"
     db_create_group(group_name)
-    with pytest.raises(IntegrityError):
-        db_create_group(group_name)
+    assert db_create_group(group_name)
 
 
 def test_add_delete_host_group_happy(


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17234](https://issues.redhat.com/browse/RHINENG-17234).
It:
1. removes the index name "idx_groups_org_id_name_nocase", which forces uniqueness
2. refactors the code that enforce group name uniqueness
3. updates tests allowing the creation of multiple groups with the same group name.


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
