### PR TITLE
bugfix(rhineng-18475): bump memory limit for mq-workspaces

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2142,7 +2142,7 @@ parameters:
 - name: MEMORY_REQUEST_WORKSPACES_MQ
   value: 256Mi
 - name: MEMORY_LIMIT_WORKSPACES_MQ
-  value: 512Mi
+  value: 768Mi
 
 - name: CPU_REQUEST_REAPER
   value: 250m


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18475](https://issues.redhat.com/browse/RHINENG-18475).
* Increase the memory limit for mq-workspaces component

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
