### PR TITLE
fix(RHINENG-18212) Return 404 when attempting to remove host from nonexistent group

### DIFF
--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -559,6 +559,21 @@ def test_delete_host_from_group_no_ungrouped(
     ungrouped_group = db_create_group_with_hosts("ungrouped", 1, ungrouped=False)
     host_id_to_delete = str(db_get_hosts_for_group(ungrouped_group.id)[0].id)
 
-    response_status, response_data = api_remove_hosts_from_group(ungrouped_group.id, [host_id_to_delete])
+    response_status, _ = api_remove_hosts_from_group(ungrouped_group.id, [host_id_to_delete])
 
     assert_response_status(response_status, 204)
+
+
+@pytest.mark.usefixtures("event_producer")
+def test_delete_host_from_nonexistent_group(
+    mocker, db_create_group_with_hosts, db_get_hosts_for_group, api_remove_hosts_from_group
+):
+    mocker.patch("api.host_group.get_flag_value", return_value=True)
+
+    ungrouped_group = db_create_group_with_hosts("test group", 1, ungrouped=False)
+    host_id = str(db_get_hosts_for_group(ungrouped_group.id)[0].id)
+
+    response_status, response_data = api_remove_hosts_from_group(str(generate_uuid()), [host_id])
+
+    assert_response_status(response_status, 404)
+    assert "Group not found" in response_data["detail"]


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-xxxx](https://issues.redhat.com/browse/RHINENG-18212).
Return HTTP 404 (instead of 500) when attempting to remove host from nonexistent group. Checks for the existence of the specified group before attempting to check whether said group is "ungrouped".

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
