### PR TITLE
PoC: Batch Insert Hosts

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -4,6 +4,7 @@ services:
       container_name: hbi-db
       image: docker.io/library/postgres:16.4
       restart: always
+      shm_size: 1gb
       environment:
           POSTGRES_PASSWORD: insights
           POSTGRES_USER: insights
@@ -69,7 +70,7 @@ services:
 
     kafka:
       container_name: kafka
-      image: docker.io/confluentinc/cp-kafka
+      image: docker.io/confluentinc/cp-kafka:7.4.0
       restart: always
       ports:
         - "29092:29092"

--- a/migrations/versions/1a07436e7411_add_find_host_by_canonical_facts.py
+++ b/migrations/versions/1a07436e7411_add_find_host_by_canonical_facts.py
@@ -1,0 +1,62 @@
+"""add_find_host_by_canonical_facts
+
+Revision ID: 1a07436e7411
+Revises: 28280de3f1ce
+Create Date: 2025-07-05 10:15:32.973929
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1a07436e7411'
+down_revision = '28280de3f1ce'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create the find_host_by_canonical_facts function
+    # Potential Future work
+    #  -Filter by staleness requirements
+    #  -Secondary order by modified
+    op.execute("""
+        CREATE OR REPLACE FUNCTION public.find_host_by_canonical_facts(
+            p_org_id text,
+            p_provider_id uuid,
+            p_provider_type text,
+            p_subscription_manager_id uuid,
+            p_insights_id uuid
+        ) RETURNS uuid AS
+        $$ SELECT COALESCE((SELECT id
+                    FROM hbi.hosts
+                    WHERE org_id = p_org_id AND (
+                       -- First priority: provider_id
+                        (canonical_facts @> JSONB_BUILD_OBJECT('provider_id', p_provider_id, 'provider_type', p_provider_type))
+
+                       OR
+
+                       -- Second priority: subscription_manager_id
+                        (canonical_facts @> JSONB_BUILD_OBJECT('subscription_manager_id', p_subscription_manager_id))
+
+                       OR
+
+                       -- Third priority: insights_id
+                        (canonical_facts @> JSONB_BUILD_OBJECT('insights_id', p_insights_id)))
+
+                    ORDER BY CASE
+                                 WHEN canonical_facts ? 'provider_id' THEN 1
+                                 WHEN canonical_facts ? 'subscription_manager_id' THEN 2
+                                 WHEN canonical_facts ? 'insights_id' THEN 3
+                                 END
+                    -- Generate a random UUID if no host is found
+                    LIMIT 1), gen_random_uuid());
+        $$
+            LANGUAGE sql STABLE;
+    """)
+
+
+def downgrade():
+    # Drop the find_host_by_canonical_facts function
+    op.execute("DROP FUNCTION IF EXISTS find_host_by_canonical_facts(text, uuid, text, uuid, uuid);")

--- a/utils/fast-seed.sql
+++ b/utils/fast-seed.sql
@@ -1,0 +1,104 @@
+SET seed.num_rows = :num_rows;
+SET seed.num_org_ids = :num_org_ids;
+SET search_path = hbi;
+DO $$
+    DECLARE
+        v_batch_start integer;
+        v_batch_end integer;
+        v_total_rows integer := current_setting('seed.num_rows')::integer;
+        v_batch_size integer := 10000;
+        v_start_time timestamp;
+        v_batch_duration interval;
+        v_rows_per_second numeric;
+    BEGIN
+        FOR v_batch_start IN 1..v_total_rows BY v_batch_size LOOP
+                v_batch_end := LEAST(v_batch_start + v_batch_size - 1, v_total_rows);
+                v_start_time := clock_timestamp();
+                INSERT INTO hosts (
+                    id,
+                    account,
+                    display_name,
+                    created_on,
+                    modified_on,
+                    facts,
+                    tags,
+                    canonical_facts,
+                    system_profile_facts,
+                    ansible_host,
+                    stale_timestamp,
+                    reporter,
+                    per_reporter_staleness,
+                    org_id,
+                    groups,
+                    tags_alt,
+                    last_check_in,
+                    stale_warning_timestamp,
+                    deletion_timestamp
+                )
+                SELECT
+                    gen_random_uuid(),
+                    NULL,
+                    chr(97 + floor(random() * 26)::int) ||
+                    chr(97 + floor(random() * 26)::int) ||
+                    chr(97 + floor(random() * 26)::int) ||
+                    chr(97 + floor(random() * 26)::int) ||
+                    chr(97 + floor(random() * 26)::int) ||
+                    chr(97 + floor(random() * 26)::int) ||
+                    '.foo.redhat.com',
+                    CURRENT_TIMESTAMP,
+                    CURRENT_TIMESTAMP,
+                    '{}'::jsonb,
+                    '{"NS1": {"key3": ["val3"]}, "NS3": {"key3": ["val3"]}, "Sat": {"prod": []}, "SPECIAL": {"key": ["val"]}}'::jsonb,
+                    -- Generate canonical_facts using md5 hash of row number + field name for unique UUIDs
+                    -- Ensure at least one of insights_id, subscription_manager_id, or provider_id is present
+                    (CASE 
+                        WHEN random() > 0.66 THEN
+                            jsonb_build_object('bios_uuid', md5(random()::text || 'bios' || gs)::uuid) ||
+                            jsonb_build_object('insights_id', md5(random()::text || 'insights' || gs)::uuid) ||
+                            CASE WHEN random() > 0.5 THEN jsonb_build_object('subscription_manager_id', md5(random()::text || 'sub' || gs)::uuid) ELSE '{}'::jsonb END ||
+                            CASE WHEN random() > 0.5 THEN jsonb_build_object('provider_id', md5(random()::text || 'provider' || gs)::uuid) ||
+                                                          jsonb_build_object('provider_type',
+                                                                             (ARRAY['gcp', 'aws', 'azure', 'ibm'])[1 + floor(random() * 4)::int]) ELSE '{}'::jsonb END
+                        WHEN random() > 0.33 THEN
+                            jsonb_build_object('bios_uuid', md5(random()::text || 'bios' || gs)::uuid) ||
+                            CASE WHEN random() > 0.5 THEN jsonb_build_object('insights_id', md5(random()::text || 'insights' || gs)::uuid) ELSE '{}'::jsonb END ||
+                            jsonb_build_object('subscription_manager_id', md5(random()::text || 'sub' || gs)::uuid) ||
+                            CASE WHEN random() > 0.5 THEN jsonb_build_object('provider_id', md5(random()::text || 'provider' || gs)::uuid) ||
+                                                          jsonb_build_object('provider_type',
+                                                                             (ARRAY['gcp', 'aws', 'azure', 'ibm'])[1 + floor(random() * 4)::int]) ELSE '{}'::jsonb END
+                        ELSE
+                            jsonb_build_object('bios_uuid', md5(random()::text || 'bios' || gs)::uuid) ||
+                            CASE WHEN random() > 0.5 THEN jsonb_build_object('insights_id', md5(random()::text || 'insights' || gs)::uuid) ELSE '{}'::jsonb END ||
+                            CASE WHEN random() > 0.5 THEN jsonb_build_object('subscription_manager_id', md5(random()::text || 'sub' || gs)::uuid) ELSE '{}'::jsonb END ||
+                            jsonb_build_object('provider_id', md5(random()::text || 'provider' || gs)::uuid) ||
+                            jsonb_build_object('provider_type',
+                                               (ARRAY['gcp', 'aws', 'azure', 'ibm'])[1 + floor(random() * 4)::int])
+                    END),
+                    '{"arch": "x86-64", "owner_id": "1b36b20f-7fa0-4454-a6d2-008294e06378", "cpu_flags": ["flag1", "flag2"], "cpu_model": "Intel(R) Xeon(R) CPU E5-2690 0 @ 2.90GHz", "yum_repos": [{"name": "repo1", "enabled": true, "base_url": "http://rpms.redhat.com", "gpgcheck": true}], "os_release": "Red Hat EL 7.0.1", "bios_vendor": "Turd Ferguson", "bios_version": "1.0.0uhoh", "disk_devices": [{"type": "ext3", "label": "home drive", "device": "/dev/sdb1", "options": {"ro": true, "uid": "0"}, "mount_point": "/home"}], "captured_date": "2020-02-13T12:16:00Z", "rhc_client_id": "044e36dc-4e2b-4e69-8948-9c65a7bf4976", "is_marketplace": false, "kernel_modules": ["i915", "e1000e"], "last_boot_time": "2020-02-13T12:08:55Z", "number_of_cpus": 1, "cores_per_socket": 4, "enabled_services": ["ndb", "krb5"], "operating_system": {"name": "RHEL", "major": 8, "minor": 1}, "rhc_config_state": "044e36dc-4e2b-4e69-8948-9c65a7bf4976", "bios_release_date": "10/31/2013", "number_of_sockets": 2, "os_kernel_version": "3.10.0", "running_processes": ["vim", "gcc", "python"], "satellite_managed": false, "installed_products": [{"id": "123", "name": "eap", "status": "UP"}, {"id": "321", "name": "jbws", "status": "DOWN"}], "installed_services": ["ndb", "krb5"], "network_interfaces": [{"mtu": 1500, "name": "eth0", "type": "loopback", "state": "UP", "mac_address": "aa:bb:cc:dd:ee:ff", "ipv4_addresses": ["10.10.10.1"], "ipv6_addresses": ["2001:0db8:85a3:0000:0000:8a2e:0370:7334"]}], "infrastructure_type": "jingleheimer junction cpu", "selinux_config_file": "enforcing", "subscription_status": "valid", "system_memory_bytes": 1024, "insights_egg_version": "120.0.1", "selinux_current_mode": "enforcing", "system_update_method": "yum", "infrastructure_vendor": "dell", "katello_agent_running": false, "insights_client_version": "12.0.12", "subscription_auto_attach": "yes"}'::jsonb,
+                    NULL,
+                    CURRENT_TIMESTAMP + INTERVAL '24 hours',
+                    'puptoo',
+                    jsonb_build_object('puptoo', jsonb_build_object(
+                            'last_check_in', to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"'),
+                            'stale_timestamp', to_char(CURRENT_TIMESTAMP + INTERVAL '24 hours', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"'),
+                            'check_in_succeeded', true
+                                                 )),
+                    LPAD(((100000 + (gs % current_setting('seed.num_org_ids')::integer)))::text, 6, '0'),
+                    '[]'::jsonb,
+                    '[{"key": "key", "value": "val", "namespace": "SPECIAL"}, {"key": "key3", "value": "val3", "namespace": "NS3"}, {"key": "key3", "value": "val3", "namespace": "NS1"}, {"key": "prod", "value": null, "namespace": "Sat"}]'::jsonb,
+                    CURRENT_TIMESTAMP,
+                    NULL,
+                    NULL
+                FROM generate_series(v_batch_start, v_batch_end) gs;
+
+
+                v_batch_duration := clock_timestamp() - v_start_time;
+                v_rows_per_second := (v_batch_end - v_batch_start + 1) / EXTRACT(EPOCH FROM v_batch_duration);
+
+                IF v_batch_end % 20000 = 0 THEN
+                    RAISE NOTICE 'Inserted % rows (% rows/sec for this batch)',
+                        v_batch_end, ROUND(v_rows_per_second);
+                END IF;
+            END LOOP;
+    END $$;
+ANALYZE hosts;

--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -1,19 +1,42 @@
 import logging
 import os
 import sys
+import time
+
+from confluent_kafka.admin import AdminClient
 
 import payloads
-from confluent_kafka import Producer as KafkaProducer
+from confluent_kafka import Producer as KafkaProducer, TopicPartition, ConsumerGroupTopicPartitions, Consumer
+
+from app import create_app
+from app.environment import RuntimeEnvironment
+from app.models import Host
 
 HOST_INGRESS_TOPIC = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
 BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
+CONSUMER_GROUP = "inventory-mq"
 NUM_HOSTS = int(os.environ.get("NUM_HOSTS", 1))
+USE_EXISTING_HOSTS = os.environ.get("USE_EXISTING_HOSTS", "false").lower() == "true"
+
+admin_client = AdminClient({'bootstrap.servers': BOOTSTRAP_SERVERS})
+consumer = Consumer({'bootstrap.servers': BOOTSTRAP_SERVERS, 'group.id': 'fake'})
 
 
 def main():
-    # Create list of host payloads to add to the message queue
-    # payloads.build_payloads takes two optional args: number of hosts, and payload type ("default", "rhsm", "qpc")
-    all_payloads = [payloads.build_mq_payload() for _ in range(NUM_HOSTS)]
+    if USE_EXISTING_HOSTS:
+        application = create_app(RuntimeEnvironment.COMMAND)
+        with application.app.app_context():
+            canonical_facts_list = Host.query.with_entities(
+                Host.canonical_facts,
+                Host.org_id
+            ).limit(NUM_HOSTS).all()
+            # The ratio of updates to inserts in prod is about 100 to 1.  For every 100 updated systems, add a new system
+            all_payloads = [payloads.build_mq_payload(canonical_facts = canonical_facts_list[i] if i % 100 != 0 else None) for i in range(NUM_HOSTS)]
+
+    else:
+        # Create list of host payloads to add to the message queue
+        # payloads.build_payloads takes two optional args: number of hosts, and payload type ("default", "rhsm", "qpc")
+        all_payloads = [payloads.build_mq_payload() for _ in range(NUM_HOSTS)]
     print("Number of hosts (payloads): ", len(all_payloads))
 
     producer = KafkaProducer({"bootstrap.servers": BOOTSTRAP_SERVERS})
@@ -28,6 +51,27 @@ def main():
     for payload in all_payloads:
         producer.produce(HOST_INGRESS_TOPIC, value=payload, callback=delivery_callback)
     producer.flush()
+    wait_for_processing_complete()
+    consumer.close()
+
+
+def get_consumer_lag():
+    group_request = ConsumerGroupTopicPartitions(CONSUMER_GROUP)
+    committed_tp = admin_client.list_consumer_group_offsets([group_request])[CONSUMER_GROUP].result().topic_partitions[0]
+    _, high_offset = consumer.get_watermark_offsets(committed_tp, timeout=1)
+    return max(0, high_offset - committed_tp.offset)
+
+def wait_for_processing_complete():
+    start_time = time.time()
+
+    while True:
+        lag = get_consumer_lag()
+        print(lag)
+        if lag == 0:
+            break
+        time.sleep(0.5)
+
+    print("Duration: ", time.time() - start_time)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
(This is not production code.  It will break a lot of stuff)
### Summary
This PR demonstrates how hosts can be updated and created in batches to greatly reduce database resource consumption. The current approach in production is very ORM-centric: a single host is queried for, marshaled into a Python object, mutated, and saved back to the database. This is wasteful in two significant ways - extra round trips and unnecessary data being loaded from the database into the service. In the new approach, we skip loading data into the service and instead send batches of hosts to be upserted.

| Old    | New |
| -------- | ------- |
| host = Host.query.filter(...).first()<br> host.modified = now() <br>host.save() | insert(Host).values(hosts).on_conflict_do_update(...).returning(Host.id)   |

There are over 450 lines changed, but most of it consists of incidental changes to support the core difference shown above in the table. There are two commits. The first - `Benchmark` - is just code that can be used to measure the change. The second commit is where the actual message processing change is implemented.

### Measuring the Performance
Run the mq service:
```
PYTHONUNBUFFERED=1 BYPASS_TENANT_TRANSLATION=true INVENTORY_LOG_LEVEL=INFO KAFKA_CONSUMER_AUTO_COMMIT_INTERVAL_MS=500 KAFKA_EVENT_TOPIC=platform.inventory.events MQ_DB_BATCH_MAX_MESSAGES=100 PAYLOAD_TRACKER_SERVICE_NAME=inventory-mq-service python inv_mq_service.py
```

Seed a realistic number of hosts into the database:
```
make run_fast_seed_hosts NUM_HOSTS=1000000
```

Measure how long it takes to process hosts. This command will print out a duration for processing 4,000 hosts:
```
make run_inv_mq_service_test_producer NUM_HOSTS=4000 USE_EXISTING_HOSTS=true
```

Compare it to without the change:
```
git checkout HEAD^
```
Restart the mq service and run the benchmark again.

### Results
On my laptop, here's the time it takes to process 4,000 hosts:

| Old    | New |
| -------- | ------- |
| 31s  |  19s  |

It comes out to about 35% faster. On its own, this is not that impressive. However, if you look more closely, this doesn't tell the whole story. It turns out the mq service is highly CPU bottlenecked. If you comment out the database inserts in both methods, you can measure just how much time it takes to read the message from Kafka, validate the data, turn it into model objects, and create the outgoing events. It turns out these non-database activities consume a majority of the time. You can then calculate how much time is spent in the database by subtracting the two.

| | Old    | New |
| ------ | -------- | ------- |
| Total Time | 31s  |  20s  |
| Non-DB Time |  15s | 15s |
| DB Time | 16s | 5s |

So if you subtract out the non-database time-consuming activities, this method is actually over 3 times faster.

## Summary by Sourcery

Replace per-host ORM calls with bulk upsert logic for hosts, refactor the MQ consumer to handle message batches, and add supporting tooling and scripts for benchmarking and seeding performance tests

New Features:
- Handle and process messages in batches in the message consumer
- Introduce `add_hosts` repository method to perform bulk upsert of hosts
- Add a SQL function `find_host_by_canonical_facts` to resolve host IDs by canonical facts
- Enhance Kafka test producer to support existing hosts, consumer lag tracking, and processing completion

Enhancements:
- Optimize the event loop to batch validate, commit, and notify messages reducing database round trips
- Improve metrics for batch success/failure counts and message sizes

Build:
- Update Makefile with `USE_EXISTING_HOSTS` flag, fast seeding, and improved mq service commands
- Adjust dev container configuration for increased shared memory and explicit Kafka image version