### PR TITLE
fix(dev_env): pin Zookeeper and Kafka images to version 7.4.4

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -62,14 +62,14 @@ services:
 
     zookeeper:
       container_name: zookeeper
-      image: docker.io/confluentinc/cp-zookeeper
+      image: docker.io/confluentinc/cp-zookeeper:7.4.4
       environment:
         - ZOOKEEPER_CLIENT_PORT=32181
         - ZOOKEEPER_SERVER_ID=1
 
     kafka:
       container_name: kafka
-      image: docker.io/confluentinc/cp-kafka
+      image: docker.io/confluentinc/cp-kafka:7.4.4
       restart: always
       ports:
         - "29092:29092"


### PR DESCRIPTION
- Updated dev.yml to specify exact versions for Zookeeper and Kafka
- Ensures consistent development environment across deployments

# Overview

Our `dev.yml` was getting the latest version of cp-kafka images and it brings a lot of architectural changes from Confluent. This PR only pins Zookeeper and Kafka until we decide to make the big change.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Pin Zookeeper and Kafka Docker images to version 7.4.4 in the development environment to ensure consistency across deployments

Enhancements:
- Pin Zookeeper image to docker.io/confluentinc/cp-zookeeper:7.4.4 in dev.yml
- Pin Kafka image to docker.io/confluentinc/cp-kafka:7.4.4 in dev.yml