### PR TITLE
fix(RHINENG-18150) Fix host message production in group-deletion MQ flow

### DIFF
--- a/app/serialization.py
+++ b/app/serialization.py
@@ -194,7 +194,7 @@ def serialize_host(
     # Handle groups separately
     if "groups" in fields:
         serialized_host["groups"] = (
-            [{key: group[key] for key in ["name", "id"]} for group in host.groups]
+            [{key: group[key] for key in ["name", "id", "ungrouped"]} for group in host.groups]
             if for_mq and host.groups
             else host.groups or []
         )

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -194,7 +194,10 @@ def serialize_host(
     # Handle groups separately
     if "groups" in fields:
         serialized_host["groups"] = (
-            [{key: group[key] for key in ["name", "id", "ungrouped"]} for group in host.groups]
+            [
+                {"name": group["name"], "id": group["id"], "ungrouped": group.get("ungrouped", False)}
+                for group in host.groups
+            ]
             if for_mq and host.groups
             else host.groups or []
         )

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -326,7 +326,11 @@ def delete_group_list(group_id_list: list[str], identity: Identity, event_produc
                 else:
                     log_group_delete_failed(logger, group_id, get_control_rule())
 
-    serialized_groups, host_list = _update_hosts_for_group_changes(deleted_host_ids, [], identity)
+    new_group_list = []
+    if get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION):
+        new_group_list = [str(get_or_create_ungrouped_hosts_group_for_identity(identity).id)]
+
+    serialized_groups, host_list = _update_hosts_for_group_changes(deleted_host_ids, new_group_list, identity)
     _produce_host_update_events(event_producer, serialized_groups, host_list, identity, staleness=staleness)
     _invalidate_system_cache(host_list, identity)
     return deletion_count


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18150](https://issues.redhat.com/browse/RHINENG-18150).

- When a non-empty workspace is deleted and the Kessel flag is enabled, move the hosts to the org's Ungrouped group
- Fix host.groups serialization
- Add to workspace-mq deletion test

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Handle workspace deletion under the Kessel migration flag by relocating hosts to the Ungrouped group, ensure host group serialization includes the "ungrouped" attribute, and add tests to validate MQ message production.

New Features:
- Relocate hosts to the organization’s Ungrouped group when deleting a workspace with the Kessel migration feature flag enabled

Bug Fixes:
- Include the "ungrouped" attribute in serialized host group data for MQ messages

Enhancements:
- Pass the new group list into host update events during group deletion

Tests:
- Add parameterized tests for workspace deletion to verify host event production and group assignment across different host counts