### PR TITLE
chore(RHINENG-16546): Stop using regular canonical facts for deduplication

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -81,22 +81,6 @@
             "createdAt": "2025-04-25T16:32:16.409Z"
         },
         {
-            "name": "hbi.deduplication-elevate-subman_id",
-            "description": "If active, subscription_manager_id will have the highest priority out of mutable elevated canonical facts, and mac_addresses will not be included in elevated canonical facts.",
-            "type": "release",
-            "project": "default",
-            "stale": false,
-            "enabled": false,
-            "strategies": [
-                {
-                    "name": "default",
-                    "parameters": {}
-                }
-            ],
-            "variants": [],
-            "createdAt": "2025-02-17T16:18:18.842Z"
-        },
-        {
             "name": "hbi.create_last_check_in_update_per_reporter_staleness",
             "description": "Use last_check_in field to create host staleness, and update the per_reporter_staleness field with stale_warning and culled_timestamps.",
             "type": "release",

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ COPY assign_ungrouped_hosts_to_groups.py assign_ungrouped_hosts_to_groups.py
 COPY export_group_data_s3.py export_group_data_s3.py
 COPY update_hosts_last_check_in.py update_hosts_last_check_in.py
 COPY update_edge_hosts_prs.py update_edge_hosts_prs.py
+COPY delete_hosts_without_id_facts.py delete_hosts_without_id_facts.py
 COPY app_migrations/ app_migrations/
 COPY jobs/ jobs/
 

--- a/app/config.py
+++ b/app/config.py
@@ -15,6 +15,15 @@ PRODUCER_ACKS = {"0": 0, "1": 1, "all": "all"}
 HOST_TYPES = ["edge", None]
 ALL_STALENESS_STATES = ["fresh", "stale", "stale_warning"]
 
+# NOTE: The order of this tuple is important. The order defines the priority.
+ID_FACTS = ("provider_id", "subscription_manager_id", "insights_id")
+# This elevated fact is to be used when the USE_SUBMAN_ID env is True
+ID_FACTS_USE_SUBMAN_ID = ("subscription_manager_id",)
+
+COMPOUND_ID_FACTS_MAP = {"provider_id": "provider_type"}
+COMPOUND_ID_FACTS = tuple(COMPOUND_ID_FACTS_MAP.values())
+IMMUTABLE_ID_FACTS = ("provider_id",)
+
 
 class Config:
     SSL_VERIFY_FULL = "verify-full"

--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from logging import Logger
 
@@ -79,7 +81,7 @@ def message_not_produced(logger, error, topic, event, key, headers, message=None
         event_producer_failure.labels(event_type=dict(headers)["event_type"].decode("utf-8"), topic=topic).inc()
 
 
-def get_control_rule():
+def get_control_rule() -> str:
     if hasattr(g, "access_control_rule"):
         return g.access_control_rule
     else:
@@ -87,7 +89,7 @@ def get_control_rule():
 
 
 # delete host
-def log_host_delete_succeeded(logger, host_id, control_rule, sp_fields_to_log):
+def log_host_delete_succeeded(logger: Logger, host_id: str, control_rule: str | None, sp_fields_to_log: dict) -> None:
     logger.info(
         "Deleted host: %s",
         host_id,

--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -1,4 +1,5 @@
 import json
+from logging import Logger
 
 from flask import g
 
@@ -254,7 +255,7 @@ def log_add_host_failure(logger, message, host_data, sp_fields_to_log):
 
 
 # update system profile
-def log_update_system_profile_success(logger, host_data, sp_fields_to_log):
+def log_update_system_profile_success(logger: Logger, sp_fields_to_log: dict, host_data: dict):
     metrics.update_system_profile_success.inc()
     logger.info(
         "System profile updated for host ID: %s",

--- a/app/models.py
+++ b/app/models.py
@@ -45,6 +45,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from yaml import safe_load
 
 from app.common import inventory_config
+from app.config import ID_FACTS
 from app.culling import Timestamps
 from app.culling import days_to_seconds
 from app.exceptions import InventoryException
@@ -350,6 +351,9 @@ class Host(LimitedHost):
 
         if not canonical_facts:
             raise ValidationException("At least one of the canonical fact fields must be present.")
+
+        if not any(id_fact in canonical_facts for id_fact in ID_FACTS):
+            raise ValidationException(f"At least one of the ID fact fields must be present: {ID_FACTS}")
 
         if current_app.config["USE_SUBMAN_ID"] and "subscription_manager_id" in canonical_facts:
             id = canonical_facts["subscription_manager_id"]

--- a/app/models.py
+++ b/app/models.py
@@ -352,7 +352,7 @@ class Host(LimitedHost):
         if not canonical_facts:
             raise ValidationException("At least one of the canonical fact fields must be present.")
 
-        if not any(id_fact in canonical_facts for id_fact in ID_FACTS):
+        if all(id_fact not in canonical_facts for id_fact in ID_FACTS):
             raise ValidationException(f"At least one of the ID fact fields must be present: {ID_FACTS}")
 
         if current_app.config["USE_SUBMAN_ID"] and "subscription_manager_id" in canonical_facts:

--- a/delete_hosts_without_id_facts.py
+++ b/delete_hosts_without_id_facts.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+
+import sys
+from functools import partial
+from logging import Logger
+
+from connexion import FlaskApp
+from sqlalchemy.dialects.postgresql import array
+from sqlalchemy.orm import Session
+
+from app.config import Config
+from app.environment import RuntimeEnvironment
+from app.logging import get_logger
+from app.logging import threadctx
+from app.models import Host
+from app.queue.event_producer import EventProducer
+from jobs.common import excepthook
+from jobs.common import job_setup
+from lib.handlers import ShutdownHandler
+from lib.host_delete import delete_hosts
+
+PROMETHEUS_JOB = "inventory-delete-hosts-without-id-facts"
+LOGGER_NAME = "delete_hosts_without_id_facts"
+RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
+
+
+def run(
+    config: Config,
+    logger: Logger,
+    session: Session,
+    event_producer: EventProducer,
+    notifications_event_producer: EventProducer,
+    shutdown_handler: ShutdownHandler,
+    application: FlaskApp,
+) -> None:
+    with application.app.app_context():
+        threadctx.request_id = None
+        query = session.query(Host).filter(
+            ~Host.canonical_facts.has_any(array(["provider_id", "subscription_manager_id", "insights_id"]))
+        )
+
+        try:
+            logger.info(f"Deleting {query.count()} hosts without ID facts")
+            deleted_hosts_count = len(
+                list(
+                    delete_hosts(
+                        query,
+                        event_producer,
+                        notifications_event_producer,
+                        config.host_delete_chunk_size,
+                        shutdown_handler.shut_down,
+                    )
+                )
+            )
+        except InterruptedError:
+            logger.info(f"{PROMETHEUS_JOB} was interrupted.")
+            deleted_hosts_count = 0
+
+        logger.info(f"Finished deleting {deleted_hosts_count} hosts without ID facts.")
+
+
+if __name__ == "__main__":
+    logger = get_logger(LOGGER_NAME)
+    job_type = "Delete hosts without ID facts"
+    sys.excepthook = partial(excepthook, logger, job_type)
+
+    config, session, event_producer, notifications_event_producer, shutdown_handler, application = job_setup(
+        (), PROMETHEUS_JOB
+    )
+    run(config, logger, session, event_producer, notifications_event_producer, shutdown_handler, application)

--- a/deploy/cji.yml
+++ b/deploy/cji.yml
@@ -38,6 +38,16 @@ objects:
   metadata:
     labels:
       app: host-inventory
+    name: delete-hosts-without-id-facts-${DELETE_HOSTS_WITHOUT_ID_FACTS_RUN_NUMBER}
+  spec:
+    appName: host-inventory
+    jobs:
+      - delete-hosts-without-id-facts
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    labels:
+      app: host-inventory
     name: export-group-data-s3-${GROUP_S3_EXPORT_RUN_NUMBER}
   spec:
     appName: host-inventory
@@ -49,6 +59,8 @@ parameters:
 - name: CREATE_UNGROUPED_GROUPS_RUN_NUMBER
   value: '1'
 - name: ASSIGN_UNGROUPED_HOSTS_RUN_NUMBER
+  value: '1'
+- name: DELETE_HOSTS_WITHOUT_ID_FACTS_RUN_NUMBER
   value: '1'
 - name: GROUP_S3_EXPORT_RUN_NUMBER
   value: '1'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1053,6 +1053,8 @@ objects:
             value: "${INVENTORY_CACHE_INSIGHTS_CLIENT_SYSTEM_TIMEOUT_SEC}"
           - name: INVENTORY_CACHE_THREAD_POOL_MAX_WORKERS
             value: "${INVENTORY_CACHE_THREAD_POOL_MAX_WORKERS}"
+          - name: HOST_DELETE_CHUNK_SIZE
+            value: ${HOST_DELETE_CHUNK_SIZE}
           - name: UNLEASH_URL
             value: ${UNLEASH_URL}
           - name: UNLEASH_TOKEN
@@ -1662,6 +1664,71 @@ objects:
           requests:
             cpu: ${CPU_REQUEST_EDGE_HOSTS_PRS}
             memory: ${MEMORY_REQUEST_EDGE_HOSTS_PRS}
+    - name: delete-hosts-without-id-facts
+      restartPolicy: OnFailure
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        args: [ "./delete_hosts_without_id_facts.py" ]
+        env:
+          - name: INVENTORY_LOG_LEVEL
+            value: ${LOG_LEVEL}
+          - name: INVENTORY_DB_SSL_MODE
+            value: ${INVENTORY_DB_SSL_MODE}
+          - name: INVENTORY_DB_SSL_CERT
+            value: ${INVENTORY_DB_SSL_CERT}
+          - name: INVENTORY_DB_SCHEMA
+            value: "${INVENTORY_DB_SCHEMA}"
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            value: ${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}
+          - name: KAFKA_EVENT_TOPIC
+            value: ${KAFKA_EVENT_TOPIC}
+          - name: KAFKA_NOTIFICATION_TOPIC
+            value: ${KAFKA_NOTIFICATION_TOPIC}
+          - name: PAYLOAD_TRACKER_KAFKA_TOPIC
+            value: ${PAYLOAD_TRACKER_KAFKA_TOPIC}
+          - name: PAYLOAD_TRACKER_SERVICE_NAME
+            value: inventory-mq-service
+          - name: PAYLOAD_TRACKER_ENABLED
+            value: 'true'
+          - name: PROMETHEUS_PUSHGATEWAY
+            value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: KAFKA_PRODUCER_ACKS
+            value: ${KAFKA_PRODUCER_ACKS}
+          - name: KAFKA_PRODUCER_RETRIES
+            value: ${KAFKA_PRODUCER_RETRIES}
+          - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
+            value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: KAFKA_SECURITY_PROTOCOL
+            value: ${KAFKA_SECURITY_PROTOCOL}
+          - name: KAFKA_SASL_MECHANISM
+            value: ${KAFKA_SASL_MECHANISM}
+          - name: CLOWDER_ENABLED
+            value: "true"
+          - name: UNLEASH_URL
+            value: ${UNLEASH_URL}
+          - name: UNLEASH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: ${UNLEASH_SECRET_NAME}
+                key: CLIENT_ACCESS_TOKEN
+                optional: true
+          - name: BYPASS_UNLEASH
+            value: ${BYPASS_UNLEASH}
+          - name: UNLEASH_REFRESH_INTERVAL
+            value: ${UNLEASH_REFRESH_INTERVAL}
+          - name: HOST_DELETE_CHUNK_SIZE
+            value: ${HOST_DELETE_CHUNK_SIZE}
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_HOSTS_WITHOUT_ID_FACTS_JOB}
+            memory: ${MEMORY_LIMIT_HOSTS_WITHOUT_ID_FACTS_JOB}
+          requests:
+            cpu: ${CPU_REQUEST_HOSTS_WITHOUT_ID_FACTS_JOB}
+            memory: ${MEMORY_REQUEST_HOSTS_WITHOUT_ID_FACTS_JOB}
     database:
       name: ${DB_NAME}
       version: 16
@@ -1977,6 +2044,8 @@ parameters:
   value: 256Mi
 - name: MEMORY_LIMIT_REAPER
   value: 512Mi
+- name: HOST_DELETE_CHUNK_SIZE
+  value: "1000"
 
 - name: CPU_REQUEST_STALE_HOST_NOTIFICAION
   value: 250m
@@ -2068,6 +2137,15 @@ parameters:
 - name: MEMORY_REQUEST_EDGE_HOSTS_PRS
   value: 256Mi
 - name: MEMORY_LIMIT_EDGE_HOSTS_PRS
+  value: 512Mi
+
+- name: CPU_REQUEST_HOSTS_WITHOUT_ID_FACTS_JOB
+  value: 250m
+- name: CPU_LIMIT_HOSTS_WITHOUT_ID_FACTS_JOB
+  value: 500m
+- name: MEMORY_REQUEST_HOSTS_WITHOUT_ID_FACTS_JOB
+  value: 256Mi
+- name: MEMORY_LIMIT_HOSTS_WITHOUT_ID_FACTS_JOB
   value: 512Mi
 
 - description: Replica count for p1 consumer

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -39,6 +39,7 @@ COPY assign_ungrouped_hosts_to_groups.py assign_ungrouped_hosts_to_groups.py
 COPY export_group_data_s3.py export_group_data_s3.py
 COPY update_hosts_last_check_in.py update_hosts_last_check_in.py
 COPY update_edge_hosts_prs.py update_edge_hosts_prs.py
+COPY delete_hosts_without_id_facts.py delete_hosts_without_id_facts.py
 RUN chown -R 1001:0 ./
 USER 1001
 

--- a/jobs/common.py
+++ b/jobs/common.py
@@ -18,7 +18,7 @@ __all__ = "job_setup"
 RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
 
 
-def init_config():
+def init_config() -> Config:
     config = Config(RUNTIME_ENVIRONMENT)
     config.log_configuration()
     return config

--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -13,7 +13,6 @@ logger = get_logger(__name__)
 FLAG_INVENTORY_USE_CACHED_INSIGHTS_CLIENT_SYSTEM = "hbi.api.use-cached-insights-client-system"
 FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION = "hbi.api.kessel-workspace-migration"
 FLAG_INVENTORY_API_READ_ONLY = "hbi.api.read-only"
-FLAG_INVENTORY_DEDUPLICATION_ELEVATE_SUBMAN_ID = "hbi.deduplication-elevate-subman_id"
 FLAG_INVENTORY_KESSEL_PHASE_1 = "hbi.api.kessel-phase-1"
 FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS = (
     "hbi.create_last_check_in_update_per_reporter_staleness"
@@ -27,7 +26,6 @@ FLAG_FALLBACK_VALUES = {
     FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION: False,
     FLAG_INVENTORY_API_READ_ONLY: False,
     FLAG_INVENTORY_KESSEL_PHASE_1: False,
-    FLAG_INVENTORY_DEDUPLICATION_ELEVATE_SUBMAN_ID: True,
     FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS: ENV_FLAG_LAST_CHECKIN_PER_REPORTER_STALENESS,
     # Use when all hosts are populated with stale_warning/deletion_timestamps
     FLAG_INVENTORY_FILTER_STALENESS_USING_COLUMNS: False,

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from collections.abc import Generator
 from functools import partial
+from typing import Callable
 
 from confluent_kafka import KafkaException
+from flask_sqlalchemy.query import Query
+from sqlalchemy.orm import Session
 
+from app.auth.identity import Identity
 from app.auth.identity import to_auth_header
 from app.instrumentation import log_host_delete_succeeded
 from app.logging import get_logger
@@ -24,7 +31,13 @@ __all__ = ("delete_hosts",)
 logger = get_logger(__name__)
 
 
-def _delete_host_db_records(select_query, chunk_size, identity, interrupt, control_rule) -> list[OperationResult]:
+def _delete_host_db_records(
+    select_query: Query,
+    chunk_size: int,
+    identity: Identity | None,
+    interrupt: Callable[[], bool],
+    control_rule: str | None,
+) -> list[OperationResult]:
     results_list = []
 
     for host in select_query.limit(chunk_size):
@@ -44,7 +57,7 @@ def _send_delete_messages_for_batch(
     event_producer: EventProducer,
     notification_event_producer: EventProducer,
     initiated_by_frontend: bool,
-):
+) -> None:
     for result in processed_rows:
         if result is not None:
             delete_host_count.inc()
@@ -53,15 +66,15 @@ def _send_delete_messages_for_batch(
 
 
 def delete_hosts(
-    select_query,
-    event_producer,
-    notification_event_producer,
-    chunk_size,
-    interrupt=lambda: False,
-    identity=None,
-    control_rule=None,
-    initiated_by_frontend=False,
-):
+    select_query: Query,
+    event_producer: EventProducer,
+    notification_event_producer: EventProducer,
+    chunk_size: int,
+    interrupt: Callable[[], bool] = lambda: False,
+    identity: Identity | None = None,
+    control_rule: str | None = None,
+    initiated_by_frontend: bool = False,
+) -> Generator[OperationResult]:
     while select_query.count():
         if kafka_available():
             with session_guard(select_query.session):
@@ -78,7 +91,7 @@ def delete_hosts(
             raise KafkaException("Kafka server not available. Stopping host deletions.")
 
 
-def _delete_host(session, host, identity, control_rule) -> OperationResult:
+def _delete_host(session: Session, host: Host, identity: Identity | None, control_rule: str | None) -> OperationResult:
     sp_fields_to_log = extract_host_model_sp_to_log(host)
     assoc_delete_query = session.query(HostGroupAssoc).filter(HostGroupAssoc.host_id == host.id)
     host_delete_query = session.query(Host).filter(Host.id == host.id)

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -75,6 +75,7 @@ def delete_hosts(
     control_rule: str | None = None,
     initiated_by_frontend: bool = False,
 ) -> Generator[OperationResult]:
+    """This function will yield nothing if no hosts are found."""
     while select_query.count():
         if kafka_available():
             with session_guard(select_query.session):

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -20,7 +20,12 @@ from api.filtering.db_filters import update_query_for_owner_id
 from api.staleness_query import get_staleness_obj
 from app.auth.identity import Identity
 from app.config import ALL_STALENESS_STATES
+from app.config import COMPOUND_ID_FACTS
+from app.config import COMPOUND_ID_FACTS_MAP
 from app.config import HOST_TYPES
+from app.config import ID_FACTS
+from app.config import ID_FACTS_USE_SUBMAN_ID
+from app.config import IMMUTABLE_ID_FACTS
 from app.exceptions import InventoryException
 from app.logging import get_logger
 from app.models import Group
@@ -30,8 +35,6 @@ from app.models import LimitedHost
 from app.serialization import serialize_staleness_to_dict
 from app.staleness_serialization import get_sys_default_staleness
 from lib import metrics
-from lib.feature_flags import FLAG_INVENTORY_DEDUPLICATION_ELEVATE_SUBMAN_ID
-from lib.feature_flags import get_flag_value
 
 __all__ = (
     "AddHostResult",
@@ -39,27 +42,12 @@ __all__ = (
     "multiple_canonical_facts_host_query",
     "create_new_host",
     "find_existing_host",
-    "find_host_by_multiple_canonical_facts",
     "find_hosts_by_staleness",
     "find_non_culled_hosts",
     "update_existing_host",
 )
 
 AddHostResult = Enum("AddHostResult", ("created", "updated"))
-
-# These are the "elevated" canonical facts that are
-# given priority in the host deduplication process.
-# NOTE: The order of this tuple is important. The order defines the priority.
-ELEVATED_CANONICAL_FACT_FIELDS = ("provider_id", "mac_addresses", "insights_id", "subscription_manager_id")
-# These "v2" elevated facts are used when "hbi.deduplication-elevate-subman_id" FF is turned on.
-ELEVATED_CANONICAL_FACT_FIELDS_V2 = ("provider_id", "subscription_manager_id", "insights_id")
-# This elevated fact is to be used when the USE_SUBMAN_ID env is True
-ELEVATED_CANONICAL_FACT_FIELDS_USE_SUBMAN_ID = ("subscription_manager_id",)
-COMPOUND_CANONICAL_FACTS_MAP = {"provider_id": "provider_type"}
-COMPOUND_CANONICAL_FACTS = tuple(COMPOUND_CANONICAL_FACTS_MAP.values())
-IMMUTABLE_CANONICAL_FACTS = ("provider_id",)
-
-NULL = None
 
 logger = get_logger(__name__)
 
@@ -106,17 +94,65 @@ def add_host(
         return create_new_host(input_host)
 
 
+def _extract_immutable_and_id_facts(canonical_facts: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    """
+    Returns two dictionaries:
+    - immutable_facts: All immutable facts present in the canonical facts, together with their compound facts
+    - id_facts: All id facts present in the canonical facts, except for the immutable facts
+    """
+    id_fields = ID_FACTS_USE_SUBMAN_ID if current_app.config["USE_SUBMAN_ID"] else ID_FACTS
+    logger.debug(f"Using {id_fields} for deduplication")
+
+    immutable_facts = {}
+    id_facts = {}
+
+    # Iterate through the ID fields in the priority order
+    for key in id_fields:
+        if key not in canonical_facts.keys():
+            continue
+
+        if key in IMMUTABLE_ID_FACTS:
+            immutable_facts[key] = canonical_facts[key]
+            # Add compound facts (for example, add provider_type if provider_id is present)
+            if compound_fact := COMPOUND_ID_FACTS_MAP.get(key):
+                immutable_facts[compound_fact] = canonical_facts[compound_fact]
+        else:
+            id_facts[key] = canonical_facts[key]
+
+    return immutable_facts, id_facts
+
+
 @metrics.host_dedup_processing_time.time()
-def find_existing_host(identity: Identity, canonical_facts: dict, from_hosts: list[Host] | None = None) -> Host | None:
+def find_existing_host(
+    identity: Identity, canonical_facts: dict[str, Any], from_hosts: list[Host] | None = None
+) -> Host | None:
     logger.debug(f"find_existing_host({identity}, {canonical_facts}, {from_hosts})")
-    existing_host = _find_host_by_elevated_ids(identity, canonical_facts, from_hosts)
+    immutable_facts, id_facts = _extract_immutable_and_id_facts(canonical_facts)
 
-    if existing_host or current_app.config["USE_SUBMAN_ID"]:
-        return existing_host
+    # First search based on immutable id facts.
+    if immutable_facts:
+        existing_host = _find_host_by_multiple_facts_in_db_or_in_memory(identity, immutable_facts, from_hosts)
+        if existing_host:
+            return existing_host
 
-    existing_host = find_host_by_multiple_canonical_facts(identity, canonical_facts, from_hosts)
+    if not id_facts:
+        return None
 
-    return existing_host
+    # Now search based on other ID facts
+    # Dicts have been ordered since Python 3.7, so the priority ordering will be respected
+    for target_key, target_value in id_facts.items():
+        # Keep immutable facts in the search to prevent matching if they are different.
+        target_facts = dict(immutable_facts, **{target_key: target_value})
+
+        # Ensure both components of compound facts are collected.
+        if compound_fact := COMPOUND_ID_FACTS_MAP.get(target_key):
+            target_facts[compound_fact] = canonical_facts[compound_fact]
+
+        existing_host = _find_host_by_multiple_facts_in_db_or_in_memory(identity, target_facts, from_hosts)
+        if existing_host:
+            return existing_host
+
+    return None
 
 
 def find_existing_host_by_id(identity: Identity, host_id: str) -> Host | None:
@@ -126,7 +162,7 @@ def find_existing_host_by_id(identity: Identity, host_id: str) -> Host | None:
 
 
 def _find_host_by_multiple_facts_in_db_or_in_memory(
-    identity: Identity, canonical_facts: dict, from_hosts: list[Host] | None = None
+    identity: Identity, canonical_facts: dict[str, str], from_hosts: list[Host] | None = None
 ) -> Host | None:
     if from_hosts:
         with metrics.find_host_by_facts_in_memory.time():
@@ -143,69 +179,11 @@ def _find_host_by_multiple_facts_in_db_or_in_memory(
         )
 
 
-@metrics.find_host_using_elevated_ids.time()
-def _find_host_by_elevated_ids(
-    identity: Identity, canonical_facts: dict, from_hosts: list[Host] | None = None
-) -> Host | None:
-    elevated_facts = {}
-    elevated_keys = []
-    immutable_facts = {}
-
-    elevated_fields = (
-        ELEVATED_CANONICAL_FACT_FIELDS_V2
-        if get_flag_value(FLAG_INVENTORY_DEDUPLICATION_ELEVATE_SUBMAN_ID, context={"orgId": identity.org_id})
-        else ELEVATED_CANONICAL_FACT_FIELDS
-    )
-    if current_app.config["USE_SUBMAN_ID"]:
-        elevated_fields = ELEVATED_CANONICAL_FACT_FIELDS_USE_SUBMAN_ID  # type: ignore
-    logger.info(f"Using {elevated_fields} as elevated fields for org {identity.org_id}")
-
-    for key in elevated_fields:
-        if key not in canonical_facts.keys():
-            continue
-
-        if key in IMMUTABLE_CANONICAL_FACTS:
-            immutable_facts[key] = canonical_facts[key]
-            if compound_fact := COMPOUND_CANONICAL_FACTS_MAP.get(key):  # noqa: SIM102
-                if compound_fact_val := canonical_facts.get(compound_fact):
-                    immutable_facts[compound_fact] = compound_fact_val
-        else:
-            elevated_facts[key] = canonical_facts[key]
-            elevated_keys.append(key)
-
-    # First search based on immutable elevated canonical facts.
-    if immutable_facts:
-        existing_host = _find_host_by_multiple_facts_in_db_or_in_memory(identity, immutable_facts, from_hosts)
-        if existing_host:
-            return existing_host
-
-    if not elevated_facts:
-        return None
-
-    for target_key in elevated_keys:
-        #
-        # Keep immutable facts in the search, to prevent matching if
-        # they are different.
-        #
-        target_facts = dict(immutable_facts, **{target_key: elevated_facts[target_key]})
-
-        # Ensure both components of compound facts are collected.
-        if compound_fact := COMPOUND_CANONICAL_FACTS_MAP.get(target_key):  # noqa: SIM102
-            if compound_fact_val := canonical_facts.get(compound_fact):
-                target_facts[compound_fact] = compound_fact_val
-
-        existing_host = _find_host_by_multiple_facts_in_db_or_in_memory(identity, target_facts, from_hosts)
-        if existing_host:
-            return existing_host
-
-    return None
-
-
 # The CanonicalFactsSchema ensures that both components of compound
 # canonical facts are provided. This check is included to detect any
 # unforeseen issues.
-def _check_compound_canonical_facts(canonical_facts):
-    for key, value in COMPOUND_CANONICAL_FACTS_MAP.items():
+def _check_compound_id_facts(canonical_facts: dict[str, Any]) -> None:
+    for key, value in COMPOUND_ID_FACTS_MAP.items():
         if key in canonical_facts and value not in canonical_facts:
             raise InventoryException(title="Invalid request", detail=f"Unpaired compound fact: {key} missing {value}")
 
@@ -213,7 +191,7 @@ def _check_compound_canonical_facts(canonical_facts):
 def multiple_canonical_facts_host_query(
     identity: Identity, canonical_facts: dict[str, Any], restrict_to_owner_id: bool = True
 ) -> Query:
-    _check_compound_canonical_facts(canonical_facts)
+    _check_compound_id_facts(canonical_facts)
 
     query = Host.query.filter(
         (Host.org_id == identity.org_id)
@@ -236,26 +214,6 @@ def multiple_canonical_facts_host_query_in_memory(
         )
 
     return _query
-
-
-def find_host_by_multiple_canonical_facts(
-    identity: Identity, canonical_facts: dict, from_hosts: list[Host] | None = None
-) -> Host | None:
-    """
-    Returns first match for a host containing given canonical facts
-    """
-    logger.debug(f"find_host_by_multiple_canonical_facts({canonical_facts}, {from_hosts})")
-
-    # If no canonical facts are supplied, it can't match anything.
-    # Just in case the last canonical fact was removed during the process.
-    if not canonical_facts:
-        return None
-
-    host = _find_host_by_multiple_facts_in_db_or_in_memory(identity, canonical_facts, from_hosts)
-    if host:
-        logger.debug(f"Found existing host using canonical_fact match: {host}")
-
-    return host
 
 
 def find_hosts_by_staleness(staleness_types: list[str], query: Query, identity: Identity) -> Query:
@@ -362,9 +320,7 @@ def contains_no_incorrect_facts_filter(canonical_facts: dict[str, Any]) -> Binar
     # -> NOT( OR( *Incorrect values ) )
     filter_: tuple = ()
     for key, value in canonical_facts.items():
-        filter_ += (
-            and_(Host.canonical_facts.has_key(key), not_(Host.canonical_facts.contains({key: value}))),  # noqa: W601
-        )
+        filter_ += (and_(Host.canonical_facts.has_key(key), not_(Host.canonical_facts.contains({key: value}))),)
 
     return not_(or_(*filter_))
 
@@ -386,7 +342,7 @@ def matches_at_least_one_canonical_fact_filter(canonical_facts: dict[str, Any]) 
         # Don't include the second component of compound canonical facts
         # in the OR logic of the query. It was already included in the
         # AND logic generated by contains_no_incorrect_facts_filter().
-        if key in COMPOUND_CANONICAL_FACTS:
+        if key in COMPOUND_ID_FACTS:
             continue
         filter_ += (Host.canonical_facts.contains({key: value}),)
 

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -131,9 +131,8 @@ def find_existing_host(
     immutable_facts, id_facts = _extract_immutable_and_id_facts(canonical_facts)
 
     # First search based on immutable id facts.
-    if immutable_facts:
-        existing_host = _find_host_by_multiple_facts_in_db_or_in_memory(identity, immutable_facts, from_hosts)
-        if existing_host:
+    if immutable_facts:  # noqa: SIM102
+        if existing_host := _find_host_by_multiple_facts_in_db_or_in_memory(identity, immutable_facts, from_hosts):
             return existing_host
 
     if not id_facts:
@@ -148,10 +147,9 @@ def find_existing_host(
         # Ensure both components of compound facts are collected.
         if compound_fact := COMPOUND_ID_FACTS_MAP.get(target_key):  # noqa: SIM102
             if compound_fact_value := canonical_facts.get(compound_fact):
-                immutable_facts[compound_fact] = compound_fact_value
+                target_facts[compound_fact] = compound_fact_value
 
-        existing_host = _find_host_by_multiple_facts_in_db_or_in_memory(identity, target_facts, from_hosts)
-        if existing_host:
+        if existing_host := _find_host_by_multiple_facts_in_db_or_in_memory(identity, target_facts, from_hosts):
             return existing_host
 
     return None

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -114,8 +114,9 @@ def _extract_immutable_and_id_facts(canonical_facts: dict[str, Any]) -> tuple[di
         if key in IMMUTABLE_ID_FACTS:
             immutable_facts[key] = canonical_facts[key]
             # Add compound facts (for example, add provider_type if provider_id is present)
-            if compound_fact := COMPOUND_ID_FACTS_MAP.get(key):
-                immutable_facts[compound_fact] = canonical_facts[compound_fact]
+            if compound_fact := COMPOUND_ID_FACTS_MAP.get(key):  # noqa: SIM102
+                if compound_fact_value := canonical_facts.get(compound_fact):
+                    immutable_facts[compound_fact] = compound_fact_value
         else:
             id_facts[key] = canonical_facts[key]
 
@@ -145,8 +146,9 @@ def find_existing_host(
         target_facts = dict(immutable_facts, **{target_key: target_value})
 
         # Ensure both components of compound facts are collected.
-        if compound_fact := COMPOUND_ID_FACTS_MAP.get(target_key):
-            target_facts[compound_fact] = canonical_facts[compound_fact]
+        if compound_fact := COMPOUND_ID_FACTS_MAP.get(target_key):  # noqa: SIM102
+            if compound_fact_value := canonical_facts.get(compound_fact):
+                immutable_facts[compound_fact] = compound_fact_value
 
         existing_host = _find_host_by_multiple_facts_in_db_or_in_memory(identity, target_facts, from_hosts)
         if existing_host:

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -4,10 +4,6 @@ from prometheus_client import Summary
 host_dedup_processing_time = Summary(
     "inventory_dedup_processing_seconds", "Time spent looking for existing host (dedup logic)"
 )
-find_host_using_elevated_ids = Summary(
-    "inventory_find_host_using_elevated_ids_processing_seconds",
-    "Time spent looking for existing host using the elevated ids",
-)
 find_host_by_facts_in_db = Summary(
     "inventory_find_host_by_facts_in_db_processing_seconds",
     "Time spent looking for existing host by canonical facts in db",

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -7,6 +7,7 @@ from typing import Callable
 
 import pytest
 from connexion import FlaskApp
+from sqlalchemy.orm import Query
 from sqlalchemy_utils import create_database
 from sqlalchemy_utils import database_exists
 from sqlalchemy_utils import drop_database
@@ -64,8 +65,8 @@ def db_get_host(flask_app):  # noqa: ARG001
 
 
 @pytest.fixture(scope="function")
-def db_get_hosts(flask_app):  # noqa: ARG001
-    def _db_get_hosts(host_ids):
+def db_get_hosts(flask_app: FlaskApp) -> Callable[[list[str]], Query]:  # noqa: ARG001
+    def _db_get_hosts(host_ids: list[str]) -> Query:
         return Host.query.filter(Host.id.in_(host_ids))
 
     return _db_get_hosts

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -150,8 +150,13 @@ def db_create_host(flask_app: FlaskApp) -> Callable[..., Host]:  # noqa: ARG001
 
 
 @pytest.fixture(scope="function")
-def db_create_multiple_hosts(flask_app):  # noqa: ARG001
-    def _db_create_multiple_hosts(identity=SYSTEM_IDENTITY, hosts=None, how_many=10, extra_data=None):
+def db_create_multiple_hosts(flask_app: FlaskApp) -> Callable[..., list[Host]]:  # noqa: ARG001
+    def _db_create_multiple_hosts(
+        identity: dict[str, Any] = SYSTEM_IDENTITY,
+        hosts: list[Host] | None = None,
+        how_many: int = 10,
+        extra_data: dict[str, Any] | None = None,
+    ) -> list[Host]:
         extra_data = extra_data or {}
         created_hosts = []
         if isinstance(hosts, list):

--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -2,10 +2,12 @@ import json
 from collections.abc import Generator
 from datetime import datetime
 from datetime import timezone
+from typing import Callable
 from unittest.mock import patch
 
 import pytest
 from connexion import FlaskApp
+from pytest_mock import MockFixture
 
 from app.models import db
 from app.queue.event_producer import EventProducer
@@ -30,10 +32,10 @@ from tests.helpers.test_utils import now
 
 @pytest.fixture(scope="function")
 def mq_create_or_update_host(
-    flask_app,
-    event_producer_mock,
-    notification_event_producer_mock,
-):
+    flask_app: FlaskApp,
+    event_producer_mock: MockEventProducer,
+    notification_event_producer_mock: MockEventProducer,
+) -> Callable:
     def _mq_create_or_update_host(
         host_data,
         platform_metadata=None,
@@ -171,7 +173,7 @@ def notification_event_producer(flask_app, notification_kafka_producer):  # noqa
 
 
 @pytest.fixture(scope="function")
-def event_producer_mock(flask_app, mocker):
+def event_producer_mock(flask_app: FlaskApp, mocker: MockFixture) -> Generator[MockEventProducer]:
     flask_app.app.event_producer = MockEventProducer()
     mocker.patch("lib.host_delete.kafka_available")
     yield flask_app.app.event_producer
@@ -179,7 +181,7 @@ def event_producer_mock(flask_app, mocker):
 
 
 @pytest.fixture(scope="function")
-def notification_event_producer_mock(flask_app, mocker):
+def notification_event_producer_mock(flask_app: FlaskApp, mocker: MockFixture) -> Generator[MockEventProducer]:
     flask_app.app.notification_event_producer = MockEventProducer()
     mocker.patch("lib.host_delete.kafka_available")
     yield flask_app.app.notification_event_producer

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -16,9 +16,9 @@ from random import choice
 from random import randint
 from typing import Any
 
+from app.config import COMPOUND_ID_FACTS_MAP
 from app.models import ProviderType
 from app.utils import HostWrapper
-from lib.host_repository import COMPOUND_CANONICAL_FACTS_MAP
 
 NS = "testns"
 ID = "whoabuddy"
@@ -263,7 +263,7 @@ def generate_fact(fact_name, num=1):
 
 def generate_fact_dict(fact_name, num=1):
     fact_dict = {fact_name: generate_fact(fact_name, num)}
-    if compound_fact := COMPOUND_CANONICAL_FACTS_MAP.get(fact_name):
+    if compound_fact := COMPOUND_ID_FACTS_MAP.get(fact_name):
         fact_dict[compound_fact] = COMPOUND_FACT_VALUES[compound_fact]
 
     return fact_dict

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -17,6 +17,7 @@ from random import randint
 from typing import Any
 
 from app.config import COMPOUND_ID_FACTS_MAP
+from app.config import ID_FACTS
 from app.models import ProviderType
 from app.utils import HostWrapper
 
@@ -60,6 +61,18 @@ SATELLITE_IDENTITY = deepcopy(SYSTEM_IDENTITY)
 SATELLITE_IDENTITY["system"]["cert_type"] = "satellite"
 
 COMPOUND_FACT_VALUES = {"provider_type": ProviderType.AWS.value}
+
+CANONICAL_FACTS_LIST = (
+    "provider_id",
+    "provider_type",
+    "subscription_manager_id",
+    "insights_id",
+    "satellite_id",
+    "fqdn",
+    "bios_uuid",
+    "ip_addresses",
+    "mac_addresses",
+)
 
 
 def generate_uuid():
@@ -117,7 +130,8 @@ def base_host(**values):
 # It should be used in test cases where specific canonical facts are not needed.
 def minimal_host(**values) -> HostWrapper:
     host_wrapper = HostWrapper(_base_host_data(**values))
-    host_wrapper.bios_uuid = generate_uuid()
+    if not any(id_fact in values for id_fact in ID_FACTS):
+        host_wrapper.subscription_manager_id = generate_uuid()
     return host_wrapper
 
 
@@ -239,7 +253,7 @@ def get_platform_metadata(identity=SYSTEM_IDENTITY):
     }
 
 
-def random_mac():
+def random_mac() -> str:
     return (
         f"{random.randint(0, 255):02x}:{random.randint(0, 255):02x}:"
         f"{random.randint(0, 255):02x}:{random.randint(0, 255):02x}:"
@@ -247,17 +261,26 @@ def random_mac():
     )
 
 
-def generate_mac_addresses(num_mac):
-    macs = []
-    for _ in range(num_mac):
-        macs.append(random_mac())
-    return macs
+def random_ip() -> str:
+    return ".".join(str(random.randint(0, 255)) for _ in range(4))
+
+
+def generate_mac_addresses(num_macs: int) -> list[str]:
+    return [random_mac() for _ in range(num_macs)]
+
+
+def generate_ip_addresses(num_ips: int) -> list[str]:
+    return [random_ip() for _ in range(num_ips)]
 
 
 # Extend this method as new types are required.
-def generate_fact(fact_name, num=1):
+def generate_fact(fact_name: str, num: int = 1) -> str | list[str]:
     if fact_name == "mac_addresses":
         return generate_mac_addresses(num)
+    if fact_name == "ip_addresses":
+        return generate_ip_addresses(num)
+    if fact_name == "provider_type":
+        return choice(list(ProviderType))
     return generate_uuid()
 
 
@@ -267,6 +290,10 @@ def generate_fact_dict(fact_name, num=1):
         fact_dict[compound_fact] = COMPOUND_FACT_VALUES[compound_fact]
 
     return fact_dict
+
+
+def generate_all_canonical_facts() -> dict[str, str | list[str]]:
+    return {canonical_fact: generate_fact(canonical_fact) for canonical_fact in CANONICAL_FACTS_LIST}
 
 
 class MockResponseObject:

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -130,7 +130,7 @@ def base_host(**values):
 # It should be used in test cases where specific canonical facts are not needed.
 def minimal_host(**values) -> HostWrapper:
     host_wrapper = HostWrapper(_base_host_data(**values))
-    if not any(id_fact in values for id_fact in ID_FACTS):
+    if all(id_fact not in values for id_fact in ID_FACTS):
         host_wrapper.subscription_manager_id = generate_uuid()
     return host_wrapper
 

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -420,8 +420,6 @@ def test_delete_hosts_from_diff_groups_post_kessel_migration(
 
     ungrouped_group_id = str(db_create_group("ungrouped", ungrouped=True).id)
 
-    mocker.patch("lib.host_repository.get_flag_value", return_value=True)
-
     hosts_to_delete = [str(group1.hosts[0].id), str(group2.hosts[0].id), str(group3.hosts[0].id)]
     response_status, _ = api_remove_hosts_from_diff_groups(hosts_to_delete)
 

--- a/tests/test_api_groups_update.py
+++ b/tests/test_api_groups_update.py
@@ -430,8 +430,6 @@ def test_patch_ungrouped_name_is_denied(db_create_group, db_get_group_by_id, api
     orig_modified_on = group.modified_on
     patch_doc = {"name": "modified_group"}
 
-    mocker.patch("lib.host_repository.get_flag_value", return_value=True)
-
     # Try to edit name of ungrouped group
     response_status, _ = api_patch_group(group_id, patch_doc)
     assert_response_status(response_status, 400)

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1318,7 +1318,7 @@ def test_query_all_sp_filters_basic(db_create_host, api_get, sp_filter_param):
             "?hostname_or_id=1*m",
             [
                 {"display_name": "HkqL12lmIW"},
-                {"canonical_facts": {"fqdn": "HkqL1m2lIW"}},
+                {"canonical_facts": {"fqdn": "HkqL1m2lIW", "subscription_manager_id": generate_uuid()}},
             ],
         ),
     ),
@@ -1330,7 +1330,7 @@ def test_query_host_fuzzy_match(db_create_host, api_get, query_filter_param, mat
     # Create host with differing SP
     nomatch_host_facts = [
         {"display_name": "masdf1"},
-        {"canonical_facts": {"fqdn": "masdf1"}},
+        {"canonical_facts": {"fqdn": "masdf1", "subscription_manager_id": generate_uuid()}},
     ]
     nomatch_host_id_list = [str(db_create_host(extra_data=host_fact).id) for host_fact in nomatch_host_facts]
 

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -2,10 +2,10 @@ import pytest
 from pytest import mark
 
 from app.auth.identity import Identity
+from app.config import IMMUTABLE_ID_FACTS
 from app.exceptions import InventoryException
 from app.exceptions import ValidationException
 from app.models import ProviderType
-from lib.host_repository import IMMUTABLE_CANONICAL_FACTS
 from lib.host_repository import find_existing_host
 from tests.helpers.db_utils import assert_host_exists_in_db
 from tests.helpers.db_utils import assert_host_missing_from_db
@@ -153,7 +153,7 @@ def test_high_prio_change_low_prio_match(mq_create_or_update_host, high_prio_cha
     wrapper = base_host(**base_canonical_facts)
     second_host = mq_create_or_update_host(wrapper)
 
-    if high_prio_change in IMMUTABLE_CANONICAL_FACTS:
+    if high_prio_change in IMMUTABLE_ID_FACTS:
         # When an immutable fact is different, then it should never match.
         assert first_host.id != second_host.id
     else:
@@ -205,7 +205,7 @@ def test_elevated_id_priority_order_nomatch(db_create_host, changing_id):
     created_host = db_create_host(host=minimal_db_host(canonical_facts=created_host_canonical_facts))
 
     assert_host_exists_in_db(created_host.id, created_host_canonical_facts)
-    if changing_id in IMMUTABLE_CANONICAL_FACTS:
+    if changing_id in IMMUTABLE_ID_FACTS:
         # When an immutable fact is different, then it should never match.
         assert_host_missing_from_db(search_canonical_facts)
     else:

--- a/tests/test_delete_hosts_without_id_facts_script.py
+++ b/tests/test_delete_hosts_without_id_facts_script.py
@@ -1,0 +1,66 @@
+from typing import Callable
+
+from connexion import FlaskApp
+from pytest_mock import MockerFixture
+from sqlalchemy.orm import Query
+
+from app.models import Host
+from app.models import db
+from delete_hosts_without_id_facts import run
+from jobs.common import init_config
+from lib.handlers import ShutdownHandler
+from tests.helpers.test_utils import generate_uuid
+
+
+def test_delete_hosts_without_id_facts_happy_path(
+    flask_app: FlaskApp,
+    db_create_host: Callable[..., Host],
+    db_get_hosts: Callable[[list[str]], Query],
+    mocker: MockerFixture,
+):
+    host_with_provider_id = db_create_host(
+        extra_data={"canonical_facts": {"provider_id": generate_uuid(), "provider_type": "aws"}}
+    )
+    host_with_subscription_manager_id = db_create_host(
+        extra_data={"canonical_facts": {"subscription_manager_id": generate_uuid()}}
+    )
+    host_with_insights_id = db_create_host(extra_data={"canonical_facts": {"insights_id": generate_uuid()}})
+    host_with_all_id_facts = db_create_host(
+        extra_data={
+            "canonical_facts": {
+                "provider_id": generate_uuid(),
+                "provider_type": "aws",
+                "subscription_manager_id": generate_uuid(),
+                "insights_id": generate_uuid(),
+            }
+        }
+    )
+
+    # We have to create the host with ID fact first to prevent ValidationException
+    host_without_id_facts = db_create_host(extra_data={"canonical_facts": {"insights_id": generate_uuid()}})
+    # Then we can update the canonical facts
+    host_without_id_facts.canonical_facts = {"fqdn": generate_uuid()}
+    db_create_host(host=host_without_id_facts)
+
+    all_host_ids = {
+        host_with_provider_id.id,
+        host_with_subscription_manager_id.id,
+        host_with_insights_id.id,
+        host_with_all_id_facts.id,
+        host_without_id_facts.id,
+    }
+    expected_host_ids = all_host_ids - {host_without_id_facts.id}
+
+    run(
+        config=init_config(),
+        logger=mocker.Mock(),
+        session=db.session,
+        event_producer=mocker.Mock(),
+        notifications_event_producer=mocker.Mock(),
+        shutdown_handler=ShutdownHandler(),
+        application=flask_app,
+    )
+
+    existing_hosts = db_get_hosts(list(all_host_ids)).all()
+    assert len(existing_hosts) == 4
+    assert set(host.id for host in existing_hosts) == expected_host_ids

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -1459,7 +1459,7 @@ def test_host_account_using_mq(mq_create_or_update_host, db_get_host, db_get_hos
     assert len(first_batch.all()) == len(second_batch.all())
 
 
-@pytest.mark.parametrize("id_type", ("id", "insights_id", "fqdn"))
+@pytest.mark.parametrize("id_type", ("id", "insights_id"))
 def test_update_system_profile(mq_create_or_update_host, db_get_host, id_type):
     expected_ids = {"insights_id": generate_uuid(), "fqdn": "foo.test.redhat.com"}
     input_host = base_host(
@@ -2246,7 +2246,7 @@ def test_add_host_logs(identity, mocker, caplog):
     mock_notification_event_producer.write_event.assert_not_called()
 
 
-@pytest.mark.parametrize("id_type", ("id", "insights_id", "fqdn"))
+@pytest.mark.parametrize("id_type", ("id", "insights_id"))
 def test_log_update_system_profile(mq_create_or_update_host, db_get_host, id_type, caplog):
     caplog.at_level(logging.INFO)
     expected_ids = {"insights_id": generate_uuid(), "fqdn": "foo.test.redhat.com"}
@@ -2275,7 +2275,8 @@ def test_log_update_system_profile(mq_create_or_update_host, db_get_host, id_typ
         "number_of_cpus": 4,
         "number_of_sockets": 8,
     }
-    assert caplog.records[0].input_host["system_profile"] == "{}"
+    assert caplog.records[-1].message.startswith(f"System profile updated for host ID: {first_host_from_event.id}")
+    assert caplog.records[-1].system_profile == "{}"
 
 
 def test_add_host_subman_id(mq_create_or_update_host_subman_id, db_get_host):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -68,6 +68,7 @@ from tests.helpers.system_profile_utils import system_profile_specification
 from tests.helpers.test_utils import SERVICE_ACCOUNT_IDENTITY
 from tests.helpers.test_utils import SYSTEM_IDENTITY
 from tests.helpers.test_utils import USER_IDENTITY
+from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import now
 from tests.helpers.test_utils import set_environment
 
@@ -869,7 +870,7 @@ class SerializationDeserializeHostCompoundTestCase(TestCase):
         org_id = "some org_id"
         stale_timestamp = now()
         reporter = "puptoo"
-        canonical_facts = {"fqdn": "some fqdn"}
+        canonical_facts = {"subscription_manager_id": generate_uuid()}
 
         with self.subTest(schema=HostSchema):
             host = deserialize_host(
@@ -1037,7 +1038,7 @@ class SerializationDeserializeHostCompoundTestCase(TestCase):
                 "org_id": "3340851",
                 "stale_timestamp": now().isoformat(),
                 "reporter": "puptoo",
-                "fqdn": "some fqdn",
+                "subscription_manager_id": generate_uuid(),
                 "tags": tags,
             }
         )
@@ -1615,7 +1616,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
                     }
                     host_init_data = {
                         "stale_timestamp": now(),
-                        "canonical_facts": {"fqdn": "some fqdn"},
+                        "canonical_facts": {"subscription_manager_id": generate_uuid()},
                         **unchanged_data,
                         "facts": {},
                     }
@@ -1638,7 +1639,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
                     expected = {
                         **host_init_data["canonical_facts"],
                         "insights_id": None,
-                        "subscription_manager_id": None,
+                        "fqdn": None,
                         "satellite_id": None,
                         "bios_uuid": None,
                         "ip_addresses": None,
@@ -1693,7 +1694,7 @@ class SerializationSerializeHostCompoundTestCase(SerializationSerializeHostBaseT
                 ):
                     stale_timestamp = now() + timedelta(days=1)
                     host = Host(
-                        {"fqdn": "some fqdn"},
+                        {"subscription_manager_id": generate_uuid()},
                         facts={},
                         stale_timestamp=stale_timestamp,
                         reporter="some reporter",
@@ -1839,7 +1840,7 @@ class SerializationSerializeHostSystemProfileTestCase(TestCase):
             "system_memory_bytes": 4,
         }
         host = Host(
-            canonical_facts={"fqdn": "some fqdn"},
+            canonical_facts={"subscription_manager_id": generate_uuid()},
             display_name="some display name",
             system_profile_facts=system_profile_facts,
             stale_timestamp=now(),
@@ -1854,7 +1855,7 @@ class SerializationSerializeHostSystemProfileTestCase(TestCase):
 
     def test_empty_profile_is_empty_dict(self):
         host = Host(
-            canonical_facts={"fqdn": "some fqdn"},
+            canonical_facts={"subscription_manager_id": generate_uuid()},
             display_name="some display name",
             stale_timestamp=now(),
             reporter="yupana",
@@ -2054,7 +2055,7 @@ class SerializationSerializeUuid(TestCase):
 
 class HostUpdateStaleTimestamp(TestCase):
     def _make_host(self, **values):
-        return Host(**{"canonical_facts": {"fqdn": "some fqdn"}, **values})
+        return Host(**{"canonical_facts": {"subscription_manager_id": generate_uuid()}, **values})
 
     def test_always_updated(self):
         old_stale_timestamp = now() + timedelta(days=2)
@@ -2177,7 +2178,7 @@ class EventProducerTests(TestCase):
             "reporter": "test_reporter",
             "account": "test",
             "org_id": "test",
-            "fqdn": "fqdn",
+            "subscription_manager_id": generate_uuid(),
         }
 
     def test_happy_path(self):


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-16546](https://issues.redhat.com/browse/RHINENG-16546).

Almost all of the incoming payloads (99.999993%) include at least one of the "elevated" canonical facts, so the subset/superset deduplication functionality for other canonical facts is already not used. This PR removes it from the code to simplify the dedup logic. It's the implementation of step 1 from [this document](https://docs.google.com/document/d/1OOyDaOU9XFKQJHLUbOhlSRsW5u3zgFgwaG7RmaH8bFU/edit?tab=t.0#heading=h.oi0pn2n4rb2b).

To do:
- [x] Update IQE tests and run them against this PR: https://gitlab.cee.redhat.com/insights-qe/iqe-host-inventory-plugin/-/merge_requests/1494
- [x] Prepare documentation updates: https://gitlab.cee.redhat.com/consoledot/consoledot.pages.redhat.com/-/merge_requests/308
- [x] Create a script / job / DB migration, that will remove all existing hosts without any "elevated" canonical fact from the DB. At the time of writing the proposal documents, there were only QA hosts in the Prod DB without elevated facts. If that is still true, we can delete them manually from UI.

I will keep this PR in a Draft state until the above is ready.

Initially I renamed the facts that are going to be used for deduplication to `ID_FACTS`. However, now I don't know if it's not confusing and if someone won't think that `host.id` is also part of the `ID_FACTS`. Should I rename them? Would `DEDUP_FACTS` be a better name?

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [x] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Simplify host deduplication by removing matching on regular canonical facts and relying exclusively on prioritized ID_FACTS.

Enhancements:
- Refactor find_existing_host to extract immutable and ID facts (provider_id, subscription_manager_id, insights_id) and match hosts in priority order.
- Remove legacy subset/superset deduplication functions and feature-flag logic related to elevated canonical facts.
- Introduce IMMUTABLE_ID_FACTS and COMPOUND_ID_FACTS_MAP in configuration and enforce at least one ID fact in the Host model validation.
- Update metrics to drop the old find_host_using_elevated_ids summary and retain overall deduplication timing.
- Adjust test suite and utilities to require ID facts and remove tests for non-ID canonical fact matching.

## Summary by Sourcery

Stop using regular canonical facts for host deduplication and rely only on prioritized ID facts; remove legacy subset/superset deduplication code, update tests, enforce ID fact validation, and add a job to delete hosts without any ID facts.

New Features:
- Add delete_hosts_without_id_facts script and corresponding ClowdJobInvocation to purge hosts lacking ID facts

Enhancements:
- Simplify host deduplication by removing subset/superset matching on non-ID canonical facts and rely exclusively on prioritized ID facts (provider_id, subscription_manager_id, insights_id)
- Refactor find_existing_host to extract immutable and ID facts, perform prioritized matching, and drop legacy elevated-facts logic and feature flags
- Introduce ID_FACTS, COMPOUND_ID_FACTS_MAP, and IMMUTABLE_ID_FACTS in configuration and enforce presence of at least one ID fact in Host model validation

Deployment:
- Add HOST_DELETE_CHUNK_SIZE environment variable and include delete-hosts-without-id-facts job in deployment manifests

Tests:
- Update tests to require an ID fact for host creation and validate deduplication behavior solely on ID facts, removing tests for non-ID fact matching