### PR TITLE
fix(RHINENG-18027) Standardize on "ungrouped-hosts" workspace type

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -61,13 +61,12 @@ def get_group_list(
     per_page=100,
     order_by=None,
     order_how=None,
-    workspace_type=None,
+    type=None,
     rbac_filter=None,
 ):
+    print(f">>> type: {type}")
     try:
-        group_list, total = get_filtered_group_list_db(
-            name, page, per_page, order_by, order_how, rbac_filter, workspace_type
-        )
+        group_list, total = get_filtered_group_list_db(name, page, per_page, order_by, order_how, rbac_filter, type)
     except ValueError as e:
         log_get_group_list_failed(logger)
         abort(400, str(e))

--- a/api/group_query.py
+++ b/api/group_query.py
@@ -48,7 +48,7 @@ GROUPS_ORDER_BY_MAPPING = {
 
 GROUPS_ORDER_HOW_MAPPING = {"asc": asc, "desc": desc, "name": asc, "host_count": desc, "updated": desc}
 
-WORKSPACE_TYPE_MAPPING = {
+GROUP_TYPE_MAPPING = {
     "standard": Group.ungrouped.is_(False),
     "ungrouped-hosts": Group.ungrouped.is_(True),
 }
@@ -121,9 +121,9 @@ def does_group_with_name_exist(group_name: str, org_id: str):
     ).scalar()
 
 
-def get_filtered_group_list_db(group_name, page, per_page, order_by, order_how, rbac_filter, workspace_type=None):
+def get_filtered_group_list_db(group_name, page, per_page, order_by, order_how, rbac_filter, group_type=None):
     filters = (Group.org_id == get_current_identity().org_id,)
-    if (type_filter := WORKSPACE_TYPE_MAPPING.get(workspace_type)) is not None:
+    if (type_filter := GROUP_TYPE_MAPPING.get(group_type)) is not None:
         filters += (type_filter,)
     if group_name:
         filters += (func.lower(Group.name).contains(func.lower(group_name)),)

--- a/api/group_query.py
+++ b/api/group_query.py
@@ -50,7 +50,7 @@ GROUPS_ORDER_HOW_MAPPING = {"asc": asc, "desc": desc, "name": asc, "host_count":
 
 WORKSPACE_TYPE_MAPPING = {
     "standard": Group.ungrouped.is_(False),
-    "ungrouped": Group.ungrouped.is_(True),
+    "ungrouped-hosts": Group.ungrouped.is_(True),
 }
 
 __all__ = (

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1103,7 +1103,7 @@ components:
         for host_count
     workspaceTypeParam:
       in: query
-      name: workspace_type
+      name: type
       required: false
       schema:
         type: string

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1110,7 +1110,7 @@ components:
         default: all
         enum:
           - standard
-          - ungrouped
+          - ungrouped-hosts
           - all
       description: >-
         The type of workspaces that should be returned.

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1107,7 +1107,7 @@ components:
       required: false
       schema:
         type: string
-        default: all
+        default: standard
         enum:
           - standard
           - ungrouped-hosts

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1796,7 +1796,7 @@
           "default": "all",
           "enum": [
             "standard",
-            "ungrouped",
+            "ungrouped-hosts",
             "all"
           ]
         },

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1789,7 +1789,7 @@
       },
       "workspaceTypeParam": {
         "in": "query",
-        "name": "workspace_type",
+        "name": "type",
         "required": false,
         "schema": {
           "type": "string",

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1793,7 +1793,7 @@
         "required": false,
         "schema": {
           "type": "string",
-          "default": "all",
+          "default": "standard",
           "enum": [
             "standard",
             "ungrouped-hosts",

--- a/tests/test_api_groups_get.py
+++ b/tests/test_api_groups_get.py
@@ -20,21 +20,21 @@ def test_basic_group_query(db_create_group, api_get):
         assert group_result["id"] in group_id_list
 
 
-@pytest.mark.parametrize("workspace_type, expected_groups", (("standard", 2), ("ungrouped", 1), ("all", 3)))
-def test_group_query_type_filter(db_create_group, api_get, workspace_type, expected_groups):
+@pytest.mark.parametrize("group_type, expected_groups", (("standard", 2), ("ungrouped-hosts", 1), ("all", 3)))
+def test_group_query_type_filter(db_create_group, api_get, group_type, expected_groups):
     group_id_list_dict = {
         "standard": [str(db_create_group(f"testGroup_{idx}").id) for idx in range(2)],
-        "ungrouped": [str(db_create_group("ungroupedTest", ungrouped=True).id)],
+        "ungrouped-hosts": [str(db_create_group("ungroupedTest", ungrouped=True).id)],
     }
 
-    response_status, response_data = api_get(build_groups_url(query=f"?workspace_type={workspace_type}"))
+    response_status, response_data = api_get(build_groups_url(query=f"?type={group_type}"))
 
     assert_response_status(response_status, 200)
     assert response_data["total"] == expected_groups
     assert response_data["count"] == expected_groups
-    if workspace_type != "all":
+    if group_type != "all":
         for group_result in response_data["results"]:
-            assert group_result["id"] in group_id_list_dict[workspace_type]
+            assert group_result["id"] in group_id_list_dict[group_type]
 
 
 @pytest.mark.usefixtures("enable_rbac")


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18027](https://issues.redhat.com/browse/RHINENG-18027).
It change the filter value "ungrouped" to "ungrouped-hosts" for consistency with Kessel/RBAC.
It also changes its default value from "all" to "standard".

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Standardize the workspace type filter by renaming "ungrouped" to "ungrouped-hosts" in the backend mapping and API documentation.

Enhancements:
- Rename workspace type filter key to "ungrouped-hosts" in the group query mapping

Documentation:
- Update OpenAPI/Swagger spec enum value from "ungrouped" to "ungrouped-hosts"