### PR TITLE
feat(RHINENG-17920): deep merge system profile on update

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -586,11 +586,25 @@ class Host(LimitedHost):
 
     def update_system_profile(self, input_system_profile):
         logger.debug("Updating host's (id=%s) system profile", self.id)
+
+        def deep_merge_dicts(existing, updates):
+            """
+            Recursively merges two dictionaries. Values in `updates` overwrite or
+            merge with values in `existing`.
+            """
+            for key, value in updates.items():
+                if isinstance(value, dict) and isinstance(existing.get(key), dict):
+                    # Recursively merge nested dictionaries
+                    deep_merge_dicts(existing[key], value)
+                else:
+                    # Overwrite with the new value
+                    existing[key] = value
+
         if not self.system_profile_facts:
             self.system_profile_facts = input_system_profile
         else:
             # Update the fields that were passed in
-            self.system_profile_facts = {**self.system_profile_facts, **input_system_profile}
+            deep_merge_dicts(self.system_profile_facts, input_system_profile)
         orm.attributes.flag_modified(self, "system_profile_facts")
 
     def _update_staleness_timestamps(self):

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -1453,7 +1453,14 @@ def test_host_account_using_mq(mq_create_or_update_host, db_get_host, db_get_hos
 @pytest.mark.parametrize("id_type", ("id", "insights_id", "fqdn"))
 def test_update_system_profile(mq_create_or_update_host, db_get_host, id_type):
     expected_ids = {"insights_id": generate_uuid(), "fqdn": "foo.test.redhat.com"}
-    input_host = base_host(**expected_ids, system_profile={"owner_id": OWNER_ID, "number_of_cpus": 1})
+    input_host = base_host(
+        **expected_ids,
+        system_profile={
+            "owner_id": OWNER_ID,
+            "number_of_cpus": 1,
+            "rhsm": {"version": "9.1", "environment_ids": ["01fd642e02de4e6da2da6172081a971e"]},
+        },
+    )
     first_host_from_event = mq_create_or_update_host(input_host)
     first_host_from_db = db_get_host(first_host_from_event.id)
     expected_ids["id"] = str(first_host_from_db.id)
@@ -1462,7 +1469,8 @@ def test_update_system_profile(mq_create_or_update_host, db_get_host, id_type):
     assert first_host_from_db.system_profile_facts.get("number_of_cpus") == 1
 
     input_host = base_host(
-        **{id_type: expected_ids[id_type]}, system_profile={"number_of_cpus": 4, "number_of_sockets": 8}
+        **{id_type: expected_ids[id_type]},
+        system_profile={"number_of_cpus": 4, "number_of_sockets": 8, "rhsm": {"version": "8.7"}},
     )
     input_host.stale_timestamp = None
     input_host.reporter = None
@@ -1477,6 +1485,7 @@ def test_update_system_profile(mq_create_or_update_host, db_get_host, id_type):
         "owner_id": OWNER_ID,
         "number_of_cpus": 4,
         "number_of_sockets": 8,
+        "rhsm": {"version": "8.7", "environment_ids": ["01fd642e02de4e6da2da6172081a971e"]},
     }
 
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17920](https://issues.redhat.com/browse/RHINENG-17920).

SystemProfile has nested dictionaries, we want to deep merge these in some cases. Please think hard if this might not what we want in some cases.

This is more agressive version. For a safer version see https://github.com/RedHatInsights/insights-host-inventory/pull/2544

## Summary by Sourcery

Enable recursive merging of nested system profile data on update, update tests to assert deep merge behavior, and refine deployment analytics queries for group metrics

New Features:
- Deep merge nested dictionaries when updating system_profile_facts using a new deep_merge_dicts helper

Deployment:
- Update clowdapp analytics SQL to include host_count aggregation and add group_id and org_id columns in group metrics queries

Tests:
- Extend system_profile update tests to validate deep merge behavior for nested fields