### PR TITLE
fix(RHINENG-13683): Correctly process multiple messages for the same host in the same MQ batch

### DIFF
--- a/api/staleness_query.py
+++ b/api/staleness_query.py
@@ -2,13 +2,14 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app.logging import get_logger
 from app.models import Staleness
+from app.staleness_serialization import AttrDict
 from app.staleness_serialization import build_serialized_acc_staleness_obj
 from app.staleness_serialization import build_staleness_sys_default
 
 logger = get_logger(__name__)
 
 
-def get_staleness_obj(org_id):
+def get_staleness_obj(org_id: str) -> AttrDict:
     try:
         staleness = Staleness.query.filter(Staleness.org_id == org_id).one()
         logger.info("Using custom account staleness")

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -230,7 +230,7 @@ def process_system_profile_spec():
         return process_spec(yaml.safe_load(fp)["$defs"]["SystemProfile"]["properties"])
 
 
-def create_app(runtime_environment):
+def create_app(runtime_environment) -> connexion.FlaskApp:
     # This feels like a hack but it is needed.  The logging configuration
     # needs to be setup before the flask app is initialized.
     configure_logging()

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -177,7 +177,7 @@ class ServiceAccountIdentitySchema(IdentityBaseSchema):
 
 # Messages from the system_profile topic don't need to provide a real Identity,
 # So this helper function creates a basic User-type identity from the host data.
-def create_mock_identity_with_org_id(org_id):
+def create_mock_identity_with_org_id(org_id: str) -> Identity:
     return Identity(
         {
             "org_id": org_id,

--- a/app/queue/events.py
+++ b/app/queue/events.py
@@ -148,5 +148,5 @@ def build_event(event_type, host, **kwargs):
         return result
 
 
-def operation_results_to_event_type(results):
+def operation_results_to_event_type(results) -> EventType:
     return EventType[results.name]

--- a/app/queue/mq_common.py
+++ b/app/queue/mq_common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 from app.logging import get_logger
@@ -7,7 +9,7 @@ logger = get_logger(__name__)
 
 
 @metrics.common_message_parsing_time.time()
-def common_message_parser(message):
+def common_message_parser(message: str | bytes):
     try:
         # Due to RHCLOUD-3610 we're receiving messages with invalid unicode code points (invalid surrogate pairs)
         # Python pretty much ignores that but it is not possible to store such strings in the database (db INSERTS

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any
+from typing import Callable
 from uuid import UUID
 
 from flask import current_app
+from flask_sqlalchemy.query import Query
 from sqlalchemy import and_
 from sqlalchemy import not_
 from sqlalchemy import or_
+from sqlalchemy.sql.elements import BinaryExpression
+from sqlalchemy.sql.elements import BooleanClauseList
 
 from api.filtering.db_filters import find_stale_host_in_window
 from api.filtering.db_filters import stale_timestamp_filter
@@ -21,6 +26,7 @@ from app.logging import get_logger
 from app.models import Group
 from app.models import Host
 from app.models import HostGroupAssoc
+from app.models import LimitedHost
 from app.serialization import serialize_staleness_to_dict
 from app.staleness_serialization import get_sys_default_staleness
 from lib import metrics
@@ -28,8 +34,8 @@ from lib.feature_flags import FLAG_INVENTORY_DEDUPLICATION_ELEVATE_SUBMAN_ID
 from lib.feature_flags import get_flag_value
 
 __all__ = (
+    "AddHostResult",
     "add_host",
-    "single_canonical_fact_host_query",
     "multiple_canonical_facts_host_query",
     "create_new_host",
     "find_existing_host",
@@ -59,7 +65,11 @@ logger = get_logger(__name__)
 
 
 def add_host(
-    input_host: Host, identity: Identity, update_system_profile: bool = True, operation_args: dict | None = None
+    input_host: Host,
+    identity: Identity,
+    update_system_profile: bool = True,
+    operation_args: dict | None = None,
+    existing_hosts: list[Host] | None = None,
 ) -> tuple[Host, AddHostResult]:
     """
     Add or update a host
@@ -67,32 +77,44 @@ def add_host(
     Required parameters:
      - at least one of the canonical facts fields is required
      - org_id
+
+     The only supported argument in the operation_args for now is "defer_to_reporter".
+     It is documented here:
+     https://inscope.corp.redhat.com/docs/default/Component/consoledot-pages/services/inventory/#expected-message-format
     """
     if operation_args is None:
         operation_args = {}
-    existing_host = find_existing_host(identity, input_host.canonical_facts)
-    if existing_host:
+
+    matched_host = None
+    if existing_hosts:
+        # First, try to match the host in memory - from the provided list of existing hosts
+        matched_host = find_existing_host(identity, input_host.canonical_facts, existing_hosts)
+    if matched_host is None:
+        # If the list of existing hosts was not provided, or the match was not found, try querying DB
+        matched_host = find_existing_host(identity, input_host.canonical_facts)
+
+    if matched_host:
         defer_to_reporter = operation_args.get("defer_to_reporter", None)
         if defer_to_reporter is not None:
             logger.debug("host_repository.add_host: defer_to_reporter = %s", defer_to_reporter)
-            if not existing_host.reporter_stale(defer_to_reporter):
+            if not matched_host.reporter_stale(defer_to_reporter):
                 logger.debug("host_repository.add_host: setting update_system_profile = False")
                 update_system_profile = False
 
-        return update_existing_host(existing_host, input_host, update_system_profile)
+        return update_existing_host(matched_host, input_host, update_system_profile)
     else:
         return create_new_host(input_host)
 
 
 @metrics.host_dedup_processing_time.time()
-def find_existing_host(identity: Identity, canonical_facts: dict) -> Host | None:
-    logger.debug("find_existing_host(%s, %s)", identity, canonical_facts)
-    existing_host = _find_host_by_elevated_ids(identity, canonical_facts)
+def find_existing_host(identity: Identity, canonical_facts: dict, from_hosts: list[Host] | None = None) -> Host | None:
+    logger.debug(f"find_existing_host({identity}, {canonical_facts}, {from_hosts})")
+    existing_host = _find_host_by_elevated_ids(identity, canonical_facts, from_hosts)
 
     if existing_host or current_app.config["USE_SUBMAN_ID"]:
         return existing_host
 
-    existing_host = find_host_by_multiple_canonical_facts(identity, canonical_facts)
+    existing_host = find_host_by_multiple_canonical_facts(identity, canonical_facts, from_hosts)
 
     return existing_host
 
@@ -103,8 +125,28 @@ def find_existing_host_by_id(identity: Identity, host_id: str) -> Host | None:
     return find_non_culled_hosts(query, identity).order_by(Host.modified_on.desc()).first()
 
 
+def _find_host_by_multiple_facts_in_db_or_in_memory(
+    identity: Identity, canonical_facts: dict, from_hosts: list[Host] | None = None
+) -> Host | None:
+    if from_hosts:
+        with metrics.find_host_by_facts_in_memory.time():
+            existing_hosts = list(
+                filter(multiple_canonical_facts_host_query_in_memory(identity, canonical_facts), from_hosts)
+            )
+        return existing_hosts[0] if existing_hosts else None
+
+    with metrics.find_host_by_facts_in_db.time():
+        return (
+            multiple_canonical_facts_host_query(identity, canonical_facts, restrict_to_owner_id=False)
+            .order_by(Host.modified_on.desc())
+            .first()
+        )
+
+
 @metrics.find_host_using_elevated_ids.time()
-def _find_host_by_elevated_ids(identity: Identity, canonical_facts: dict) -> Host | None:
+def _find_host_by_elevated_ids(
+    identity: Identity, canonical_facts: dict, from_hosts: list[Host] | None = None
+) -> Host | None:
     elevated_facts = {}
     elevated_keys = []
     immutable_facts = {}
@@ -133,11 +175,7 @@ def _find_host_by_elevated_ids(identity: Identity, canonical_facts: dict) -> Hos
 
     # First search based on immutable elevated canonical facts.
     if immutable_facts:
-        existing_host = (
-            multiple_canonical_facts_host_query(identity, immutable_facts, False)
-            .order_by(Host.modified_on.desc())
-            .first()
-        )
+        existing_host = _find_host_by_multiple_facts_in_db_or_in_memory(identity, immutable_facts, from_hosts)
         if existing_host:
             return existing_host
 
@@ -155,24 +193,12 @@ def _find_host_by_elevated_ids(identity: Identity, canonical_facts: dict) -> Hos
         if compound_fact := COMPOUND_CANONICAL_FACTS_MAP.get(target_key):  # noqa: SIM102
             if compound_fact_val := canonical_facts.get(compound_fact):
                 target_facts[compound_fact] = compound_fact_val
-        existing_host = (
-            multiple_canonical_facts_host_query(identity, target_facts, False)
-            .order_by(Host.modified_on.desc())
-            .first()
-        )
+
+        existing_host = _find_host_by_multiple_facts_in_db_or_in_memory(identity, target_facts, from_hosts)
         if existing_host:
             return existing_host
 
     return None
-
-
-def single_canonical_fact_host_query(identity, canonical_fact, value, restrict_to_owner_id=True):
-    query = Host.query.filter(
-        (Host.org_id == identity.org_id) & (Host.canonical_facts[canonical_fact].astext == value)
-    )
-    if restrict_to_owner_id:
-        query = update_query_for_owner_id(identity, query)
-    return find_non_culled_hosts(query, identity)
 
 
 # The CanonicalFactsSchema ensures that both components of compound
@@ -184,7 +210,9 @@ def _check_compound_canonical_facts(canonical_facts):
             raise InventoryException(title="Invalid request", detail=f"Unpaired compound fact: {key} missing {value}")
 
 
-def multiple_canonical_facts_host_query(identity, canonical_facts, restrict_to_owner_id=True):
+def multiple_canonical_facts_host_query(
+    identity: Identity, canonical_facts: dict[str, Any], restrict_to_owner_id: bool = True
+) -> Query:
     _check_compound_canonical_facts(canonical_facts)
 
     query = Host.query.filter(
@@ -197,30 +225,40 @@ def multiple_canonical_facts_host_query(identity, canonical_facts, restrict_to_o
     return find_non_culled_hosts(query, identity)
 
 
-def find_host_by_multiple_canonical_facts(identity: Identity, canonical_facts: dict) -> Host | None:
+def multiple_canonical_facts_host_query_in_memory(
+    identity: Identity, canonical_facts: dict[str, Any]
+) -> Callable[[Host], bool]:
+    def _query(host: Host) -> bool:
+        return (
+            host.org_id == identity.org_id
+            and contains_no_incorrect_facts_filter_in_memory(host, canonical_facts)
+            and matches_at_least_one_canonical_fact_filter_in_memory(host, canonical_facts)
+        )
+
+    return _query
+
+
+def find_host_by_multiple_canonical_facts(
+    identity: Identity, canonical_facts: dict, from_hosts: list[Host] | None = None
+) -> Host | None:
     """
     Returns first match for a host containing given canonical facts
     """
-    logger.debug("find_host_by_multiple_canonical_facts(%s)", canonical_facts)
+    logger.debug(f"find_host_by_multiple_canonical_facts({canonical_facts}, {from_hosts})")
 
     # If no canonical facts are supplied, it can't match anything.
     # Just in case the last canonical fact was removed during the process.
     if not canonical_facts:
         return None
 
-    host = (
-        multiple_canonical_facts_host_query(identity, canonical_facts, restrict_to_owner_id=False)
-        .order_by(Host.modified_on.desc())
-        .first()
-    )
-
+    host = _find_host_by_multiple_facts_in_db_or_in_memory(identity, canonical_facts, from_hosts)
     if host:
-        logger.debug("Found existing host using canonical_fact match: %s", host)
+        logger.debug(f"Found existing host using canonical_fact match: {host}")
 
     return host
 
 
-def find_hosts_by_staleness(staleness_types, query, identity):
+def find_hosts_by_staleness(staleness_types: list[str], query: Query, identity: Identity) -> Query:
     logger.debug("find_hosts_by_staleness(%s)", staleness_types)
     staleness_obj = serialize_staleness_to_dict(get_staleness_obj(identity.org_id))
     staleness_conditions = [
@@ -287,7 +325,7 @@ def find_hosts_sys_default_staleness(staleness_types):
     return or_(False, *staleness_conditions)
 
 
-def find_non_culled_hosts(query, identity):
+def find_non_culled_hosts(query: Query, identity: Identity) -> Query:
     return find_hosts_by_staleness(ALL_STALENESS_STATES, query, identity)
 
 
@@ -318,11 +356,11 @@ def update_existing_host(
     return existing_host, AddHostResult.updated
 
 
-def contains_no_incorrect_facts_filter(canonical_facts):
+def contains_no_incorrect_facts_filter(canonical_facts: dict[str, Any]) -> BinaryExpression:
     # Does not contain any incorrect CF values
     # Incorrect value = AND( key exists, NOT( contains key:value ) )
     # -> NOT( OR( *Incorrect values ) )
-    filter_ = ()
+    filter_: tuple = ()
     for key, value in canonical_facts.items():
         filter_ += (
             and_(Host.canonical_facts.has_key(key), not_(Host.canonical_facts.contains({key: value}))),  # noqa: W601
@@ -331,11 +369,19 @@ def contains_no_incorrect_facts_filter(canonical_facts):
     return not_(or_(*filter_))
 
 
-def matches_at_least_one_canonical_fact_filter(canonical_facts):
+def contains_no_incorrect_facts_filter_in_memory(host: Host, canonical_facts: dict[str, Any]) -> bool:
+    def _per_fact_query(host: Host, key: str, value: Any) -> bool:
+        # Either the key is not present in the host, or the fact matches
+        return key not in host.canonical_facts or host.canonical_facts[key] == value
+
+    return all(_per_fact_query(host, key, value) for key, value in canonical_facts.items())
+
+
+def matches_at_least_one_canonical_fact_filter(canonical_facts: dict[str, Any]) -> BooleanClauseList:
     # Contains at least one correct CF value
     # Correct value = contains key:value
     # -> OR( *correct values )
-    filter_ = ()
+    filter_: tuple = ()
     for key, value in canonical_facts.items():
         # Don't include the second component of compound canonical facts
         # in the OR logic of the query. It was already included in the
@@ -347,7 +393,11 @@ def matches_at_least_one_canonical_fact_filter(canonical_facts):
     return or_(*filter_)
 
 
-def update_system_profile(input_host, identity):
+def matches_at_least_one_canonical_fact_filter_in_memory(host: Host, canonical_facts: dict[str, Any]) -> bool:
+    return any(host.canonical_facts.get(key) == value for key, value in canonical_facts.items())
+
+
+def update_system_profile(input_host: Host | LimitedHost, identity: Identity):
     if not input_host.system_profile_facts:
         raise InventoryException(
             title="Invalid request", detail="Cannot update System Profile, since no System Profile data was provided."

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -8,6 +8,14 @@ find_host_using_elevated_ids = Summary(
     "inventory_find_host_using_elevated_ids_processing_seconds",
     "Time spent looking for existing host using the elevated ids",
 )
+find_host_by_facts_in_db = Summary(
+    "inventory_find_host_by_facts_in_db_processing_seconds",
+    "Time spent looking for existing host by canonical facts in db",
+)
+find_host_by_facts_in_memory = Summary(
+    "inventory_find_host_by_facts_in_memory_processing_seconds",
+    "Time spent looking for existing host by canonical facts in memory (during MQ batch processing)",
+)
 new_host_commit_processing_time = Summary(
     "inventory_new_host_commit_seconds", "Time spent committing a new host to the database"
 )

--- a/tests/fixtures/app_fixtures.py
+++ b/tests/fixtures/app_fixtures.py
@@ -1,4 +1,7 @@
+from collections.abc import Generator
+
 import pytest
+from connexion import FlaskApp
 from sqlalchemy import text as sa_text
 
 from app import create_app
@@ -9,7 +12,7 @@ from tests.helpers.db_utils import clean_tables
 
 
 @pytest.fixture(scope="session")
-def new_flask_app(database):  # noqa: ARG001
+def new_flask_app(database: str) -> Generator[FlaskApp]:  # noqa: ARG001
     application = create_app(RuntimeEnvironment.TEST)
     with application.app.app_context():
         db.session.execute(sa_text("CREATE SCHEMA IF NOT EXISTS hbi"))
@@ -23,13 +26,13 @@ def new_flask_app(database):  # noqa: ARG001
 
 
 @pytest.fixture(scope="function")
-def flask_app(new_flask_app):
+def flask_app(new_flask_app: FlaskApp) -> Generator[FlaskApp]:
     yield new_flask_app
 
     clean_tables()
 
 
 @pytest.fixture(scope="function")
-def inventory_config(flask_app):
+def inventory_config(flask_app: FlaskApp):
     yield flask_app.app.config["INVENTORY_CONFIG"]
     flask_app.app.config["INVENTORY_CONFIG"] = Config(RuntimeEnvironment.TEST)

--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -1,9 +1,11 @@
 import json
+from collections.abc import Generator
 from datetime import datetime
 from datetime import timezone
 from unittest.mock import patch
 
 import pytest
+from connexion import FlaskApp
 
 from app.models import db
 from app.queue.event_producer import EventProducer
@@ -153,7 +155,7 @@ def notification_kafka_producer(mocker):
 
 
 @pytest.fixture(scope="function")
-def event_producer(flask_app, kafka_producer):  # noqa: ARG001
+def event_producer(flask_app: FlaskApp, kafka_producer) -> Generator[EventProducer]:  # noqa: ARG001
     config = flask_app.app.config["INVENTORY_CONFIG"]
     flask_app.app.event_producer = EventProducer(config, config.event_topic)
     yield flask_app.app.event_producer

--- a/tests/helpers/db_utils.py
+++ b/tests/helpers/db_utils.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import timedelta
 from random import randint
+from typing import Any
 
 from sqlalchemy.exc import InvalidRequestError
 
@@ -39,12 +40,12 @@ def clean_tables():
     _clean_tables()
 
 
-def minimal_db_host(**values):
+def minimal_db_host(**values) -> Host:
     data = minimal_db_host_dict(**values)
     return Host(**data)
 
 
-def minimal_db_host_dict(**values):
+def minimal_db_host_dict(**values) -> dict[str, Any]:
     data = {
         "canonical_facts": {"insights_id": generate_uuid()},
         "stale_timestamp": (now() + timedelta(days=randint(1, 7))),

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -95,7 +95,7 @@ def set_environment(new_env=None):
     patched_dict.stop()
 
 
-def _base_host_data(**values):
+def _base_host_data(**values) -> dict[str, Any]:
     return {
         "org_id": USER_IDENTITY["org_id"],
         "display_name": "test" + generate_random_string(),
@@ -115,7 +115,7 @@ def base_host(**values):
 # This method returns a host wrapper that contains a single canonical fact, making it
 # a minimal host that's valid for use with mq_create_or_update_host().
 # It should be used in test cases where specific canonical facts are not needed.
-def minimal_host(**values):
+def minimal_host(**values) -> HostWrapper:
     host_wrapper = HostWrapper(_base_host_data(**values))
     host_wrapper.bios_uuid = generate_uuid()
     return host_wrapper


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-13683](https://issues.redhat.com/browse/RHINENG-13683) and [RHINENG-17921](https://issues.redhat.com/browse/RHINENG-17921).

Summary of the issue: When we are processing a payload message, we check if the host already exists in the DB, if yes we update it, if no we create a new host. However, we only flush and commit our changes after a batch of MQ messages have been processed. So, if we are processing 2nd input message for the same host within the same MQ batch, we don't find the existing host (because it is not committed yet) and we create a new one - and we end up with a duplicate.

This PR creates new methods for finding existing hosts by canonical facts in a provided list of hosts. These methods (`multiple_canonical_facts_host_query_in_memory`, `contains_no_incorrect_facts_filter_in_memory`, and `matches_at_least_one_canonical_fact_filter_in_memory`) are creating a python filter queries (NOT sqlalchemy query) which do the same thing as the existing DB query methods, but these filters are intended to be used on an existing in-memory list of hosts, instead of for querying the DB.

Functions like `find_existing_host` are now accepting one additional parameter (`from_hosts`). If this parameter is provided, then they use the new python filter to filter out the provided list of hosts. Otherwise, they use the old DB queries.

In the event loop, we pass the `processed_rows` to the lower-level methods `handle_message` and `process_message`, which use this list to first check if we can find a match inside the `processed_rows`. Only if we can't, then we try to query the DB.

My main concern is around metrics. The `find_existing_host` and other functions are collecting metrics for the dedup process, which will happen only in-memory in this case, so the metrics will be affected by this. Do you think this is an issue?

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Refactor host deduplication and message processing to enable correct handling of multiple messages for the same host within a single MQ batch by passing already-processed hosts in memory to lookup and add operations.

Bug Fixes:
- Ensure subsequent messages for the same host in the same MQ batch match the already-processed host instead of creating duplicates.

Enhancements:
- Extend find_existing_host and related lookup methods to accept an optional in-memory host list and branch between DB and in-memory queries.
- Propagate the processed_rows list through handle_message and process_message in MQ consumers and update add_host signature with an existing_host parameter.
- Introduce in-memory filtering functions (multiple_canonical_facts_host_query_in_memory, contains_no_incorrect_facts_filter_in_memory, matches_at_least_one_canonical_fact_filter_in_memory).
- Add type annotations to various functions (parse_operation_message, common_message_parser, update_query_for_owner_id, create_mock_identity_with_org_id, get_staleness_obj, initialize_thread_local_storage, operation_results_to_event_type).
- Add validation in write_add_update_event_message to enforce non-null event_type and platform_metadata.
- Remove unused single_canonical_fact_host_query function.

Tests:
- Update tests to account for the new processed_rows argument in handle_message and process_message signatures.

## Summary by Sourcery

Implement in-memory deduplication of hosts within an MQ batch by extending host lookup functions to accept a list of already-processed hosts and propagating processed rows through message consumers to prevent duplicate host creation.

Bug Fixes:
- Deduplicate multiple messages for the same host in a single MQ batch by matching against already-processed hosts before querying the database

Enhancements:
- Extend find_existing_host and related lookup methods to accept an optional in-memory host list and branch between DB and in-memory queries
- Introduce Python-based in-memory filter helpers for canonical facts matching to mirror existing DB queries
- Propagate processed_rows through HBI message consumers and update event loop and post_process_rows to commit and publish batched events using in-memory deduplication

Tests:
- Add tests for in-batch deduplication, two-host batch processing, and fallback to DB-based deduplication

Chores:
- Add type annotations across multiple functions, validate non-null event payloads, and remove unused single_canonical_fact_host_query function