### PR TITLE
fix: remove port from url

### DIFF
--- a/utils/run_gabi.py
+++ b/utils/run_gabi.py
@@ -31,6 +31,7 @@ Arguments:
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 
@@ -51,7 +52,8 @@ def get_oc_token():
 def get_oc_server():
     """Retrieve the OpenShift server URL using `oc whoami --show-server`."""
     try:
-        return subprocess.check_output(["oc", "whoami", "--show-server"], text=True).strip()
+        regex = r":[^:]*$"
+        return re.sub(regex, "", subprocess.check_output(["oc", "whoami", "--show-server"], text=True).strip())
     except subprocess.CalledProcessError:
         print("Failed to retrieve server URL using `oc whoami --show-server`. Please provide the --url argument.")
         sys.exit(1)


### PR DESCRIPTION
# Overview

Fix gabi script

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Remove trailing port segment from the URL in `get_oc_server` to avoid including the port in the returned value