### PR TITLE
fix(RHINENG-18475) Update mq-workspaces memory usage

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2136,13 +2136,13 @@ parameters:
   value: 512Mi
 
 - name: CPU_REQUEST_WORKSPACES_MQ
-  value: 500m
+  value: 250m
 - name: CPU_LIMIT_WORKSPACES_MQ
-  value: 1Gi
+  value: 500m
 - name: MEMORY_REQUEST_WORKSPACES_MQ
-  value: 256Mi
+  value: 500Mi
 - name: MEMORY_LIMIT_WORKSPACES_MQ
-  value: 768Mi
+  value: 1Gi
 
 - name: CPU_REQUEST_REAPER
   value: 250m


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18475](https://issues.redhat.com/browse/RHINENG-18475).
Increases the default memory request and limit for the mq-workspaces deployment. Should help with the OOM issue.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Increase resource allocations for the mq-workspaces deployment to mitigate OOM issues by raising CPU limits and memory requests/limits.

Enhancements:
- Bump CPU limit for mq-workspaces from 500m to 1Gi
- Increase default memory request and limit for mq-workspaces