### PR TITLE
Use lazy default for session param

### DIFF
--- a/api/staleness_query.py
+++ b/api/staleness_query.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -11,7 +13,8 @@ from app.staleness_serialization import build_staleness_sys_default
 logger = get_logger(__name__)
 
 
-def get_staleness_obj(org_id: str, session: Session = db.session) -> AttrDict:
+def get_staleness_obj(org_id: str, session: Optional[Session] = None) -> AttrDict:
+    session = session or db.session
     try:
         staleness = session.query(Staleness).filter(Staleness.org_id == org_id).one()
         logger.info(f"Using custom staleness for org {org_id}.")

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -247,7 +247,8 @@ def _get_unculled_hosts(group, org_id, session=db.session):
     return hosts
 
 
-def serialize_group(group: Group, org_id: str, session: Session = db.session):
+def serialize_group(group: Group, org_id: str, session: Session | None = None):
+    session = session or db.session
     unculled_hosts = _get_unculled_hosts(group, org_id, session)
     return {
         "id": _serialize_uuid(group.id),

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -48,8 +48,9 @@ logger = get_logger(__name__)
 
 
 def _update_hosts_for_group_changes(
-    host_id_list: list[str], group_id_list: list[str], identity: Identity, session: Session = db.session
+    host_id_list: list[str], group_id_list: list[str], identity: Identity, session: Optional[Session] = None
 ):
+    session = session or db.session
     if group_id_list is None:
         group_id_list = []
 
@@ -118,8 +119,9 @@ def validate_add_host_list_to_group_for_group_create(host_id_list: list[str], gr
 
 
 def validate_add_host_list_to_group(
-    host_id_list: list[str], group_id: str, org_id: str, session: Session = db.session
+    host_id_list: list[str], group_id: str, org_id: str, session: Optional[Session] = None
 ):
+    session = session or db.session
     # Check if the hosts exist in Inventory and have correct org_id
     host_query = session.query(Host).filter((Host.org_id == org_id) & Host.id.in_(host_id_list)).all()
     found_ids_set = {str(host.id) for host in host_query}
@@ -147,7 +149,8 @@ def validate_add_host_list_to_group(
         )
 
 
-def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str, session: Session = db.session):
+def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str, session: Optional[Session] = None):
+    session = session or db.session
     # First, validate that the hosts can even be added to the group
     validate_add_host_list_to_group(host_id_list, group_id, org_id, session)
 
@@ -201,8 +204,9 @@ def add_hosts_to_group(
     host_id_list: list[str],
     identity: Identity,
     event_producer: EventProducer,
-    session: Session = db.session,
+    session: Optional[Session] = None,
 ):
+    session = session or db.session
     staleness = get_staleness_obj(identity.org_id, session)
     with session_guard(session):
         _add_hosts_to_group(group_id, host_id_list, identity.org_id, session)
@@ -221,8 +225,9 @@ def add_group(
     account: Optional[str] = None,
     group_id: Optional[UUID] = None,
     ungrouped: bool = False,
-    session: Session = db.session,
+    session: Optional[Session] = None,
 ) -> Group:
+    session = session or db.session
     new_group = Group(org_id=org_id, name=group_name, account=account, id=group_id, ungrouped=ungrouped)
     session.add(new_group)
     session.flush()
@@ -392,7 +397,8 @@ def _remove_hosts_from_group(group_id, host_id_list, org_id):
     return removed_host_ids
 
 
-def get_group_by_id_from_db(group_id: str, org_id: str, session: Session = db.session) -> Group:
+def get_group_by_id_from_db(group_id: str, org_id: str, session: Optional[Session] = None) -> Group:
+    session = session or db.session
     query = session.query(Group).filter(Group.org_id == org_id, Group.id == group_id)
     return query.one_or_none()
 
@@ -444,7 +450,8 @@ def patch_group(group: Group, patch_data: dict, identity: Identity, event_produc
         _invalidate_system_cache(host_list, identity)
 
 
-def _update_group_update_time(group_id: str, org_id: str, session: Session = db.session):
+def _update_group_update_time(group_id: str, org_id: str, session: Optional[Session] = None):
+    session = session or db.session
     group = get_group_by_id_from_db(group_id, org_id, session)
     group.update_modified_on()
     session.add(group)


### PR DESCRIPTION
# Overview

This PR is being created as a follow-up to #2605. Some changes to `assign_ungrouped_hosts_to_groups.py` were required, and passing the session fixed the issue; however, because we were in a hurry, we didn't implement lazy-default for the Session params. This PR fixes that.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enhancements:
- Default session parameters to None and assign db.session inside each function, updating type hints to Optional[Session] in lib/group_repository.py, api/staleness_query.py, and app/serialization.py.