### PR TITLE
ci: Automerge with default token

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,6 +1,10 @@
 name: Dependabot Auto-merge
 on: pull_request
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   dependabot-automerge:
     runs-on: ubuntu-latest
@@ -22,5 +26,5 @@ jobs:
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --merge "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.AUTOMERGE_PAT}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Overview

This PR is being created to address issues with the automerging.
According to https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request it seems we can use the default token in the action if we just pass the write parameters. I don't know where I read it is not possible to use with dependabot. Let see if it works ;)

## Summary by Sourcery

Enable Dependabot auto-merge with the default GITHUB_TOKEN by adding necessary write permissions and replacing the custom PAT.

CI:
- Grant write permissions for contents and pull-requests in the Dependabot auto-merge workflow
- Replace the custom automerge PAT with the default GITHUB_TOKEN