### PR TITLE
Add config to bypass kessel jobs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -320,6 +320,7 @@ class Config:
             "IMMUTABLE_TIME_TO_DELETE_SECONDS", days_to_seconds(730)
         )
 
+        self.bypass_kessel_jobs = os.getenv("BYPASS_KESSEL_JOBS", "false").lower() == "true"
         self.rbac_v2_force_org_admin = os.getenv("RBAC_V2_FORCE_ORG_ADMIN", "false").lower() == "true"
         self.use_sub_man_id_for_host_id = os.environ.get("USE_SUBMAN_ID", "false").lower() == "true"
         self.host_delete_chunk_size = int(os.getenv("HOST_DELETE_CHUNK_SIZE", "1000"))

--- a/assign_ungrouped_hosts_to_groups.py
+++ b/assign_ungrouped_hosts_to_groups.py
@@ -73,5 +73,9 @@ if __name__ == "__main__":
     job_type = "Assign ungrouped hosts to ungrouped groups"
     sys.excepthook = partial(excepthook, logger, job_type)
 
-    _, session, event_producer, _, _, application = job_setup((), PROMETHEUS_JOB)
-    run(logger, session, event_producer, application)
+    config, session, event_producer, _, _, application = job_setup((), PROMETHEUS_JOB)
+    if config.bypass_kessel_jobs:
+        logger.info("bypass_kessel_jobs was set to True; exiting.")
+        sys.exit(0)
+    else:
+        run(logger, session, event_producer, application)

--- a/create_ungrouped_host_groups.py
+++ b/create_ungrouped_host_groups.py
@@ -52,5 +52,9 @@ if __name__ == "__main__":
     job_type = "Create ungrouped host groups"
     sys.excepthook = partial(excepthook, logger, job_type)
 
-    _, session, _, _, _, application = job_setup((), PROMETHEUS_JOB)
-    run(logger, session, application)
+    config, session, _, _, _, application = job_setup((), PROMETHEUS_JOB)
+    if config.bypass_kessel_jobs:
+        logger.info("bypass_kessel_jobs was set to True; exiting.")
+        sys.exit(0)
+    else:
+        run(logger, session, application)

--- a/delete_ungrouped_host_groups.py
+++ b/delete_ungrouped_host_groups.py
@@ -42,5 +42,9 @@ if __name__ == "__main__":
     job_type = "Delete ungrouped host groups"
     sys.excepthook = partial(excepthook, logger, job_type)
 
-    _, session, event_producer, _, _, application = job_setup((), PROMETHEUS_JOB)
-    run(logger, session, event_producer, application)
+    config, session, event_producer, _, _, application = job_setup((), PROMETHEUS_JOB)
+    if config.bypass_kessel_jobs:
+        logger.info("bypass_kessel_jobs was set to True; exiting.")
+        sys.exit(0)
+    else:
+        run(logger, session, event_producer, application)

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1409,6 +1409,8 @@ objects:
             value: ${BYPASS_UNLEASH}
           - name: UNLEASH_REFRESH_INTERVAL
             value: ${UNLEASH_REFRESH_INTERVAL}
+          - name: BYPASS_KESSEL_JOBS
+            value: ${BYPASS_KESSEL_JOBS}
         resources:
           limits:
             cpu: ${CPU_LIMIT_UNGROUPED_HOSTS_JOB}
@@ -1472,6 +1474,8 @@ objects:
             value: ${BYPASS_UNLEASH}
           - name: UNLEASH_REFRESH_INTERVAL
             value: ${UNLEASH_REFRESH_INTERVAL}
+          - name: BYPASS_KESSEL_JOBS
+            value: ${BYPASS_KESSEL_JOBS}
         resources:
           limits:
             cpu: ${CPU_LIMIT_UNGROUPED_HOSTS_JOB}
@@ -1516,6 +1520,8 @@ objects:
               secretKeyRef:
                 name: ${S3_AWS_SECRET}
                 key: bucket
+          - name: BYPASS_KESSEL_JOBS
+            value: ${BYPASS_KESSEL_JOBS}
         resources:
           limits:
             cpu: ${CPU_LIMIT_GROUPS_S3_EXPORT}
@@ -1579,6 +1585,10 @@ objects:
             value: ${BYPASS_UNLEASH}
           - name: UNLEASH_REFRESH_INTERVAL
             value: ${UNLEASH_REFRESH_INTERVAL}
+          - name: BYPASS_KESSEL_JOBS
+            value: ${BYPASS_KESSEL_JOBS}
+          - name: ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE
+            value: ${ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_UNGROUPED_HOSTS_JOB}
@@ -2286,6 +2296,12 @@ parameters:
 - name: RBAC_V2_FORCE_ORG_ADMIN
   description: Whether to force User Identities to use is_org_admin=True for RBAC v2 calls
   value: 'false'
+- name: BYPASS_KESSEL_JOBS
+  description: Whether to bypass Kessel-related jobs, even when triggered via CJI
+  value: 'true'
+- name: ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE
+  description: The batch size to use for the assign-ungrouped-hosts script.
+  value: '10'
 
 # NGINX
 - displayName: Minimum replicas

--- a/export_group_data_s3.py
+++ b/export_group_data_s3.py
@@ -61,5 +61,9 @@ if __name__ == "__main__":
     job_type = "Create ungrouped host groups"
     sys.excepthook = partial(excepthook, logger, job_type)
 
-    config, session, _, _, _, application = job_setup(tuple(), PROMETHEUS_JOB)
-    run(config, logger, session, application)
+    config, session, _, _, _, application = job_setup((), PROMETHEUS_JOB)
+    if config.bypass_kessel_jobs:
+        logger.info("bypass_kessel_jobs was set to True; exiting.")
+        sys.exit(0)
+    else:
+        run(config, logger, session, application)


### PR DESCRIPTION
# Overview

This PR is being created to support a Prod deploy. It adds a `BYPASS_KESSEL_JOBS` env var that, when unset or set to True, will exit kessel-related jobs without running them. This will ensure that the new CJIs will not trigger job runs in Prod before we are ready.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
