### PR TITLE
feat(RHINENG-18027) Add workspace_type filter, adjust resource_types behavior

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -61,10 +61,13 @@ def get_group_list(
     per_page=100,
     order_by=None,
     order_how=None,
+    workspace_type=None,
     rbac_filter=None,
 ):
     try:
-        group_list, total = get_filtered_group_list_db(name, page, per_page, order_by, order_how, rbac_filter)
+        group_list, total = get_filtered_group_list_db(
+            name, page, per_page, order_by, order_how, rbac_filter, workspace_type
+        )
     except ValueError as e:
         log_get_group_list_failed(logger)
         abort(400, str(e))

--- a/api/group_query.py
+++ b/api/group_query.py
@@ -48,6 +48,11 @@ GROUPS_ORDER_BY_MAPPING = {
 
 GROUPS_ORDER_HOW_MAPPING = {"asc": asc, "desc": desc, "name": asc, "host_count": desc, "updated": desc}
 
+WORKSPACE_TYPE_MAPPING = {
+    "standard": Group.ungrouped.is_(False),
+    "ungrouped": Group.ungrouped.is_(True),
+}
+
 __all__ = (
     "build_paginated_group_list_response",
     "build_group_response",
@@ -116,10 +121,10 @@ def does_group_with_name_exist(group_name: str, org_id: str):
     ).scalar()
 
 
-def get_filtered_group_list_db(group_name, page, per_page, order_by, order_how, rbac_filter, exclude_ungrouped=False):
+def get_filtered_group_list_db(group_name, page, per_page, order_by, order_how, rbac_filter, workspace_type=None):
     filters = (Group.org_id == get_current_identity().org_id,)
-    if exclude_ungrouped:
-        filters += (Group.ungrouped.is_(False),)
+    if (type_filter := WORKSPACE_TYPE_MAPPING.get(workspace_type)) is not None:
+        filters += (type_filter,)
     if group_name:
         filters += (func.lower(Group.name).contains(func.lower(group_name)),)
     return get_group_list_from_db(filters, page, per_page, order_by, order_how, rbac_filter)

--- a/api/resource_type.py
+++ b/api/resource_type.py
@@ -15,8 +15,6 @@ from app.instrumentation import log_get_resource_type_list_failed
 from app.instrumentation import log_get_resource_type_list_succeeded
 from app.logging import get_logger
 from app.serialization import serialize_group
-from lib.feature_flags import FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION
-from lib.feature_flags import get_flag_value
 from lib.middleware import rbac
 
 logger = get_logger(__name__)
@@ -60,7 +58,7 @@ def get_resource_type_groups_list(
             order_by,
             order_how,
             rbac_filter,
-            get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION),
+            "standard",
         )
     except ValueError as e:
         log_get_group_list_failed(logger)

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -400,6 +400,7 @@ paths:
         - $ref: '#/components/parameters/pageParam'
         - $ref: '#/components/parameters/groupOrderByParam'
         - $ref: '#/components/parameters/groupOrderHowParam'
+        - $ref: '#/components/parameters/workspaceTypeParam'
       responses:
         '200':
           description: Successfully read the groups list.
@@ -1100,6 +1101,19 @@ components:
       description: >-
         Direction of the ordering (case-insensitive); defaults to ASC for name, and to DESC
         for host_count
+    workspaceTypeParam:
+      in: query
+      name: workspace_type
+      required: false
+      schema:
+        type: string
+        default: all
+        enum:
+          - standard
+          - ungrouped
+          - all
+      description: >-
+        The type of workspaces that should be returned.
     stalenessParam:
       name: staleness
       in: query

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -683,6 +683,9 @@
           },
           {
             "$ref": "#/components/parameters/groupOrderHowParam"
+          },
+          {
+            "$ref": "#/components/parameters/workspaceTypeParam"
           }
         ],
         "responses": {
@@ -1783,6 +1786,21 @@
           "$ref": "#/components/schemas/OrderHow"
         },
         "description": "Direction of the ordering (case-insensitive); defaults to ASC for name, and to DESC for host_count"
+      },
+      "workspaceTypeParam": {
+        "in": "query",
+        "name": "workspace_type",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "default": "all",
+          "enum": [
+            "standard",
+            "ungrouped",
+            "all"
+          ]
+        },
+        "description": "The type of workspaces that should be returned."
       },
       "stalenessParam": {
         "name": "staleness",

--- a/tests/test_api_groups_get.py
+++ b/tests/test_api_groups_get.py
@@ -20,6 +20,23 @@ def test_basic_group_query(db_create_group, api_get):
         assert group_result["id"] in group_id_list
 
 
+@pytest.mark.parametrize("workspace_type, expected_groups", (("standard", 2), ("ungrouped", 1), ("all", 3)))
+def test_group_query_type_filter(db_create_group, api_get, workspace_type, expected_groups):
+    group_id_list_dict = {
+        "standard": [str(db_create_group(f"testGroup_{idx}").id) for idx in range(2)],
+        "ungrouped": [str(db_create_group("ungroupedTest", ungrouped=True).id)],
+    }
+
+    response_status, response_data = api_get(build_groups_url(query=f"?workspace_type={workspace_type}"))
+
+    assert_response_status(response_status, 200)
+    assert response_data["total"] == expected_groups
+    assert response_data["count"] == expected_groups
+    if workspace_type != "all":
+        for group_result in response_data["results"]:
+            assert group_result["id"] in group_id_list_dict[workspace_type]
+
+
 @pytest.mark.usefixtures("enable_rbac")
 def test_get_groups_RBAC_denied(subtests, mocker, api_get):
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")

--- a/tests/test_api_resource_types_get.py
+++ b/tests/test_api_resource_types_get.py
@@ -131,9 +131,8 @@ def test_get_resource_types_ungrouped_is_not_returned(
     db_create_group("ungrouped_group", ungrouped=True)  # should not be returned
     group_id = str(group.id)
 
-    with mocker.patch("api.resource_type.get_flag_value", return_value=True):
-        response_status, response_data = api_get(build_resource_types_groups_url())
+    response_status, response_data = api_get(build_resource_types_groups_url())
 
-        assert_response_status(response_status, 200)
-        assert response_data["meta"]["count"] == 1
-        assert response_data["data"][0]["id"] == group_id
+    assert_response_status(response_status, 200)
+    assert response_data["meta"]["count"] == 1
+    assert response_data["data"][0]["id"] == group_id


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18027](https://issues.redhat.com/browse/RHINENG-18027).

- Adds the `workspace_type` param to the `GET /groups` endpoint. This param allows users to filter workspaces using the values "standard", "ungrouped", and "all".
- Makes it so the `GET /resource-types/inventory-groups` endpoint excludes Ungrouped groups, both pre- and post-migration (requested in yesterday's HBI+RBAC working session).
- Adds a test, and modifies the `GET /resource-types/inventory-groups` test to exclude the Ungrouped group regardless of the feature flag value.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add workspace_type filtering to group listings, enforce exclusion of ungrouped groups in resource‐types inventory‐groups, and update related tests and API documentation.

New Features:
- Introduce a workspace_type query parameter on GET /groups to filter by standard, ungrouped, or all workspaces.

Enhancements:
- Refactor group listing logic to apply workspace_type filters and replace the exclude_ungrouped flag.
- Always exclude ungrouped groups in the inventory‐groups endpoint by removing the migration feature‐flag check and defaulting to standard.
- Remove obsolete feature‐flag imports related to workspace migration.

Documentation:
- Extend the OpenAPI spec to define and include the workspace_type query parameter for the GET /groups endpoint.

Tests:
- Add parameterized tests for workspace_type filtering in the groups endpoint.
- Update resource‐types inventory‐groups tests to verify ungrouped groups are excluded without needing a feature flag.