### PR TITLE
fix(RHINENG-17657) Fix removing hosts from group w/ Kessel

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -218,8 +218,8 @@ def delete_groups(group_id_list, rbac_filter=None):
         ungrouped_group_id = str(ungrouped_group.id) if ungrouped_group else None
 
         for group_id in group_id_list:
-            if ungrouped_group_id and ungrouped_group_id == group_id:
-                abort(HTTPStatus.BAD_REQUEST, f"Workspace {group_id} can not be deleted.")
+            if ungrouped_group_id == group_id:
+                abort(HTTPStatus.BAD_REQUEST, f"Ungrouped workspace {group_id} can not be deleted.")
 
         delete_count = sum((delete_rbac_workspace(group_id)) is True for group_id in group_id_list)
     else:

--- a/api/host_group.py
+++ b/api/host_group.py
@@ -69,7 +69,7 @@ def delete_hosts_from_group(group_id, host_id_list, rbac_filter=None):
         get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION)
         and get_group_by_id_from_db(group_id, identity.org_id).ungrouped is True
     ):
-        abort(HTTPStatus.BAD_REQUEST, f"Can not remove hosts from ungrouped workspace {group_id}")
+        abort(HTTPStatus.BAD_REQUEST, f"Cannot remove hosts from ungrouped workspace {group_id}")
 
     delete_count = remove_hosts_from_group(group_id, host_id_list, identity, current_app.event_producer)
 

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -507,3 +507,15 @@ def test_delete_host_from_ungrouped_group(mocker, db_create_group_with_hosts, ap
 
     assert_response_status(response_status, 400)
     assert str(ungrouped_group.id) in response_data["detail"]
+
+
+@pytest.mark.usefixtures("event_producer")
+def test_delete_host_from_group_no_ungrouped(mocker, db_create_group_with_hosts, api_remove_hosts_from_group):
+    mocker.patch("api.host_group.get_flag_value", return_value=True)
+
+    ungrouped_group = db_create_group_with_hosts("ungrouped", 1, ungrouped=False)
+    host_id_to_delete = str(ungrouped_group.hosts[0].id)
+
+    response_status, response_data = api_remove_hosts_from_group(ungrouped_group.id, [host_id_to_delete])
+
+    assert_response_status(response_status, 204)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17657](https://issues.redhat.com/browse/RHINENG-17657).
Fixes the removal of hosts from a group with the Kessel flag enabled. This was breaking when the Ungrouped group did not exist, since it attempted to query the Ungrouped group before it created it. Now it just queries the group specified in the request and checks whether it's Ungrouped.

Follows up on #2524.


## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Fix host removal logic for Kessel-enabled workspaces by directly checking a group's ungrouped status and ensure correct behavior when the default Ungrouped group is absent.

Bug Fixes:
- Prevent removal of hosts from an ungrouped workspace by checking the group’s ungrouped flag instead of querying the Ungrouped group.
- Allow host removal from non-ungrouped groups when the Ungrouped group does not exist under the Kessel migration flag.

Enhancements:
- Simplify ungrouped group detection by using the group’s ungrouped attribute rather than fetching the Ungrouped group unconditionally.

Tests:
- Add test to validate host removal from a custom group when the Ungrouped group is missing and the Kessel workspace migration flag is enabled.