### PR TITLE
adhoc: dont send kafka message if in new replica namespace

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -88,8 +88,8 @@ class Config:
 
         self.export_service_token = os.environ.get("EXPORT_SERVICE_TOKEN", "testing-a-psk")
 
-        REPLICA_NAMESPACE = os.environ.get("REPLICA_NAMESPACE", "false").lower() == "true"
-        if not REPLICA_NAMESPACE:
+        self.replica_namespace = os.environ.get("REPLICA_NAMESPACE", "false").lower() == "true"
+        if not self.replica_namespace:
 
             def topic(t):
                 if t:

--- a/app/config.py
+++ b/app/config.py
@@ -88,44 +88,47 @@ class Config:
 
         self.export_service_token = os.environ.get("EXPORT_SERVICE_TOKEN", "testing-a-psk")
 
-        def topic(t):
-            if t:
-                t_topic = app_common_python.KafkaTopics.get(t)
-                if t_topic:
-                    return t_topic.name
-            return None
+        REPLICA_NAMESPACE = os.environ.get("REPLICA_NAMESPACE", "false").lower() == "true"
+        if not REPLICA_NAMESPACE:
 
-        self.host_ingress_topic = topic(os.environ.get("KAFKA_HOST_INGRESS_TOPIC"))
-        self.additional_validation_topic = topic(os.environ.get("KAFKA_ADDITIONAL_VALIDATION_TOPIC"))
-        self.system_profile_topic = topic(os.environ.get("KAFKA_SYSTEM_PROFILE_TOPIC"))
-        self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC"))
-        self.notification_topic = topic(os.environ.get("KAFKA_NOTIFICATION_TOPIC"))
-        self.event_topic = topic(os.environ.get("KAFKA_EVENT_TOPIC"))
-        self.payload_tracker_kafka_topic = topic("platform.payload-status")
-        self.export_service_topic = topic(os.environ.get("KAFKA_EXPORT_SERVICE_TOPIC", "platform.export.requests"))
-        self.workspaces_topic = topic(os.environ.get("KAFKA_WORKSPACES_TOPIC"))
+            def topic(t):
+                if t:
+                    t_topic = app_common_python.KafkaTopics.get(t)
+                    if t_topic:
+                        return t_topic.name
+                return None
 
-        self.bootstrap_servers = ",".join(app_common_python.KafkaServers)
-        if custom_broker := os.getenv("CONSUMER_MQ_BROKER"):
-            self.bootstrap_servers = custom_broker
+            self.host_ingress_topic = topic(os.environ.get("KAFKA_HOST_INGRESS_TOPIC"))
+            self.additional_validation_topic = topic(os.environ.get("KAFKA_ADDITIONAL_VALIDATION_TOPIC"))
+            self.system_profile_topic = topic(os.environ.get("KAFKA_SYSTEM_PROFILE_TOPIC"))
+            self.kafka_consumer_topic = topic(os.environ.get("KAFKA_CONSUMER_TOPIC"))
+            self.notification_topic = topic(os.environ.get("KAFKA_NOTIFICATION_TOPIC"))
+            self.event_topic = topic(os.environ.get("KAFKA_EVENT_TOPIC"))
+            self.payload_tracker_kafka_topic = topic("platform.payload-status")
+            self.export_service_topic = topic(os.environ.get("KAFKA_EXPORT_SERVICE_TOPIC", "platform.export.requests"))
+            self.workspaces_topic = topic(os.environ.get("KAFKA_WORKSPACES_TOPIC"))
 
-        broker_cfg = cfg.kafka.brokers[0]
+            self.bootstrap_servers = ",".join(app_common_python.KafkaServers)
+            if custom_broker := os.getenv("CONSUMER_MQ_BROKER"):
+                self.bootstrap_servers = custom_broker
 
-        # certificates are required in fedramp, but not in managed kafka
-        try:
-            self.kafka_ssl_cafile = self._kafka_ca(broker_cfg.cacert)
-        except AttributeError:
-            self.kafka_ssl_cafile = None
-        try:
-            self.kafka_sasl_username = broker_cfg.sasl.username
-            self.kafka_sasl_password = broker_cfg.sasl.password
-            self.kafka_sasl_mechanism = broker_cfg.sasl.saslMechanism
-            self.kafka_security_protocol = broker_cfg.sasl.securityProtocol
-        except AttributeError:
-            self.kafka_sasl_username = ""
-            self.kafka_sasl_password = ""
-            self.kafka_sasl_mechanism = "PLAIN"
-            self.kafka_security_protocol = "PLAINTEXT"
+            broker_cfg = cfg.kafka.brokers[0]
+
+            # certificates are required in fedramp, but not in managed kafka
+            try:
+                self.kafka_ssl_cafile = self._kafka_ca(broker_cfg.cacert)
+            except AttributeError:
+                self.kafka_ssl_cafile = None
+            try:
+                self.kafka_sasl_username = broker_cfg.sasl.username
+                self.kafka_sasl_password = broker_cfg.sasl.password
+                self.kafka_sasl_mechanism = broker_cfg.sasl.saslMechanism
+                self.kafka_security_protocol = broker_cfg.sasl.securityProtocol
+            except AttributeError:
+                self.kafka_sasl_username = ""
+                self.kafka_sasl_password = ""
+                self.kafka_sasl_mechanism = "PLAIN"
+                self.kafka_security_protocol = "PLAINTEXT"
 
         # Feature flags
         unleash = cfg.featureFlags

--- a/app/queue/event_producer.py
+++ b/app/queue/event_producer.py
@@ -1,3 +1,5 @@
+import os
+
 from confluent_kafka import KafkaError
 from confluent_kafka import KafkaException
 from confluent_kafka import Producer as KafkaProducer
@@ -41,6 +43,11 @@ class EventProducer:
         self.mq_topic = topic
 
     def write_event(self, event, key, headers, *, wait=False):
+        # This is an adhoc for us to test kessel migration on the new OCP replica namespace
+        REPLICA_NAMESPACE = os.environ.get("REPLICA_NAMESPACE", "false").lower() == "true"
+        if REPLICA_NAMESPACE:
+            return
+
         logger.debug("Topic: %s, key: %s, event: %s, headers: %s", self.mq_topic, key, event, headers)
 
         k = key.encode("utf-8") if key else None

--- a/app/queue/event_producer.py
+++ b/app/queue/event_producer.py
@@ -1,5 +1,3 @@
-import os
-
 from confluent_kafka import KafkaError
 from confluent_kafka import KafkaException
 from confluent_kafka import Producer as KafkaProducer
@@ -41,11 +39,11 @@ class EventProducer:
         logger.info("Starting EventProducer()")
         self._kafka_producer = KafkaProducer({"bootstrap.servers": config.bootstrap_servers, **config.kafka_producer})
         self.mq_topic = topic
+        self.bypass_write_event = config.replica_namespace
 
     def write_event(self, event, key, headers, *, wait=False):
         # This is an adhoc for us to test kessel migration on the new OCP replica namespace
-        REPLICA_NAMESPACE = os.environ.get("REPLICA_NAMESPACE", "false").lower() == "true"
-        if REPLICA_NAMESPACE:
+        if self.bypass_write_event:
             return
 
         logger.debug("Topic: %s, key: %s, event: %s, headers: %s", self.mq_topic, key, event, headers)

--- a/deploy/clowdapp-replica.yml
+++ b/deploy/clowdapp-replica.yml
@@ -1,0 +1,962 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: insights-host-inventory-replica
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdApp
+  metadata:
+    name: ${CLOWDAPP_NAME}
+  spec:
+    envName: ${ENV_NAME}
+    featureFlags: true
+    inMemoryDb: true
+    testing:
+      iqePlugin: host-inventory
+    jobs:
+    - name: synchronizer-only
+      restartPolicy: OnFailure
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        args: ["./host_synchronizer.py"]
+        env:
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
+          - name: INVENTORY_LOG_LEVEL
+            value: ${LOG_LEVEL}
+          - name: INVENTORY_DB_SSL_MODE
+            value: ${INVENTORY_DB_SSL_MODE}
+          - name: INVENTORY_DB_SSL_CERT
+            value: ${INVENTORY_DB_SSL_CERT}
+          - name: INVENTORY_DB_SCHEMA
+            value: "${INVENTORY_DB_SCHEMA}"
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            value: ${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}
+          - name: KAFKA_EVENT_TOPIC
+            value: ${KAFKA_EVENT_TOPIC}
+          - name: KAFKA_NOTIFICATION_TOPIC
+            value: ${KAFKA_NOTIFICATION_TOPIC}
+          - name: PAYLOAD_TRACKER_KAFKA_TOPIC
+            value: ${PAYLOAD_TRACKER_KAFKA_TOPIC}
+          - name: PAYLOAD_TRACKER_SERVICE_NAME
+            value: inventory-mq-service
+          - name: PAYLOAD_TRACKER_ENABLED
+            value: 'true'
+          - name: PROMETHEUS_PUSHGATEWAY
+            value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: KAFKA_PRODUCER_ACKS
+            value: ${KAFKA_PRODUCER_ACKS}
+          - name: KAFKA_PRODUCER_RETRIES
+            value: ${KAFKA_PRODUCER_RETRIES}
+          - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
+            value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: KAFKA_SECURITY_PROTOCOL
+            value: ${KAFKA_SECURITY_PROTOCOL}
+          - name: KAFKA_SASL_MECHANISM
+            value: ${KAFKA_SASL_MECHANISM}
+          - name: CLOWDER_ENABLED
+            value: "true"
+          - name: SCRIPT_CHUNK_SIZE
+            value: ${SCRIPT_CHUNK_SIZE}
+          - name: UNLEASH_URL
+            value: ${UNLEASH_URL}
+          - name: UNLEASH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: ${UNLEASH_SECRET_NAME}
+                key: CLIENT_ACCESS_TOKEN
+                optional: true
+          - name: BYPASS_UNLEASH
+            value: ${BYPASS_UNLEASH}
+          - name: FF_LAST_CHECKIN
+            value: ${FF_LAST_CHECKIN}
+          - name: UNLEASH_REFRESH_INTERVAL
+            value: ${UNLEASH_REFRESH_INTERVAL}
+          - name: REBUILD_EVENTS_TIME_LIMIT
+            value: ${REBUILD_EVENTS_TIME_LIMIT}
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_SYNCHRONIZER}
+            memory: ${MEMORY_LIMIT_SYNCHRONIZER}
+          requests:
+            cpu: ${CPU_REQUEST_SYNCHRONIZER}
+            memory: ${MEMORY_REQUEST_SYNCHRONIZER}
+    - name: create-ungrouped-host-groups
+      restartPolicy: OnFailure
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        args: ["./create_ungrouped_host_groups.py"]
+        env:
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
+          - name: INVENTORY_LOG_LEVEL
+            value: ${LOG_LEVEL}
+          - name: INVENTORY_DB_SSL_MODE
+            value: ${INVENTORY_DB_SSL_MODE}
+          - name: INVENTORY_DB_SSL_CERT
+            value: ${INVENTORY_DB_SSL_CERT}
+          - name: INVENTORY_DB_SCHEMA
+            value: "${INVENTORY_DB_SCHEMA}"
+          - name: PROMETHEUS_PUSHGATEWAY
+            value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CLOWDER_ENABLED
+            value: "true"
+          - name: UNLEASH_URL
+            value: ${UNLEASH_URL}
+          - name: UNLEASH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: ${UNLEASH_SECRET_NAME}
+                key: CLIENT_ACCESS_TOKEN
+                optional: true
+          - name: BYPASS_UNLEASH
+            value: ${BYPASS_UNLEASH}
+          - name: FF_LAST_CHECKIN
+            value: ${FF_LAST_CHECKIN}
+          - name: UNLEASH_REFRESH_INTERVAL
+            value: ${UNLEASH_REFRESH_INTERVAL}
+          - name: BYPASS_KESSEL_JOBS
+            value: ${BYPASS_KESSEL_JOBS}
+          - name: CREATE_UNGROUPED_GROUPS_BATCH_SIZE
+            value: ${CREATE_UNGROUPED_GROUPS_BATCH_SIZE}
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_UNGROUPED_HOSTS_JOB}
+            memory: ${MEMORY_LIMIT_UNGROUPED_HOSTS_JOB}
+          requests:
+            cpu: ${CPU_REQUEST_UNGROUPED_HOSTS_JOB}
+            memory: ${MEMORY_REQUEST_UNGROUPED_HOSTS_JOB}
+    - name: assign-ungrouped-host-groups
+      restartPolicy: OnFailure
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        args: ["./assign_ungrouped_hosts_to_groups.py"]
+        env:
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
+          - name: INVENTORY_LOG_LEVEL
+            value: ${LOG_LEVEL}
+          - name: INVENTORY_DB_SSL_MODE
+            value: ${INVENTORY_DB_SSL_MODE}
+          - name: INVENTORY_DB_SSL_CERT
+            value: ${INVENTORY_DB_SSL_CERT}
+          - name: INVENTORY_DB_SCHEMA
+            value: "${INVENTORY_DB_SCHEMA}"
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            value: ${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}
+          - name: KAFKA_EVENT_TOPIC
+            value: ${KAFKA_EVENT_TOPIC}
+          - name: KAFKA_NOTIFICATION_TOPIC
+            value: ${KAFKA_NOTIFICATION_TOPIC}
+          - name: PAYLOAD_TRACKER_KAFKA_TOPIC
+            value: ${PAYLOAD_TRACKER_KAFKA_TOPIC}
+          - name: PAYLOAD_TRACKER_SERVICE_NAME
+            value: inventory-mq-service
+          - name: PAYLOAD_TRACKER_ENABLED
+            value: 'true'
+          - name: PROMETHEUS_PUSHGATEWAY
+            value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: KAFKA_PRODUCER_ACKS
+            value: ${KAFKA_PRODUCER_ACKS}
+          - name: KAFKA_PRODUCER_RETRIES
+            value: ${KAFKA_PRODUCER_RETRIES}
+          - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
+            value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: KAFKA_SECURITY_PROTOCOL
+            value: ${KAFKA_SECURITY_PROTOCOL}
+          - name: KAFKA_SASL_MECHANISM
+            value: ${KAFKA_SASL_MECHANISM}
+          - name: CLOWDER_ENABLED
+            value: "true"
+          - name: UNLEASH_URL
+            value: ${UNLEASH_URL}
+          - name: UNLEASH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: ${UNLEASH_SECRET_NAME}
+                key: CLIENT_ACCESS_TOKEN
+                optional: true
+          - name: BYPASS_UNLEASH
+            value: ${BYPASS_UNLEASH}
+          - name: FF_LAST_CHECKIN
+            value: ${FF_LAST_CHECKIN}
+          - name: UNLEASH_REFRESH_INTERVAL
+            value: ${UNLEASH_REFRESH_INTERVAL}
+          - name: BYPASS_KESSEL_JOBS
+            value: ${BYPASS_KESSEL_JOBS}
+          - name: ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE
+            value: ${ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE}
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_UNGROUPED_HOSTS_JOB}
+            memory: ${MEMORY_LIMIT_UNGROUPED_HOSTS_JOB}
+          requests:
+            cpu: ${CPU_REQUEST_UNGROUPED_HOSTS_JOB}
+            memory: ${MEMORY_REQUEST_UNGROUPED_HOSTS_JOB}
+    database:
+      name: ${DB_NAME}
+      version: 16
+    kafkaTopics: # The number of Kafka partitions variables provided are the Ephemeral environments.
+      - topicName: ${KAFKA_SYSTEM_PROFILE_TOPIC}
+        partitions: ${{NUMBER_OF_KAFKA_SYSTEM_PROFILE_TOPIC_PARTITIONS}}
+      - topicName: ${PAYLOAD_TRACKER_KAFKA_TOPIC}
+        partitions: ${{NUMBER_OF_PAYLOAD_TRACKER_KAFKA_TOPIC_PARTITIONS}}
+      - topicName: ${KAFKA_EVENT_TOPIC}
+        partitions: ${{NUMBER_OF_KAFKA_EVENT_TOPIC_PARTITIONS}}
+      - topicName: ${KAFKA_NOTIFICATION_TOPIC}
+        partitions: ${{NUMBER_OF_KAFKA_NOTIFICATION_TOPIC_PARTITIONS}}
+      - topicName: ${KAFKA_HOST_INGRESS_TOPIC}
+        partitions: ${{NUMBER_OF_KAFKA_HOST_INGRESS_TOPIC_PARTITIONS}}
+      - topicName: ${KAFKA_HOST_INGRESS_P1_TOPIC}
+        partitions: ${{NUMBER_OF_KAFKA_HOST_INGRESS_P1_TOPIC_PARTITIONS}}
+      - topicName: ${KAFKA_EXPORT_SERVICE_TOPIC}
+        partitions: ${{NUMBER_OF_KAFKA_EXPORT_SERVICE_TOPIC_PARTITIONS}}
+      - topicName: ${KAFKA_KESSEL_WORKSPACES_TOPIC}
+        partitions: ${{NUMBER_OF_KAFKA_KESSEL_WORKSPACES_TOPIC_PARTITIONS}}
+# this service proxies requests for the old URL (insights-inventory:8080) to the clowderized service (host-inventory-service:8000)
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: insights-inventory
+    name: insights-inventory
+  spec:
+    ports:
+    - name: port-8080
+      port: 8080
+      protocol: TCP
+      targetPort: 8000
+    selector:
+      pod: host-inventory-service
+- apiVersion: metrics.console.redhat.com/v1alpha1
+  kind: FloorPlan
+  metadata:
+    name: host-inventory
+  spec:
+    database:
+      secretName: ${FLOORIST_DB_SECRET_NAME}
+    objectStore:
+      secretName: ${FLOORIST_BUCKET_SECRET_NAME}
+    suspend: ${{FLOORIST_SUSPEND}}
+    logLevel: ${FLOORIST_LOGLEVEL}
+    queries:
+      - prefix: insights/inventory/hosts
+        chunksize: 50000
+        query: >-
+          SELECT
+            "id",
+            "account" AS "account_number",
+            "created_on" AS "created_at",
+            "modified_on" AS "updated_at",
+            "ansible_host" AS "ansible_host",
+            CONCAT_WS('.',"system_profile_facts"->'operating_system'->>'name',"system_profile_facts"->'operating_system'->'major',"system_profile_facts"->'operating_system'->'minor') AS "os_version",
+            "system_profile_facts"->'host_type' AS "host_type",
+            "system_profile_facts"->'ansible'->'controller_version' AS "ansible_controller_version",
+            "system_profile_facts"->'ansible'->'hub_version' AS "ansible_hub_version",
+            "system_profile_facts"->'rhsm'->'version' AS "rhsm_version",
+            "system_profile_facts"->'is_marketplace' AS "is_marketplace_installation",
+            "system_profile_facts"->'insights_client_version' AS "insights_client_version",
+            "system_profile_facts"->'insights_egg_version' AS "insights_egg_version",
+            "system_profile_facts"->'satellite_managed' AS "is_satellite_managed",
+            "system_profile_facts"->'subscription_status' AS "subscription_status",
+            "system_profile_facts"->'ansible' AS "ansible_workload",
+            "system_profile_facts"->'mssql' AS "mssql_workload",
+            "system_profile_facts"->'sap' AS "sap_workload",
+            "system_profile_facts"->'rhc_client_id' AS "rhc_client_id"
+          FROM "hbi"."hosts"
+- apiVersion: metrics.console.redhat.com/v1alpha1
+  kind: FloorPlan
+  metadata:
+    name: host-inventory-hms
+  spec:
+    database:
+      secretName: ${FLOORIST_DB_SECRET_NAME}
+    objectStore:
+      secretName: ${FLOORIST_HMS_BUCKET_SECRET_NAME}
+    suspend: ${{FLOORIST_SUSPEND}}
+    logLevel: ${FLOORIST_LOGLEVEL}
+    queries:
+#      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts
+#        query: >-
+#          SELECT
+#            "id",
+#            COALESCE("account", '0') AS "account",
+#            "org_id" AS "org_id",
+#            "created_on" AS "created_at",
+#            "modified_on" AS "updated_at",
+#            "reporter" AS "reporter",
+#            "canonical_facts"->>'insights_id' AS "insights_id",
+#            "canonical_facts"->>'subscription_manager_id' AS "subscription_manager_id",
+#            "canonical_facts"->>'bios_uuid' AS "bios_uuid",
+#            "canonical_facts"->>'provider_id' AS "provider_id",
+#            "canonical_facts"->>'provider_type' AS "provider_type"
+#          FROM "hbi"."hosts";
+      - prefix: hms_analytics/inventory/${ENV_NAME}/groups
+        chunksize: 10000
+        query: >-
+          SELECT
+            "id",
+            "org_id" AS "org_id",
+            COALESCE("account", '0') AS "account",
+            "name" AS "name",
+            "created_on" AS "created_at",
+            "modified_on" AS "updated_at"
+          FROM "hbi"."groups"
+      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/hosts_count
+        query: >-
+          SELECT COUNT(*) AS "hosts_count"
+          FROM "hbi"."hosts";
+      - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/groups_count
+        query: >-
+          SELECT COUNT(*) AS "group_counts"
+          FROM "hbi"."groups";
+      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/daily_created_by_reporters
+        query: >-
+          SELECT
+            "reporter" AS "reporter",
+            count(*) AS "hosts_created"
+          FROM "hbi"."hosts"
+          WHERE "created_on" >= NOW() - INTERVAL '1 day'
+          GROUP BY "reporter";
+      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/daily_updated_by_reporters
+        query: >-
+          SELECT  "reporter" AS "reporter", count(*) AS "hosts_updated"
+          FROM "hbi"."hosts"
+          WHERE "modified_on" >= NOW() - INTERVAL '1 day'
+          GROUP BY "reporter";
+      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/hosts_per_org_id
+        chunksize: 10000
+        query: >-
+          SELECT
+            "org_id" AS "org_id",
+            COUNT(*) AS "host_count"
+          FROM "hbi"."hosts"
+          GROUP BY "org_id"
+          ORDER BY "host_count" DESC;
+      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/hosts_per_public_cloud
+        query: >-
+          SELECT
+            "canonical_facts"->>'provider_type' AS "provider_type",
+            COUNT(*) AS "host_count"
+          FROM "hbi"."hosts"
+          GROUP BY "provider_type";
+      - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/duplicated_hosts_by_org
+        chunksize: 10000
+        query: >-
+          SELECT
+            "aa"."org_id",
+            "aa"."id_value",
+            "aa"."hosts_count",
+            "aa"."reporter",
+            "aa"."id_type"
+          FROM (
+            SELECT
+              "org_id",
+              "canonical_facts"->>'insights_id' AS "id_value",
+              COUNT(*) AS "hosts_count",
+              "reporter",
+              'insights_id' AS "id_type"
+            FROM
+              "hbi"."hosts"
+            WHERE
+              "canonical_facts"->'provider_id' IS NULL
+              AND "canonical_facts"->>'insights_id' IS NOT NULL
+            GROUP BY
+              "org_id",
+              "canonical_facts"->>'insights_id',
+              "reporter"
+
+            UNION ALL
+
+            SELECT
+              "org_id",
+              "canonical_facts"->>'subscription_manager_id' AS "id_value",
+              COUNT(*) AS "hosts_count",
+              "reporter",
+              'subscription_manager_id' AS "id_type"
+            FROM
+              "hbi"."hosts"
+            WHERE
+              "canonical_facts"->'provider_id' IS NULL
+              AND "canonical_facts"->>'insights_id' IS NULL
+              AND "canonical_facts"->>'subscription_manager_id' IS NOT NULL
+            GROUP BY
+              "org_id",
+              "canonical_facts"->>'subscription_manager_id',
+              "reporter"
+          ) AS "aa"
+          WHERE
+            "aa"."hosts_count" > 1
+          ORDER BY
+            "aa"."org_id" ASC,
+            "aa"."id_type" ASC;
+      - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/org_ids_with_group_names
+        chunksize: 10000
+        query: >-
+          SELECT
+            DISTINCT "org_id" AS "org_id", "name" AS "name"
+          FROM "hbi"."groups"
+          ORDER BY "name" ASC;
+      - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/hosts_per_groups
+        chunksize: 10000
+        query: >-
+          SELECT
+            "id" AS "group_id",
+            "name" AS "group_name",
+            COUNT(*) AS "host_count"
+          FROM "hbi"."groups"
+          JOIN "hbi"."hosts_groups" ON "groups"."id" = "hbi"."hosts_groups"."group_id"
+          GROUP BY "groups"."id"
+          ORDER BY "host_count" DESC;
+- apiVersion: v1
+  data:
+    nginx.conf: |-
+      worker_processes  1;
+      error_log  /dev/stderr warn;
+      pid        /run/nginx.pid;
+
+      events {
+        worker_connections  1024;
+      }
+      http {
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_proto" "$http_x_forwarded_for"';
+
+        access_log  /dev/stdout  main;
+
+        sendfile            on;
+        tcp_nopush          on;
+        tcp_nodelay         on;
+        keepalive_timeout   65;
+        server_tokens       off;
+
+        upstream host-inventory-service-reads {
+          server host-inventory-service-reads:8000;
+          server host-inventory-service-secondary-reads:8000;
+        }
+        upstream host-inventory-service-writes {
+          server host-inventory-service-writes:8000;
+        }
+        map $request_method $upstream_location {
+                    GET     host-inventory-service-reads;
+                    HEAD    host-inventory-service-reads;
+                    POST    host-inventory-service-writes;
+                    PUT     host-inventory-service-writes;
+                    DELETE  host-inventory-service-writes;
+                    default host-inventory-service-writes;
+        }
+        server {
+          error_log  stderr;
+          listen 8000;
+          listen 9000;
+
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+          proxy_set_header Host $http_host;
+          proxy_redirect off;
+
+          client_max_body_size 500M;
+          client_header_buffer_size 46k;
+          location /healthz {
+              auth_basic          off;
+              allow               all;
+              return              200;
+          }
+          location /metrics {
+              auth_basic          off;
+              allow               all;
+              return              200;
+          }
+          location / {
+            proxy_pass http://$upstream_location;
+            proxy_read_timeout 600s;
+          }
+        }
+      }
+  kind: ConfigMap
+  metadata:
+    name: inventory-nginx-conf
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: rbac-psks
+  data:
+    psks.json: >-
+      ewogICJhZHZpc29yIjogewogICAgImFsdC1zZWNyZXQiOiAiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiCiAgfSwKICAiYXBwcm92YWwiOiB7CiAgICAiYWx0LXNlY3JldCI6ICIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMiIKICB9LAogICJub3RpZmljYXRpb25zIjogewogICAgImFsdC1zZWNyZXQiOiAiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiCiAgfSwKICAiaW52ZW50b3J5IjogewogICAgInNlY3JldCI6ICI0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiCiAgfQp9
+  type: Opaque
+
+parameters:
+- name: LOG_LEVEL
+  value: INFO
+
+- name: CPU_REQUEST_SERVICE
+  value: 250m
+- name: CPU_LIMIT_SERVICE
+  value: 500m
+- name: MEMORY_REQUEST_SERVICE
+  value: 256Mi
+- name: MEMORY_LIMIT_SERVICE
+  value: 512Mi
+
+- name: CPU_REQUEST_MQ_PMIN
+  value: 250m
+- name: CPU_LIMIT_MQ_PMIN
+  value: 500m
+- name: MEMORY_REQUEST_MQ_PMIN
+  value: 256Mi
+- name: MEMORY_LIMIT_MQ_PMIN
+  value: 512Mi
+
+- name: CPU_REQUEST_MQ_P1
+  value: 250m
+- name: CPU_LIMIT_MQ_P1
+  value: 500m
+- name: MEMORY_REQUEST_MQ_P1
+  value: 256Mi
+- name: MEMORY_LIMIT_MQ_P1
+  value: 512Mi
+
+- name: CPU_REQUEST_MQ_SP
+  value: 250m
+- name: CPU_LIMIT_MQ_SP
+  value: 500m
+- name: MEMORY_REQUEST_MQ_SP
+  value: 256Mi
+- name: MEMORY_LIMIT_MQ_SP
+  value: 512Mi
+
+- name: CPU_REQUEST_WORKSPACES_MQ
+  value: 250m
+- name: CPU_LIMIT_WORKSPACES_MQ
+  value: 500m
+- name: MEMORY_REQUEST_WORKSPACES_MQ
+  value: 512Mi
+- name: MEMORY_LIMIT_WORKSPACES_MQ
+  value: 1Gi
+
+- name: CPU_REQUEST_REAPER
+  value: 250m
+- name: CPU_LIMIT_REAPER
+  value: 500m
+- name: MEMORY_REQUEST_REAPER
+  value: 256Mi
+- name: MEMORY_LIMIT_REAPER
+  value: 512Mi
+- name: HOST_DELETE_CHUNK_SIZE
+  value: "1000"
+
+- name: CPU_REQUEST_STALE_HOST_NOTIFICAION
+  value: 250m
+- name: CPU_LIMIT_STALE_HOST_NOTIFICAION
+  value: 500m
+- name: MEMORY_REQUEST_STALE_HOST_NOTIFICAION
+  value: 256Mi
+- name: MEMORY_LIMIT_STALE_HOST_NOTIFICAION
+  value: 512Mi
+
+- name: CPU_REQUEST_SP_VALIDATOR
+  value: 250m
+- name: CPU_LIMIT_SP_VALIDATOR
+  value: 500m
+- name: MEMORY_REQUEST_SP_VALIDATOR
+  value: 256Mi
+- name: MEMORY_LIMIT_SP_VALIDATOR
+  value: 512Mi
+
+- name: CPU_REQUEST_PENDO_SYNCHER
+  value: 250m
+- name: CPU_LIMIT_PENDO_SYNCHER
+  value: 500m
+- name: MEMORY_REQUEST_PENDO_SYNCHER
+  value: 256Mi
+- name: MEMORY_LIMIT_PENDO_SYNCHER
+  value: 512Mi
+
+- name: CPU_REQUEST_SYNCHRONIZER
+  value: 250m
+- name: CPU_LIMIT_SYNCHRONIZER
+  value: 500m
+- name: MEMORY_REQUEST_SYNCHRONIZER
+  value: 256Mi
+- name: MEMORY_LIMIT_SYNCHRONIZER
+  value: 512Mi
+
+- name: CPU_REQUEST_UNGROUPED_HOSTS_JOB
+  value: 250m
+- name: CPU_LIMIT_UNGROUPED_HOSTS_JOB
+  value: 500m
+- name: MEMORY_REQUEST_UNGROUPED_HOSTS_JOB
+  value: 256Mi
+- name: MEMORY_LIMIT_UNGROUPED_HOSTS_JOB
+  value: 512Mi
+
+- name: CPU_REQUEST_GROUPS_S3_EXPORT
+  value: 250m
+- name: CPU_LIMIT_GROUPS_S3_EXPORT
+  value: 500m
+- name: MEMORY_REQUEST_GROUPS_S3_EXPORT
+  value: 256Mi
+- name: MEMORY_LIMIT_GROUPS_S3_EXPORT
+  value: 512Mi
+
+- name: CPU_REQUEST_SYNDICATOR
+  value: 250m
+- name: CPU_LIMIT_SYNDICATOR
+  value: 500m
+- name: MEMORY_REQUEST_SYNDICATOR
+  value: 256Mi
+- name: MEMORY_LIMIT_SYNDICATOR
+  value: 512Mi
+
+- name: CPU_REQUEST_EXPORT_SVC
+  value: 250m
+- name: CPU_LIMIT_EXPORT_SVC
+  value: 500m
+- name: MEMORY_REQUEST_EXPORT_SVC
+  value: 256Mi
+- name: MEMORY_LIMIT_EXPORT_SVC
+  value: 512Mi
+
+- name: CPU_REQUEST_HOSTS_LAST_CHECK_IN
+  value: 250m
+- name: CPU_LIMIT_HOSTS_LAST_CHECK_IN
+  value: 500m
+- name: MEMORY_REQUEST_HOSTS_LAST_CHECK_IN
+  value: 256Mi
+- name: MEMORY_LIMIT_HOSTS_LAST_CHECK_IN
+  value: 512Mi
+- name: HOST_UPDATE_LIMIT
+  value: "50000"
+
+- name: CPU_REQUEST_EDGE_HOSTS_PRS
+  value: 250m
+- name: CPU_LIMIT_EDGE_HOSTS_PRS
+  value: 500m
+- name: MEMORY_REQUEST_EDGE_HOSTS_PRS
+  value: 256Mi
+- name: MEMORY_LIMIT_EDGE_HOSTS_PRS
+  value: 512Mi
+
+- name: CPU_REQUEST_HOSTS_WITHOUT_ID_FACTS_JOB
+  value: 250m
+- name: CPU_LIMIT_HOSTS_WITHOUT_ID_FACTS_JOB
+  value: 500m
+- name: MEMORY_REQUEST_HOSTS_WITHOUT_ID_FACTS_JOB
+  value: 256Mi
+- name: MEMORY_LIMIT_HOSTS_WITHOUT_ID_FACTS_JOB
+  value: 512Mi
+
+- description: Replica count for p1 consumer
+  name: REPLICAS_P1
+  value: "5"
+- description: Replica count for pmin consumer
+  name: REPLICAS_PMIN
+  value: "3"
+- description: Replica count for sp consumer
+  name: REPLICAS_SP
+  value: "2"
+- description: Replica count for webservice
+  name: REPLICAS_SVC_READS
+  value: "7"
+- description: Replica count for webservice
+  name: REPLICAS_SVC_SECONDARY_READS
+  value: "1"
+- description: Replica count for webservice
+  name: REPLICAS_SVC_WRITES
+  value: "3"
+- description: Replica count for export-service
+  name: REPLICAS_EXPORT_SVC
+  value: "2"
+- description: Replica count for mq-workspaces consumer
+  name: REPLICAS_WORKSPACES
+  value: "1"
+- description: Image tag
+  name: IMAGE_TAG
+  required: true
+- description: Image NAME
+  name: IMAGE
+  required: true
+  value: quay.io/redhat-services-prod/insights-management-tenant/insights-host-inventory/insights-host-inventory
+- description : ClowdEnvironment name
+  name: ENV_NAME
+  value: stage
+- name: APP_NAME
+  value: inventory
+- description: ClowdApp name
+  name: CLOWDAPP_NAME
+  value: host-inventory-replica
+- description: Database name
+  name: DB_NAME
+  value: host-inventory
+- name: PATH_PREFIX
+  value: api
+- name: CONSOLEDOT_HOSTNAME
+  value: localhost
+- name: URLLIB3_LOG_LEVEL
+  value: WARNING
+- description: SSL validation mode for the DB
+  name: INVENTORY_DB_SSL_MODE
+  value: prefer
+- description: disable RBAC middleware
+  name: BYPASS_RBAC
+  value: 'false'
+- description: disable account-to-org_id translation, defaulting to None where org_id is not provided
+  name: BYPASS_TENANT_TRANSLATION
+  value: 'false'
+- name: KAFKA_PRODUCER_ACKS
+  value: '1'
+- name: KAFKA_PRODUCER_RETRIES
+  value: '0'
+- name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
+  value: '100'
+- name: KAFKA_HOST_INGRESS_TOPIC
+  description: The topic containing Host data sent by reporters
+  value: platform.inventory.host-ingress
+- name: NUMBER_OF_KAFKA_HOST_INGRESS_TOPIC_PARTITIONS
+  description: Number of partitions for the Kafka host ingress topic
+  value: '1'
+- name: KAFKA_HOST_INGRESS_P1_TOPIC
+  description: The TOP-PRIORITY topic containing Host data sent by reporters
+  value: platform.inventory.host-ingress-p1
+- name: NUMBER_OF_KAFKA_HOST_INGRESS_P1_TOPIC_PARTITIONS
+  description: Number of partitions for the Kafka host ingress P1 topic
+  value: '1'
+- name: KAFKA_KESSEL_WORKSPACES_TOPIC
+  description: The Kafka topic for Kessel Workspace data
+  value: outbox.event.workspace
+- name: NUMBER_OF_KAFKA_KESSEL_WORKSPACES_TOPIC_PARTITIONS
+  description: Number of partitions for the Kafka kessel workspaces topic
+  value: '1'
+- name: KAFKA_EVENT_TOPIC
+  description: The topic for Host data that were processed by Inventory
+  value: platform.inventory.events
+- name: NUMBER_OF_KAFKA_EVENT_TOPIC_PARTITIONS
+  description: Number of partitions for the Kafka event topic
+  value: '1'
+- name: KAFKA_NOTIFICATION_TOPIC
+  description: The topic containing messages to be sent as notifications
+  value: platform.notifications.ingress
+- name: NUMBER_OF_KAFKA_NOTIFICATION_TOPIC_PARTITIONS
+  description: Number of partitions for the Kafka notification topic
+  value: '1'
+- name: KAFKA_ADDITIONAL_VALIDATION_TOPIC
+  description: Used by system_profile_validator
+  value: platform.inventory.host-ingress-p1
+- name: KAFKA_SYSTEM_PROFILE_TOPIC
+  description: The topic containing Host data for System Profile updates
+  value: platform.inventory.system-profile
+- name: NUMBER_OF_KAFKA_SYSTEM_PROFILE_TOPIC_PARTITIONS
+  description: Number of partitions for the Kafka system-profile topic
+  value: '1'
+- name: PAYLOAD_TRACKER_KAFKA_TOPIC
+  description: The topic for payload tracker
+  value: platform.payload-status
+- name: NUMBER_OF_PAYLOAD_TRACKER_KAFKA_TOPIC_PARTITIONS
+  description: Number of partitions for the payload tracker topic.
+  value: '1'
+- name: KAFKA_EXPORT_SERVICE_TOPIC
+  description: The topic used to consume Export Service data
+  value: platform.export.requests
+- name: NUMBER_OF_KAFKA_EXPORT_SERVICE_TOPIC_PARTITIONS
+  description: Number of partitions for the export-service topic
+  value: '1'
+- name: KAFKA_HOST_INGRESS_GROUP
+  description: The Kafka consumer group name
+  value: inventory-mq
+- name: KAFKA_SECURITY_PROTOCOL
+  description: The Kafka Security Protocol
+  value: PLAINTEXT
+- name: KAFKA_SASL_MECHANISM
+  value: 'PLAIN'
+- name: CONSUMER_MQ_BROKER
+  value: ''
+- name: PROMETHEUS_PUSHGATEWAY
+  value: 'localhost:9091'
+- name: KAFKA_BOOTSTRAP_HOST
+  value: 'localhost'
+- name: KAFKA_BOOTSTRAP_PORT
+  value: '29092'
+- name: INVENTORY_DB_SSL_CERT
+  value: ''
+- name: PENDO_SYNCHER_SUSPEND
+  value: 'true'
+- name: PENDO_CRON_SCHEDULE
+  value: '@daily'
+- name: PENDO_SYNC_ACTIVE
+  value: 'false'
+- name: SP_VALIDATOR_SUSPEND
+  value: 'true'
+- name: REAPER_SUSPEND
+  value: 'true'
+- name: STALE_HOST_NOTIFICATION_SUSPEND
+  value: 'true'
+- name: STALE_HOST_NOTIFICATION_SCHEDULE
+  value: '*/1 * * * *'
+- name: SYNDICATOR_SUSPEND
+  value: 'false'
+- name: SYNDICATOR_CRON_SCHEDULE
+  value: '*/5 * * * *'
+- name: HOSTS_LAST_CHECK_IN_SCHEDULE
+  value: '@hourly'
+- name: HOSTS_LAST_CHECK_IN_SUSPEND
+  value: 'false'
+- name: EDGE_HOSTS_PRS_SCHEDULE
+  value: '@hourly'
+- name: EDGE_HOSTS_PRS_SUSPEND
+  value: 'false'
+- name: KAFKA_SP_VALIDATOR_MAX_MESSAGES
+  value: '10000'
+- name: TENANT_TRANSLATOR_HOST
+  value: 'gateway.3scale-dev.svc.cluster.local'
+- name: TENANT_TRANSLATOR_PORT
+  value: '8892'
+- name: GUNICORN_WORKERS
+  value: '4'
+- name: GUNICORN_THREADS
+  value: '8'
+- name: GUNICORN_REQUEST_FIELD_LIMIT
+  value: '16380'
+- name: GUNICORN_REQUEST_LINE_LIMIT
+  value: '8190'
+- name: SCRIPT_CHUNK_SIZE
+  value: '500'
+- name: REBUILD_EVENTS_TIME_LIMIT
+  value: '3600'
+- name: INVENTORY_DB_STATEMENT_TIMEOUT
+  value: '30000'
+- name: INVENTORY_DB_LOCK_TIMEOUT
+  value: '30000'
+- name: INVENTORY_API_CACHE_TIMEOUT_SECONDS
+  value: '0'
+- name: INVENTORY_API_CACHE_TYPE
+  value: 'NullCache'
+- name: MQ_DB_BATCH_MAX_MESSAGES
+  value: '1'
+- name: MQ_WORKSPACES_DB_BATCH_MAX_MESSAGES
+  value: '1'
+- name: MQ_DB_BATCH_MAX_SECONDS
+  value: '0.5'
+- name: INVENTORY_API_USE_READREPLICA
+  value: 'false'
+- name: INVENTORY_API_READREPLICA_SECRET
+  value: 'host-inventory-read-only-db'
+- name: INVENTORY_API_SECONDARY_READREPLICA_SECRET
+  value: 'host-inventory-read-only-db'
+- name: INVENTORY_CACHE_INSIGHTS_CLIENT_SYSTEM_TIMEOUT_SEC
+  value: '129600'
+- name: INVENTORY_CACHE_THREAD_POOL_MAX_WORKERS
+  value: '5'
+- name: KAFKA_CONSUMER_SESSION_TIMEOUT_MS
+  value: '10000'
+- name: KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS
+  value: '3000'
+- name: INVENTORY_API_WRITES_LIVENESS_PROBE_PERIOD_SECONDS
+  value: '30'
+- name: INVENTORY_API_WRITES_LIVENESS_PROBE_TIMEOUT_SECONDS
+  value: '60'
+- name: INVENTORY_API_READS_LIVENESS_PROBE_PERIOD_SECONDS
+  value: '30'
+- name: INVENTORY_API_READS_LIVENESS_PROBE_TIMEOUT_SECONDS
+  value: '60'
+- name: INVENTORY_API_WRITES_READINESS_PROBE_PERIOD_SECONDS
+  value: '30'
+- name: INVENTORY_API_WRITES_READINESS_PROBE_TIMEOUT_SECONDS
+  value: '60'
+- name: INVENTORY_API_READS_READINESS_PROBE_PERIOD_SECONDS
+  value: '30'
+- name: INVENTORY_API_READS_READINESS_PROBE_TIMEOUT_SECONDS
+  value: '60'
+- name: INVENTORY_DB_SCHEMA
+  value: 'hbi'
+- name: S3_AWS_SECRET
+  description: The AWS secret for S3
+  value: 'hbi-kessel-s3'
+- name: RBAC_V2_FORCE_ORG_ADMIN
+  description: Whether to force User Identities to use is_org_admin=True for RBAC v2 calls
+  value: 'false'
+- name: BYPASS_KESSEL_JOBS
+  description: Whether to bypass Kessel-related jobs, even when triggered via CJI
+  value: 'false'
+- name: CREATE_UNGROUPED_GROUPS_BATCH_SIZE
+  description: The batch size to use for the create-ungrouped-groups script.
+  value: '100'
+- name: ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE
+  description: The batch size to use for the assign-ungrouped-hosts script.
+  value: '10'
+
+# NGINX
+- displayName: Minimum replicas
+  name: NGINX_REPLICAS
+  required: true
+  value: "1"
+- displayName: Memory Request
+  name: NGINX_MEMORY_REQUEST
+  required: true
+  value: 100Mi
+- displayName: Memory Limit
+  name: NGINX_MEMORY_LIMIT
+  required: true
+  value: 200Mi
+- displayName: CPU Request
+  name: NGINX_CPU_REQUEST
+  required: true
+  value: 100m
+- displayName: CPU Limit
+  name: NGINX_CPU_LIMIT
+  required: true
+  value: 200m
+
+# Feature flags
+- description: Unleash secret name
+  name: UNLEASH_SECRET_NAME
+  value: bypass
+- description: Unleash API url
+  name: UNLEASH_URL
+- description: disable Unleash (feature flags), defaulting to fallback values
+  name: BYPASS_UNLEASH
+  value: 'false'
+- description: How frequently the Unleash client refreshes data from the server (in seconds)
+  name: UNLEASH_REFRESH_INTERVAL
+  value: "15"
+- name: FF_LAST_CHECKIN
+  description: Env var used to enable last checkin feature flag
+  value: 'false'
+
+#floorist
+- name: FLOORIST_SUSPEND
+  description: Disable Floorist cronjob execution
+  required: true
+  value: 'true'
+- description: bucket secret name
+  name: FLOORIST_BUCKET_SECRET_NAME
+  required: true
+  value: dummy-secret
+- description: bucket secret name
+  name: FLOORIST_HMS_BUCKET_SECRET_NAME
+  required: true
+  value: dummy-hms-secret
+- name: FLOORIST_LOGLEVEL
+  description: Floorist loglevel config
+  value: 'INFO'
+- name: FLOORIST_DB_SECRET_NAME
+  description: database secret name
+  value: host-inventory-db
+
+
+# new namespace
+- name: REPLICA_NAMESPACE
+  value: 'false'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1414,8 +1414,6 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         args: ["./host_synchronizer.py"]
         env:
-          - name: REPLICA_NAMESPACE
-            value: ${REPLICA_NAMESPACE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -2591,8 +2589,3 @@ parameters:
 - name: FLOORIST_DB_SECRET_NAME
   description: database secret name
   value: host-inventory-db
-
-
-# new namespace
-- name: REPLICA_NAMESPACE
-  value: 'false'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1414,6 +1414,8 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         args: ["./host_synchronizer.py"]
         env:
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -2589,3 +2591,8 @@ parameters:
 - name: FLOORIST_DB_SECRET_NAME
   description: database secret name
   value: host-inventory-db
+
+
+# new namespace
+- name: REPLICA_NAMESPACE
+  value: 'false'

--- a/inv_export_service.py
+++ b/inv_export_service.py
@@ -40,4 +40,5 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    pass
+    # main()

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -56,4 +56,5 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    pass
+    # main()

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -124,4 +124,4 @@ if __name__ == "__main__":
     sys.excepthook = partial(_excepthook, logger)
 
     threadctx.request_id = None
-    main(logger)
+    # main(logger)

--- a/system_profile_validator.py
+++ b/system_profile_validator.py
@@ -206,4 +206,4 @@ if __name__ == "__main__":
     sys.excepthook = partial(_excepthook, logger)
 
     threadctx.request_id = None
-    main(logger)
+    # main(logger)

--- a/utils/kafka_consumer.py
+++ b/utils/kafka_consumer.py
@@ -40,4 +40,5 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    pass
+    # main()


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19000](https://issues.redhat.com/browse/RHINENG-19000).
Adhoc for us to not send events on the new replica namespace

DO NOT MERGE: WE MAY BE ABLE TO TEST THE PR

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Introduce a configuration flag to disable Kafka event publication in replica namespaces

Enhancements:
- Add REPLICA_NAMESPACE parameter and environment variable in deployment config
- Skip sending Kafka events in host synchronizer when REPLICA_NAMESPACE is enabled