### PR TITLE
feat(rhineng-17526): Clean up job for access tags in non-hosted deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ COPY delete_hosts_without_id_facts.py delete_hosts_without_id_facts.py
 COPY app_migrations/ app_migrations/
 COPY jobs/ jobs/
 COPY add_inventory_view.py add_inventory_view.py
+COPY delete_host_namespace_access_tags.py delete_host_namespace_access_tags.py
 
 ENV PIP_NO_CACHE_DIR=1
 ENV PIPENV_CLEAR=1

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ run_pendo_syncher:
 run_host_view_create:
 	python3 add_inventory_view.py
 
+run_host_delete_access_tags:
+	python3 delete_host_namespace_access_tags.py
+
 style:
 	pre-commit run --all-files
 

--- a/delete_host_namespace_access_tags.py
+++ b/delete_host_namespace_access_tags.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python
+import os
+import sys
+from functools import partial
+from logging import Logger
+
+from connexion import FlaskApp
+from sqlalchemy.orm import Session
+
+from app.environment import RuntimeEnvironment
+from app.logging import get_logger
+from app.models import Host
+from jobs.common import excepthook
+from jobs.common import job_setup
+from lib.db import session_guard
+
+PROMETHEUS_JOB = "inventory-delete-host-namespace-access-tags"
+LOGGER_NAME = "delete-host-namespace-access-tags"
+RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
+NUM_HOSTS_TAG_DELETION_BATCH_COUNT = int(os.getenv("NUM_HOSTS_TAG_DELETION_BATCH_COUNT", 500))
+TAG_ACCESS_NAMESPACE = os.getenv("TAG_ACCESS_NAMESPACE", "sat_iam")
+
+
+def run(logger: Logger, session: Session, application: FlaskApp):
+    with application.app.app_context():
+        logger.info("Starting job to delete access tags on hosts")
+        hosts_query = session.query(Host).filter(Host.tags.has_key(TAG_ACCESS_NAMESPACE)).order_by(Host.org_id)
+        hosts_count = hosts_query.count()
+        logger.info(f"Found {hosts_count} to be updated")
+        processed_in_current_batch = 0
+        total_hosts_updated = 0
+
+        for host in hosts_query.yield_per(NUM_HOSTS_TAG_DELETION_BATCH_COUNT):
+            try:
+                if host.tags is not None and TAG_ACCESS_NAMESPACE in host.tags:
+                    host._delete_tags_namespace(TAG_ACCESS_NAMESPACE)
+                    host._delete_tags_alt_namespace(TAG_ACCESS_NAMESPACE)
+                processed_in_current_batch += 1
+                total_hosts_updated += 1
+                if processed_in_current_batch >= NUM_HOSTS_TAG_DELETION_BATCH_COUNT:
+                    logger.info(f"Updating batch of {processed_in_current_batch} hosts...")
+                    session.flush()  # Flush current session so we free memory
+                    logger.info(f"Flushed. Total updated so far: {total_hosts_updated}")
+                    processed_in_current_batch = 0  # Reset counter for the next batch
+
+            except Exception as e:
+                logger.error(f"Error committing batch: {e}", exc_info=True)
+                session.rollback()
+
+        if total_hosts_updated > 0:
+            try:
+                logger.info(f"Committing {total_hosts_updated} hosts.")
+                session.commit()
+                logger.info(f"Job finished. Successfully deleted access tags for {total_hosts_updated} hosts.")
+            except Exception:
+                session.rollback()
+        else:
+            logger.info("No hosts to be updated. Finishing job")
+
+
+if __name__ == "__main__":
+    logger = get_logger(LOGGER_NAME)
+    job_type = "Delete host access tags hosts"
+    sys.excepthook = partial(excepthook, logger, job_type)
+
+    _, session, event_producer, _, _, application = job_setup(tuple(), PROMETHEUS_JOB)
+    session.expire_on_commit = False
+    with session_guard(session):
+        run(logger, session, application)

--- a/tests/test_delete_host_namespace_access_tags.py
+++ b/tests/test_delete_host_namespace_access_tags.py
@@ -1,0 +1,26 @@
+from typing import Callable
+
+from connexion import FlaskApp
+from pytest_mock import MockerFixture
+
+from app.models import Host
+from app.models import db
+from delete_host_namespace_access_tags import run
+
+
+def test_delete_access_namespace_happy_path(
+    flask_app: FlaskApp,
+    db_create_host: Callable[..., Host],
+    mocker: MockerFixture,
+):
+    db_create_host(extra_data={"tags": {"sat_iam": {"hash": "value1"}}})
+    db_create_host(extra_data={"tags": {"ns1": {"key2": "value2"}, "sat_iam": {"hash": "value2"}}})
+
+    run(
+        logger=mocker.Mock(),
+        session=db.session,
+        application=flask_app,
+    )
+
+    access_tag_hosts = Host.query.filter(Host.tags.has_key("sat_iam")).all()
+    assert len(access_tag_hosts) == 0


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17526](https://issues.redhat.com/browse/RHINENG-17526).
* Creates a script that clears subset tags used for access management
* Adds script to Dockerfile
* Adds Makefile target for consistent usage

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Provide a new job to batch-delete access-management tags from host records in non-hosted deployments and integrate it into the build and run workflows

New Features:
- Add delete_host_namespace_access_tags.py script to remove host access tags in configurable batches
- Include the new deletion script in the Docker image
- Add Makefile target to execute the access-tag cleanup job