### PR TITLE
chore(RHINENG-18586) Remove logs; explicitly commit and expunge

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -1,4 +1,3 @@
-import resource
 from http import HTTPStatus
 
 from flask import Response
@@ -214,9 +213,7 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
 @rbac(RbacResourceType.GROUPS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_groups(group_id_list, rbac_filter=None):
-    logger.debug(f">>> Memory usage 1: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
     rbac_group_id_check(rbac_filter, set(group_id_list))
-    logger.debug(f">>> Memory usage 2: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
 
     if get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION):
         # Write is not allowed for the ungrouped through API requests
@@ -230,30 +227,24 @@ def delete_groups(group_id_list, rbac_filter=None):
         group_ids_to_delete = []
         delete_count = 0
 
-        logger.debug(f">>> Memory usage 3: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
-
         # Attempt to delete the RBAC workspaces
         for group_id in group_id_list:
             try:
                 if delete_rbac_workspace(group_id):
-                    logger.debug(f">>> Memory usage 4: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
                     delete_count += 1
             except ResourceNotFoundException:
-                logger.debug(f">>> Memory usage 5: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
                 # For workspaces that are missing from RBAC,
                 # we'll attempt to delete the groups on our side
                 group_ids_to_delete.append(group_id)
 
         # Attempt to delete the "not found" groups on our side
         delete_count += delete_group_list(group_ids_to_delete, get_current_identity(), current_app.event_producer)
-        logger.debug(f">>> Memory usage 6: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
     else:
         delete_count = delete_group_list(group_id_list, get_current_identity(), current_app.event_producer)
 
     if delete_count == 0:
         log_get_group_list_failed(logger)
         abort(HTTPStatus.NOT_FOUND, "No groups found for deletion.")
-    logger.debug(f">>> Memory usage 7: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
     return Response(None, HTTPStatus.NO_CONTENT)
 
 

--- a/api/staleness_query.py
+++ b/api/staleness_query.py
@@ -1,5 +1,3 @@
-import resource
-
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.logging import get_logger
@@ -14,15 +12,12 @@ logger = get_logger(__name__)
 
 def get_staleness_obj(org_id: str) -> AttrDict:
     try:
-        logger.debug(f">>> Memory usage gso1: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
         staleness = db.session.query(Staleness).filter(Staleness.org_id == org_id).one()
         logger.info(f"Using custom staleness for org {org_id}.")
         staleness = build_serialized_acc_staleness_obj(staleness)
     except NoResultFound:
         logger.debug(f"No custom staleness data found for org {org_id}, using system default values instead.")
-        logger.debug(f">>> Memory usage gso2: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
         staleness = build_staleness_sys_default(org_id)
-        logger.debug(f">>> Memory usage gso3: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
         return staleness
 
     return staleness

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import resource
 from datetime import datetime
 from datetime import timezone
 
@@ -239,28 +238,18 @@ def serialize_host_for_export_svc(
 # get hosts not marked for deletion
 def _get_unculled_hosts(group, org_id):
     hosts = []
-    logger.debug(f">>> Memory usage guh1: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
     staleness_timestamps = Timestamps.from_config(inventory_config())
-    logger.debug(f">>> Memory usage guh2: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
     staleness = get_staleness_obj(org_id)
-    logger.debug(f">>> Memory usage guh3: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
     for host in group.hosts:
-        logger.debug(f">>> Memory usage guh4: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
         serialized_host = serialize_host(host, staleness_timestamps=staleness_timestamps, staleness=staleness)
-        logger.debug(f">>> Memory usage guh5: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
         if _deserialize_datetime(serialized_host["culled_timestamp"]) > datetime.now(tz=timezone.utc):
             hosts.append(host)
 
-        logger.debug(f">>> Memory usage guh6: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
-
-    logger.debug(f">>> Memory usage guh7: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
     return hosts
 
 
 def serialize_group(group: Group, org_id: str):
-    logger.debug(f">>> Memory usage ser1: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
     unculled_hosts = _get_unculled_hosts(group, org_id)
-    logger.debug(f">>> Memory usage gso2: {resource.getrusage(resource.RUSAGE_SELF).ru_maxrss}")
     return {
         "id": _serialize_uuid(group.id),
         "org_id": group.org_id,


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18586](https://issues.redhat.com/browse/RHINENG-18586).
Removes all the memory logs I added earlier; also adds an explicit commit() and expunge_all() to see if that helps.
I do have an idea of how to reduce memory usage in general, but that PR is forthcoming.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Remove verbose memory logging and improve session handling in group deletion and serialization workflows

Enhancements:
- Remove memory usage debug logs across group repository, serialization, API endpoint, and staleness query modules
- Add explicit db.session.commit() and db.session.expunge_all() in delete_group_list to clear session state after host changes
- Refactor delete_group_list to fetch staleness inside the session guard and reorder host update processing