### PR TITLE
fix(RHINENG-18532): Only PG notify after commit

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -31,6 +31,7 @@ from app.instrumentation import log_patch_group_failed
 from app.instrumentation import log_patch_group_success
 from app.logging import get_logger
 from app.models import InputGroupSchema
+from app.queue.events import EventType
 from lib.feature_flags import FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION
 from lib.feature_flags import get_flag_value
 from lib.group_repository import add_hosts_to_group
@@ -42,7 +43,7 @@ from lib.group_repository import get_ungrouped_group
 from lib.group_repository import patch_group
 from lib.group_repository import remove_hosts_from_group
 from lib.group_repository import validate_add_host_list_to_group_for_group_create
-from lib.group_repository import wait_for_workspace_creation
+from lib.group_repository import wait_for_workspace_event
 from lib.metrics import create_group_count
 from lib.middleware import delete_rbac_workspace
 from lib.middleware import patch_rbac_workspace
@@ -125,7 +126,7 @@ def create_group(body, rbac_filter=None):
 
             # Wait for the MQ to notify us of the workspace creation
             try:
-                wait_for_workspace_creation(workspace_id, inventory_config().rbac_timeout)
+                wait_for_workspace_event(workspace_id, EventType.created, inventory_config().rbac_timeout)
             except TimeoutError:
                 abort(HTTPStatus.SERVICE_UNAVAILABLE, "Timed out waiting for a message from RBAC v2.")
 

--- a/api/host.py
+++ b/api/host.py
@@ -272,7 +272,7 @@ def _delete_host_list(host_id_list, rbac_filter):
             initiated_by_frontend=initiated_by_frontend,
         )
 
-        deleted_id_list = [str(r.host_row.id) for r in result_list]
+        deleted_id_list = [str(r.row.id) for r in result_list]
 
         for host_id in host_id_list:
             tracker_message = "deleted host" if host_id in deleted_id_list else "not deleted host"

--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -346,9 +346,9 @@ def log_host_stale_notification_succeeded(logger, host_id, control_rule):
     logger.info("Sent Notification for stale host: %s", host_id, extra={"access_rule": control_rule})
 
 
-def log_create_workspace_via_mq(logger, group_id, control_rule):
-    logger.info("Workspace created via MQ: %s", group_id, extra={"access_rule": control_rule})
+def log_create_workspace_via_mq(logger, group_id):
+    logger.info("Workspace created via MQ: %s", group_id)
 
 
-def log_update_workspace_via_mq(logger, group_id, control_rule):
-    logger.info("Workspace updated via MQ: %s", group_id, extra={"access_rule": control_rule})
+def log_update_workspace_via_mq(logger, group_id):
+    logger.info("Workspace updated via MQ: %s", group_id)

--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -346,9 +346,13 @@ def log_host_stale_notification_succeeded(logger, host_id, control_rule):
     logger.info("Sent Notification for stale host: %s", host_id, extra={"access_rule": control_rule})
 
 
-def log_create_workspace_via_mq(logger, group_id):
-    logger.info("Workspace created via MQ: %s", group_id)
+def log_create_group_via_mq(logger, group_id):
+    logger.info(f"Group created via MQ: {group_id}")
 
 
-def log_update_workspace_via_mq(logger, group_id):
-    logger.info("Workspace updated via MQ: %s", group_id)
+def log_update_group_via_mq(logger, group_id):
+    logger.info(f"Group updated via MQ: {group_id}")
+
+
+def log_delete_groups_via_mq(logger, num_deleted, group_id):
+    logger.info(f"{num_deleted} groups deleted via MQ with ID: {group_id}", num_deleted)

--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -344,3 +344,11 @@ def log_create_staleness_failed(logger, org_id):
 # stale host notification
 def log_host_stale_notification_succeeded(logger, host_id, control_rule):
     logger.info("Sent Notification for stale host: %s", host_id, extra={"access_rule": control_rule})
+
+
+def log_create_workspace_via_mq(logger, group_id, control_rule):
+    logger.info("Workspace created via MQ: %s", group_id, extra={"access_rule": control_rule})
+
+
+def log_update_workspace_via_mq(logger, group_id, control_rule):
+    logger.info("Workspace updated via MQ: %s", group_id, extra={"access_rule": control_rule})

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 from confluent_kafka import Consumer
 from connexion import FlaskApp
+from flask_sqlalchemy.model import Model
 from marshmallow import Schema
 from marshmallow import ValidationError
 from marshmallow import fields
@@ -34,9 +35,11 @@ from app.exceptions import ValidationException
 from app.instrumentation import log_add_host_attempt
 from app.instrumentation import log_add_host_failure
 from app.instrumentation import log_add_update_host_succeeded
+from app.instrumentation import log_create_workspace_via_mq
 from app.instrumentation import log_db_access_failure
 from app.instrumentation import log_update_system_profile_failure
 from app.instrumentation import log_update_system_profile_success
+from app.instrumentation import log_update_workspace_via_mq
 from app.logging import get_logger
 from app.logging import threadctx
 from app.models import Host
@@ -107,14 +110,14 @@ class DebeziumEnvelopeSchema(Schema):
 class OperationResult:
     def __init__(
         self,
-        hr: Host,
+        row: Model,
         pm: dict[str, Any] | None,
         st: Timestamps | None,
         so: AttrDict | None,
         et: EventType | None,
         sl: Callable,
     ):
-        self.host_row = hr
+        self.row = row
         self.platform_metadata = pm
         self.staleness_timestamps = st
         self.staleness_object = so
@@ -209,8 +212,15 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
                     group_id=workspace["id"],
                     ungrouped=(validated_operation_msg["workspace"]["type"] == "ungrouped-hosts"),
                 )
-                logger.info(f"Created group with ID {str(group.id)}")
-                _pg_notify_workspace(operation, str(group.id))
+                return OperationResult(
+                    group,
+                    None,
+                    None,
+                    None,
+                    EventType.created,
+                    partial(log_create_workspace_via_mq, logger, workspace["id"]),
+                )
+
             except (IntegrityError, UniqueViolation):
                 logger.warning(f"Group with ID {workspace['id']} already exists; skipping creation")
                 db.session.rollback()
@@ -223,7 +233,14 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
                 identity=identity,
                 event_producer=self.event_producer,
             )
-            logger.info(f"Updated group with ID {workspace['id']}")
+            return OperationResult(
+                group_to_update,
+                None,
+                None,
+                None,
+                EventType.updated,
+                partial(log_update_workspace_via_mq, logger, workspace["id"]),
+            )
 
         elif operation == "delete":
             num_deleted = group_repository.delete_group_list(
@@ -234,6 +251,26 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
             logger.info(f"Deleted {num_deleted} group(s) with ID {workspace['id']}")
         else:
             raise ValidationError("Operation must be 'create', 'update', or 'delete'.")
+
+    def post_process_rows(self) -> None:
+        try:
+            if len(self.processed_rows) > 0:
+                db.session.commit()
+                # The above session is automatically committed or rolled back.
+                # Now we need to send out messages for the batch of hosts we just processed.
+
+            for processed_row in self.processed_rows:
+                # PG Notify for each processed workspace
+                if processed_row.event_type:
+                    _pg_notify_workspace(processed_row.event_type.name, str(processed_row.row.id))
+
+        except StaleDataError as exc:
+            metrics.ingress_message_handler_failure.inc(amount=len(self.processed_rows))
+            logger.error(
+                f"Session data is stale; failed to commit data from {len(self.processed_rows)} payloads.",
+                exc_info=exc,
+            )
+            db.session.rollback()
 
 
 class HostMessageConsumer(HBIMessageConsumerBase):
@@ -333,7 +370,7 @@ class IngressMessageConsumer(HostMessageConsumer):
                 input_host = _set_owner(input_host, identity)
 
             log_add_host_attempt(logger, input_host, sp_fields_to_log, identity)
-            processed_hosts = [result.host_row for result in self.processed_rows]
+            processed_hosts = [result.row for result in self.processed_rows]
             host_row, add_result = host_repository.add_host(
                 input_host, identity, operation_args=operation_args, existing_hosts=processed_hosts
             )
@@ -559,25 +596,23 @@ def sync_event_message(message, session, event_producer):
 def write_delete_event_message(event_producer: EventProducer, result: OperationResult, initiated_by_frontend: bool):
     event = build_event(
         EventType.delete,
-        result.host_row,
+        result.row,
         platform_metadata=result.platform_metadata,
         initiated_by_frontend=initiated_by_frontend,
     )
     headers = message_headers(
         EventType.delete,
-        result.host_row.canonical_facts.get("insights_id"),
-        result.host_row.reporter,
-        result.host_row.system_profile_facts.get("host_type"),
-        result.host_row.system_profile_facts.get("operating_system", {}).get("name"),
-        str(result.host_row.system_profile_facts.get("bootc_status", {}).get("booted") is not None),
+        result.row.canonical_facts.get("insights_id"),
+        result.row.reporter,
+        result.row.system_profile_facts.get("host_type"),
+        result.row.system_profile_facts.get("operating_system", {}).get("name"),
+        str(result.row.system_profile_facts.get("bootc_status", {}).get("booted") is not None),
     )
-    event_producer.write_event(event, str(result.host_row.id), headers, wait=True)
-    insights_id = result.host_row.canonical_facts.get("insights_id")
-    owner_id = result.host_row.system_profile_facts.get("owner_id")
+    event_producer.write_event(event, str(result.row.id), headers, wait=True)
+    insights_id = result.row.canonical_facts.get("insights_id")
+    owner_id = result.row.system_profile_facts.get("owner_id")
     if insights_id and owner_id:
-        delete_cached_system_keys(
-            insights_id=insights_id, org_id=result.host_row.org_id, owner_id=owner_id, spawn=True
-        )
+        delete_cached_system_keys(insights_id=insights_id, org_id=result.row.org_id, owner_id=owner_id, spawn=True)
     result.success_logger()
 
 
@@ -591,17 +626,17 @@ def write_add_update_event_message(
 
     # The request ID in the headers is fetched from threadctx.request_id
     request_id = result.platform_metadata.get("request_id")
-    initialize_thread_local_storage(request_id, result.host_row.org_id, result.host_row.account)
+    initialize_thread_local_storage(request_id, result.row.org_id, result.row.account)
     payload_tracker = get_payload_tracker(request_id=request_id)
 
     with PayloadTrackerProcessingContext(
         payload_tracker,
         processing_status_message="host operation complete",
         current_operation="write_message_batch",
-        inventory_id=result.host_row.id,
+        inventory_id=result.row.id,
     ):
-        output_host = serialize_host(result.host_row, result.staleness_timestamps, staleness=result.staleness_object)
-        insights_id = result.host_row.canonical_facts.get("insights_id")
+        output_host = serialize_host(result.row, result.staleness_timestamps, staleness=result.staleness_object)
+        insights_id = result.row.canonical_facts.get("insights_id")
         event = build_event(result.event_type, output_host, platform_metadata=result.platform_metadata)
 
         headers = message_headers(
@@ -613,7 +648,7 @@ def write_add_update_event_message(
             str(output_host.get("system_profile", {}).get("bootc_status", {}).get("booted") is not None),
         )
 
-    event_producer.write_event(event, str(result.host_row.id), headers, wait=True)
+    event_producer.write_event(event, str(result.row.id), headers, wait=True)
 
     if result.event_type.name == HOST_EVENT_TYPE_CREATED:
         # Notifications are expected to omit null canonical facts

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -256,10 +256,12 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
         try:
             if len(self.processed_rows) > 0:
                 db.session.commit()
-                # The above session is automatically committed or rolled back.
-                # Now we need to send out messages for the batch of hosts we just processed.
 
             for processed_row in self.processed_rows:
+                # Invoke OperationResult success logger for each processed row
+                if hasattr(processed_row, "success_logger") and callable(processed_row.success_logger):
+                    processed_row.success_logger()
+
                 # PG Notify for each processed workspace
                 if processed_row.event_type:
                     _pg_notify_workspace(processed_row.event_type.name, str(processed_row.row.id))

--- a/generate_stale_host_notifications.py
+++ b/generate_stale_host_notifications.py
@@ -156,9 +156,7 @@ def run(
             for host in query.yield_per(500):
                 identity = create_mock_identity_with_org_id(host.org_id)
                 result = _create_host_operation_result(host, identity, logger)
-                send_notification(
-                    notification_event_producer, NotificationType.system_became_stale, vars(result.host_row)
-                )
+                send_notification(notification_event_producer, NotificationType.system_became_stale, vars(result.row))
 
                 stale_host_notification_success_count.inc()
                 result.success_logger()

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -181,19 +181,19 @@ def wait_for_workspace_creation(workspace_id: str, timeout: int = 5):
     conn = db.session.connection().connection
     conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
     cursor = conn.cursor()
-    cursor.execute("LISTEN workspace_create;")
+    cursor.execute("LISTEN workspace_created;")
     timeout_start = time.time()
     try:
         while time.time() < timeout_start + timeout:
             conn.poll()
             for notify in conn.notifies:
-                if str(notify.payload) == str(workspace_id):
+                if str(notify.payload) == workspace_id:
                     return
 
             conn.notifies.clear()
             time.sleep(0.1)
     finally:
-        cursor.execute("UNLISTEN workspace_create;")
+        cursor.execute("UNLISTEN workspace_created;")
         cursor.close()
 
     raise TimeoutError("No workspace creation message consumed in time.")

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -177,11 +177,11 @@ def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str, ses
     log_host_group_add_succeeded(logger, host_id_list, group_id)
 
 
-def wait_for_workspace_creation(workspace_id: str, timeout: int = 5):
+def wait_for_workspace_event(workspace_id: str, event_type: EventType, timeout: int = 5):
     conn = db.session.connection().connection
     conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
     cursor = conn.cursor()
-    cursor.execute("LISTEN workspace_created;")
+    cursor.execute(f"LISTEN workspace_{event_type.name};")
     timeout_start = time.time()
     try:
         while time.time() < timeout_start + timeout:
@@ -193,7 +193,7 @@ def wait_for_workspace_creation(workspace_id: str, timeout: int = 5):
             conn.notifies.clear()
             time.sleep(0.1)
     finally:
-        cursor.execute("UNLISTEN workspace_created;")
+        cursor.execute(f"UNLISTEN workspace_{event_type.name};")
         cursor.close()
 
     raise TimeoutError("No workspace creation message consumed in time.")

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -43,7 +43,7 @@ def _delete_host_db_records(
     for host in select_query.limit(chunk_size):
         with delete_host_processing_time.time():
             result = _delete_host(select_query.session, host, identity, control_rule)
-        if deleted_by_this_query(result.host_row):
+        if deleted_by_this_query(result.row):
             results_list.append(result)
 
         if interrupt():
@@ -62,7 +62,7 @@ def _send_delete_messages_for_batch(
         if result is not None:
             delete_host_count.inc()
             write_delete_event_message(event_producer, result, initiated_by_frontend)
-            send_notification(notification_event_producer, NotificationType.system_deleted, vars(result.host_row))
+            send_notification(notification_event_producer, NotificationType.system_deleted, vars(result.row))
 
 
 def delete_hosts(

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -144,13 +144,13 @@ def test_handle_message_happy_path(
     result = ingress_message_consumer_mock.handle_message(json.dumps(message))
 
     assert result.event_type == EventType.created
-    assert result.host_row.canonical_facts["insights_id"] == expected_insights_id
+    assert result.row.canonical_facts["insights_id"] == expected_insights_id
     if kessel_migration:
-        assert len(result.host_row.groups) == 1
-        assert result.host_row.groups[0]["name"] == existing_group_name if existing_ungrouped else "Ungrouped Hosts"
-        assert result.host_row.groups[0]["ungrouped"] is True
+        assert len(result.row.groups) == 1
+        assert result.row.groups[0]["name"] == existing_group_name if existing_ungrouped else "Ungrouped Hosts"
+        assert result.row.groups[0]["ungrouped"] is True
     else:
-        assert result.host_row.groups == []
+        assert result.row.groups == []
 
     mock_notification_event_producer.write_event.assert_not_called()
 
@@ -201,9 +201,9 @@ def test_handle_message_existing_ungrouped_workspace(mocker, db_create_group):
         result = consumer.handle_message(json.dumps(message))
 
         assert result.event_type == EventType.created
-        assert result.host_row.canonical_facts["insights_id"] == expected_insights_id
-        assert result.host_row.groups[0]["name"] == "kessel-test"
-        assert result.host_row.groups[0]["id"] == str(group_id)
+        assert result.row.canonical_facts["insights_id"] == expected_insights_id
+        assert result.row.groups[0]["name"] == "kessel-test"
+        assert result.row.groups[0]["id"] == str(group_id)
 
         mock_notification_event_producer.write_event.assert_not_called()
 
@@ -2241,7 +2241,7 @@ def test_add_host_logs(identity, mocker, caplog):
     result = consumer.handle_message(json.dumps(message))
 
     assert result.event_type == EventType.created
-    assert result.host_row.canonical_facts["insights_id"] == expected_insights_id
+    assert result.row.canonical_facts["insights_id"] == expected_insights_id
     assert caplog.records[0].input_host["system_profile"] == "{}"
     mock_notification_event_producer.write_event.assert_not_called()
 
@@ -2298,7 +2298,8 @@ def test_add_host_subman_id(mq_create_or_update_host_subman_id, db_get_host):
     ),
 )
 @mock.patch.object(WorkspaceMessageConsumer, "handle_message")
-def test_workspace_mq_event_loop(handle_message_mock, flask_app, mocker, additional_fields):
+@mock.patch.object(WorkspaceMessageConsumer, "post_process_rows")
+def test_workspace_mq_event_loop(handle_message_mock, post_process_rows_mock, flask_app, mocker, additional_fields):
     message = {
         "operation": "create",
         "org_id": SYSTEM_IDENTITY["org_id"],
@@ -2320,6 +2321,7 @@ def test_workspace_mq_event_loop(handle_message_mock, flask_app, mocker, additio
     # Make sure it properly calls handle_message, and does not error out
     consumer.event_loop(interrupt=mocker.Mock(side_effect=(False, True)))
     handle_message_mock.assert_called_once()
+    post_process_rows_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18532](https://issues.redhat.com/browse/RHINENG-18532).

- Moves the pg_notify to run in the MQ post-processing phase, so it will always commit before notifying. I think that's what was causing the `'NoneType' object has no attribute 'update_modified_on'` error we were seeing.
- Generalizes OperationResult. One of its fields, `hostRow`, was host-specific; this PR changes it to just `row`, so it makes sense for Groups as well.
- Generalizes `wait_for_workspace_creation` to `wait_for_workspace_event`. Makes it so we can wait on any type of workspace event, and links it directly to EventType to avoid hardcoding.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Ensure PostgreSQL notifications are sent only after successful database commits and generalize messaging constructs for broader model support.

Bug Fixes:
- Move pg_notify calls to post-processing phase to avoid NoneType errors

Enhancements:
- Introduce post_process_rows to commit processed rows in batch and send notifications post-commit
- Rename OperationResult.host_row to row to support generic model payloads
- Generalize wait_for_workspace_creation to wait_for_workspace_event with EventType integration
- Add workspace creation and update logging via MQ instrumentation

Tests:
- Update tests to use row instead of host_row and assert post_process_rows invocation