### PR TITLE
chore: Allow non-codeowner approvals on dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 # Default owners
 * @RedHatInsights/host-based-inventory-committers
+Pipfile
+Pipfile.lock


### PR DESCRIPTION
# Overview

To keep CODEOWNERS and still allow a bot to merge PR, we need to remove the ownership from those specific files.

According to a [discussion](https://github.com/orgs/community/discussions/23064) it's not possible to add a bot as a CODEOWNER, the only other alternative would be a personal token, which is dirty.

Removing dependencies from CODEOWNERS makes sense, that gives those files broader permissions.

## Summary by Sourcery

Chores:
- Remove CODEOWNERS entries for dependency files to broaden merge permissions