### PR TITLE
Revert "feat(rhineng-18067): Update nginx to latest on ubi9"

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -31,7 +31,7 @@ objects:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: registry.access.redhat.com/ubi9/nginx-124:latest
+        image: quay.io/cloudservices/ubi8-nginx-124:1-39.1741813445
         livenessProbe:
           failureThreshold: 5
           httpGet:


### PR DESCRIPTION
Reverts RedHatInsights/insights-host-inventory#2555

## Summary by Sourcery

Deployment:
- Revert the nginx container image in ClowdApp configuration back to the quay.io/cloudservices/ubi8-nginx-124:1-39.1741813445 release.