### PR TITLE
Revert recent ungrouped hosts changes

### DIFF
--- a/assign_ungrouped_hosts_to_groups.py
+++ b/assign_ungrouped_hosts_to_groups.py
@@ -16,13 +16,12 @@ from app.models import Host
 from app.queue.event_producer import EventProducer
 from jobs.common import excepthook
 from jobs.common import job_setup
-from lib.db import session_guard
 from lib.group_repository import add_hosts_to_group
 
 PROMETHEUS_JOB = "inventory-assign-ungrouped-groups"
 LOGGER_NAME = "assign_ungrouped_groups"
 RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
-BATCH_SIZE = int(os.getenv("ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE", 25))
+BATCH_SIZE = int(os.getenv("ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE", 10))
 
 
 def run(logger: Logger, session: Session, event_producer: EventProducer, application: FlaskApp):
@@ -30,9 +29,7 @@ def run(logger: Logger, session: Session, event_producer: EventProducer, applica
         threadctx.request_id = None
         # For each org_id in the Hosts table
         # Using "org_id," (with comma) because the query returns tuples
-        org_id_list = [org_id for (org_id,) in session.query(Host.org_id).distinct()]
-        for org_id in org_id_list:
-            org_id = org_id_list.pop(0)
+        for (org_id,) in session.query(Host.org_id).distinct():
             logger.info(f"Processing org_id: {org_id}")
 
             # Find the org's "ungrouped" group and store its ID
@@ -48,21 +45,16 @@ def run(logger: Logger, session: Session, event_producer: EventProducer, applica
             while True:
                 # Grab the first batch of ungrouped hosts in the org.
                 # We don't need offset() because Host.groups is populated during add_hosts_to_group().
-                with session_guard(session):
-                    host_ids = (
-                        session.query(Host.id).filter(Host.org_id == org_id, Host.groups == []).limit(BATCH_SIZE).all()
-                    )
-                    if not host_ids:
-                        break
-                    # host_ids is a list of tuples, so extract the ids
-                    host_id_list = [str(host_id) for (host_id,) in host_ids]
-                    add_hosts_to_group(
-                        ungrouped_group_id,
-                        host_id_list,
-                        create_mock_identity_with_org_id(org_id),
-                        event_producer,
-                        session,
-                    )
+                host_ids = (
+                    session.query(Host.id).filter(Host.org_id == org_id, Host.groups == []).limit(BATCH_SIZE).all()
+                )
+                if not host_ids:
+                    break
+                # host_ids is a list of tuples, so extract the ids
+                host_id_list = [str(host_id) for (host_id,) in host_ids]
+                add_hosts_to_group(
+                    ungrouped_group_id, host_id_list, create_mock_identity_with_org_id(org_id), event_producer
+                )
 
 
 if __name__ == "__main__":

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -392,8 +392,8 @@ def _remove_hosts_from_group(group_id, host_id_list, org_id):
     return removed_host_ids
 
 
-def get_group_by_id_from_db(group_id: str, org_id: str, session: Session = db.session) -> Group:
-    query = session.query(Group).filter(Group.org_id == org_id, Group.id == group_id)
+def get_group_by_id_from_db(group_id: str, org_id: str) -> Group:
+    query = Group.query.filter(Group.org_id == org_id, Group.id == group_id)
     return query.one_or_none()
 
 
@@ -445,7 +445,7 @@ def patch_group(group: Group, patch_data: dict, identity: Identity, event_produc
 
 
 def _update_group_update_time(group_id: str, org_id: str, session: Session = db.session):
-    group = get_group_by_id_from_db(group_id, org_id, session)
+    group = get_group_by_id_from_db(group_id, org_id)
     group.update_modified_on()
     session.add(group)
     session.flush()

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -47,9 +47,7 @@ from lib.middleware import rbac_create_ungrouped_hosts_workspace
 logger = get_logger(__name__)
 
 
-def _update_hosts_for_group_changes(
-    host_id_list: list[str], group_id_list: list[str], identity: Identity, session: Session = db.session
-):
+def _update_hosts_for_group_changes(host_id_list: list[str], group_id_list: list[str], identity: Identity):
     if group_id_list is None:
         group_id_list = []
 
@@ -60,7 +58,7 @@ def _update_hosts_for_group_changes(
 
     # Update groups data on each host record
     Host.query.filter(Host.id.in_(host_id_list)).update({"groups": serialized_groups}, synchronize_session="fetch")
-    session.commit()
+    db.session.commit()
     host_list = get_host_list_by_id_list_from_db(host_id_list, identity)
     return serialized_groups, host_list
 
@@ -117,11 +115,9 @@ def validate_add_host_list_to_group_for_group_create(host_id_list: list[str], gr
         )
 
 
-def validate_add_host_list_to_group(
-    host_id_list: list[str], group_id: str, org_id: str, session: Session = db.session
-):
+def validate_add_host_list_to_group(host_id_list: list[str], group_id: str, org_id: str):
     # Check if the hosts exist in Inventory and have correct org_id
-    host_query = session.query(Host).filter((Host.org_id == org_id) & Host.id.in_(host_id_list)).all()
+    host_query = Host.query.filter((Host.org_id == org_id) & Host.id.in_(host_id_list)).all()
     found_ids_set = {str(host.id) for host in host_query}
     if found_ids_set != set(host_id_list):
         nonexistent_hosts = set(host_id_list) - found_ids_set
@@ -132,8 +128,7 @@ def validate_add_host_list_to_group(
 
     # Check if the hosts are already associated with another (ungrouped) group
     if assoc_query := (
-        session.query(HostGroupAssoc)
-        .join(Group)
+        HostGroupAssoc.query.join(Group)
         .filter(
             HostGroupAssoc.host_id.in_(host_id_list), HostGroupAssoc.group_id != group_id, Group.ungrouped.is_(False)
         )
@@ -147,9 +142,9 @@ def validate_add_host_list_to_group(
         )
 
 
-def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str, session: Session = db.session):
+def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str):
     # First, validate that the hosts can even be added to the group
-    validate_add_host_list_to_group(host_id_list, group_id, org_id, session)
+    validate_add_host_list_to_group(host_id_list, group_id, org_id)
 
     # Filter out hosts that are already in the group
     assoc_query = HostGroupAssoc.query.filter(
@@ -167,9 +162,9 @@ def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str, ses
         for host_id in host_id_list
         if host_id not in ids_already_in_this_group
     ]
-    session.add_all(host_group_assoc)
+    db.session.add_all(host_group_assoc)
 
-    _update_group_update_time(group_id, org_id, session)
+    _update_group_update_time(group_id, org_id)
 
     log_host_group_add_succeeded(logger, host_id_list, group_id)
 
@@ -196,20 +191,14 @@ def wait_for_workspace_creation(workspace_id: str, timeout: int = 5):
     raise TimeoutError("No workspace creation message consumed in time.")
 
 
-def add_hosts_to_group(
-    group_id: str,
-    host_id_list: list[str],
-    identity: Identity,
-    event_producer: EventProducer,
-    session: Session = db.session,
-):
+def add_hosts_to_group(group_id: str, host_id_list: list[str], identity: Identity, event_producer: EventProducer):
     staleness = get_staleness_obj(identity.org_id)
-    with session_guard(session):
-        _add_hosts_to_group(group_id, host_id_list, identity.org_id, session)
+    with session_guard(db.session):
+        _add_hosts_to_group(group_id, host_id_list, identity.org_id)
 
     # Produce update messages once the DB session has been closed
     serialized_groups, host_list = _update_hosts_for_group_changes(
-        host_id_list, group_id_list=[group_id], identity=identity, session=session
+        host_id_list, group_id_list=[group_id], identity=identity
     )
     _produce_host_update_events(event_producer, serialized_groups, host_list, identity, staleness=staleness)
     _invalidate_system_cache(host_list, identity)
@@ -444,11 +433,11 @@ def patch_group(group: Group, patch_data: dict, identity: Identity, event_produc
         _invalidate_system_cache(host_list, identity)
 
 
-def _update_group_update_time(group_id: str, org_id: str, session: Session = db.session):
+def _update_group_update_time(group_id: str, org_id: str):
     group = get_group_by_id_from_db(group_id, org_id)
     group.update_modified_on()
-    session.add(group)
-    session.flush()
+    db.session.add(group)
+    db.session.flush()
 
 
 def get_group_using_host_id(host_id: str, org_id: str):


### PR DESCRIPTION
# Overview

This PR is being created to revert some recent changes to the assign-ungrouped-hosts script. I'm making this because I think some recent changes are causing the required PR check to fail. 

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Revert recent changes to the ungrouped hosts assignment logic by restoring direct db.session usage, simplifying the assignment script, and adjusting batch size.

Enhancements:
- Consolidate database session management by removing explicit session parameters in repository functions and always using db.session
- Simplify the assign-ungrouped-hosts script by dropping session_guard wrappers and iterating org_ids directly
- Update add_hosts_to_group signature to remove session argument and align with repository changes
- Reduce the default batch size for ungrouped host assignment from 25 to 10