### PR TITLE
chore(RHINENG-15823): Add create-ungrouped-groups CJI

### DIFF
--- a/deploy/cji.yml
+++ b/deploy/cji.yml
@@ -18,6 +18,16 @@ objects:
   metadata:
     labels:
       app: host-inventory
+    name: create-ungrouped-groups-${CREATE_UNGROUPED_GROUPS_RUN_NUMBER}
+  spec:
+    appName: host-inventory
+    jobs:
+      - create-ungrouped-host-groups
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    labels:
+      app: host-inventory
     name: export-group-data-s3-${GROUP_S3_EXPORT_RUN_NUMBER}
   spec:
     appName: host-inventory
@@ -25,6 +35,8 @@ objects:
       - export-group-data-s3
 parameters:
 - name: SYNCHRONIZER_RUN_NUMBER
+  value: '1'
+- name: CREATE_UNGROUPED_GROUPS_RUN_NUMBER
   value: '1'
 - name: GROUP_S3_EXPORT_RUN_NUMBER
   value: '1'


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-15823](https://issues.redhat.com/browse/RHINENG-15823).
Adds a CJI for the create-ungrouped-groups job. Merging this will trigger running the job in Stage.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add a ClowdJobInvocation for the create-ungrouped-host-groups job and introduce its run number parameter in the CJI configuration

Enhancements:
- Introduce ClowdJobInvocation for `create-ungrouped-host-groups` in deploy/cji.yml
- Add `CREATE_UNGROUPED_GROUPS_RUN_NUMBER` parameter to the CJI parameters list