### PR TITLE
feat(rhineng-18497): Enable postgres connection via unix socket

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,6 @@ import json
 import os
 import tempfile
 from datetime import timedelta
-from urllib.parse import urlencode
 
 from app.common import get_build_version
 from app.culling import days_to_seconds
@@ -394,7 +393,7 @@ class Config:
     def _build_db_uri(self, ssl_mode, hide_password=False):
         db_user = self._db_user
         db_password = self._db_password
-        query_params = {}
+        query_parts = []
         socket_path = None
 
         if hide_password:
@@ -412,15 +411,15 @@ class Config:
             netloc = f"{self._db_host}:{self._db_port}"
             path = f"/{self._db_name}"
 
-        # Add SSL parameters if needed
+        # Add query parameters
+        if socket_path:
+            query_parts.append(f"host={socket_path}")
         if ssl_mode == self.SSL_VERIFY_FULL:
-            query_params.update({"sslmode": self._db_ssl_mode, "sslrootcert": self._db_ssl_cert})
+            query_parts.append(f"sslmode={self._db_ssl_mode}")
+            query_parts.append(f"sslrootcert={self._db_ssl_cert}")
 
         # Construct the query string
-        query_string = urlencode(query_params) if query_params else ""
-        if socket_path:
-            # For Unix socket, manually append the unencoded host parameter
-            query_string = f"host={socket_path}" + (f"&{query_string}" if query_string else "")
+        query_string = "&".join(query_parts) if query_parts else ""
 
         # Construct the URI
         db_uri = f"postgresql://{db_user}:{db_password}@{netloc}{path}"

--- a/app/config.py
+++ b/app/config.py
@@ -395,6 +395,8 @@ class Config:
         db_password = self._db_password
         query_parts = []
         socket_path = None
+        netloc = ""
+        path = f"/{self._db_name}"
 
         if hide_password:
             db_user = "xxxx"
@@ -403,13 +405,10 @@ class Config:
         # Check if the host is a Unix socket (e.g., starts with '/')
         if self._db_host.startswith("/"):
             # Unix socket: no host/port, use query param for socket path
-            netloc = ""
-            path = f"/{self._db_name}"
             socket_path = self._db_host  # Keep socket path unencoded
         else:
             # TCP connection: include host and port
             netloc = f"{self._db_host}:{self._db_port}"
-            path = f"/{self._db_name}"
 
         # Add query parameters
         if socket_path:


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18497](https://issues.redhat.com/browse/RHINENG-18497).
* Update connection string logic for connecting over unix socket to postgres database

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enable PostgreSQL connections over UNIX sockets and refactor the database URI builder to construct URIs from components including socket path and SSL settings

New Features:
- Enable PostgreSQL connections via UNIX socket by detecting socket paths and mapping them to the host query parameter

Enhancements:
- Refactor database URI construction to assemble netloc, path, and query parameters dynamically for socket and SSL options