### PR TITLE
fix(RHINENG-17925): Workspace MQ error handling

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -12,6 +12,7 @@ from flask.app import Flask
 from marshmallow import Schema
 from marshmallow import ValidationError
 from marshmallow import fields
+from psycopg2.errors import UniqueViolation
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.exc import OperationalError
@@ -196,7 +197,7 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
                 db.session.commit()
                 logger.info(f"Created group with ID {str(group.id)}")
                 _pg_notify_workspace(operation, str(group.id))
-            except IntegrityError:
+            except (IntegrityError, UniqueViolation):
                 db.session.rollback()
                 logger.warning(f"Group with ID {workspace['id']} already exists; skipping creation.")
 

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -13,6 +13,7 @@ from marshmallow import Schema
 from marshmallow import ValidationError
 from marshmallow import fields
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.exc import StaleDataError
 
@@ -185,15 +186,20 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
         logger.info(f"Received {operation} message for workspace ID {workspace['id']}")
 
         if operation == "create":
-            group = group_repository.add_group(
-                group_name=workspace["name"],
-                org_id=org_id,
-                group_id=workspace["id"],
-                ungrouped=(validated_operation_msg["workspace"]["type"] == "ungrouped-hosts"),
-            )
-            db.session.commit()
-            logger.info(f"Created group with ID {str(group.id)}")
-            _pg_notify_workspace(operation, str(group.id))
+            try:
+                group = group_repository.add_group(
+                    group_name=workspace["name"],
+                    org_id=org_id,
+                    group_id=workspace["id"],
+                    ungrouped=(validated_operation_msg["workspace"]["type"] == "ungrouped-hosts"),
+                )
+                db.session.commit()
+                logger.info(f"Created group with ID {str(group.id)}")
+                _pg_notify_workspace(operation, str(group.id))
+            except IntegrityError:
+                db.session.rollback()
+                logger.warning(f"Group with ID {workspace['id']} already exists; skipping creation.")
+
         elif operation == "update":
             group_to_update = group_repository.get_group_by_id_from_db(str(workspace["id"]), org_id)
             group_repository.patch_group(
@@ -204,6 +210,7 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
             )
             db.session.commit()
             logger.info(f"Updated group with ID {workspace['id']}")
+
         elif operation == "delete":
             num_deleted = group_repository.delete_group_list(
                 group_id_list=[str(workspace["id"])],

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -197,9 +197,9 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
                 db.session.commit()
                 logger.info(f"Created group with ID {str(group.id)}")
                 _pg_notify_workspace(operation, str(group.id))
-            except (IntegrityError, UniqueViolation):
+            except (IntegrityError, UniqueViolation) as err:
                 db.session.rollback()
-                logger.warning(f"Group with ID {workspace['id']} already exists; skipping creation.")
+                logger.warning(f"Group with ID {workspace['id']} already exists; skipping creation", exc_info=err)
 
         elif operation == "update":
             group_to_update = group_repository.get_group_by_id_from_db(str(workspace["id"]), org_id)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17925](https://issues.redhat.com/browse/RHINENG-17925).
It catches errors that can be raised when duplicate IDs are detected (`sqlalchemy.exc.IntegrityError`, `psycopg2.errors.UniqueViolation`). When this happens, it rolls back the transaction and logs a warning.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Improve error handling for workspace creation in the message queue service to gracefully handle duplicate group ID scenarios

Bug Fixes:
- Handle duplicate group ID creation by catching IntegrityError and UniqueViolation exceptions
- Prevent duplicate group creation by rolling back the transaction and logging a warning

Enhancements:
- Implement robust error handling for workspace message queue creation process

Tests:
- Add test case to verify behavior when attempting to create a group with an existing ID
- Ensure original group details are preserved when duplicate creation is attempted