### PR TITLE
feat(RHINENG-19732): Add account_number to workspace MQ schema

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -91,6 +91,7 @@ class WorkspaceSchema(Schema):
 class WorkspaceOperationSchema(Schema):
     operation = fields.Str(required=True)
     org_id = fields.Str(required=True)
+    account_number = fields.Str(required=False)
     workspace = fields.Nested(WorkspaceSchema)
 
 
@@ -184,6 +185,7 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
         org_id = validated_operation_msg["org_id"]
         workspace = validated_operation_msg["workspace"]
         identity = create_mock_identity_with_org_id(org_id)
+        identity.account_number = validated_operation_msg["account_number"]
         logger.info(f"Received {operation} message for workspace ID {workspace['id']}")
 
         if operation == "create":
@@ -191,6 +193,7 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
                 group = group_repository.add_group(
                     group_name=workspace["name"],
                     org_id=org_id,
+                    account=identity.account_number,
                     group_id=workspace["id"],
                     ungrouped=(validated_operation_msg["workspace"]["type"] == "ungrouped-hosts"),
                 )

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -91,6 +91,7 @@ def generate_kessel_workspace_message(operation: str, id: str, name: str, type: 
     payload_dict = {
         "operation": operation,
         "org_id": SYSTEM_IDENTITY["org_id"],
+        "account_number": SYSTEM_IDENTITY["account_number"],
         "workspace": {
             "id": id,
             "name": name,

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -2124,6 +2124,7 @@ def test_workspace_mq_event_loop(handle_message_mock, flask_app, mocker):
     message = {
         "operation": "create",
         "org_id": SYSTEM_IDENTITY["org_id"],
+        "account_number": SYSTEM_IDENTITY["account_number"],
         "workspace": {
             "id": str(generate_uuid()),
             "name": "test",
@@ -2213,7 +2214,7 @@ def test_workspace_mq_update(mocker, flask_app, db_create_group_with_hosts, db_g
     host_id_list = [str(host.id) for host in group.hosts]
 
     new_name = "test-kessel-workspace"
-    message = generate_kessel_workspace_message("update", str(workspace_id), new_name)
+    message = generate_kessel_workspace_message("update", workspace_id, new_name)
     mock_event_producer = mocker.Mock()
     consumer = WorkspaceMessageConsumer(mocker.Mock(), flask_app, mock_event_producer, mocker.Mock())
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19732](https://issues.redhat.com/browse/RHINENG-19732).
It adds `account_number` to the workspace MQ schema. This will allow RBAC to send us the `account_number` of a workspace, if they have that data, which then allows us to add that field to the Group when we create it. I'm marking the field as optional so that the MQ consumer will still work before they add the field on their side.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
