### PR TITLE
ci: Fix env var name in automerge.yaml

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -23,4 +23,4 @@ jobs:
           gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.AUTOMERGE_PAT}}
+          GH_TOKEN: ${{secrets.AUTOMERGE_PAT}}


### PR DESCRIPTION
GITHUB_TOKEN needs to be GH_TOKEN