### PR TITLE
ci(RHIENG-18106): Deploy konflux built image by default

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2286,7 +2286,7 @@ parameters:
 - description: Image NAME
   name: IMAGE
   required: true
-  value: quay.io/cloudservices/insights-inventory
+  value: quay.io/redhat-services-prod/insights-management-tenant/insights-host-inventory/insights-host-inventory
 - description : ClowdEnvironment name
   name: ENV_NAME
   value: stage


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18106](https://issues.redhat.com/browse/RHINENG-18106).

This will default to a Konflux built image for Stage (turned off manually for Prod and Ephemeral)

## Summary by Sourcery

Deployment:
- Switch the default image to the Konflux-built quay.io/redhat-services-prod/insights-management-tenant/insights-host-inventory/insights-host-inventory for stage