### PR TITLE
fix(RHINENG-17920): Merge system_profile nested fields

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -584,13 +584,18 @@ class Host(LimitedHost):
             self.facts[namespace] = facts_dict
         orm.attributes.flag_modified(self, "facts")
 
-    def update_system_profile(self, input_system_profile):
+    def update_system_profile(self, input_system_profile: dict):
         logger.debug("Updating host's (id=%s) system profile", self.id)
         if not self.system_profile_facts:
             self.system_profile_facts = input_system_profile
         else:
             # Update the fields that were passed in
-            self.system_profile_facts = {**self.system_profile_facts, **input_system_profile}
+            for key, value in input_system_profile.items():
+                if key in ["rhsm", "workloads"]:
+                    # Special case to deep merge these.
+                    self.system_profile_facts[key] = {**self.system_profile_facts.get(key, {}), **value}
+                else:
+                    self.system_profile_facts[key] = value
         orm.attributes.flag_modified(self, "system_profile_facts")
 
     def _update_staleness_timestamps(self):

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -1453,7 +1453,15 @@ def test_host_account_using_mq(mq_create_or_update_host, db_get_host, db_get_hos
 @pytest.mark.parametrize("id_type", ("id", "insights_id", "fqdn"))
 def test_update_system_profile(mq_create_or_update_host, db_get_host, id_type):
     expected_ids = {"insights_id": generate_uuid(), "fqdn": "foo.test.redhat.com"}
-    input_host = base_host(**expected_ids, system_profile={"owner_id": OWNER_ID, "number_of_cpus": 1})
+    input_host = base_host(
+        **expected_ids,
+        system_profile={
+            "owner_id": OWNER_ID,
+            "number_of_cpus": 1,
+            "rhsm": {"version": "9.1", "environment_ids": ["01fd642e02de4e6da2da6172081a971e"]},
+            "workloads": {"rhel_ai": {"variant": "RHEL AI"}, "crowdstrike": {"falcon_version": "7.0.1"}},
+        },
+    )
     first_host_from_event = mq_create_or_update_host(input_host)
     first_host_from_db = db_get_host(first_host_from_event.id)
     expected_ids["id"] = str(first_host_from_db.id)
@@ -1462,7 +1470,13 @@ def test_update_system_profile(mq_create_or_update_host, db_get_host, id_type):
     assert first_host_from_db.system_profile_facts.get("number_of_cpus") == 1
 
     input_host = base_host(
-        **{id_type: expected_ids[id_type]}, system_profile={"number_of_cpus": 4, "number_of_sockets": 8}
+        **{id_type: expected_ids[id_type]},
+        system_profile={
+            "number_of_cpus": 4,
+            "number_of_sockets": 8,
+            "rhsm": {"version": "8.7"},
+            "workloads": {"crowdstrike": {"falcon_version": "7.2.2"}},
+        },
     )
     input_host.stale_timestamp = None
     input_host.reporter = None
@@ -1477,6 +1491,8 @@ def test_update_system_profile(mq_create_or_update_host, db_get_host, id_type):
         "owner_id": OWNER_ID,
         "number_of_cpus": 4,
         "number_of_sockets": 8,
+        "rhsm": {"version": "8.7", "environment_ids": ["01fd642e02de4e6da2da6172081a971e"]},
+        "workloads": {"rhel_ai": {"variant": "RHEL AI"}, "crowdstrike": {"falcon_version": "7.2.2"}},
     }
 
 


### PR DESCRIPTION
Some reporters do not send all the info and we might be loosing data. In workloads and rhsm fields we do want to perform nested merge. We want to take extra care when updating these fields.

# Overview

This PR is being created to address [RHINENG-17519](https://issues.redhat.com/browse/RHINENG-17519).

Deep merge 'workloads' and 'rhsm' fields on system profile update.
This is a safer version of #2543.

Current plan: Merge this ASAP to address the overriding of parameters we know about. Once in, we can discuss further how to improve the logic.

## Summary by Sourcery

Deep merge workloads and rhsm fields in system_profile updates to avoid losing nested data and add tests to validate this behavior.

Bug Fixes:
- Prevent data loss by deep merging nested "rhsm" and "workloads" fields on system profile updates.

Enhancements:
- Refactor update_system_profile to deep merge the "rhsm" and "workloads" sub-dictionaries instead of overwriting them.

Tests:
- Extend tests to verify that nested "rhsm" and "workloads" fields are correctly merged across multiple updates.