### PR TITLE
fix(RHINENG-19064) Workaround for functionality that's not supported by postgres

### DIFF
--- a/delete_hosts_s3.py
+++ b/delete_hosts_s3.py
@@ -71,12 +71,12 @@ def process_batch(
 
         # Get the count of hosts that match, but have multiple reporters, so they shouldn't be deleted
         not_deleted_count += base_query.filter(
-            func.jsonb_array_length(func.jsonb_object_keys(Host.per_reporter_staleness)) > 1
+            func.cardinality(func.array(func.jsonb_object_keys(Host.per_reporter_staleness))) > 1
         ).count()
 
         # Get the hosts that that match and only have 1 reporter
         delete_query = base_query.filter(
-            func.jsonb_array_length(func.jsonb_object_keys(Host.per_reporter_staleness)) == 1
+            func.cardinality(func.array(func.jsonb_object_keys(Host.per_reporter_staleness))) == 1
         )
 
         if config.dry_run:


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19064](https://issues.redhat.com/browse/RHINENG-19064).
Use of `jsonb_array_length(jsonb_object_keys(...))` is not allowed in WHERE in Postgres. This updates it with a workaround that uses `func.cardinality(func.array())`.


## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
