### PR TITLE
feat(RHINENG-18446): Allow x-inventory-org-id header for RHSM Errata requests

### DIFF
--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -26,7 +26,7 @@ class AuthType(str, Enum):
     JWT = "jwt-auth"
     UHC = "uhc-auth"
     SAML = "saml-auth"
-    X509 = "X509"
+    X509 = "x509"
 
 
 class CertType(str, Enum):
@@ -221,8 +221,8 @@ def comes_from_rhsm(identity_dict: dict[str, Any]) -> bool:
     'x-inventory-org-id' header instead.
     """
     return (
-        identity_dict["type"] == IdentityType.X509
-        and identity_dict["auth_type"] == AuthType.X509
+        identity_dict["type"] == IdentityType.X509.value
+        and identity_dict["auth_type"].lower() == AuthType.X509.value.lower()
         and identity_dict.get("x509", {}).get("subject_dn") == "<TODO>"
         and identity_dict.get("x509", {}).get("issuer_dn") == "<TODO>"
     )
@@ -233,7 +233,7 @@ def from_auth_header(base64: str, org_id: str | None = None) -> Identity:
     identity_dict = loads(json)
 
     if comes_from_rhsm(identity_dict["identity"]) and org_id:
-        identity_dict["org_id"] = org_id
+        identity_dict["identity"]["org_id"] = org_id
 
     return Identity(identity_dict["identity"])
 

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -219,12 +219,20 @@ def comes_from_rhsm(identity_dict: dict[str, Any]) -> bool:
     This function determines if the API request comes from RHSM Errata service.
     If it does, the org_id can be missing from the identity header, and it is set by the
     'x-inventory-org-id' header instead.
+
+    Here is how Prod subject_dn and issuer_dn look like for RHSM at the time of writing this function:
+    subject_dn: "/O=mpaas/OU=serviceaccounts/UID=mpp:rhsm:prod-errata-notifications"
+    issuer_dn: "/O=Red Hat/OU=prod/CN=2023 Certificate Authority RHCSv2"
+
+    And here is Preprod:
+    subject_dn: "/O=mpaas/OU=serviceaccounts/UID=mpp:rhsm:nonprod-errata-notifications"
+    issuer_dn: "/O=Red Hat/OU=prod/CN=2023 Certificate Authority RHCSv2"
     """
     return (
         identity_dict["type"] == IdentityType.X509.value
         and identity_dict["auth_type"].lower() == AuthType.X509.value.lower()
-        and identity_dict.get("x509", {}).get("subject_dn") == "<TODO>"
-        and identity_dict.get("x509", {}).get("issuer_dn") == "<TODO>"
+        and "errata-notifications" in identity_dict.get("x509", {}).get("subject_dn", "")
+        and "O=Red Hat" in identity_dict.get("x509", {}).get("issuer_dn", "")
     )
 
 

--- a/app/auth/identity.py
+++ b/app/auth/identity.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import os
 from base64 import b64decode
 from base64 import b64encode
 from enum import Enum
 from json import dumps
 from json import loads
+from typing import Any
 
 import marshmallow as m
 
@@ -79,6 +82,8 @@ class Identity:
                 self.system = result.get("system")
             if "service_account" in result:
                 self.service_account = result.get("service_account")
+            if "x509" in result:
+                self.x509 = result.get("x509")
 
             threadctx.org_id = self.org_id
 
@@ -105,6 +110,10 @@ class Identity:
 
         if self.identity_type == IdentityType.SERVICE_ACCOUNT:
             ident["service_account"] = self.service_account.copy()
+            return ident
+
+        if self.identity_type == IdentityType.X509:
+            ident["x509"] = self.x509.copy()
             return ident
 
     def __eq__(self, other):
@@ -136,6 +145,8 @@ class IdentitySchema(IdentityBaseSchema):
             result = UserIdentitySchema().load(in_data)
         elif in_data["type"] == IdentityType.SYSTEM:
             result = SystemIdentitySchema().load(in_data)
+        elif in_data["type"] == IdentityType.X509:
+            result = X509IdentitySchema().load(in_data)
         else:
             result = ServiceAccountIdentitySchema().load(in_data)
 
@@ -175,6 +186,15 @@ class ServiceAccountIdentitySchema(IdentityBaseSchema):
     service_account = m.fields.Nested(ServiceAccountInfoIdentitySchema, required=True)
 
 
+class X509InfoIdentitySchema(IdentityBaseSchema):
+    subject_dn = m.fields.Str(required=True, validate=m.validate.Length(min=1))
+    issuer_dn = m.fields.Str(required=True, validate=m.validate.Length(min=1))
+
+
+class X509IdentitySchema(IdentityBaseSchema):
+    x509 = m.fields.Nested(X509InfoIdentitySchema, required=True)
+
+
 # Messages from the system_profile topic don't need to provide a real Identity,
 # So this helper function creates a basic User-type identity from the host data.
 def create_mock_identity_with_org_id(org_id: str) -> Identity:
@@ -194,9 +214,27 @@ def to_auth_header(identity: Identity):
     return b64_id.decode("ascii")
 
 
-def from_auth_header(base64):
+def comes_from_rhsm(identity_dict: dict[str, Any]) -> bool:
+    """
+    This function determines if the API request comes from RHSM Errata service.
+    If it does, the org_id can be missing from the identity header, and it is set by the
+    'x-inventory-org-id' header instead.
+    """
+    return (
+        identity_dict["type"] == IdentityType.X509
+        and identity_dict["auth_type"] == AuthType.X509
+        and identity_dict.get("x509", {}).get("subject_dn") == "<TODO>"
+        and identity_dict.get("x509", {}).get("issuer_dn") == "<TODO>"
+    )
+
+
+def from_auth_header(base64: str, org_id: str | None = None) -> Identity:
     json = b64decode(base64)
     identity_dict = loads(json)
+
+    if comes_from_rhsm(identity_dict["identity"]) and org_id:
+        identity_dict["org_id"] = org_id
+
     return Identity(identity_dict["identity"])
 
 

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -1,5 +1,12 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
 import pytest
+from connexion import FlaskApp
 from flask import abort
+from starlette.testclient import TestClient
 
 from tests.helpers.api_utils import GROUP_URL
 from tests.helpers.api_utils import HOST_URL
@@ -10,7 +17,7 @@ from tests.helpers.test_utils import generate_uuid
 
 
 @pytest.fixture(scope="function")
-def flask_client(flask_app):
+def flask_client(flask_app: FlaskApp) -> TestClient:
     return flask_app.test_client()
 
 
@@ -39,8 +46,13 @@ def api_put(flask_client):
 
 
 @pytest.fixture(scope="function")
-def api_get(flask_client):
-    def _api_get(url, identity=USER_IDENTITY, query_parameters=None, extra_headers=None):
+def api_get(flask_client: TestClient) -> Callable[..., tuple[int, dict]]:
+    def _api_get(
+        url: str,
+        identity: dict[str, Any] = USER_IDENTITY,
+        query_parameters: dict[str, Any] | None = None,
+        extra_headers: dict[str, Any] | None = None,
+    ) -> tuple[int, dict]:
         return do_request(
             flask_client.get, url, identity, query_parameters=query_parameters, extra_headers=extra_headers
         )
@@ -60,8 +72,12 @@ def api_delete_host(flask_client):
 
 
 @pytest.fixture(scope="function")
-def api_delete_filtered_hosts(flask_client):
-    def _api_delete_filtered_hosts(query_parameters, identity=USER_IDENTITY, extra_headers=None):
+def api_delete_filtered_hosts(flask_client: TestClient) -> Callable[..., tuple[int, dict]]:
+    def _api_delete_filtered_hosts(
+        query_parameters: dict[str, Any],
+        identity: dict[str, Any] = USER_IDENTITY,
+        extra_headers: dict[str, Any] | None = None,
+    ) -> tuple[int, dict]:
         return do_request(
             flask_client.delete, HOST_URL, identity, query_parameters=query_parameters, extra_headers=extra_headers
         )

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -137,10 +137,12 @@ def db_get_groups_for_host(flask_app):  # noqa: ARG001
 @pytest.fixture(scope="function")
 def db_create_host(flask_app: FlaskApp) -> Callable[..., Host]:  # noqa: ARG001
     def _db_create_host(
-        identity: dict[str, Any] = SYSTEM_IDENTITY, host: Host | None = None, extra_data: dict[str, Any] | None = None
+        identity: dict[str, Any] | None = None, host: Host | None = None, extra_data: dict[str, Any] | None = None
     ) -> Host:
+        identity = identity or SYSTEM_IDENTITY
         extra_data = extra_data or {}
-        host = host or minimal_db_host(org_id=identity["org_id"], account=identity["account_number"], **extra_data)
+        org_id = extra_data.pop("org_id", None) or identity["org_id"]
+        host = host or minimal_db_host(org_id=org_id, account=identity["account_number"], **extra_data)
         db.session.add(host)
         db.session.commit()
         return host
@@ -151,11 +153,12 @@ def db_create_host(flask_app: FlaskApp) -> Callable[..., Host]:  # noqa: ARG001
 @pytest.fixture(scope="function")
 def db_create_multiple_hosts(flask_app: FlaskApp) -> Callable[..., list[Host]]:  # noqa: ARG001
     def _db_create_multiple_hosts(
-        identity: dict[str, Any] = SYSTEM_IDENTITY,
+        identity: dict[str, Any] | None = None,
         hosts: list[Host] | None = None,
         how_many: int = 10,
         extra_data: dict[str, Any] | None = None,
     ) -> list[Host]:
+        identity = identity or SYSTEM_IDENTITY
         extra_data = extra_data or {}
         created_hosts = []
         if isinstance(hosts, list):
@@ -177,7 +180,8 @@ def db_create_multiple_hosts(flask_app: FlaskApp) -> Callable[..., list[Host]]: 
 
 @pytest.fixture(scope="function")
 def db_create_bulk_hosts(flask_app):  # noqa: ARG001
-    def _db_create_bulk_hosts(identity=SYSTEM_IDENTITY, how_many=10, extra_data=None):
+    def _db_create_bulk_hosts(identity=None, how_many=10, extra_data=None):
+        identity = identity or SYSTEM_IDENTITY
         extra_data = extra_data or {}
         host_dicts = []
 
@@ -206,7 +210,8 @@ def models_datetime_mock(mocker):
 
 @pytest.fixture(scope="function")
 def db_create_group(flask_app):  # noqa: ARG001
-    def _db_create_group(name, identity=SYSTEM_IDENTITY, ungrouped=False):
+    def _db_create_group(name, identity=None, ungrouped=False):
+        identity = identity or SYSTEM_IDENTITY
         group = db_group(org_id=identity["org_id"], account=identity["account_number"], name=name, ungrouped=ungrouped)
         db.session.add(group)
         db.session.commit()

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import math
 from base64 import b64encode
@@ -6,6 +8,7 @@ from http import HTTPStatus
 from itertools import product
 from struct import unpack
 from typing import Any
+from typing import Callable
 from urllib.parse import parse_qs
 from urllib.parse import quote_plus as url_quote
 from urllib.parse import urlencode
@@ -178,7 +181,14 @@ _INPUT_DATA = {
 }
 
 
-def do_request(func, url, identity, data=None, query_parameters=None, extra_headers=None):
+def do_request(
+    func: Callable[..., Response],
+    url: str,
+    identity: dict[str, Any],
+    data: dict[str, Any] | None = None,
+    query_parameters: dict[str, Any] | None = None,
+    extra_headers: dict[str, Any] | None = None,
+) -> tuple[int, dict]:
     url = inject_qs(url, **query_parameters) if query_parameters else url
     headers = get_required_headers(identity)
 
@@ -200,21 +210,21 @@ def do_request(func, url, identity, data=None, query_parameters=None, extra_head
     return response.status_code, response_data
 
 
-def get_valid_auth_header(identity):
+def get_valid_auth_header(identity: dict[str, Any]) -> dict[str, Any]:
     if identity["type"] in IdentityType.__members__.values():
         return build_account_auth_header(identity)
 
     return build_token_auth_header()
 
 
-def get_required_headers(identity):
+def get_required_headers(identity: dict[str, Any]) -> dict[str, Any]:
     headers = get_valid_auth_header(identity)
     headers["content-type"] = "application/json"
 
     return headers
 
 
-def build_account_auth_header(identity):
+def build_account_auth_header(identity: dict[str, Any]) -> dict[str, bytes]:
     dict_ = {"identity": identity}
 
     json_doc = json.dumps(dict_)
@@ -222,7 +232,7 @@ def build_account_auth_header(identity):
     return auth_header
 
 
-def build_token_auth_header(token=SHARED_SECRET):
+def build_token_auth_header(token: str = SHARED_SECRET) -> dict[str, str]:
     auth_header = {"Authorization": f"Bearer {token}"}
     return auth_header
 

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -53,6 +53,19 @@ SERVICE_ACCOUNT_IDENTITY: dict[str, Any] = {
     "type": "ServiceAccount",
 }
 
+X509_IDENTITY: dict[str, Any] = {
+    "type": "X509",
+    "auth_type": "X509",
+    "x509": {
+        "subject_dn": "/CN=some-host.example.com",
+        "issuer_dn": "/CN=certificate-authority.example.com",
+    },
+}
+
+RHSM_ERRATA_IDENTITY = deepcopy(X509_IDENTITY)
+RHSM_ERRATA_IDENTITY["x509"]["subject_dn"] = "<TODO>"
+RHSM_ERRATA_IDENTITY["x509"]["issuer_dn"] = "<TODO>"
+
 YUM_REPO1 = {"id": "repo1", "name": "repo1", "gpgcheck": True, "enabled": True, "base_url": "http://rpms.redhat.com"}
 
 YUM_REPO2 = {"id": "repo2", "name": "repo2", "gpgcheck": True, "enabled": True, "base_url": "http://rpms.redhat.com"}

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -62,9 +62,14 @@ X509_IDENTITY: dict[str, Any] = {
     },
 }
 
-RHSM_ERRATA_IDENTITY = deepcopy(X509_IDENTITY)
-RHSM_ERRATA_IDENTITY["x509"]["subject_dn"] = "<TODO>"
-RHSM_ERRATA_IDENTITY["x509"]["issuer_dn"] = "<TODO>"
+RHSM_ERRATA_IDENTITY_PROD = deepcopy(X509_IDENTITY)
+RHSM_ERRATA_IDENTITY_PROD["x509"]["subject_dn"] = "/O=mpaas/OU=serviceaccounts/UID=mpp:rhsm:prod-errata-notifications"
+RHSM_ERRATA_IDENTITY_PROD["x509"]["issuer_dn"] = "/O=Red Hat/OU=prod/CN=2023 Certificate Authority RHCSv2"
+
+RHSM_ERRATA_IDENTITY_STAGE = deepcopy(RHSM_ERRATA_IDENTITY_PROD)
+RHSM_ERRATA_IDENTITY_STAGE["x509"]["subject_dn"] = (
+    "/O=mpaas/OU=serviceaccounts/UID=mpp:rhsm:nonprod-errata-notifications"
+)
 
 YUM_REPO1 = {"id": "repo1", "name": "repo1", "gpgcheck": True, "enabled": True, "base_url": "http://rpms.redhat.com"}
 

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 from base64 import b64encode
 from copy import deepcopy
 from json import dumps
+from typing import Any
 
 import pytest
+from pytest_subtests import SubTests
+from starlette.testclient import TestClient
 
 from app import process_identity_header
 from app.auth.identity import Identity
@@ -13,40 +18,86 @@ from tests.helpers.api_utils import build_token_auth_header
 from tests.helpers.test_utils import SERVICE_ACCOUNT_IDENTITY
 from tests.helpers.test_utils import SYSTEM_IDENTITY
 from tests.helpers.test_utils import USER_IDENTITY
+from tests.helpers.test_utils import X509_IDENTITY
 
 
-def invalid_identities(identity_type):
+def invalid_identities(identity_type: IdentityType) -> list[dict[str, Any]]:
+    identities = []
+
     if identity_type == IdentityType.SYSTEM:
-        no_cert_type = Identity(SYSTEM_IDENTITY)._asdict()
-        no_cert_type["system"].pop("cert_type", None)
+        base_identity = Identity(SYSTEM_IDENTITY)._asdict()
 
-        no_cn = Identity(SYSTEM_IDENTITY)._asdict()
-        no_cn["system"].pop("cn", None)
+        no_cert_type = deepcopy(base_identity)
+        no_cert_type["system"].pop("cert_type")
 
-        no_system = Identity(SYSTEM_IDENTITY)._asdict()
-        no_system.pop("system", None)
+        no_cn = deepcopy(base_identity)
+        no_cn["system"].pop("cn")
 
-        return (no_cert_type, no_cn, no_system)
+        no_system = deepcopy(base_identity)
+        no_system.pop("system")
+
+        identities += [no_cert_type, no_cn, no_system]
+
+    if identity_type == IdentityType.SERVICE_ACCOUNT:
+        base_identity = Identity(SERVICE_ACCOUNT_IDENTITY)._asdict()
+
+        no_client_id = deepcopy(base_identity)
+        no_client_id["service_account"].pop("client_id")
+
+        no_username = deepcopy(base_identity)
+        no_username["service_account"].pop("username")
+
+        no_service_account = deepcopy(base_identity)
+        no_service_account.pop("service_account")
+
+        identities += [no_client_id, no_username, no_service_account]
+
+    if identity_type == IdentityType.X509:
+        base_identity = Identity(X509_IDENTITY)._asdict()
+
+        no_subject_dn = deepcopy(base_identity)
+        no_subject_dn["x509"].pop("subject_dn")
+
+        no_issuer_dn = deepcopy(base_identity)
+        no_issuer_dn["x509"].pop("issuer_dn")
+
+        no_x509 = deepcopy(base_identity)
+        no_x509.pop("x509")
+
+        identities += [no_subject_dn, no_issuer_dn, no_x509]
+
+    else:
+        base_identity = Identity(USER_IDENTITY)._asdict()
+
+    no_org_id = deepcopy(base_identity)
+    no_org_id.pop("org_id")
+
+    no_type = deepcopy(base_identity)
+    no_type.pop("type")
+
+    no_auth_type = deepcopy(base_identity)
+    no_auth_type.pop("auth_type")
+
+    return identities + [no_org_id, no_type, no_auth_type]
 
 
-def invalid_payloads(identity_type):
-    if identity_type == IdentityType.SYSTEM:
-        payloads = ()
-        for identity in invalid_identities(IdentityType.SYSTEM):
-            dict_ = {"identity": identity}
-            json = dumps(dict_)
-            payloads += (b64encode(json.encode()),)
-        return payloads
+def invalid_payloads(identity_type: IdentityType) -> tuple[bytes, ...]:
+    payloads: tuple[bytes, ...] = ()
+    for identity in invalid_identities(identity_type):
+        dict_ = {"identity": identity}
+        json = dumps(dict_)
+        payloads += (b64encode(json.encode()),)
+    return payloads
 
 
-def create_identity_payload(identity):
+def create_identity_payload(identity: dict[str, Any]) -> bytes:
     # Load into Identity object for validation, then return to dict
     dict_ = {"identity": Identity(identity)._asdict()}
     json = dumps(dict_)
     return b64encode(json.encode())
 
 
-def test_validate_missing_identity(flask_client):
+def test_validate_missing_identity(flask_client: TestClient):
     """
     Identity header is not present.
     """
@@ -54,7 +105,7 @@ def test_validate_missing_identity(flask_client):
     assert response.status_code == 401
 
 
-def test_validate_invalid_identity(flask_client):
+def test_validate_empty_identity(flask_client: TestClient):
     """
     Identity header is not valid – empty in this case
     """
@@ -62,82 +113,47 @@ def test_validate_invalid_identity(flask_client):
     assert response.status_code == 401
 
 
+@pytest.mark.parametrize("remove_account_number", (True, False))
 @pytest.mark.parametrize(
-    "remove_account_number, identity",
-    ((True, USER_IDENTITY), (False, USER_IDENTITY), (False, SERVICE_ACCOUNT_IDENTITY)),
+    "identity",
+    (USER_IDENTITY, SYSTEM_IDENTITY, SERVICE_ACCOUNT_IDENTITY),
+    ids=("user", "system", "service-account"),
 )
-def test_validate_valid_identity(flask_client, remove_account_number, identity):
+def test_validate_valid_identity(flask_client: TestClient, remove_account_number: bool, identity: dict[str, Any]):
     """
     Identity header is valid – non-empty in this case
     """
-    identity = deepcopy(identity)
+    test_identity = deepcopy(identity)
     if remove_account_number:
-        del identity["account_number"]
+        test_identity.pop("account_number", None)
 
-    payload = create_identity_payload(identity)
+    payload = create_identity_payload(test_identity)
     response = flask_client.get(HOST_URL, headers={"x-rh-identity": payload})
     assert response.status_code == 200  # OK
 
 
-def test_validate_non_admin_user_identity(flask_client):
+@pytest.mark.parametrize(
+    "identity",
+    (USER_IDENTITY, SYSTEM_IDENTITY, SERVICE_ACCOUNT_IDENTITY),
+    ids=("user", "system", "service-account"),
+)
+def test_validate_non_admin_identity(flask_client: TestClient, identity: dict[str, Any]):
     """
-    Identity header is valid and user is provided, but is not an Admin
+    Identity header is valid, but is not an Admin
     """
-    identity = deepcopy(USER_IDENTITY)
-    identity["user"]["username"] = "regularjoe@redhat.com"
-    payload = create_identity_payload(identity)
+    test_identity = deepcopy(identity)
+    if "user" in test_identity:
+        test_identity["user"]["username"] = "regularjoe@redhat.com"
+    payload = create_identity_payload(test_identity)
     response = flask_client.post(
         f"{SYSTEM_PROFILE_URL}/validate_schema?repo_branch=master&days=1", headers={"x-rh-identity": payload}
     )
     assert response.status_code == 403  # User is not an HBI admin
 
 
-def test_validate_non_admin_service_account_identity(flask_client):
-    """
-    Identity header is valid and service account is provided, but is not an Admin
-    """
-    identity = deepcopy(SERVICE_ACCOUNT_IDENTITY)
-    identity["service_account"]["username"] = "regularjoe@redhat.com"
-    payload = create_identity_payload(identity)
-    response = flask_client.post(
-        f"{SYSTEM_PROFILE_URL}/validate_schema?repo_branch=master&days=1", headers={"x-rh-identity": payload}
-    )
-    assert response.status_code == 403  # User is not an HBI admin
-
-
-def test_validate_non_user_admin_endpoint(flask_client):
-    """
-    Identity header is valid and system is provided, but is not an Admin
-    """
-    payload = create_identity_payload(SYSTEM_IDENTITY)
-    response = flask_client.post(
-        f"{SYSTEM_PROFILE_URL}/validate_schema?repo_branch=master&days=1", headers={"x-rh-identity": payload}
-    )
-    assert response.status_code == 403  # Endpoint not available to Systems
-
-
-def test_validate_valid_system_identity(flask_client):
-    """
-    Identity header is valid – non-empty in this case
-    """
-    payload = create_identity_payload(SYSTEM_IDENTITY)
-    response = flask_client.get(HOST_URL, headers={"x-rh-identity": payload})
-    assert response.status_code == 200  # OK
-
-
-def test_validate_service_account_admin_endpoint(flask_client):
-    """
-    Identity header is valid and service account is provided, but is not an Admin
-    """
-    payload = create_identity_payload(SERVICE_ACCOUNT_IDENTITY)
-    response = flask_client.post(
-        f"{SYSTEM_PROFILE_URL}/validate_schema?repo_branch=master&days=1", headers={"x-rh-identity": payload}
-    )
-    assert response.status_code == 403  # Endpoint not available to Service accounts
-
-
-def test_invalid_system_identities(flask_client, subtests):
-    payloads = invalid_payloads(IdentityType.SYSTEM)
+@pytest.mark.parametrize("identity_type", (IdentityType.USER, IdentityType.SYSTEM, IdentityType.SERVICE_ACCOUNT))
+def test_validate_invalid_identity(flask_client: TestClient, subtests: SubTests, identity_type: IdentityType):
+    payloads = invalid_payloads(identity_type)
 
     for payload in payloads:
         with subtests.test():
@@ -145,7 +161,7 @@ def test_invalid_system_identities(flask_client, subtests):
             assert response.status_code == 401  # Bad identity
 
 
-def test_validate_invalid_token_on_get(flask_client):
+def test_validate_invalid_token_on_get(flask_client: TestClient):
     auth_header = build_token_auth_header("NotTheSuperSecretValue")
     response = flask_client.get(HOST_URL, headers=auth_header)
     assert response.status_code == 401

--- a/tests/test_api_hosts_delete.py
+++ b/tests/test_api_hosts_delete.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
+from typing import Any
 from typing import Callable
 from unittest import mock
 from unittest.mock import patch
@@ -23,7 +24,8 @@ from tests.helpers.db_utils import db_host
 from tests.helpers.mq_utils import MockEventProducer
 from tests.helpers.mq_utils import assert_delete_event_is_valid
 from tests.helpers.mq_utils import assert_delete_notification_is_valid
-from tests.helpers.test_utils import RHSM_ERRATA_IDENTITY
+from tests.helpers.test_utils import RHSM_ERRATA_IDENTITY_PROD
+from tests.helpers.test_utils import RHSM_ERRATA_IDENTITY_STAGE
 from tests.helpers.test_utils import SYSTEM_IDENTITY
 from tests.helpers.test_utils import USER_IDENTITY
 from tests.helpers.test_utils import generate_uuid
@@ -599,12 +601,18 @@ def test_postgres_delete_filtered_hosts(
 
 
 @pytest.mark.usefixtures("notification_event_producer_mock")
+@pytest.mark.parametrize("identity", (RHSM_ERRATA_IDENTITY_PROD, RHSM_ERRATA_IDENTITY_STAGE), ids=("prod", "stage"))
 def test_delete_hosts_by_subman_id_internal_rhsm_request(
     db_create_host: Callable[..., Host],
     api_get: Callable[..., tuple[int, dict]],
     api_delete_filtered_hosts: Callable[..., tuple[int, dict]],
     event_producer_mock: MockEventProducer,
+    identity: dict[str, Any],
 ):
+    """
+    This test simulates the internal `DELETE /hosts?subscription_manager_id=...` request from RHSM
+    that they make when a host is unregistered from RHSM, to delete it from Insights Inventory.
+    """
     searched_subman_id = generate_uuid()
     matching_host_id = str(
         db_create_host(extra_data={"canonical_facts": {"subscription_manager_id": searched_subman_id}}).id
@@ -621,23 +629,27 @@ def test_delete_hosts_by_subman_id_internal_rhsm_request(
     # Delete the host using the bulk deletion endpoint
     response_status, response_data = api_delete_filtered_hosts(
         {"subscription_manager_id": searched_subman_id},
-        identity=RHSM_ERRATA_IDENTITY,
+        identity=identity,
         extra_headers={"x-inventory-org-id": "test"},
     )
     assert_response_status(response_status, expected_status=202)
     assert response_data["hosts_deleted"] == 1
     assert response_data["hosts_found"] == 1
 
-    # Make sure it was deleted and produced a deletion event
+    # Make sure the correct host was deleted and produced a deletion event
     assert '"type": "delete"' in event_producer_mock.event
 
     _, response_data = api_get(build_hosts_url([matching_host_id, not_matching_host_id, different_org_host_id]))
     assert len(response_data["results"]) == 1
     assert response_data["results"][0]["id"] == not_matching_host_id
 
+    # Make sure the host from different org wasn't deleted
     different_org_identity = deepcopy(USER_IDENTITY)
     different_org_identity["org_id"] = "12345"
-    _, response_data = api_get(build_hosts_url(different_org_host_id), identity=different_org_identity)
+    _, response_data = api_get(
+        build_hosts_url([matching_host_id, not_matching_host_id, different_org_host_id]),
+        identity=different_org_identity,
+    )
     assert len(response_data["results"]) == 1
     assert response_data["results"][0]["id"] == different_org_host_id
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18446](https://issues.redhat.com/browse/RHINENG-18446).

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add support for X509-based RHSM Errata identities with conditional org_id injection from the x-inventory-org-id header and update authentication logic accordingly

New Features:
- Introduce X509 identity schema and include x509 field in Identity model
- Allow RHSM Errata X509 requests to supply org_id via x-inventory-org-id header when missing

Enhancements:
- Add comes_from_rhsm helper to detect RHSM Errata X509 identities and inject org_id
- Lower-case X509 auth type and extend authentication_header_handler to accept request context

Tests:
- Expand invalid_payloads and invalid_identities generators to cover X509 identities
- Add parameterized tests for RHSM and non-RHSM X509 identity scenarios with and without x-inventory-org-id
- Add tests for bulk delete via RHSM Errata and for ignoring x-inventory-org-id on non-RHSM identities