### PR TITLE
feat(RHINENG-15659): update staleness columns for RHSM hosts

### DIFF
--- a/api/staleness.py
+++ b/api/staleness.py
@@ -101,7 +101,7 @@ def _update_hosts_staleness_async(identity: Identity, app: Flask, staleness: Sta
             if num_hosts > 0:
                 logger.debug(f"Found {num_hosts} hosts for org_id: {identity.org_id}")
                 for host in hosts_query.yield_per(500):
-                    host._update_all_per_reporter_staleness()
+                    host._update_all_per_reporter_staleness(staleness_dict, st)
                     host._update_staleness_timestamps()
                     serialized_host = serialize_host(
                         host, for_mq=True, staleness_timestamps=st, staleness=staleness_dict

--- a/host_reaper.py
+++ b/host_reaper.py
@@ -95,6 +95,8 @@ def run(config, logger, session, event_producer, notification_event_producer, sh
         for host in rhsm_bridge_hosts_query.yield_per(config.host_delete_chunk_size):
             host._update_modified_date()
             host._update_last_check_in_date()
+            host._update_staleness_timestamps()
+            host._update_all_per_reporter_staleness()
 
         query = session.query(Host).filter(and_(or_(False, *filter_hosts_to_delete)))
         hosts_processed = config.host_delete_chunk_size


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-15659](https://issues.redhat.com/browse/RHINENG-15659).

This PR does:
- Update staleness columns for the RHSM hosts, that are not deleted by reaper.
- Update per_reporter_staleness for the RHSM hosts, that are not deleted by reaper.
- Add a new method to correctly update all reporters inside the per_reporter_staleness using each reporter last_check_in

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enhancements:
- Refresh staleness columns by invoking _update_staleness_timestamps() for each RHSM host during reaping