### PR TITLE
refactor(RHINENG-18217): change GET /groups query parameter

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -61,12 +61,13 @@ def get_group_list(
     per_page=100,
     order_by=None,
     order_how=None,
-    type=None,
+    group_type=None,
     rbac_filter=None,
 ):
-    print(f">>> type: {type}")
     try:
-        group_list, total = get_filtered_group_list_db(name, page, per_page, order_by, order_how, rbac_filter, type)
+        group_list, total = get_filtered_group_list_db(
+            name, page, per_page, order_by, order_how, rbac_filter, group_type
+        )
     except ValueError as e:
         log_get_group_list_failed(logger)
         abort(400, str(e))

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1103,7 +1103,7 @@ components:
         for host_count
     workspaceTypeParam:
       in: query
-      name: type
+      name: group_type
       required: false
       schema:
         type: string

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1789,7 +1789,7 @@
       },
       "workspaceTypeParam": {
         "in": "query",
-        "name": "type",
+        "name": "group_type",
         "required": false,
         "schema": {
           "type": "string",

--- a/tests/test_api_groups_get.py
+++ b/tests/test_api_groups_get.py
@@ -27,7 +27,7 @@ def test_group_query_type_filter(db_create_group, api_get, group_type, expected_
         "ungrouped-hosts": [str(db_create_group("ungroupedTest", ungrouped=True).id)],
     }
 
-    response_status, response_data = api_get(build_groups_url(query=f"?type={group_type}"))
+    response_status, response_data = api_get(build_groups_url(query=f"?group_type={group_type}"))
 
     assert_response_status(response_status, 200)
     assert response_data["total"] == expected_groups


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18217](https://issues.redhat.com/browse/RHINENG-18217).
Change GET /groups `type` query parameter to `group_type` to fix openAPI generate bug.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Change the GET /groups endpoint query parameter from `type` to `group_type` across the codebase to resolve the OpenAPI generation issue

Enhancements:
- Rename the `type` parameter to `group_type` in the API route and underlying database call

Documentation:
- Update Swagger/OpenAPI specification to reflect the `group_type` query parameter

Tests:
- Adjust endpoint tests to use `group_type` for filtering groups