### PR TITLE
fix(RHINENG-17906) Return 404 when attempting to delete nonexistent groups w/ Kessel

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -221,10 +221,7 @@ def delete_groups(group_id_list, rbac_filter=None):
             if ungrouped_group_id and ungrouped_group_id == group_id:
                 abort(HTTPStatus.BAD_REQUEST, f"Workspace {group_id} can not be deleted.")
 
-        for group_id in group_id_list:
-            delete_rbac_workspace(group_id)
-
-        return Response(None, HTTPStatus.NO_CONTENT)
+        delete_count = sum((delete_rbac_workspace(group_id)) is True for group_id in group_id_list)
     else:
         delete_count = delete_group_list(group_id_list, get_current_identity(), current_app.event_producer)
 

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -120,13 +120,24 @@ def api_create_group_kessel(flask_client, mocker):
 def api_delete_groups(flask_client, mocker):
     def _api_delete_group(group_id_list, identity=USER_IDENTITY, query_parameters=None, extra_headers=None):
         delete_rbac_group_mock = mocker.patch("api.group.delete_rbac_workspace")
-        delete_rbac_group_mock.return_value = None
+        delete_rbac_group_mock.return_value = True
         url = f"{GROUP_URL}/{','.join([str(group_id) for group_id in group_id_list])}"
         return do_request(
             flask_client.delete, url, identity, query_parameters=query_parameters, extra_headers=extra_headers
         )
 
     return _api_delete_group
+
+
+@pytest.fixture(scope="function")
+def api_delete_groups_kessel(flask_client):
+    def _api_delete_groups_kessel(group_id_list, identity=USER_IDENTITY, query_parameters=None, extra_headers=None):
+        url = f"{GROUP_URL}/{','.join([str(group_id) for group_id in group_id_list])}"
+        return do_request(
+            flask_client.delete, url, identity, query_parameters=query_parameters, extra_headers=extra_headers
+        )
+
+    return _api_delete_groups_kessel
 
 
 @pytest.fixture(scope="function")

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -614,3 +614,11 @@ def mocked_export_post(_self: Any, url: str, *, data: bytes, **_: Any) -> Respon
     response.status_code = HTTPStatus.ACCEPTED
     response._content = b"Export successful"
     return response
+
+
+def mocked_post_workspace_not_found(_self: Any, url: str, **_: Any) -> Response:
+    response = Response()
+    response.url = url
+    response.status_code = HTTPStatus.NOT_FOUND
+    response._content = b"Workspace not found"
+    return response


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17906](https://issues.redhat.com/browse/RHINENG-17906).
- Makes it so if we have the Kessel feature flag enabled and attempt to delete multiple groups, one of which does not exist, we correctly return 404.
- Adds a test for this, and also adds a test to verify that if I attempt to delete two groups, one of which is the ungrouped group, we return HTTP 400.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Fix group deletion behavior under the Kessel feature flag by returning appropriate error codes for invalid requests, improve RBAC workspace deletion error handling, and update related tests.

Bug Fixes:
- Return 404 when deleting a non-existent group with Kessel enabled
- Maintain 400 response when attempting to delete the ungrouped group under Kessel

Enhancements:
- Make delete_rbac_workspace return a boolean and gracefully handle RBAC 404 and client/server errors
- Adjust delete_groups to tally successful RBAC workspace deletions instead of always returning no-content

Tests:
- Add test to verify deleting a nonexistent group under Kessel returns 404
- Refactor ungrouped group deletion tests to use subtests and assert no groups are deleted
- Introduce api_delete_groups_kessel fixture for Kessel-specific delete requests