### PR TITLE
feat(rhineng-15712): Migration to add insights_id column for replica identity

### DIFF
--- a/inv_publish_hosts.py
+++ b/inv_publish_hosts.py
@@ -37,7 +37,7 @@ groups,tags_alt,last_check_in,stale_warning_timestamp,deletion_timestamp"
 CHECK_PUBLICATION = f"SELECT EXISTS(SELECT * FROM pg_catalog.pg_publication WHERE pubname = '{PUBLICATION_NAME}')"
 CREATE_PUBLICATION = f"CREATE PUBLICATION {PUBLICATION_NAME} FOR TABLE hbi.hosts ({PUBLICATION_COLUMNS})"
 CHECK_REPLICATION_SLOTS = "SELECT slot_name, active FROM pg_replication_slots"
-DROP_PUBLICATIONS = ["hbi_hosts_pub"]
+DROP_PUBLICATIONS = ["hbi_hosts_pub_v1_0_0"]
 DROP_PUBLICATION = "DROP PUBLICATION IF EXISTS "
 
 

--- a/migrations/versions/1d2ef4ad13e8_add_insights_id_column.py
+++ b/migrations/versions/1d2ef4ad13e8_add_insights_id_column.py
@@ -1,0 +1,68 @@
+"""Add index for replica identity with pk and insights_id and org_id
+
+Revision ID: 1d2ef4ad13e8
+Revises: 002843d515cb
+Create Date: 2025-05-12 10:38:12.056799
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "1d2ef4ad13e8"
+down_revision = "002843d515cb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add the insights_id column as UUID, non-nullable, with default
+    op.add_column(
+        "hosts",
+        sa.Column(
+            "insights_id", UUID(as_uuid=False), nullable=False, server_default="00000000-0000-0000-0000-000000000000"
+        ),
+        schema="hbi",
+    )
+
+    # Update insights_id for records where system_profile_facts->>'host_type' = 'edge'
+    op.execute("""
+        UPDATE hbi.hosts
+        SET insights_id = (canonical_facts->>'insights_id')::uuid
+        WHERE canonical_facts->>'insights_id' IS NOT NULL
+          AND system_profile_facts->>'host_type' = 'edge'
+    """)
+
+    # Create the trigger function to sync insights_id
+    op.execute("""
+        CREATE OR REPLACE FUNCTION hbi.sync_insights_id()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            NEW.insights_id = COALESCE(
+                (NEW.canonical_facts->>'insights_id')::uuid,
+                '00000000-0000-0000-0000-000000000000'
+            );
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+    """)
+
+    # Create the trigger
+    op.execute("""
+        CREATE TRIGGER trigger_sync_insights_id
+        BEFORE INSERT OR UPDATE ON hbi.hosts
+        FOR EACH ROW EXECUTE FUNCTION hbi.sync_insights_id()
+    """)
+
+
+def downgrade():
+    # Drop the trigger
+    op.execute("DROP TRIGGER IF EXISTS trigger_sync_insights_id ON hbi.hosts")
+
+    # Drop the trigger function
+    op.execute("DROP FUNCTION IF EXISTS hbi.sync_insights_id")
+
+    # Drop the insights_id column
+    op.drop_column("hosts", "insights_id", schema="hbi")


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-15712](https://issues.redhat.com/browse/RHINENG-15712).
* Migration to add insights_id column
* Migration to add function to populate insights_id column
* Migration to add trigger to run function on insert/update

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add insights_id tracking to hosts and switch the replica identity to a new index

New Features:
- Introduce insights_id column to hosts table with a non-null default UUID
- Create a concurrent unique index on (id, insights_id, org_id) and set it as the table’s replica identity

Enhancements:
- Populate existing hosts’ insights_id for records with non-null canonical_facts during migration

## Summary by Sourcery

Migrate the hosts table to support a new replica identity by adding an insights_id column, backfilling existing records, setting up a sync trigger, and creating a unique composite index.

New Features:
- Add insights_id UUID column to hbi.hosts with a non-null default
- Create a trigger and trigger function to sync insights_id from canonical_facts on insert and update

Enhancements:
- Backfill insights_id for existing hosts with non-null canonical_facts insights_id where host_type is 'edge'