### PR TITLE
RHINENG-18139: Clarify the message from get_staleness_obj()

### DIFF
--- a/api/staleness_query.py
+++ b/api/staleness_query.py
@@ -14,10 +14,10 @@ logger = get_logger(__name__)
 def get_staleness_obj(org_id: str, session: Session = db.session) -> AttrDict:
     try:
         staleness = session.query(Staleness).filter(Staleness.org_id == org_id).one()
-        logger.info("Using custom account staleness")
+        logger.info(f"Using custom staleness for org {org_id}.")
         staleness = build_serialized_acc_staleness_obj(staleness)
     except NoResultFound:
-        logger.debug(f"No staleness data found for org {org_id}, using system default values")
+        logger.debug(f"No custom staleness data found for org {org_id}, using system default values instead.")
         staleness = build_staleness_sys_default(org_id)
         return staleness
 


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

# Overview

This PR is being created to address [RHINENG-18139](https://issues.redhat.com/browse/RHINENG-18139).


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Clarify and improve logging in get_staleness_obj by including the organization ID and refining message phrasing

Enhancements:
- Include the org_id in the info log when custom staleness data is found
- Refine the debug log to specify absence of custom data and the fallback to system defaults