### PR TITLE
feat(deploy): Move hosts_per_public_cloud query to `hosts_metrics`

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1991,6 +1991,13 @@ objects:
           FROM "hbi"."hosts"
           GROUP BY "org_id"
           ORDER BY "host_count" DESC;
+      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/hosts_per_public_cloud
+        query: >-
+          SELECT
+            "canonical_facts"->>'provider_type' AS "provider_type",
+            COUNT(*) AS "host_count"
+          FROM "hbi"."hosts"
+          GROUP BY "provider_type";
       - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/org_ids_with_group_names
         chunksize: 10000
         query: >-
@@ -2009,13 +2016,6 @@ objects:
           JOIN "hbi"."hosts_groups" ON "groups"."id" = "hbi"."hosts_groups"."group_id"
           GROUP BY "groups"."id"
           ORDER BY "host_count" DESC;
-      - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/hosts_per_public_cloud
-        query: >-
-          SELECT
-            "canonical_facts"->>'provider_type' AS "provider_type",
-            COUNT(*) AS "host_count"
-          FROM "hbi"."hosts"
-          GROUP BY "provider_type";
 - apiVersion: v1
   data:
     nginx.conf: |-


### PR DESCRIPTION
Moved the query `hosts_per_public_cloud` from `groups_metrics` to `hosts_metrics` where it should be.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enhancements:
- Relocate the hosts_per_public_cloud query from the groups_metrics prefix to the hosts_metrics prefix in the deployment configuration