### PR TITLE
Fix consumer shutdown handler

### DIFF
--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-from functools import partial
 
 from confluent_kafka import Consumer as KafkaConsumer
 from prometheus_client import start_http_server
@@ -40,8 +39,7 @@ def main():
         }
     )
     consumer.subscribe([config.kafka_consumer_topic])
-    consumer_shutdown = partial(consumer.close, autocommit=True)
-    register_shutdown(consumer_shutdown, "Closing consumer")
+    register_shutdown(consumer.close, "Closing consumer")
 
     event_producer = EventProducer(config, config.event_topic)
     register_shutdown(event_producer.close, "Closing producer")


### PR DESCRIPTION
# Overview

This PR is being created to address an issue with the MQ consumer's shutdown handler. Currently, it gives this error upon shutdown:
```
TypeError: Consumer.close() takes no keyword arguments
```
So, I removed the `partial` that was adding the `autocommit` argument.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
