### PR TITLE
ci: Automerge on event pull_request_target

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,9 +1,5 @@
 name: Dependabot Auto-merge
-on: pull_request
-
-permissions:
-  contents: write
-  pull-requests: write
+on: pull_request_target
 
 jobs:
   dependabot-automerge:


### PR DESCRIPTION
# Overview

The workflow doesn't have permissions to read secrets.

## Summary by Sourcery

CI:
- Trigger Dependabot auto-merge workflow on pull_request_target instead of pull_request for proper access to secrets.