### PR TITLE
ci(RHINENG-18736): Migrate to the reusable platsec security scan

### DIFF
--- a/.github/workflows/security-workflow-template.yml
+++ b/.github/workflows/security-workflow-template.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# The default values used in the docker build commands are the root
+# directory '.' and the dockerfile name of 'Dockerfile'. If there is
+# a need to change these do so in your local workflow template (this file) and
+# change them there. HINT: Look at the bottom of this file.
+
+# This workflow checks out code, builds an image, performs a container image
+# vulnerability scan with Anchore's Grype tool, and generates an
+# SBOM via Anchore's Syft tool
+
+# For more information on Anchore's container image scanning tool Grype, see
+# https://github.com/anchore/grype
+
+# For more information about the Anchore SBOM tool, Syft, see
+# https://github.com/anchore/syft
+
+name: ConsoleDot Platform Security Scan
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main", "master" ]
+
+jobs:
+  PlatSec-Security-Workflow:
+    uses: RedHatInsights/platform-security-gh-workflow/.github/workflows/platsec-security-scan-reusable-workflow.yml@master
+    with:
+      app_name: 'host-inventory'
+      dockerfile_path: '.'
+      dockerfile_name: 'Dockerfile'
+      severity_fail_cutoff: high
+      fail_on_vulns: true


### PR DESCRIPTION
This commit adds the usage of the security scanning workflow from
platform security.

The security-scan.sh script will be remove once the Jenkins job will be
removed from app-interface.

https://github.com/RedHatInsights/platform-security-gh-workflow/

# Overview

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

CI:
- Replace custom security-scan.sh with the PlatSec reusable security scan workflow via platform-security-gh-workflow action