### PR TITLE
metrics(query): remove unused queries from metrics configuration

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1964,25 +1964,11 @@ objects:
           FROM "hbi"."hosts"
           WHERE "created_on" >= NOW() - INTERVAL '1 day'
           GROUP BY "reporter";
-      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/created_by_reporters
-        query: >-
-          SELECT
-            "reporter" AS "reporter",
-            count(*) AS "hosts_created"
-          FROM "hbi"."hosts"
-          WHERE "created_on" >= NOW() - INTERVAL '1 week'
-          GROUP BY "reporter";
       - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/daily_updated_by_reporters
         query: >-
           SELECT  "reporter" AS "reporter", count(*) AS "hosts_updated"
           FROM "hbi"."hosts"
           WHERE "modified_on" >= NOW() - INTERVAL '1 day'
-          GROUP BY "reporter";
-      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/updated_by_reporters
-        query: >-
-          SELECT  "reporter" AS "reporter", count(*) AS "hosts_updated"
-          FROM "hbi"."hosts"
-          WHERE "modified_on" >= NOW() - INTERVAL '1 week'
           GROUP BY "reporter";
       - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/hosts_per_org_id
         chunksize: 10000


### PR DESCRIPTION
- Removed weekly "created_by_reporter" and "updated_by_reporters" queries from clowdapp.yml to streamline metrics logic.
- This change reduces redundancy and improves maintainability of the configuration file.
- This change fixes RHINENG-18753

# Overview

This PR is being created to address [RHINENG-18753](https://issues.redhat.com/browse/RHINENG-18753).


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Streamline the inventory metrics configuration by removing unused weekly host reporter queries

Enhancements:
- Remove weekly "created_by_reporters" query from clowdapp metrics configuration
- Remove weekly "updated_by_reporters" query from clowdapp metrics configuration