### PR TITLE
docs: Add documentation of removing the data

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ If you want to destroy that data do the following:
 
 ```bash
 docker compose -f dev.yml down
+rm -r ~/.pg_data # or a another directory you defined in volumes
 ```
 
 ### Run database migrations


### PR DESCRIPTION
# Overview

This is a follow-up for #2569 to address left over comments.

## Summary by Sourcery

Documentation:
- Add `rm -r ~/.pg_data` command to README to clean up leftover database files