### PR TITLE
fix(RHINENG-18183): Fix removing ungrouped hosts from group

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -266,9 +266,10 @@ def delete_hosts_from_different_groups(host_id_list, rbac_filter=None):
 
     # Separate hosts per group
     for host_id in host_id_list:
-        group = get_group_using_host_id(host_id, identity.org_id)
+        if group := get_group_using_host_id(host_id, identity.org_id):
+            if group.ungrouped is True:
+                abort(HTTPStatus.BAD_REQUEST, f"Ungrouped workspace {str(group.id)} can not be deleted.")
 
-        if group:
             hosts_per_group.setdefault(str(group.id), []).append(host_id)
 
     requested_group_ids = set(hosts_per_group.keys())

--- a/api/group.py
+++ b/api/group.py
@@ -267,7 +267,7 @@ def delete_hosts_from_different_groups(host_id_list, rbac_filter=None):
     # Separate hosts per group
     for host_id in host_id_list:
         if group := get_group_using_host_id(host_id, identity.org_id):
-            if group.ungrouped is True:
+            if group.ungrouped:
                 abort(HTTPStatus.BAD_REQUEST, f"Ungrouped workspace {str(group.id)} can not be deleted.")
 
             hosts_per_group.setdefault(str(group.id), []).append(host_id)

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -497,6 +497,18 @@ def test_delete_nonexistent_group_kessel(api_delete_groups_kessel, mocker):
         assert_response_status(response_status, expected_status=404)
 
 
+def test_delete_ungrouped_host_from_group(mocker, db_create_group_with_hosts, api_remove_hosts_from_diff_groups):
+    mocker.patch("api.host_group.get_flag_value", return_value=True)
+
+    ungrouped_group = db_create_group_with_hosts("ungrouped", 1, ungrouped=True)
+    host_id_to_delete = str(ungrouped_group.hosts[0].id)
+
+    response_status, response_data = api_remove_hosts_from_diff_groups([host_id_to_delete])
+
+    assert_response_status(response_status, 400)
+    assert str(ungrouped_group.id) in response_data["detail"]
+
+
 def test_delete_host_from_ungrouped_group(mocker, db_create_group_with_hosts, api_remove_hosts_from_group):
     mocker.patch("api.host_group.get_flag_value", return_value=True)
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18183](https://issues.redhat.com/browse/RHINENG-18183).
Fixes the `DELETE /groups/hosts/<host_id_list>` endpoint so it aborts on ungrouped hosts. Before this PR, it returned HTTP 204; now it returns HTTP 400.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Abort deletion of hosts from ungrouped workspaces with HTTP 400 and add tests for this scenario

Bug Fixes:
- Return HTTP 400 instead of 204 when attempting to remove hosts from an ungrouped workspace

Tests:
- Add test to ensure removing ungrouped hosts yields an HTTP 400 error