### PR TITLE
fix: Use distinct env var for mq-workspaces pod count

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -835,7 +835,7 @@ objects:
             cpu: ${CPU_REQUEST_MQ_SP}
             memory: ${MEMORY_REQUEST_MQ_SP}
     - name: mq-workspaces
-      replicas: ${{REPLICAS_P1}}
+      replicas: ${{REPLICAS_WORKSPACES}}
       podSpec:
         args: ["./inv_mq_service.py"]
         env:
@@ -2074,6 +2074,9 @@ parameters:
 - description: Replica count for export-service
   name: REPLICAS_EXPORT_SVC
   value: "2"
+- description: Replica count for mq-workspaces consumer
+  name: REPLICAS_WORKSPACES
+  value: "1"
 - description: Image tag
   name: IMAGE_TAG
   required: true


### PR DESCRIPTION
# Overview

This PR is being created to address an issue with the mq-workspaces pod count. It changes it to use a separate env var, rather than reusing the mq-p1 pod count.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
