### PR TITLE
RHINENG-18151: Check hosts first before patching a group

### DIFF
--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -288,8 +288,11 @@ def log_patch_group_success(logger, group_id):
     logger.info(f"Patched group: {group_id}")
 
 
-def log_patch_group_failed(logger, group_id):
-    logger.debug(f"Failed to find group during patch operation: {group_id}")
+def log_patch_group_failed(logger, group_id, message=None):
+    if not message:
+        logger.debug(f"Failed to find group during patch operation: {group_id}")
+    else:
+        logger.debug(f"Failed to patch group with id: {group_id} due to {message}")
 
 
 def rbac_failure(logger, error_message=None):


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-18151](https://issues.redhat.com/browse/RHINENG-18151).  Though the defect could not be reproduced using known, this PR updates the patch group  method to avoid the situation that led to casual occurrences of the problem.  This update should be made even if the problem was not encountered by QE.

cc: @msager27 

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
