### PR TITLE
fix(RHINENG-18474): Delete group even if Kessel workspace does not exist

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -221,7 +221,21 @@ def delete_groups(group_id_list, rbac_filter=None):
             if ungrouped_group_id == group_id:
                 abort(HTTPStatus.BAD_REQUEST, f"Ungrouped workspace {group_id} can not be deleted.")
 
-        delete_count = sum((delete_rbac_workspace(group_id)) is True for group_id in group_id_list)
+        group_ids_to_delete = []
+        delete_count = 0
+
+        # Attempt to delete the RBAC workspaces
+        for group_id in group_id_list:
+            try:
+                if delete_rbac_workspace(group_id):
+                    delete_count += 1
+            except FileNotFoundError:
+                # For workspaces that are missing from RBAC,
+                # we'll attempt to delete the groups on our side
+                group_ids_to_delete.append(group_id)
+
+        # Attempt to delete the "not found" groups on our side
+        delete_count += delete_group_list(group_ids_to_delete, get_current_identity(), current_app.event_producer)
     else:
         delete_count = delete_group_list(group_id_list, get_current_identity(), current_app.event_producer)
 

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -369,7 +369,7 @@ def _handle_delete_error(e: HTTPError, workspace_id: str) -> bool:
 
     if status == 404:
         logger.info(f"404 deleting RBAC workspace {workspace_id}: {detail}")
-        return False
+        raise FileNotFoundError()
 
     if 400 <= status < 500:
         logger.warning(f"RBAC client error {status} deleting {workspace_id}: {detail}")


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18474](https://issues.redhat.com/browse/RHINENG-18474).
Currently, if a workspace doesn't exist in Kessel, but the associated group _does_ exist in the HBI DB, attempting to delete the group will result in a 404 and the group won't be deleted. This PR makes it so the HBI group will still be deleted, even if the associated workspace does not exist. This will help us to correct workspace sync issues.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
