### PR TITLE
feat(log): Add Edge request to HBI logs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -45,6 +45,7 @@ from lib.handlers import register_shutdown
 logger = get_logger(__name__)
 
 IDENTITY_HEADER = "x-rh-identity"
+EDGE_REQUEST_ID_HEADER = "x-rh-edge-request-id"
 REQUEST_ID_HEADER = "x-rh-insights-request-id"
 
 SPECIFICATION_FILE = join(SPECIFICATION_DIR, "openapi.json")
@@ -316,6 +317,7 @@ def create_app(runtime_environment):
     @flask_app.before_request
     def set_request_id():
         threadctx.request_id = request.headers.get(REQUEST_ID_HEADER)
+        threadctx.edge_request_id = request.headers.get(EDGE_REQUEST_ID_HEADER)
 
     @flask_app.after_request
     def after_request_org_check(response):

--- a/app/logging.py
+++ b/app/logging.py
@@ -98,17 +98,12 @@ class ContextualFilter(logging.Filter):
     def filter(self, log_record):
         try:
             log_record.request_id = threadctx.request_id
+            log_record.edge_request_id = threadctx.edge_request_id
         except Exception:
             # TODO: need to decide what to do when you log outside the context
             # of a request
             log_record.request_id = None
-
-        try:
-            log_record.account_number = threadctx.account_number
-        except Exception:
-            # TODO: need to decide what to do when you log outside the context
-            # of a request
-            log_record.account_number = None
+            log_record.edge_request_id = None
 
         try:
             log_record.org_id = threadctx.org_id


### PR DESCRIPTION
# Overview

This is to get the request id that is matching the gateway log.

<img width="1226" alt="Snímek obrazovky 2025-05-07 v 16 39 41" src="https://github.com/user-attachments/assets/8cf716c6-39d4-44b3-9e0c-c61a0b274e6f" />

## Summary by Sourcery

Add support for capturing Edge request ID in application logging

New Features:
- Capture Edge request ID from incoming HTTP headers
- Add Edge request ID to logging context

Enhancements:
- Modify logging filter to include Edge request ID in log records
- Remove unused account number logging