### PR TITLE
Remove "reviewers" field from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       interval: "daily"
     # Allow up to 3 open pull requests for pip dependencies
     open-pull-requests-limit: 3
-    reviewers:
-      - "host-based-inventory-committers"
     labels:
       - "dependencies"
   - package-ecosystem: "github-actions"
@@ -20,7 +18,5 @@ updates:
     schedule:
       # Check for update to GitHub Actions every weekday
       interval: "weekly"
-    reviewers:
-      - "host-based-inventory-committers"
     labels:
       - "GitHub-Actions-Updates"


### PR DESCRIPTION
# Overview

This PR is being created to remove the "reviewers" field from `dependabot.yml`. You can see on our dependabot PRs that it recently always comments with:
```
The reviewers field in the dependabot.yml file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs.
```

We already use CODEOWNERS, so no further change is required.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
