### PR TITLE
Revert PR 2637

### DIFF
--- a/api/staleness_query.py
+++ b/api/staleness_query.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.logging import get_logger
@@ -10,9 +13,10 @@ from app.staleness_serialization import build_staleness_sys_default
 logger = get_logger(__name__)
 
 
-def get_staleness_obj(org_id: str) -> AttrDict:
+def get_staleness_obj(org_id: str, session: Optional[Session] = None) -> AttrDict:
+    session = session or db.session
     try:
-        staleness = db.session.query(Staleness).filter(Staleness.org_id == org_id).one()
+        staleness = session.query(Staleness).filter(Staleness.org_id == org_id).one()
         logger.info(f"Using custom staleness for org {org_id}.")
         staleness = build_serialized_acc_staleness_obj(staleness)
     except NoResultFound:

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -5,6 +5,7 @@ from datetime import timezone
 
 from dateutil.parser import isoparse
 from marshmallow import ValidationError
+from sqlalchemy.orm import Session
 
 from api.staleness_query import get_staleness_obj
 from app.auth import get_current_identity
@@ -19,6 +20,7 @@ from app.models import Host
 from app.models import HostSchema
 from app.models import LimitedHost
 from app.models import LimitedHostSchema
+from app.models import db
 from app.staleness_serialization import get_staleness_timestamps
 from app.utils import Tag
 from lib.feature_flags import FLAG_INVENTORY_CREATE_LAST_CHECK_IN_UPDATE_PER_REPORTER_STALENESS
@@ -233,10 +235,10 @@ def serialize_host_for_export_svc(
 
 
 # get hosts not marked for deletion
-def _get_unculled_hosts(group, org_id):
+def _get_unculled_hosts(group, org_id, session=db.session):
     hosts = []
     staleness_timestamps = Timestamps.from_config(inventory_config())
-    staleness = get_staleness_obj(org_id)
+    staleness = get_staleness_obj(org_id, session)
     for host in group.hosts:
         serialized_host = serialize_host(host, staleness_timestamps=staleness_timestamps, staleness=staleness)
         if _deserialize_datetime(serialized_host["culled_timestamp"]) > datetime.now(tz=timezone.utc):
@@ -245,8 +247,9 @@ def _get_unculled_hosts(group, org_id):
     return hosts
 
 
-def serialize_group(group: Group, org_id: str):
-    unculled_hosts = _get_unculled_hosts(group, org_id)
+def serialize_group(group: Group, org_id: str, session: Session | None = None):
+    session = session or db.session
+    unculled_hosts = _get_unculled_hosts(group, org_id, session)
     return {
         "id": _serialize_uuid(group.id),
         "org_id": group.org_id,

--- a/assign_ungrouped_hosts_to_groups.py
+++ b/assign_ungrouped_hosts_to_groups.py
@@ -7,15 +7,17 @@ from logging import Logger
 from connexion import FlaskApp
 from sqlalchemy.orm import Session
 
+from app.auth.identity import create_mock_identity_with_org_id
 from app.environment import RuntimeEnvironment
 from app.logging import get_logger
 from app.logging import threadctx
 from app.models import Group
 from app.models import Host
 from app.models import HostGroupAssoc
+from app.queue.event_producer import EventProducer
 from jobs.common import excepthook
 from jobs.common import job_setup
-from lib.db import session_guard
+from lib.group_repository import add_hosts_to_group
 
 PROMETHEUS_JOB = "inventory-assign-ungrouped-groups"
 LOGGER_NAME = "assign_ungrouped_groups"
@@ -23,7 +25,7 @@ RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
 BATCH_SIZE = int(os.getenv("ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE", 25))
 
 
-def run(logger: Logger, session: Session, application: FlaskApp):
+def run(logger: Logger, session: Session, event_producer: EventProducer, application: FlaskApp):
     with application.app.app_context():
         threadctx.request_id = None
         # For each org_id in the Hosts table
@@ -42,23 +44,28 @@ def run(logger: Logger, session: Session, application: FlaskApp):
             ungrouped_group_id = ungrouped_group.id
 
             # Assign all ungrouped hosts to this new Group in batches
-            hosts_to_process = 1
-            while hosts_to_process > 0:
+            while True:
                 # Grab the first batch of ungrouped hosts in the org.
                 # We don't need offset() because Host are assigned to Groups in add_hosts_to_group().
-                with session_guard(session):
-                    host_ids = (
-                        session.query(Host.id)
-                        .outerjoin(HostGroupAssoc, Host.id == HostGroupAssoc.host_id)
-                        .filter(Host.org_id == org_id, HostGroupAssoc.host_id.is_(None))
-                        .limit(BATCH_SIZE)
-                        .all()
+                host_ids = (
+                    session.query(Host.id)
+                    .outerjoin(HostGroupAssoc, Host.id == HostGroupAssoc.host_id)
+                    .filter(Host.org_id == org_id, HostGroupAssoc.host_id.is_(None))
+                    .limit(BATCH_SIZE)
+                    .all()
+                )
+                if host_id_list := [str(host_id) for (host_id,) in host_ids]:
+                    add_hosts_to_group(
+                        ungrouped_group_id,
+                        host_id_list,
+                        create_mock_identity_with_org_id(org_id),
+                        event_producer,
+                        session,
                     )
-                    hosts_to_process = len(host_ids)
-                    for (host_id,) in host_ids:
-                        assoc = HostGroupAssoc(host_id, ungrouped_group_id)
-                        session.add(assoc)
-                    logger.info(f"Created {len(host_ids)} host-group associations for org {org_id}.")
+                else:
+                    break
+
+            session.expunge_all()
 
 
 if __name__ == "__main__":
@@ -66,9 +73,9 @@ if __name__ == "__main__":
     job_type = "Assign ungrouped hosts to ungrouped groups"
     sys.excepthook = partial(excepthook, logger, job_type)
 
-    config, session, _, _, _, application = job_setup((), PROMETHEUS_JOB)
+    config, session, event_producer, _, _, application = job_setup((), PROMETHEUS_JOB)
     if config.bypass_kessel_jobs:
         logger.info("bypass_kessel_jobs was set to True; exiting.")
         sys.exit(0)
     else:
-        run(logger, session, application)
+        run(logger, session, event_producer, application)

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -48,18 +48,21 @@ from lib.middleware import rbac_create_ungrouped_hosts_workspace
 logger = get_logger(__name__)
 
 
-def _update_hosts_for_group_changes(host_id_list: list[str], group_id_list: list[str], identity: Identity):
+def _update_hosts_for_group_changes(
+    host_id_list: list[str], group_id_list: list[str], identity: Identity, session: Optional[Session] = None
+):
+    session = session or db.session
     if group_id_list is None:
         group_id_list = []
 
     serialized_groups = [
-        serialize_group(get_group_by_id_from_db(group_id, identity.org_id), identity.org_id)
+        serialize_group(get_group_by_id_from_db(group_id, identity.org_id), identity.org_id, session)
         for group_id in group_id_list
     ]
 
     # Update groups data on each host record
     Host.query.filter(Host.id.in_(host_id_list)).update({"groups": serialized_groups}, synchronize_session="fetch")
-    db.session.commit()
+    session.commit()
 
     return serialized_groups, host_id_list
 
@@ -116,9 +119,12 @@ def validate_add_host_list_to_group_for_group_create(host_id_list: list[str], gr
         )
 
 
-def validate_add_host_list_to_group(host_id_list: list[str], group_id: str, org_id: str):
+def validate_add_host_list_to_group(
+    host_id_list: list[str], group_id: str, org_id: str, session: Optional[Session] = None
+):
+    session = session or db.session
     # Check if the hosts exist in Inventory and have correct org_id
-    host_query = db.session.query(Host).filter((Host.org_id == org_id) & Host.id.in_(host_id_list)).all()
+    host_query = session.query(Host).filter((Host.org_id == org_id) & Host.id.in_(host_id_list)).all()
     found_ids_set = {str(host.id) for host in host_query}
     if found_ids_set != set(host_id_list):
         nonexistent_hosts = set(host_id_list) - found_ids_set
@@ -129,7 +135,7 @@ def validate_add_host_list_to_group(host_id_list: list[str], group_id: str, org_
 
     # Check if the hosts are already associated with another (ungrouped) group
     if assoc_query := (
-        db.session.query(HostGroupAssoc)
+        session.query(HostGroupAssoc)
         .join(Group)
         .filter(
             HostGroupAssoc.host_id.in_(host_id_list), HostGroupAssoc.group_id != group_id, Group.ungrouped.is_(False)
@@ -144,9 +150,10 @@ def validate_add_host_list_to_group(host_id_list: list[str], group_id: str, org_
         )
 
 
-def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str):
+def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str, session: Optional[Session] = None):
+    session = session or db.session
     # First, validate that the hosts can even be added to the group
-    validate_add_host_list_to_group(host_id_list, group_id, org_id)
+    validate_add_host_list_to_group(host_id_list, group_id, org_id, session)
 
     # Filter out hosts that are already in the group
     assoc_query = HostGroupAssoc.query.filter(
@@ -164,9 +171,9 @@ def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str):
         for host_id in host_id_list
         if host_id not in ids_already_in_this_group
     ]
-    db.session.add_all(host_group_assoc)
+    session.add_all(host_group_assoc)
 
-    _update_group_update_time(group_id, org_id)
+    _update_group_update_time(group_id, org_id, session)
 
     log_host_group_add_succeeded(logger, host_id_list, group_id)
 
@@ -216,14 +223,16 @@ def add_hosts_to_group(
     host_id_list: list[str],
     identity: Identity,
     event_producer: EventProducer,
+    session: Optional[Session] = None,
 ):
-    staleness = get_staleness_obj(identity.org_id)
-    with session_guard(db.session):
-        _add_hosts_to_group(group_id, host_id_list, identity.org_id)
+    session = session or db.session
+    staleness = get_staleness_obj(identity.org_id, session)
+    with session_guard(session):
+        _add_hosts_to_group(group_id, host_id_list, identity.org_id, session)
 
     # Produce update messages once the DB session has been closed
     serialized_groups, host_id_list = _update_hosts_for_group_changes(
-        host_id_list, group_id_list=[group_id], identity=identity
+        host_id_list, group_id_list=[group_id], identity=identity, session=session
     )
     _process_host_changes(host_id_list, serialized_groups, staleness, identity, event_producer)
 
@@ -455,11 +464,12 @@ def patch_group(group: Group, patch_data: dict, identity: Identity, event_produc
         _process_host_changes(host_id_list, serialized_groups, staleness, identity, event_producer)
 
 
-def _update_group_update_time(group_id: str, org_id: str):
-    group = get_group_by_id_from_db(group_id, org_id)
+def _update_group_update_time(group_id: str, org_id: str, session: Optional[Session] = None):
+    session = session or db.session
+    group = get_group_by_id_from_db(group_id, org_id, session)
     group.update_modified_on()
-    db.session.add(group)
-    db.session.flush()
+    session.add(group)
+    session.flush()
 
 
 def get_group_using_host_id(host_id: str, org_id: str):

--- a/tests/test_ungrouped_group_scripts.py
+++ b/tests/test_ungrouped_group_scripts.py
@@ -41,6 +41,7 @@ def test_assignment_happy_path(
     db_create_group_with_hosts,
     db_get_hosts_for_group,
     db_get_groups_for_host,
+    event_producer_mock,
     num_ungrouped_hosts,
 ):
     EXISTING_GROUP_NAME = "existing group"
@@ -63,6 +64,7 @@ def test_assignment_happy_path(
     run_assignment_script(
         logger=mock.MagicMock(),
         session=db.session,
+        event_producer=event_producer_mock,
         application=flask_app,
     )
 


### PR DESCRIPTION
Reverts PR #2637, because I think it may be affecting host MQ consumers.
If this resolves the issue, I'll open another PR with a potential fix.
If not, I'll revert this PR.

## Summary by Sourcery

Revert PR #2637 by restoring explicit session injection and usage across repository, serialization, and job scripts; revert the removal of session parameters and manual association handling; update tests to align with restored signatures.

Enhancements:
- Reintroduce optional session parameters for group repository methods to use provided DB sessions
- Restore session argument in serialize_group, _get_unculled_hosts, and get_staleness_obj for serialization and staleness queries
- Refactor assign_ungrouped_hosts_to_groups script to use add_hosts_to_group with shared session and event producer instead of manual HostGroupAssoc creation

Tests:
- Update ungrouped group assignment tests to pass mock event_producer to the run function