### PR TITLE
Allow using INVENTORY_HOST_ACCOUNT to override the org_id for hosts created with test helpers

### DIFF
--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -579,6 +579,7 @@ def random_uuid():
 IS_EDGE = os.environ.get("IS_EDGE", False)
 USE_RANDOMNESS = os.environ.get("USE_RANDOMNESS", "True").lower() == "true"
 
+
 def build_host_chunk():
     fqdn = random_uuid()[:6] + ".foo.redhat.com"
     system_profile = create_system_profile()

--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -7,12 +7,13 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
+org_id = os.environ.get("INVENTORY_HOST_ACCOUNT", "321")
 # kessel user identity known to rbac deployed by bonfire in Ephemeral cluster
 IDENTITY = {
     "account_number": "123",
     "auth_type": "jwt-auth",
-    "internal": {"auth_time": 0, "cross_access": "false", "org_id": "321"},
-    "org_id": "321",
+    "internal": {"auth_time": 0, "cross_access": "false", "org_id": org_id},
+    "org_id": org_id,
     "type": "User",
     "user": {
         "email": "Jane.Doe@example.com",
@@ -578,9 +579,7 @@ def random_uuid():
 IS_EDGE = os.environ.get("IS_EDGE", False)
 USE_RANDOMNESS = os.environ.get("USE_RANDOMNESS", "True").lower() == "true"
 
-
 def build_host_chunk():
-    org_id = os.environ.get("INVENTORY_HOST_ACCOUNT", IDENTITY["org_id"])
     fqdn = random_uuid()[:6] + ".foo.redhat.com"
     system_profile = create_system_profile()
 


### PR DESCRIPTION
Currently, the org_id in the IDENTITY value in payloads.py is a literal value, even though the host chunk bit uses the INVENTORY_HOST_ACCOUNT environment variable (if available, otherwise falling back to the org_id from IDENTITY) to determine the org_id to use. This creates a contradiction between the identity and the host itself when using INVENTORY_HOST_ACCOUNT to override the org id to use (ex: in ephemeral environments where the org_id is prescribed.)

These changes:
- Make the IDENTITY value in payloads.py vary with the INVENTORY_HOST_ACCOUNT environment variable
- Still default to 321 if not specified

# Overview

This PR is being created to address [RHINENG-xxxx](https://issues.redhat.com/browse/RHINENG-xxxx).
(A description of your PR's changes, along with why/context to the PR, goes here.)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Allow overriding the organization ID used in test payloads via the INVENTORY_HOST_ACCOUNT environment variable, defaulting to "321" when not set, and ensure consistency across IDENTITY and host chunk generation.

Bug Fixes:
- Fix inconsistency between IDENTITY.org_id and the host chunk org_id when using INVENTORY_HOST_ACCOUNT

Enhancements:
- Centralize org_id retrieval from INVENTORY_HOST_ACCOUNT with a "321" fallback in payloads
- Remove redundant org_id assignment in build_host_chunk to rely on the centralized value