### PR TITLE
fix(RHINENG-18586) Group serialization fix

### DIFF
--- a/api/group_query.py
+++ b/api/group_query.py
@@ -7,7 +7,7 @@ from app.logging import get_logger
 from app.models import Group
 from app.models import HostGroupAssoc
 from app.models import db
-from app.serialization import serialize_group
+from lib.group_repository import serialize_group
 
 logger = get_logger(__name__)
 

--- a/api/group_query.py
+++ b/api/group_query.py
@@ -131,8 +131,7 @@ def get_filtered_group_list_db(group_name, page, per_page, order_by, order_how, 
 
 
 def build_paginated_group_list_response(total, page, per_page, group_list):
-    identity = get_current_identity()
-    json_group_list = [serialize_group(group, identity.org_id) for group in group_list]
+    json_group_list = [serialize_group(group) for group in group_list]
     return {
         "total": total,
         "count": len(json_group_list),
@@ -143,5 +142,4 @@ def build_paginated_group_list_response(total, page, per_page, group_list):
 
 
 def build_group_response(group):
-    identity = get_current_identity()
-    return serialize_group(group, identity.org_id)
+    return serialize_group(group)

--- a/api/host.py
+++ b/api/host.py
@@ -441,17 +441,21 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict, rba
 
     if rbac_filter and "groups" in rbac_filter:
         count_before_rbac_filter = find_non_culled_hosts(
-            update_query_for_owner_id(current_identity, query), current_identity
+            update_query_for_owner_id(current_identity, query), current_identity.org_id
         ).count()
         filters += (HostGroupAssoc.group_id.in_(rbac_filter["groups"]),)
         query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.id)
         if (
             count_before_rbac_filter
-            != find_non_culled_hosts(update_query_for_owner_id(current_identity, query), current_identity).count()
+            != find_non_culled_hosts(
+                update_query_for_owner_id(current_identity, query), current_identity.org_id
+            ).count()
         ):
             flask.abort(HTTPStatus.FORBIDDEN, "You do not have access to all of the requested hosts.")
 
-    hosts_to_update = find_non_culled_hosts(update_query_for_owner_id(current_identity, query), current_identity).all()
+    hosts_to_update = find_non_culled_hosts(
+        update_query_for_owner_id(current_identity, query), current_identity.org_id
+    ).all()
 
     logger.debug("hosts_to_update:%s", hosts_to_update)
 

--- a/api/resource_type.py
+++ b/api/resource_type.py
@@ -13,7 +13,7 @@ from app.instrumentation import log_get_group_list_succeeded
 from app.instrumentation import log_get_resource_type_list_failed
 from app.instrumentation import log_get_resource_type_list_succeeded
 from app.logging import get_logger
-from app.serialization import serialize_group
+from lib.group_repository import serialize_group
 from lib.middleware import rbac
 
 logger = get_logger(__name__)

--- a/api/resource_type.py
+++ b/api/resource_type.py
@@ -8,7 +8,6 @@ from api.resource_query import build_paginated_resource_list_response
 from api.resource_query import get_resources_types
 from app import RbacPermission
 from app import RbacResourceType
-from app.auth import get_current_identity
 from app.instrumentation import log_get_group_list_failed
 from app.instrumentation import log_get_group_list_succeeded
 from app.instrumentation import log_get_resource_type_list_failed
@@ -65,9 +64,6 @@ def get_resource_type_groups_list(
         flask.abort(400, str(e))
 
     log_get_group_list_succeeded(logger, group_list)
-    identity = get_current_identity()
     return flask_json_response(
-        build_paginated_resource_list_response(
-            total, page, per_page, [serialize_group(group, identity.org_id) for group in group_list]
-        )
+        build_paginated_resource_list_response(total, page, per_page, [serialize_group(group) for group in group_list])
     )

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -394,7 +394,7 @@ class IngressMessageConsumer(HostMessageConsumer):
                 group = get_or_create_ungrouped_hosts_group_for_identity(identity)
                 assoc = HostGroupAssoc(host_row.id, group.id)
                 db.session.add(assoc)
-                host_row.groups = [serialize_group(group, identity.org_id)]
+                host_row.groups = [serialize_group(group)]
                 db.session.flush()
 
             success_logger = partial(log_add_update_host_succeeded, logger, add_result, sp_fields_to_log)

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -62,7 +62,6 @@ from app.queue.notifications import NotificationType
 from app.queue.notifications import send_notification
 from app.serialization import deserialize_host
 from app.serialization import remove_null_canonical_facts
-from app.serialization import serialize_group
 from app.serialization import serialize_host
 from app.staleness_serialization import AttrDict
 from lib import group_repository
@@ -72,6 +71,7 @@ from lib.feature_flags import FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION
 from lib.feature_flags import FLAG_INVENTORY_USE_CACHED_INSIGHTS_CLIENT_SYSTEM
 from lib.feature_flags import get_flag_value
 from lib.group_repository import get_or_create_ungrouped_hosts_group_for_identity
+from lib.group_repository import serialize_group
 from utils.system_profile_log import extract_host_dict_sp_to_log
 
 logger = get_logger(__name__)

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -235,10 +235,9 @@ def serialize_host_for_export_svc(
 
 
 def serialize_group(group: Group):
-    from app.auth.identity import create_mock_identity_with_org_id
     from lib.host_repository import get_non_culled_hosts_count_in_group
 
-    host_count = get_non_culled_hosts_count_in_group(group, create_mock_identity_with_org_id(group.org_id))
+    host_count = get_non_culled_hosts_count_in_group(group, group.org_id)
 
     return {
         "id": _serialize_uuid(group.id),

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -234,11 +234,7 @@ def serialize_host_for_export_svc(
     return serialized_host
 
 
-def serialize_group(group: Group):
-    from lib.host_repository import get_non_culled_hosts_count_in_group
-
-    host_count = get_non_culled_hosts_count_in_group(group, group.org_id)
-
+def serialize_group_with_host_count(group: Group, host_count: int) -> dict:
     return {
         "id": _serialize_uuid(group.id),
         "org_id": group.org_id,

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -53,8 +53,7 @@ def _update_hosts_for_group_changes(host_id_list: list[str], group_id_list: list
         group_id_list = []
 
     serialized_groups = [
-        serialize_group(get_group_by_id_from_db(group_id, identity.org_id), identity.org_id)
-        for group_id in group_id_list
+        serialize_group(get_group_by_id_from_db(group_id, identity.org_id)) for group_id in group_id_list
     ]
 
     # Update groups data on each host record

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -32,13 +32,14 @@ from app.queue.event_producer import EventProducer
 from app.queue.events import EventType
 from app.queue.events import build_event
 from app.queue.events import message_headers
-from app.serialization import serialize_group
+from app.serialization import serialize_group_with_host_count
 from app.serialization import serialize_host
 from app.staleness_serialization import AttrDict
 from lib.db import session_guard
 from lib.feature_flags import FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION
 from lib.feature_flags import get_flag_value
 from lib.host_repository import get_host_list_by_id_list_from_db
+from lib.host_repository import get_non_culled_hosts_count_in_group
 from lib.metrics import delete_group_count
 from lib.metrics import delete_group_processing_time
 from lib.metrics import delete_host_group_count
@@ -499,3 +500,8 @@ def get_or_create_ungrouped_hosts_group_for_identity(identity: Identity) -> Grou
 def get_ungrouped_group(identity: Identity) -> Group:
     ungrouped_group = Group.query.filter(Group.org_id == identity.org_id, Group.ungrouped.is_(True)).one_or_none()
     return ungrouped_group
+
+
+def serialize_group(group: Group) -> dict:
+    host_count = get_non_culled_hosts_count_in_group(group, group.org_id)
+    return serialize_group_with_host_count(group, host_count)

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -32,6 +32,7 @@ from app.models import Group
 from app.models import Host
 from app.models import HostGroupAssoc
 from app.models import LimitedHost
+from app.models import db
 from app.serialization import serialize_staleness_to_dict
 from app.staleness_serialization import get_sys_default_staleness
 from lib import metrics
@@ -399,3 +400,10 @@ def get_host_list_by_id_list_from_db(host_id_list, identity, rbac_filter=None, c
     if columns:
         query = query.with_entities(*columns)
     return find_non_culled_hosts(update_query_for_owner_id(identity, query), identity)
+
+
+def get_non_culled_hosts_count_in_group(group: Group, identity: Identity) -> int:
+    return find_non_culled_hosts(
+        db.session.query(Host).join(HostGroupAssoc).filter(HostGroupAssoc.group_id == group.id).group_by(Host.id),
+        identity,
+    ).count()

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -12,7 +12,6 @@ from sqlalchemy_utils import create_database
 from sqlalchemy_utils import database_exists
 from sqlalchemy_utils import drop_database
 
-from app.auth.identity import Identity
 from app.config import Config
 from app.environment import RuntimeEnvironment
 from app.models import Group
@@ -26,7 +25,6 @@ from tests.helpers.db_utils import db_staleness_culling
 from tests.helpers.db_utils import minimal_db_host
 from tests.helpers.db_utils import minimal_db_host_dict
 from tests.helpers.test_utils import SYSTEM_IDENTITY
-from tests.helpers.test_utils import USER_IDENTITY
 from tests.helpers.test_utils import now
 from tests.helpers.test_utils import set_environment
 
@@ -222,8 +220,7 @@ def db_create_host_group_assoc(flask_app, db_get_group_by_id):  # noqa: ARG001
     def _db_create_host_group_assoc(host_id, group_id):
         host_group = HostGroupAssoc(host_id=host_id, group_id=group_id)
         db.session.add(host_group)
-        identity = Identity(USER_IDENTITY)
-        serialized_groups = [serialize_group(db_get_group_by_id(group_id), identity.org_id)]
+        serialized_groups = [serialize_group(db_get_group_by_id(group_id))]
         db.session.query(Host).filter(Host.id == host_id).update({"groups": serialized_groups})
 
         db.session.commit()

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -19,7 +19,7 @@ from app.models import Host
 from app.models import HostGroupAssoc
 from app.models import Staleness
 from app.models import db
-from app.serialization import serialize_group
+from lib.group_repository import serialize_group
 from tests.helpers.db_utils import db_group
 from tests.helpers.db_utils import db_staleness_culling
 from tests.helpers.db_utils import minimal_db_host


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18586](https://issues.redhat.com/browse/RHINENG-18586).
It reduces the memory consumption during the serialization of groups. Before this PR, host_count was calculated by loading in all the hosts associated with the group, and adding each one to a list if it wasn't in the "culled" state. This PR changes it to use a filtered `count()` call. 

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
