### PR TITLE
Assign ungrouped host fix attempt

### DIFF
--- a/assign_ungrouped_hosts_to_groups.py
+++ b/assign_ungrouped_hosts_to_groups.py
@@ -31,7 +31,7 @@ def run(logger: Logger, session: Session, event_producer: EventProducer, applica
         # For each org_id in the Hosts table
         # Using "org_id," (with comma) because the query returns tuples
         org_id_list = [org_id for (org_id,) in session.query(Host.org_id).distinct()]
-        while org_id_list:
+        for org_id in org_id_list:
             org_id = org_id_list.pop(0)
             logger.info(f"Processing org_id: {org_id}")
 

--- a/assign_ungrouped_hosts_to_groups.py
+++ b/assign_ungrouped_hosts_to_groups.py
@@ -22,7 +22,7 @@ from lib.group_repository import add_hosts_to_group
 PROMETHEUS_JOB = "inventory-assign-ungrouped-groups"
 LOGGER_NAME = "assign_ungrouped_groups"
 RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
-BATCH_SIZE = int(os.getenv("ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE", 10))
+BATCH_SIZE = int(os.getenv("ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE", 25))
 
 
 def run(logger: Logger, session: Session, event_producer: EventProducer, application: FlaskApp):

--- a/assign_ungrouped_hosts_to_groups.py
+++ b/assign_ungrouped_hosts_to_groups.py
@@ -30,7 +30,9 @@ def run(logger: Logger, session: Session, event_producer: EventProducer, applica
         threadctx.request_id = None
         # For each org_id in the Hosts table
         # Using "org_id," (with comma) because the query returns tuples
-        for (org_id,) in session.query(Host.org_id).distinct():
+        org_id_list = [org_id for (org_id,) in session.query(Host.org_id).distinct()]
+        while org_id_list:
+            org_id = org_id_list.pop(0)
             logger.info(f"Processing org_id: {org_id}")
 
             # Find the org's "ungrouped" group and store its ID

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -191,9 +191,15 @@ def wait_for_workspace_creation(workspace_id: str, timeout: int = 5):
     raise TimeoutError("No workspace creation message consumed in time.")
 
 
-def add_hosts_to_group(group_id: str, host_id_list: list[str], identity: Identity, event_producer: EventProducer):
+def add_hosts_to_group(
+    group_id: str,
+    host_id_list: list[str],
+    identity: Identity,
+    event_producer: EventProducer,
+    session: Session = db.session,
+):
     staleness = get_staleness_obj(identity.org_id)
-    with session_guard(db.session):
+    with session_guard(session):
         _add_hosts_to_group(group_id, host_id_list, identity.org_id)
 
     # Produce update messages once the DB session has been closed

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -169,7 +169,7 @@ def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str, ses
     ]
     session.add_all(host_group_assoc)
 
-    _update_group_update_time(group_id, org_id)
+    _update_group_update_time(group_id, org_id, session)
 
     log_host_group_add_succeeded(logger, host_id_list, group_id)
 


### PR DESCRIPTION
# Overview

This PR is being created to fix an issue with `assign_ungrouped_hosts_to_groups.py`'s memory usage. It's getting OOMKilled in Stage. I've changed it so it always uses the same DB session, and the org_id list gets smaller over time.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Improve memory management in the ungrouped-host assignment job by reusing a single database session across iterations and propagating session usage through repository methods.

Enhancements:
- Collect all organization IDs upfront and process them in a shrinking list to incrementally reduce workload.
- Wrap each batch query in a session_guard to maintain a consistent DB session across iterations.
- Extend add_hosts_to_group and related helper functions to accept an explicit session parameter and replace global db.session usage.
- Commit database changes through the passed-in session rather than the global session for better transactional control.