### PR TITLE
fix(RHINENG-15823) Update host.groups in Synchronizer

### DIFF
--- a/lib/host_synchronize.py
+++ b/lib/host_synchronize.py
@@ -35,6 +35,7 @@ def synchronize_hosts(
             if host.groups is None:
                 host.groups = []
 
+            # This is a temporary fix that we can remove later.
             # If host.groups says it's empty,
             # Get the host's associated Group (if any) and store it in the "groups" field
             if host.groups == [] and (group := get_group_using_host_id(str(host.id), host.org_id)):

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -376,7 +376,7 @@ def expected_encoded_headers(event_type, request_id, insights_id=None, reporter=
 
 
 def assert_synchronize_event_is_valid(
-    event_producer, key, host, timestamp, expected_request_id=None, expected_metadata=None
+    event_producer, key, host, groups, timestamp, expected_request_id=None, expected_metadata=None
 ):
     event = json.loads(event_producer.event)
 
@@ -389,6 +389,15 @@ def assert_synchronize_event_is_valid(
     assert event["type"] == "updated"
     assert host.canonical_facts.get("insights_id") == event["host"]["insights_id"]
     assert str(host.id) in event_producer.key
+
+    # Assert groups data
+    if groups == []:
+        assert event["host"]["groups"] == []
+    else:
+        assert event["host"]["groups"][0]["id"] == groups[0].id
+        assert event["host"]["groups"][0]["name"] == groups[0].name
+        assert event["host"]["groups"][0]["ungrouped"] is groups[0].ungrouped
+
     assert event_producer.headers == expected_headers(
         "updated",
         event["metadata"]["request_id"],

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -394,9 +394,9 @@ def assert_synchronize_event_is_valid(
     if groups == []:
         assert event["host"]["groups"] == []
     else:
-        assert event["host"]["groups"][0]["id"] == groups[0].id
+        assert event["host"]["groups"][0]["id"] == str(groups[0].id)
         assert event["host"]["groups"][0]["name"] == groups[0].name
-        assert event["host"]["groups"][0]["ungrouped"] is groups[0].ungrouped
+        assert event["host"]["groups"][0]["ungrouped"] == groups[0].ungrouped
 
     assert event_producer.headers == expected_headers(
         "updated",

--- a/tests/test_synchronizer.py
+++ b/tests/test_synchronizer.py
@@ -109,3 +109,59 @@ def test_synchronizer_update_null_groups(mocker, event_producer, db_create_multi
     for call_arg in event_producer.write_event.call_args_list:
         host = json.loads(call_arg[0][0])["host"]
         assert host["groups"] == []
+
+
+@pytest.mark.parametrize("ungrouped", [True, False])
+@pytest.mark.host_synchronizer
+def test_synchronize_grouped_host_event(
+    event_producer_mock,
+    event_datetime_mock,
+    db_create_host,
+    db_create_group,
+    db_create_host_group_assoc,
+    db_get_group_by_id,
+    db_get_host,
+    inventory_config,
+    ungrouped,
+):
+    staleness_timestamps = get_staleness_timestamps()
+
+    host = minimal_db_host(stale_timestamp=staleness_timestamps["culled"], reporter="some reporter")
+    created_host = db_create_host(host=host)
+    created_host_id = created_host.id
+
+    created_group = db_create_group("sync-test-group", ungrouped=ungrouped)
+    created_group_id = created_group.id
+
+    db_create_host_group_assoc(created_host_id, created_group_id)
+
+    # Overwrite Host.groups data
+    db.session.query(Host).filter(Host.id == created_host_id).update({"groups": []})
+    db.session.commit()
+
+    retrieved_host = db_get_host(created_host_id)
+    retrieved_group = db_get_group_by_id(created_group_id)
+
+    assert retrieved_host
+    assert retrieved_group
+    assert retrieved_host.groups == []
+
+    threadctx.request_id = None
+    host_synchronizer_run(
+        inventory_config,
+        mock.Mock(),
+        db.session,
+        event_producer_mock,
+        shutdown_handler=mock.Mock(**{"shut_down.return_value": False}),
+    )
+
+    # check if host exist thought event synchronizer must find it to produce an update event.
+    assert db_get_host(retrieved_host.id)
+
+    assert_synchronize_event_is_valid(
+        event_producer=event_producer_mock,
+        key=str(retrieved_host.id),
+        host=retrieved_host,
+        groups=[retrieved_group],
+        timestamp=event_datetime_mock,
+    )

--- a/tests/test_synchronizer.py
+++ b/tests/test_synchronizer.py
@@ -12,14 +12,25 @@ from tests.helpers.mq_utils import assert_synchronize_event_is_valid
 from tests.helpers.test_utils import get_staleness_timestamps
 
 
+@pytest.mark.parametrize("ungrouped", [True, False])
 @pytest.mark.host_synchronizer
 def test_synchronize_host_event(
-    event_producer_mock, event_datetime_mock, db_create_host, db_get_host, inventory_config
+    event_producer_mock,
+    event_datetime_mock,
+    db_create_host,
+    db_create_group,
+    db_create_host_group_assoc,
+    db_get_host,
+    inventory_config,
+    ungrouped,
 ):
     staleness_timestamps = get_staleness_timestamps()
 
     host = minimal_db_host(stale_timestamp=staleness_timestamps["culled"], reporter="some reporter")
     created_host = db_create_host(host=host)
+
+    created_group = db_create_group("sync-test-group", ungrouped=ungrouped)
+    db_create_host_group_assoc(created_host.id, created_group.id)
 
     assert db_get_host(created_host.id)
 
@@ -36,7 +47,11 @@ def test_synchronize_host_event(
     assert db_get_host(created_host.id)
 
     assert_synchronize_event_is_valid(
-        event_producer=event_producer_mock, key=str(created_host.id), host=created_host, timestamp=event_datetime_mock
+        event_producer=event_producer_mock,
+        key=str(created_host.id),
+        host=created_host,
+        groups=[created_group],
+        timestamp=event_datetime_mock,
     )
 
 


### PR DESCRIPTION
# Overview

This PR is being created to address an issue with [RHINENG-15823](https://issues.redhat.com/browse/RHINENG-15823).
Hosts that are assigned to the "ungrouped" group have `Host.groups == []`. This PR makes it so it updates the "groups" field when synchronizing a host.

Note that this is a temporary fix. We will update `assign_ungrouped_hosts_to_groups.py` with a fix (along with a performance fix) in a follow-up PR.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Fetch and populate host groups during synchronization when the host’s groups field is empty so that update events include the correct group data.

Bug Fixes:
- Populate the host.groups field in the synchronizer by retrieving the associated group when it’s initially empty.

Tests:
- Extend and parametrize synchronization tests to cover hosts with and without group associations.
- Update the test helper to assert and validate group data in synchronization events.