### PR TITLE
ci: fix input params

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -22,8 +22,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.AUTOMERGE_APP_ID }}
-          private_key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.AUTOMERGE_APP_ID }}
+          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') && (
                 steps.metadata.outputs.update-type == 'version-update:semver-minor' ||


### PR DESCRIPTION
# Overview

Wrong name of the input params :)

## Summary by Sourcery

CI:
- Update 'app_id' to 'app-id' and 'private_key' to 'private-key' for the create-github-app-token step in automerge.yaml.