### PR TITLE
metrics(query): add query for duplicated hosts by organization

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2000,6 +2000,52 @@ objects:
             COUNT(*) AS "host_count"
           FROM "hbi"."hosts"
           GROUP BY "provider_type";
+      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/duplicated_hosts_by_org
+        chunksize: 10000
+        query: >-
+          SELECT
+            "aa.org_id", "aa.id_value" AS "id_value", "aa.count", "aa.reporter", "aa.type"
+          FROM (
+            SELECT
+              "org_id",
+              "canonical_facts"->>'insights_id' AS "id_value",
+              COUNT(*) AS "count",
+              "reporter",
+              'insights_id' AS "type"
+            FROM
+              "hbi"."hosts"
+            WHERE
+              "canonical_facts"->'provider_id' IS NULL
+              AND "canonical_facts"->>'insights_id' IS NOT NULL
+            GROUP BY
+              "org_id",
+              "canonical_facts"->>'insights_id',
+              "reporter"
+
+            UNION ALL
+
+            SELECT
+              "org_id",
+              "canonical_facts"->>'subscription_manager_id' AS "id_value"m
+              COUNT(*) AS "count",
+              "reporter",
+              'subscription_manager_id' AS "type"
+            FROM
+              "hbi"."hosts"
+            WHERE
+              "canonical_facts"->'provider_id' IS NULL
+              AND "canonical_facts"->>'insights_id' IS NULL
+              AND "canonical_facts"->>'subscription_manager_id' IS NOT NULL
+            GROUP BY
+              "org_id",
+              "canonical_facts"->>'subscription_manager_id',
+              "reporter"
+          ) AS "aa"
+          WHERE
+            "aa.count" > 1
+          ORDER BY
+            "aa.org_id" ASC,
+            "aa.type" ASC;
       - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/org_ids_with_group_names
         chunksize: 10000
         query: >-


### PR DESCRIPTION
- Added a new query in ClowdApp YAML to identify duplicated hosts by organization, including insights_id and subscription_manager_id.
- Queries filter hosts missing a provider_id and group them by org_id, identifier type, and reporter.
- Results are ordered by organization ID and identifier type.

# Overview

This PR is being created to address [RHINENG-17095](https://issues.redhat.com/browse/RHINENG-17095).
(A description of your PR's changes, along with why/context to the PR, goes here.)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
