### PR TITLE
feat(RHINENG-18981): Adapt HostGroupAssoc to have org_id as PK

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -437,14 +437,14 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict, rba
         Host.facts.has_key(namespace),
     )  # noqa: W601 JSONB query filter, not a dict
 
-    query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.id)
+    query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.id, Host.org_id)
 
     if rbac_filter and "groups" in rbac_filter:
         count_before_rbac_filter = find_non_culled_hosts(
             update_query_for_owner_id(current_identity, query), current_identity.org_id
         ).count()
         filters += (HostGroupAssoc.group_id.in_(rbac_filter["groups"]),)
-        query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.id)
+        query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.id, Host.org_id)
         if (
             count_before_rbac_filter
             != find_non_culled_hosts(

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -132,7 +132,7 @@ class LimitedHost(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     account = db.Column(db.String(10))
-    org_id = db.Column(db.String(36))
+    org_id = db.Column(db.String(36), primary_key=True)
     display_name = db.Column(db.String(200), default=_set_display_name_on_save)
     ansible_host = db.Column(db.String(255))
     created_on = db.Column(db.DateTime(timezone=True), default=_time_now)

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -153,6 +153,15 @@ class Host(LimitedHost):
     stale_warning_timestamp = db.Column(db.DateTime(timezone=True))
     reporter = db.Column(db.String(255))
     per_reporter_staleness = db.Column(JSONB)
+    insights_id = db.Column(UUID(as_uuid=True), server_default="00000000-0000-0000-0000-000000000000")
+    subscription_manager_id = db.Column(db.String(36))
+    satellite_id = db.Column(db.String(255))
+    fqdn = db.Column(db.String(255))
+    bios_uuid = db.Column(db.String(36))
+    ip_addresses = db.Column(JSONB)
+    mac_addresses = db.Column(JSONB)
+    provider_id = db.Column(db.String(500))
+    provider_type = db.Column(db.String(50))
 
     def __init__(
         self,
@@ -215,6 +224,8 @@ class Host(LimitedHost):
         if not per_reporter_staleness:
             self._update_per_reporter_staleness(reporter)
 
+        self.update_canonical_facts(canonical_facts)
+
     def save(self):
         self._cleanup_tags()
         db.session.add(self)
@@ -267,9 +278,29 @@ class Host(LimitedHost):
             self.canonical_facts,
             canonical_facts,
         )
-        self.canonical_facts.update(canonical_facts)
+        self.canonical_facts.update(canonical_facts)  # Field being removed in the future
+        self.insights_id = canonical_facts.get("insights_id")
+        self.subscription_manager_id = canonical_facts.get("subscription_manager_id")
+        self.satellite_id = canonical_facts.get("satellite_id")
+        self.fqdn = canonical_facts.get("fqdn")
+        self.bios_uuid = canonical_facts.get("bios_uuid")
+        self.ip_addresses = canonical_facts.get("ip_addresses")
+        self.mac_addresses = canonical_facts.get("mac_addresses")
+        self.provider_id = canonical_facts.get("provider_id")
+        self.provider_type = canonical_facts.get("provider_type")
+
         logger.debug("Host (id=%s) has updated canonical_facts (%s)", self.id, self.canonical_facts)
-        orm.attributes.flag_modified(self, "canonical_facts")
+
+        orm.attributes.flag_modified(self, "canonical_facts")  # Field being removed in the future
+        orm.attributes.flag_modified(self, "insights_id")
+        orm.attributes.flag_modified(self, "subscription_manager_id")
+        orm.attributes.flag_modified(self, "satellite_id")
+        orm.attributes.flag_modified(self, "fqdn")
+        orm.attributes.flag_modified(self, "bios_uuid")
+        orm.attributes.flag_modified(self, "ip_addresses")
+        orm.attributes.flag_modified(self, "mac_addresses")
+        orm.attributes.flag_modified(self, "provider_id")
+        orm.attributes.flag_modified(self, "provider_type")
 
     def update_facts(self, facts_dict):
         if facts_dict:

--- a/app/models/host_group_assoc.py
+++ b/app/models/host_group_assoc.py
@@ -1,6 +1,6 @@
 from sqlalchemy import ForeignKey
+from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy import Index
-from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.models.constants import INVENTORY_SCHEMA
@@ -12,7 +12,9 @@ class HostGroupAssoc(db.Model):
     __table_args__ = (
         Index("idxhostsgroups", "host_id", "group_id"),
         Index("idxgroups_hosts", "group_id", "host_id"),
-        UniqueConstraint("host_id", name="hosts_groups_unique_host_id"),
+        ForeignKeyConstraint(
+            ["host_id", "org_id"], [f"{INVENTORY_SCHEMA}.hosts.id", f"{INVENTORY_SCHEMA}.hosts.org_id"]
+        ),
         {"schema": INVENTORY_SCHEMA},
     )
 
@@ -20,9 +22,12 @@ class HostGroupAssoc(db.Model):
         self,
         host_id,
         group_id,
+        org_id=None,
     ):
         self.host_id = host_id
         self.group_id = group_id
+        self.org_id = org_id
 
-    host_id = db.Column(UUID(as_uuid=True), ForeignKey(f"{INVENTORY_SCHEMA}.hosts.id"), primary_key=True)
+    host_id = db.Column(UUID(as_uuid=True), primary_key=True)
+    org_id = db.Column(db.String(36), primary_key=True)
     group_id = db.Column(UUID(as_uuid=True), ForeignKey(f"{INVENTORY_SCHEMA}.groups.id"), primary_key=True)

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -392,7 +392,7 @@ class IngressMessageConsumer(HostMessageConsumer):
                 db.session.flush()  # Flush so that we can retrieve the created host's ID
                 # Get org's "ungrouped hosts" group (create if not exists) and assign host to it
                 group = get_or_create_ungrouped_hosts_group_for_identity(identity)
-                assoc = HostGroupAssoc(host_row.id, group.id)
+                assoc = HostGroupAssoc(host_row.id, group.id, identity.org_id)
                 db.session.add(assoc)
                 host_row.groups = [serialize_group(group)]
                 db.session.flush()

--- a/assign_ungrouped_hosts_to_groups.py
+++ b/assign_ungrouped_hosts_to_groups.py
@@ -57,7 +57,7 @@ def run(logger: Logger, session: Session, application: FlaskApp):
                     )
                     hosts_to_process = len(host_ids)
                     for (host_id,) in host_ids:
-                        assoc = HostGroupAssoc(host_id, ungrouped_group_id)
+                        assoc = HostGroupAssoc(host_id, ungrouped_group_id, org_id)
                         session.add(assoc)
                     logger.info(f"Created {len(host_ids)} host-group associations for org {org_id}.")
 

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -162,7 +162,7 @@ def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str):
     )
 
     host_group_assoc = [
-        HostGroupAssoc(host_id=host_id, group_id=group_id)
+        HostGroupAssoc(host_id=host_id, group_id=group_id, org_id=org_id)
         for host_id in host_id_list
         if host_id not in ids_already_in_this_group
     ]

--- a/migrations/versions/61c1b152246a_partitioned_tables_transition.py
+++ b/migrations/versions/61c1b152246a_partitioned_tables_transition.py
@@ -1,0 +1,205 @@
+"""Partitioned tables transition
+
+Revision ID: 61c1b152246a
+Revises: 002843d515cb
+Create Date: 2025-07-02 16:46:52.557484
+
+"""
+
+import os
+
+from alembic import op
+
+from app.models.constants import INVENTORY_SCHEMA
+
+# revision identifiers, used by Alembic.
+revision = "61c1b152246a"
+down_revision = "28280de3f1ce"
+branch_labels = None
+depends_on = None
+
+
+"""
+This migration finalizes the transition to a partitioned `hosts` table schema.
+It assumes the new `hosts_new` and `hosts_groups_new` tables were created in the prior migration (28280de3f1ce).
+
+This script's behavior is conditional based on the `MIGRATION_MODE` environment variable:
+- **automated:** Performs the complete data copy from `hosts` to `hosts_new` and the
+final atomic table swap. This mode is intended for automated setups like local development,
+ephemeral, and on-premise environments.
+- **managed:** Skips all data operations. It only validates that the database has reached
+the final partitioned state and then "stamps" this migration as complete.
+This mode is intended for stage and production environments where the data migration is
+performed via controlled, external scripts.
+"""
+
+
+def upgrade():
+    migration_mode = os.environ.get("MIGRATION_MODE", "managed").lower()
+
+    # For 'automated' mode (local, ephemeral, on-premise), this script performs the full data copy and swap.
+    # For 'managed' mode, this logic is handled by external Python scripts running as Openshift jobs,
+    # and this migration only stamps the version.
+    if migration_mode == "automated":
+        # Step 1a: Copy data from the old hosts table to the new hosts_new table.
+        op.execute(f"""
+                INSERT INTO {INVENTORY_SCHEMA}.hosts_new (
+                    org_id, id, account, display_name, ansible_host, created_on, modified_on, facts, tags,
+                    tags_alt, system_profile_facts, groups, last_check_in, stale_timestamp, deletion_timestamp,
+                    stale_warning_timestamp, reporter, per_reporter_staleness, canonical_facts,
+                    canonical_facts_version, is_virtual, insights_id, subscription_manager_id,
+                    satellite_id, fqdn, bios_uuid, ip_addresses, mac_addresses, provider_id, provider_type
+                )
+                SELECT
+                    h.org_id, h.id, h.account, h.display_name, h.ansible_host, h.created_on,
+                    h.modified_on, h.facts, h.tags, h.tags_alt, h.system_profile_facts,
+                    h.groups, h.last_check_in, h.stale_timestamp, h.deletion_timestamp,
+                    h.stale_warning_timestamp, h.reporter, h.per_reporter_staleness,
+                    h.canonical_facts,
+                    (h.canonical_facts ->> 'canonical_facts_version')::integer,
+                    (h.canonical_facts ->> 'is_virtual')::boolean,
+                    COALESCE((h.canonical_facts->>'insights_id')::uuid, '00000000-0000-0000-0000-000000000000'),
+                    h.canonical_facts ->> 'subscription_manager_id',
+                    h.canonical_facts ->> 'satellite_id',
+                    h.canonical_facts ->> 'fqdn',
+                    h.canonical_facts ->> 'bios_uuid',
+                    h.canonical_facts -> 'ip_addresses',
+                    h.canonical_facts -> 'mac_addresses',
+                    h.canonical_facts ->> 'provider_id',
+                    h.canonical_facts ->> 'provider_type'
+                FROM {INVENTORY_SCHEMA}.hosts h;
+            """)
+
+        # Step 1b: Populate the hosts_groups_new table from the hosts.groups JSONB column.
+        op.execute(f"""
+            INSERT INTO {INVENTORY_SCHEMA}.hosts_groups_new (org_id, host_id, group_id)
+            SELECT
+                h.org_id,
+                h.id,
+                (g.value ->> 'id')::uuid
+            FROM
+                {INVENTORY_SCHEMA}.hosts h,
+                jsonb_array_elements(h.groups) AS g(value)
+            WHERE
+                jsonb_typeof(h.groups) = 'array' AND jsonb_array_length(h.groups) > 0;
+        """)
+
+        # Step 2: Perform the atomic rename swap for all tables and constraints.
+        op.execute(f"LOCK TABLE {INVENTORY_SCHEMA}.hosts IN ACCESS EXCLUSIVE MODE;")
+        op.execute(f"LOCK TABLE {INVENTORY_SCHEMA}.hosts_new IN ACCESS EXCLUSIVE MODE;")
+
+        op.execute(f"LOCK TABLE {INVENTORY_SCHEMA}.hosts_groups IN ACCESS EXCLUSIVE MODE;")
+        op.execute(f"LOCK TABLE {INVENTORY_SCHEMA}.hosts_groups_new IN ACCESS EXCLUSIVE MODE;")
+
+        # Rename old tables and their constraints
+        op.execute(f"ALTER TABLE {INVENTORY_SCHEMA}.hosts RENAME CONSTRAINT hosts_pkey TO hosts_old_pkey;")
+        op.execute(
+            f"ALTER TABLE {INVENTORY_SCHEMA}.hosts_groups "
+            "RENAME CONSTRAINT hosts_groups_pkey TO hosts_groups_old_pkey;"
+        )
+
+        op.execute(f"ALTER TABLE {INVENTORY_SCHEMA}.hosts RENAME TO hosts_old;")
+        op.execute(f"ALTER TABLE {INVENTORY_SCHEMA}.hosts_groups RENAME TO hosts_groups_old;")
+
+        # Rename new tables and their constraints to their final production names
+        op.execute(f"ALTER TABLE {INVENTORY_SCHEMA}.hosts_new RENAME TO hosts;")
+        op.execute(f"ALTER TABLE {INVENTORY_SCHEMA}.hosts_groups_new RENAME TO hosts_groups;")
+
+        op.execute(f"ALTER INDEX {INVENTORY_SCHEMA}.hosts_new_pkey RENAME TO hosts_pkey;")
+        op.execute(
+            f"ALTER TABLE {INVENTORY_SCHEMA}.hosts_groups "
+            "RENAME CONSTRAINT hosts_groups_new_pkey TO hosts_groups_pkey;"
+        )
+
+    # This safety check verifies that the table migration was successful before stamping.
+    # It runs for ALL modes to ensure consistency.
+    op.execute("""
+            DO $$
+            BEGIN
+                -- Check if the hosts table is partitioned by HASH
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_partitioned_table pt
+                    JOIN pg_class c ON c.oid = pt.partrelid
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                    WHERE n.nspname = 'hbi' AND c.relname = 'hosts' AND pt.partstrat = 'h'
+                ) THEN
+                    RAISE EXCEPTION 'MIGRATION ERROR: The hosts table is not partitioned as expected. Aborting.';
+                END IF;
+
+                -- Check if the hosts primary key is composite (has 2 columns)
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_constraint con
+                    JOIN pg_class rel ON rel.oid = con.conrelid
+                    JOIN pg_namespace n ON n.oid = rel.relnamespace
+                    WHERE n.nspname = 'hbi' AND rel.relname = 'hosts'
+                    AND con.contype = 'p' AND array_length(con.conkey, 1) = 2
+                ) THEN
+                    RAISE EXCEPTION 'MIGRATION ERROR: Expected a composite primary key on the hosts table. Aborting.';
+                END IF;
+
+                -- Check if the hosts_groups table is partitioned by HASH
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_partitioned_table pt
+                    JOIN pg_class c ON c.oid = pt.partrelid
+                    JOIN pg_namespace n ON n.oid = c.relnamespace
+                    WHERE n.nspname = 'hbi' AND c.relname = 'hosts_groups' AND pt.partstrat = 'h'
+                ) THEN
+                    RAISE EXCEPTION
+                    'MIGRATION ERROR: The hosts_groups table is not partitioned as expected. Aborting.';
+                END IF;
+
+                -- Check if the hosts_groups primary key is composite (has 3 columns)
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_constraint con
+                    JOIN pg_class rel ON rel.oid = con.conrelid
+                    JOIN pg_namespace n ON n.oid = rel.relnamespace
+                    WHERE n.nspname = 'hbi' AND rel.relname = 'hosts_groups'
+                    AND con.contype = 'p' AND array_length(con.conkey, 1) = 3
+                ) THEN
+                    RAISE EXCEPTION
+                    'MIGRATION ERROR: Expected a composite primary key on the hosts_groups table. Aborting.';
+                END IF;
+            END;
+            $$;
+        """)
+
+
+def downgrade():
+    migration_mode = os.environ.get("MIGRATION_MODE", "managed").lower()
+
+    if migration_mode == "automated":
+        # This reverses the table swap and clears the copied data from the _new tables.
+        op.execute(f"LOCK TABLE {INVENTORY_SCHEMA}.hosts IN ACCESS EXCLUSIVE MODE;")
+        op.execute(f"LOCK TABLE {INVENTORY_SCHEMA}.hosts_old IN ACCESS EXCLUSIVE MODE;")
+
+        op.execute(f"LOCK TABLE {INVENTORY_SCHEMA}.hosts_groups IN ACCESS EXCLUSIVE MODE;")
+        op.execute(f"LOCK TABLE {INVENTORY_SCHEMA}.hosts_groups_old IN ACCESS EXCLUSIVE MODE;")
+
+        # Rename tables and constraints back to their pre-upgrade state
+        op.execute(
+            f"ALTER TABLE {INVENTORY_SCHEMA}.hosts_groupsRENAME CONSTRAINT hosts_groups_pkey TO hosts_groups_new_pkey;"
+        )
+        op.execute(f"ALTER TABLE {INVENTORY_SCHEMA}.hosts RENAME CONSTRAINT hosts_pkey TO hosts_new_pkey;")
+
+        op.execute(f"ALTER TABLE {INVENTORY_SCHEMA}.hosts_groups RENAME TO hosts_groups_new;")
+        op.execute(f"ALTER TABLE {INVENTORY_SCHEMA}.hosts RENAME TO hosts_new;")
+
+        op.execute(f"ALTER TABLE {INVENTORY_SCHEMA}.hosts_groups_old RENAME TO hosts_groups;")
+        op.execute(f"ALTER TABLE {INVENTORY_SCHEMA}.hosts_old RENAME TO hosts;")
+
+        op.execute(
+            f"ALTER TABLE {INVENTORY_SCHEMA}.hosts_groups "
+            "RENAME CONSTRAINT hosts_groups_old_pkey TO hosts_groups_pkey;"
+        )
+        op.execute(f"ALTER TABLE {INVENTORY_SCHEMA}.hosts RENAME CONSTRAINT hosts_old_pkey TO hosts_pkey;")
+
+        # Truncate the _new tables to remove the data copied during the upgrade.
+        op.execute(f"TRUNCATE TABLE {INVENTORY_SCHEMA}.hosts_new;")
+        op.execute(f"TRUNCATE TABLE {INVENTORY_SCHEMA}.hosts_groups_new;")
+    else:
+        # For 'managed' environments, a downgrade is a manual operational task.
+        pass

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -223,9 +223,13 @@ def db_create_group(flask_app):  # noqa: ARG001
 @pytest.fixture(scope="function")
 def db_create_host_group_assoc(flask_app, db_get_group_by_id):  # noqa: ARG001
     def _db_create_host_group_assoc(host_id, group_id):
-        host_group = HostGroupAssoc(host_id=host_id, group_id=group_id)
+        # Get the group to obtain the org_id (same as host's org_id in test fixtures)
+        group = db_get_group_by_id(group_id)
+        if group is None:
+            raise ValueError(f"Group with id {group_id} not found")
+        host_group = HostGroupAssoc(host_id=host_id, group_id=group_id, org_id=group.org_id)
         db.session.add(host_group)
-        serialized_groups = [serialize_group(db_get_group_by_id(group_id))]
+        serialized_groups = [serialize_group(group)]
         db.session.query(Host).filter(Host.id == host_id).update({"groups": serialized_groups})
 
         db.session.commit()


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18981](https://issues.redhat.com/browse/RHINENG-18981).
It was found that we needed to add org_id to the hosts_groups table (HostGroupAssoc class), in order to make the Host table partitioning. This PR adjust our code base to handle these changes. Also, it has a migration that renames the old and new tables.

This PR required #2715 to be merged

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Introduce org_id as part of the composite primary key on hosts and host-group associations to support table partitioning, update related models, queries, scripts, and tests, and add an Alembic migration to transition to partitioned hosts and hosts_groups tables.

Enhancements:
- Make org_id part of the composite primary key for Host and HostGroupAssoc models and enforce matching foreign key constraints.
- Update repository functions and API endpoints to include Host.org_id in GROUP BY and filtering operations to accommodate the composite key.
- Modify message-processing code and group-assignment scripts to pass org_id when creating HostGroupAssoc entries.

Deployment:
- Add a comprehensive Alembic migration to finalize partitioned hosts and hosts_groups tables with both automated and managed modes and include validation checks for partitioning and composite primary keys.

Tests:
- Update test fixtures to supply org_id when creating host-group associations.