### PR TITLE
chore(RHINENG-17825) Migration to update "ungrouped" in host.groups field

### DIFF
--- a/migrations/versions/002843d515cb_add_ungrouped_field_to_host_data.py
+++ b/migrations/versions/002843d515cb_add_ungrouped_field_to_host_data.py
@@ -1,0 +1,58 @@
+"""add ungrouped field to host data
+
+Revision ID: 002843d515cb
+Revises: bfc9f9c35c66
+Create Date: 2025-05-06 08:48:49.266181
+
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "002843d515cb"
+down_revision = "bfc9f9c35c66"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # For each record in the Host table, update the "groups" column.
+    # If the group in that JSONB column does not have the "ungrouped" field,
+    # add `"ungrouped": false`.
+    conn = op.get_bind()
+    while True:
+        result = conn.execute(
+            text(
+                """
+                WITH batch AS (
+                    SELECT id
+                    FROM hbi.hosts
+                    WHERE jsonb_array_length(groups) > 0 AND NOT groups->0 ? 'ungrouped'
+                    LIMIT 1000
+                    FOR UPDATE
+                )
+                UPDATE hbi.hosts
+                SET groups = (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN NOT (group_obj ? 'ungrouped')
+                            THEN group_obj || '{"ungrouped": false}'
+                            ELSE group_obj
+                        END
+                    )
+                    FROM jsonb_array_elements(hosts.groups) AS group_obj
+                )
+                FROM batch
+                WHERE hosts.id = batch.id
+                RETURNING hosts.id
+                """
+            )
+        )
+        updated = result.rowcount
+        if updated == 0:
+            break
+
+
+def downgrade():
+    pass  # No point in removing the field once it's there


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17825](https://issues.redhat.com/browse/RHINENG-17825).
Adds a DB migration to populate the hosts.groups data to contain the "ungrouped" field, if the host is in a group. It already exists on some hosts, since it gets added when a host is added to a group. It needs to be on all hosts, though, so this migration takes care of that.

Note that this migration runs in batches of 1000, so that it doesn't lock the entire hosts table at once. This should reduce the impact of DB locking on the table.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [x] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add a database migration to ensure all hosts with groups have an "ungrouped" field in their group data

New Features:
- Adds a migration to populate 'ungrouped' field for hosts with groups

Chores:
- Implemented batch processing to minimize database locking