### PR TITLE
Revert "ci(RHIENG-18106): Deploy konflux built image by default"

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2286,7 +2286,7 @@ parameters:
 - description: Image NAME
   name: IMAGE
   required: true
-  value: quay.io/redhat-services-prod/insights-management-tenant/insights-host-inventory/insights-host-inventory
+  value: quay.io/cloudservices/insights-inventory
 - description : ClowdEnvironment name
   name: ENV_NAME
   value: stage


### PR DESCRIPTION
Reverts RedHatInsights/insights-host-inventory#2626.

## Summary by Sourcery

Deployment:
- Restore the IMAGE parameter value in deploy/clowdapp.yml to quay.io/cloudservices/insights-inventory by reverting the earlier change