### PR TITLE
fix(RHINENG-17879): modified_on won't change after _update_staleness_timestamp() is called

### DIFF
--- a/api/staleness.py
+++ b/api/staleness.py
@@ -81,8 +81,9 @@ def receive_before_host_update(mapper: Mapper, connection: Connection, host: Hos
     :param host: The Host object being updated.
     """
     host_details = sa.inspect(host)
-    flag_changed, _, _ = host_details.attrs.per_reporter_staleness.history
-    if flag_changed:
+    prs_changed, _, _ = host_details.attrs.per_reporter_staleness.history
+    staleness_changed, _, _ = host_details.attrs.deletion_timestamp.history
+    if prs_changed or staleness_changed:
         orm.attributes.flag_modified(host, "modified_on")
 
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17879](https://issues.redhat.com/browse/RHINENG-17879).
`modified_on` won't change/update when staleness columns are updated after a change to the custom stalenss

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Fix the behavior of `modified_on` timestamp when updating staleness columns to ensure it only changes when necessary

Bug Fixes:
- Prevent `modified_on` from updating when only staleness-related columns are changed

Tests:
- Add a new test case to verify that `modified_on` remains unchanged when updating staleness timestamps