### PR TITLE
feat(RHINENG-19064) Add script to delete hosts by IDs from s3 bucket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ COPY create_ungrouped_host_groups.py create_ungrouped_host_groups.py
 COPY delete_ungrouped_host_groups.py delete_ungrouped_host_groups.py
 COPY assign_ungrouped_hosts_to_groups.py assign_ungrouped_hosts_to_groups.py
 COPY export_group_data_s3.py export_group_data_s3.py
+COPY delete_hosts_s3.py delete_hosts_s3.py
 COPY update_hosts_last_check_in.py update_hosts_last_check_in.py
 COPY update_edge_hosts_prs.py update_edge_hosts_prs.py
 COPY delete_hosts_without_id_facts.py delete_hosts_without_id_facts.py

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -166,20 +166,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:a37f202978f11f384e3fd1f0ff8938367b527845493f9509357e1732debc390f",
-                "sha256:edad811edacb8c99f2fe59b117d9b9d8ee3972beb6c090c8aa164ddbc506d67d"
+                "sha256:056cfa2440fe1a157a7c2be897c749c83e1a322144aa4dad889f2fca66571019",
+                "sha256:0a367106497649ae3d8a7b571b8c3be01b7b935a0fe303d4cc2574ed03aecbb4"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==1.39.2"
+            "version": "==1.39.3"
         },
         "botocore": {
             "hashes": [
-                "sha256:474445fa8b281dd5db8fc62184f0f6e494d4f1efb96fe10312490583e67a9dd0",
-                "sha256:921cab9aa6e1e4ceddcece5b55b57daae7722168e74409f1aafcc2c5589df676"
+                "sha256:66a81cfac18ad5e9f47696c73fdf44cdbd8f8ca51ab3fca1effca0aabf61f02f",
+                "sha256:da8f477e119f9f8a3aaa8b3c99d9c6856ed0a243680aa3a3fbbfc15a8d4093fb"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.39.2"
+            "version": "==1.39.3"
         },
         "cachelib": {
             "hashes": [

--- a/app/config.py
+++ b/app/config.py
@@ -343,7 +343,7 @@ class Config:
         self.s3_access_key_id = os.getenv("S3_AWS_ACCESS_KEY_ID")
         self.s3_secret_access_key = os.getenv("S3_AWS_SECRET_ACCESS_KEY")
         self.s3_bucket = os.getenv("S3_AWS_BUCKET")
-        self.dry_run = os.getenv("DRY_RUN")
+        self.dry_run = os.getenv("DRY_RUN", "true").lower() == "true"
 
         self.sp_fields_to_log = os.getenv("SP_FIELDS_TO_LOG", "").split(",")
 

--- a/app/config.py
+++ b/app/config.py
@@ -343,6 +343,7 @@ class Config:
         self.s3_access_key_id = os.getenv("S3_AWS_ACCESS_KEY_ID")
         self.s3_secret_access_key = os.getenv("S3_AWS_SECRET_ACCESS_KEY")
         self.s3_bucket = os.getenv("S3_AWS_BUCKET")
+        self.dry_run = os.getenv("DRY_RUN")
 
         self.sp_fields_to_log = os.getenv("SP_FIELDS_TO_LOG", "").split(",")
 

--- a/delete_hosts_s3.py
+++ b/delete_hosts_s3.py
@@ -66,7 +66,7 @@ def process_batch(
     """
     global deleted_count, not_deleted_count, not_found_count
     with session_guard(session):
-        logger.info(f"Processing batch of {len(batch)} host IDs...")
+        logger.info(f"Processing batch of {len(batch)} Subscription Manager IDs...")
         base_query = session.query(Host).filter(Host.canonical_facts["subscription_manager_id"].astext.in_(batch))
 
         # Get the count of hosts that match, but have multiple reporters, so they shouldn't be deleted

--- a/delete_hosts_s3.py
+++ b/delete_hosts_s3.py
@@ -51,7 +51,7 @@ def process_batch(
     notification_event_producer: EventProducer,
 ):
     """
-    Processes a batch of host IDs and deletes hosts with only one reporter.
+    Processes a batch of Subscription Manager IDs and deletes hosts with only one reporter.
 
     This function retrieves hosts from the database whose IDs are in the provided batch.
     Hosts with only one reporter are deleted unless in dry-run mode. The function updates
@@ -59,7 +59,7 @@ def process_batch(
     committed to the database if not in dry-run mode.
 
     Args:
-        batch (list[str]): List of host IDs to process.
+        batch (list[str]): List of Subscription Manager IDs to process.
         session (Session): SQLAlchemy session for database operations.
         config (Config): Application configuration object.
         logger (Logger): Logger for logging information.
@@ -98,9 +98,9 @@ def run(
     application: FlaskApp,
 ):
     """
-    Runs the host deletion job using host IDs from a CSV file in an S3 bucket.
+    Runs the host deletion job using Subscription Manager IDs from a CSV file in an S3 bucket.
 
-    This function reads host IDs from a CSV file stored in S3, processes them in batches,
+    This function reads Subscription Manager IDs from a CSV file stored in S3, processes them in batches,
     and deletes hosts with only one reporter from the database unless in dry-run mode.
     It logs the results of the deletion process, including counts of deleted, not deleted,
     and not found hosts.
@@ -138,7 +138,7 @@ def run(
                 process_batch(batch, config, logger, session, event_producer, notification_event_producer)
 
             logger.info(f"Hosts that were not deleted because they had multiple reporters: {not_deleted_count}")
-            logger.info(f"Hosts whose IDs were not found in the DB: {not_found_count}")
+            logger.info(f"Hosts whose Subscription Manager IDs were not found in the DB: {not_found_count}")
             if config.dry_run:
                 logger.info(
                     f"This was a dry run. This many hosts would have been deleted in an actual run: {deleted_count}"

--- a/delete_hosts_s3.py
+++ b/delete_hosts_s3.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 import csv
+import io
 import os
 import sys
 from functools import partial
-from io import StringIO
 from logging import Logger
 
 import boto3
@@ -116,9 +116,10 @@ def run(
             logger.info(f"Running host_delete_s3 with batch size {BATCH_SIZE}")
             s3_client = get_s3_client(config)
 
-            # Read the CSV data from the S3 bucket one batch at a time
+            # Stream the CSV data from the S3 bucket one batch at a time
             s3_object = s3_client.get_object(Bucket=config.s3_bucket, Key=S3_OBJECT_KEY)
-            csv_stream = StringIO(s3_object["Body"].read().decode("utf-8"))
+            # s3_object["Body"] is a file-like object, so we can wrap it with TextIOWrapper for decoding
+            csv_stream = io.TextIOWrapper(s3_object["Body"], encoding="utf-8")
             reader = csv.reader(csv_stream)
 
             batch = []

--- a/delete_hosts_s3.py
+++ b/delete_hosts_s3.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python
+import csv
+import sys
+from functools import partial
+from io import StringIO
+from logging import Logger
+
+import boto3
+from connexion import FlaskApp
+from sqlalchemy.orm import Session
+
+from app.config import Config
+from app.environment import RuntimeEnvironment
+from app.logging import get_logger
+from app.models import Host
+from jobs.common import excepthook
+from jobs.common import job_setup
+from lib.db import session_guard
+
+PROMETHEUS_JOB = "inventory-delete-hosts-s3"
+LOGGER_NAME = "delete_hosts_s3"
+RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
+S3_OBJECT_KEY = "host_ids.csv"
+BATCH_SIZE = 500
+
+# Vars to keep track of the number of hosts deleted, not deleted, and not found
+deleted_count = 0
+not_deleted_count = 0
+not_found_count = 0
+
+
+def get_s3_client(config: Config):
+    """Create and return an S3 client."""
+    return boto3.client(
+        "s3",
+        aws_access_key_id=config.s3_access_key_id,
+        aws_secret_access_key=config.s3_secret_access_key,
+    )
+
+
+def process_batch(batch: list[str], session: Session, config: Config, logger: Logger):
+    """
+    Processes a batch of host IDs and deletes hosts with only one reporter.
+
+    This function retrieves hosts from the database whose IDs are in the provided batch.
+    Hosts with only one reporter are deleted unless in dry-run mode. The function updates
+    counters for deleted, not deleted, and not found hosts. After processing, changes are
+    committed to the database if not in dry-run mode.
+
+    Args:
+        batch (list[str]): List of host IDs to process.
+        session (Session): SQLAlchemy session for database operations.
+        config (Config): Application configuration object.
+        logger (Logger): Logger for logging information.
+    """
+    global deleted_count, not_deleted_count, not_found_count
+    with session_guard(session):
+        logger.info(f"Processing batch of {len(batch)} host IDs...")
+        host_list = session.query(Host).filter(Host.id.in_(batch)).all()
+        not_found_count += len(batch) - len(host_list)
+
+        for host in host_list:
+            # Check whether there's another reporter. If so, increment a counter; otherwise, delete it
+            if len(host.per_reporter_staleness) > 1:
+                not_deleted_count += 1
+            else:
+                # Delete the host if it's not in dry-run mode
+                if not config.dry_run:
+                    session.delete(host)
+                deleted_count += 1
+
+        # Commit deletions if not in dry-run mode
+        if not config.dry_run:
+            session.commit()
+
+
+def run(config: Config, logger: Logger, session: Session, application: FlaskApp):
+    """
+    Runs the host deletion job using host IDs from a CSV file in an S3 bucket.
+
+    This function reads host IDs from a CSV file stored in S3, processes them in batches,
+    and deletes hosts with only one reporter from the database unless in dry-run mode.
+    It logs the results of the deletion process, including counts of deleted, not deleted,
+    and not found hosts.
+
+    Args:
+        config (Config): Application configuration object.
+        logger (Logger): Logger for logging information.
+        session (Session): SQLAlchemy session for database operations.
+        application (FlaskApp): The Flask application instance.
+    """
+    with application.app.app_context():
+        try:
+            logger.info(f"Running host_delete_s3 with batch size {BATCH_SIZE}")
+            s3_client = get_s3_client(config)
+
+            # Read the CSV data from the S3 bucket one batch at a time
+            s3_object = s3_client.get_object(Bucket=config.s3_bucket, Key=S3_OBJECT_KEY)
+            csv_stream = StringIO(s3_object["Body"].read().decode("utf-8"))
+            reader = csv.reader(csv_stream)
+
+            batch = []
+            for row in reader:
+                if not row:
+                    continue
+                batch.append(row[0])
+                if len(batch) == BATCH_SIZE:
+                    # The batch is now full, so we should process the hosts in the batch.
+                    process_batch(batch, session, config, logger)
+
+                    # Empty the batch and start again
+                    batch = []
+
+            # If the reader ran out of rows, process that final batch
+            if batch:
+                process_batch(batch, session, config, logger)
+
+            logger.info(f"Hosts that were not deleted because they had multiple reporters: {not_deleted_count}")
+            logger.info(f"Hosts whose IDs were not found in the DB: {not_found_count}")
+            if config.dry_run:
+                logger.info(
+                    f"This was a dry run. This many hosts would have been deleted in an actual run: {deleted_count}"
+                )
+            else:
+                logger.info(f"This was NOT a dry run. Hosts that were actually deleted: {deleted_count}")
+
+        except Exception as e:
+            logger.exception(e)
+        finally:
+            s3_client.close()
+
+
+if __name__ == "__main__":
+    logger = get_logger(LOGGER_NAME)
+    job_type = "Delete host IDs via S3"
+    sys.excepthook = partial(excepthook, logger, job_type)
+
+    config, session, _, _, _, application = job_setup((), PROMETHEUS_JOB)
+    run(config, logger, session, application)

--- a/deploy/cji.yml
+++ b/deploy/cji.yml
@@ -63,6 +63,16 @@ objects:
     appName: host-inventory
     jobs:
       - export-group-data-s3
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    labels:
+      app: host-inventory
+    name: delete-hosts-s3-${DELETE_HOSTS_S3_RUN_NUMBER}
+  spec:
+    appName: host-inventory
+    jobs:
+      - delete-hosts-s3
 parameters:
 - name: SYNCHRONIZER_RUN_NUMBER
   value: '1'
@@ -75,4 +85,6 @@ parameters:
 - name: DELETE_HOSTS_WITHOUT_ID_FACTS_RUN_NUMBER
   value: '1'
 - name: GROUP_S3_EXPORT_RUN_NUMBER
+  value: '1'
+- name: DELETE_HOSTS_S3_RUN_NUMBER
   value: '1'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1618,20 +1618,66 @@ objects:
           - name: S3_AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
-                name: ${S3_AWS_SECRET}
+                name: ${KESSEL_S3_AWS_SECRET}
                 key: aws_access_key_id
           - name: S3_AWS_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: ${S3_AWS_SECRET}
+                name: ${KESSEL_S3_AWS_SECRET}
                 key: aws_secret_access_key
           - name: S3_AWS_BUCKET
             valueFrom:
               secretKeyRef:
-                name: ${S3_AWS_SECRET}
+                name: ${KESSEL_S3_AWS_SECRET}
                 key: bucket
           - name: BYPASS_KESSEL_JOBS
             value: ${BYPASS_KESSEL_JOBS}
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_GROUPS_S3_EXPORT}
+            memory: ${MEMORY_LIMIT_GROUPS_S3_EXPORT}
+          requests:
+            cpu: ${CPU_REQUEST_GROUPS_S3_EXPORT}
+            memory: ${MEMORY_REQUEST_GROUPS_S3_EXPORT}
+    - name: delete-hosts-s3
+      restartPolicy: OnFailure
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        args: ["./delete_hosts_s3.py"]
+        env:
+          - name: INVENTORY_LOG_LEVEL
+            value: ${LOG_LEVEL}
+          - name: INVENTORY_DB_SSL_MODE
+            value: ${INVENTORY_DB_SSL_MODE}
+          - name: INVENTORY_DB_SSL_CERT
+            value: ${INVENTORY_DB_SSL_CERT}
+          - name: INVENTORY_DB_SCHEMA
+            value: "${INVENTORY_DB_SCHEMA}"
+          - name: PROMETHEUS_PUSHGATEWAY
+            value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: DRY_RUN
+            value: ${DELETE_HOSTS_DRY_RUN}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CLOWDER_ENABLED
+            value: "true"
+          - name: S3_AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${DELETE_HOSTS_S3_AWS_SECRET}
+                key: aws_access_key_id
+          - name: S3_AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${DELETE_HOSTS_S3_AWS_SECRET}
+                key: aws_secret_access_key
+          - name: S3_AWS_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: ${DELETE_HOSTS_S3_AWS_SECRET}
+                key: bucket
         resources:
           limits:
             cpu: ${CPU_LIMIT_GROUPS_S3_EXPORT}
@@ -2519,9 +2565,15 @@ parameters:
   value: '60'
 - name: INVENTORY_DB_SCHEMA
   value: 'hbi'
-- name: S3_AWS_SECRET
-  description: The AWS secret for S3
+- name: KESSEL_S3_AWS_SECRET
+  description: The AWS secret for the Kessel S3 bucket
   value: 'hbi-kessel-s3'
+- name: DELETE_HOSTS_S3_AWS_SECRET
+  description: The AWS secret for the delete-hosts S3 bucket
+  value: 'hbi-delete-host-ids-s3'
+- name: DELETE_HOSTS_DRY_RUN
+  description: Whether the delete_hosts_s3 script should run in dry-run mode
+  value: 'true'
 - name: RBAC_V2_FORCE_ORG_ADMIN
   description: Whether to force User Identities to use is_org_admin=True for RBAC v2 calls
   value: 'false'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1657,6 +1657,8 @@ objects:
             value: ${PROMETHEUS_PUSHGATEWAY}
           - name: DRY_RUN
             value: ${DELETE_HOSTS_DRY_RUN}
+          - name: DELETE_HOSTS_S3_BATCH_SIZE
+            value: ${DELETE_HOSTS_S3_BATCH_SIZE}
           - name: NAMESPACE
             valueFrom:
               fieldRef:
@@ -2574,6 +2576,9 @@ parameters:
 - name: DELETE_HOSTS_DRY_RUN
   description: Whether the delete_hosts_s3 script should run in dry-run mode
   value: 'true'
+- name: DELETE_HOSTS_S3_BATCH_SIZE
+  description: The batch size to use for the delete-hosts-s3 script.
+  value: '500'
 - name: RBAC_V2_FORCE_ORG_ADMIN
   description: Whether to force User Identities to use is_org_admin=True for RBAC v2 calls
   value: 'false'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1655,6 +1655,22 @@ objects:
             value: "${INVENTORY_DB_SCHEMA}"
           - name: PROMETHEUS_PUSHGATEWAY
             value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            value: ${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}
+          - name: KAFKA_EVENT_TOPIC
+            value: ${KAFKA_EVENT_TOPIC}
+          - name: KAFKA_NOTIFICATION_TOPIC
+            value: ${KAFKA_NOTIFICATION_TOPIC}
+          - name: KAFKA_PRODUCER_ACKS
+            value: ${KAFKA_PRODUCER_ACKS}
+          - name: KAFKA_PRODUCER_RETRIES
+            value: ${KAFKA_PRODUCER_RETRIES}
+          - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
+            value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
+          - name: KAFKA_SECURITY_PROTOCOL
+            value: ${KAFKA_SECURITY_PROTOCOL}
+          - name: KAFKA_SASL_MECHANISM
+            value: ${KAFKA_SASL_MECHANISM}
           - name: DRY_RUN
             value: ${DELETE_HOSTS_DRY_RUN}
           - name: DELETE_HOSTS_S3_BATCH_SIZE

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -37,6 +37,7 @@ COPY create_ungrouped_host_groups.py create_ungrouped_host_groups.py
 COPY delete_ungrouped_host_groups.py delete_ungrouped_host_groups.py
 COPY assign_ungrouped_hosts_to_groups.py assign_ungrouped_hosts_to_groups.py
 COPY export_group_data_s3.py export_group_data_s3.py
+COPY delete_hosts_s3.py delete_hosts_s3.py
 COPY update_hosts_last_check_in.py update_hosts_last_check_in.py
 COPY update_edge_hosts_prs.py update_edge_hosts_prs.py
 COPY delete_hosts_without_id_facts.py delete_hosts_without_id_facts.py

--- a/tests/test_delete_hosts_s3.py
+++ b/tests/test_delete_hosts_s3.py
@@ -1,0 +1,178 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from app.config import Config
+
+# Patch constants and functions used in run
+BATCH_SIZE = 2
+S3_OBJECT_KEY = "host_ids.csv"
+
+
+@pytest.fixture
+def mock_logger():
+    logger = MagicMock()
+    logger.info = MagicMock()
+    logger.exception = MagicMock()
+    return logger
+
+
+@pytest.fixture
+def mock_config():
+    config = MagicMock(spec=Config)
+    config.s3_bucket = "test-bucket"
+    config.dry_run = False
+    return config
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock(spec=["query", "commit"])
+
+
+@pytest.fixture
+def mock_s3_client():
+    return MagicMock()
+
+
+@pytest.fixture
+def patch_get_s3_client(mock_s3_client):
+    with patch("delete_hosts_s3.get_s3_client", return_value=mock_s3_client):
+        yield mock_s3_client
+
+
+@pytest.fixture
+def patch_process_batch():
+    with patch("delete_hosts_s3.process_batch") as mock_proc:
+        yield mock_proc
+
+
+@pytest.fixture
+def patch_globals(monkeypatch):
+    # Patch the global counters
+    monkeypatch.setattr("delete_hosts_s3.BATCH_SIZE", BATCH_SIZE)
+    monkeypatch.setattr("delete_hosts_s3.S3_OBJECT_KEY", S3_OBJECT_KEY)
+    monkeypatch.setattr("delete_hosts_s3.not_deleted_count", 0)
+    monkeypatch.setattr("delete_hosts_s3.not_found_count", 0)
+    monkeypatch.setattr("delete_hosts_s3.deleted_count", 0)
+
+
+@pytest.mark.usefixtures("patch_globals")
+@pytest.mark.parametrize(
+    "csv_content, dry_run, expected_batches, expected_final_log",
+    [
+        (
+            "id1\nid2\nid3\nid4\n",
+            False,
+            [["id1", "id2"], ["id3", "id4"]],
+            "Hosts that were not deleted because they had multiple reporters: 0",
+        ),
+        (
+            "id1\nid2\nid3\n",
+            True,
+            [["id1", "id2"], ["id3"]],
+            "This was a dry run. This many hosts would have been deleted in an actual run: 0",
+        ),
+        (
+            "\n\nid1\n\n",
+            False,
+            [["id1"]],
+            "Hosts that were not deleted because they had multiple reporters: 0",
+        ),
+        (
+            "",
+            False,
+            [],
+            "Hosts that were not deleted because they had multiple reporters: 0",
+        ),
+    ],
+)
+def test_run_happy_and_edge_cases(
+    csv_content,
+    dry_run,
+    expected_batches,
+    expected_final_log,
+    mock_config,
+    mock_logger,
+    mock_session,
+    flask_app,
+    patch_get_s3_client,
+    patch_process_batch,
+    monkeypatch,
+):
+    # Arrange
+    mock_config.dry_run = dry_run
+    s3_body = MagicMock()
+    s3_body.read.return_value = csv_content.encode("utf-8")
+    patch_get_s3_client.get_object.return_value = {"Body": s3_body}
+
+    # Patch the global counters for logging
+    monkeypatch.setattr("delete_hosts_s3.not_deleted_count", 0)
+    monkeypatch.setattr("delete_hosts_s3.not_found_count", 0)
+    monkeypatch.setattr("delete_hosts_s3.deleted_count", 0)
+
+    import delete_hosts_s3
+
+    # Act
+    delete_hosts_s3.run(mock_config, mock_logger, mock_session, flask_app)
+
+    # Assert
+    actual_batches = [call[0][0] for call in patch_process_batch.call_args_list]
+    assert actual_batches == expected_batches
+    assert any(expected_final_log in str(c[0][0]) for c in mock_logger.info.call_args_list)
+
+
+@pytest.mark.usefixtures("patch_globals", "patch_process_batch")
+@pytest.mark.parametrize(
+    "exception_type",
+    (Exception, RuntimeError),
+)
+def test_run_exception_handling(
+    exception_type, mock_config, mock_logger, mock_session, flask_app, patch_get_s3_client
+):
+    # Arrange
+    patch_get_s3_client.get_object.side_effect = exception_type("fail!")
+    import delete_hosts_s3
+
+    # Act
+    delete_hosts_s3.run(mock_config, mock_logger, mock_session, flask_app)
+
+    # Assert
+    assert mock_logger.exception.called
+    patch_get_s3_client.close.assert_called_once()
+
+
+@pytest.mark.usefixtures("patch_globals", "patch_process_batch")
+def test_run_finally_always_closes_s3(mock_config, mock_logger, mock_session, flask_app, patch_get_s3_client):
+    # Arrange
+    s3_body = MagicMock()
+    s3_body.read.return_value = b"id1\n"
+    patch_get_s3_client.get_object.return_value = {"Body": s3_body}
+    import delete_hosts_s3
+
+    # Act
+    delete_hosts_s3.run(mock_config, mock_logger, mock_session, flask_app)
+
+    # Assert
+    patch_get_s3_client.close.assert_called_once()
+
+
+@pytest.mark.usefixtures("patch_globals", "patch_process_batch")
+def test_run_handles_app_context(mock_config, mock_logger, mock_session, patch_get_s3_client):
+    # Arrange
+    s3_body = MagicMock()
+    s3_body.read.return_value = b"id1\n"
+    patch_get_s3_client.get_object.return_value = {"Body": s3_body}
+    mock_app = MagicMock()
+    mock_ctx = MagicMock()
+    mock_app.app.app_context.return_value = mock_ctx
+    import delete_hosts_s3
+
+    # Act
+    delete_hosts_s3.run(mock_config, mock_logger, mock_session, mock_app)
+
+    # Assert
+    mock_app.app.app_context.assert_called_once()
+    mock_ctx.__enter__.assert_called_once()
+    mock_ctx.__exit__.assert_called_once()

--- a/tests/test_delete_hosts_s3.py
+++ b/tests/test_delete_hosts_s3.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+import delete_hosts_s3
 from app.config import Config
 
 # Patch constants and functions used in run
@@ -112,8 +113,6 @@ def test_run_happy_and_edge_cases(
     monkeypatch.setattr("delete_hosts_s3.not_found_count", 0)
     monkeypatch.setattr("delete_hosts_s3.deleted_count", 0)
 
-    import delete_hosts_s3
-
     # Act
     delete_hosts_s3.run(mock_config, mock_logger, mock_session, flask_app)
 
@@ -133,7 +132,6 @@ def test_run_exception_handling(
 ):
     # Arrange
     patch_get_s3_client.get_object.side_effect = exception_type("fail!")
-    import delete_hosts_s3
 
     # Act
     delete_hosts_s3.run(mock_config, mock_logger, mock_session, flask_app)
@@ -149,7 +147,6 @@ def test_run_finally_always_closes_s3(mock_config, mock_logger, mock_session, fl
     s3_body = MagicMock()
     s3_body.read.return_value = b"id1\n"
     patch_get_s3_client.get_object.return_value = {"Body": s3_body}
-    import delete_hosts_s3
 
     # Act
     delete_hosts_s3.run(mock_config, mock_logger, mock_session, flask_app)
@@ -167,7 +164,6 @@ def test_run_handles_app_context(mock_config, mock_logger, mock_session, patch_g
     mock_app = MagicMock()
     mock_ctx = MagicMock()
     mock_app.app.app_context.return_value = mock_ctx
-    import delete_hosts_s3
 
     # Act
     delete_hosts_s3.run(mock_config, mock_logger, mock_session, mock_app)

--- a/tests/test_delete_hosts_s3.py
+++ b/tests/test_delete_hosts_s3.py
@@ -1,3 +1,4 @@
+import io
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -106,8 +107,8 @@ def test_run_happy_and_edge_cases(
 ):
     # Arrange
     mock_config.dry_run = dry_run
-    s3_body = MagicMock()
-    s3_body.read.return_value = csv_content.encode("utf-8")
+    # Provide a real BytesIO stream, as the production code expects a file-like object for io.TextIOWrapper
+    s3_body = io.BytesIO(csv_content.encode("utf-8"))
     patch_get_s3_client.get_object.return_value = {"Body": s3_body}
 
     # Patch the global counters for logging
@@ -155,8 +156,7 @@ def test_run_finally_always_closes_s3(
     mock_config, mock_logger, mock_session, flask_app, patch_get_s3_client, event_producer, notification_event_producer
 ):
     # Arrange
-    s3_body = MagicMock()
-    s3_body.read.return_value = b"id1\n"
+    s3_body = io.BytesIO(b"id1\n")
     patch_get_s3_client.get_object.return_value = {"Body": s3_body}
 
     # Act
@@ -171,8 +171,7 @@ def test_run_handles_app_context(
     mock_config, mock_logger, mock_session, patch_get_s3_client, event_producer, notification_event_producer
 ):
     # Arrange
-    s3_body = MagicMock()
-    s3_body.read.return_value = b"id1\n"
+    s3_body = io.BytesIO(b"id1\n")
     patch_get_s3_client.get_object.return_value = {"Body": s3_body}
     mock_app = MagicMock()
     mock_ctx = MagicMock()


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19064](https://issues.redhat.com/browse/RHINENG-19064).
Adds a script that deletes hosts specified by the `hbi-delete-host-ids-s3` bucket's contents. For each ID in the bucket, it attempts to find the host, and if the host has only one reporter, deletes it (if it's not a dry run). Some notes:

- No hosts will be deleted if the script is running in dry-run mode, which is the default.
- The script keeps track of the number of hosts that are deleted, not found, and not deleted due to having multiple reporters. It logs this data at the end at INFO level.
- By default, this script processes hosts in batches of 500 to reduce DB load. For 4.5 million hosts, that will be ~9K batches. This is configurable via the `DELETE_HOSTS_S3_BATCH_SIZE` env var.
- This now streams data from s3 rather than loading in the whole bucket at once.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [x] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Introduce a new batch-driven host deletion job that reads host IDs from a CSV file in an S3 bucket and removes hosts with only one reporter, supporting dry-run and logging summaries, and integrate it into the deployment manifest.

New Features:
- Add delete_hosts_s3.py script for fetching host IDs from S3 and deleting eligible hosts in configurable batches with optional dry-run mode
- Add a delete-hosts-s3 Kubernetes job to the clowdapp deployment manifest with required environment variables, secrets, and resource settings

Enhancements:
- Expose DRY_RUN flag and introduce DELETE_HOSTS_S3_AWS_SECRET parameter for the new job
- Rename S3_AWS_SECRET to KESSEL_S3_AWS_SECRET for the Kessel S3 bucket secret reference

Tests:
- Add unit tests for delete_hosts_s3.run covering batching logic, dry-run behavior, exception handling, and resource cleanup