### PR TITLE
Disable Kafka operations in replica namespaces

### DIFF
--- a/api/system_profile.py
+++ b/api/system_profile.py
@@ -115,6 +115,11 @@ def validate_schema(repo_fork="RedHatInsights", repo_branch="master", days=1, ma
     _ = (rbac_filter,)  # Unused. No RBAC needed because we check for specific users.
     # Use the identity header to make sure the user is someone from our team.
     config = Config(RuntimeEnvironment.SERVICE)
+
+    if config.replica_namespace:
+        logger.info("Running in replica cluster - skipping schema validation")
+        return flask_json_response({"message": "Schema validation skipped - running in replica cluster"})
+
     identity = get_current_identity()
     if not hasattr(identity, "user") or identity.user.get("username") not in config.sp_authorized_users:
         flask.abort(403, "This endpoint is restricted to HBI Admins.")

--- a/app/config.py
+++ b/app/config.py
@@ -378,6 +378,10 @@ class Config:
             self.bypass_tenant_translation = True
             self.bypass_unleash = True
 
+        self.replica_namespace = os.environ.get("REPLICA_NAMESPACE", "false").lower() == "true"
+        if self.replica_namespace:
+            self.logger.info("***PROD REPLICA NAMESPACE DETECTED - Kafka operations will be disabled ***")
+
     def _build_base_url_path(self):
         app_name = os.getenv("APP_NAME", "inventory")
         path_prefix = os.getenv("PATH_PREFIX", "api")

--- a/app/payload_tracker/__init__.py
+++ b/app/payload_tracker/__init__.py
@@ -28,7 +28,7 @@ def init_payload_tracker(config, producer=None):
 
 
 def get_payload_tracker(account=None, org_id=None, request_id=None):
-    if _CFG.payload_tracker_enabled is False or request_id is None:
+    if _CFG.payload_tracker_enabled is False or _CFG.replica_namespace is True or request_id is None:
         return NullPayloadTracker()
 
     payload_tracker = KafkaPayloadTracker(

--- a/app/payload_tracker/__init__.py
+++ b/app/payload_tracker/__init__.py
@@ -22,6 +22,9 @@ def init_payload_tracker(config, producer=None):
     if producer is not None:
         logger.info(f"Using injected producer object ({producer}) for PayloadTracker")
         _PRODUCER = producer
+    elif config.replica_namespace:
+        logger.info("Starting NullProducer() PayloadTracker - Kafka operations disabled in replica cluster")
+        _PRODUCER = NullProducer()
     else:
         logger.info("Starting KafkaProducer() for PayloadTracker")
         _PRODUCER = KafkaProducer(**config.payload_tracker_kafka_producer)

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -177,6 +177,8 @@ objects:
               name: segmentio
               key: WRITE_KEY
               optional: true
+        - name: REPLICA_NAMESPACE
+          value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_SERVICE}
@@ -335,6 +337,8 @@ objects:
               name: segmentio
               key: WRITE_KEY
               optional: true
+        - name: REPLICA_NAMESPACE
+          value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_SERVICE}
@@ -491,6 +495,8 @@ objects:
               name: segmentio
               key: WRITE_KEY
               optional: true
+        - name: REPLICA_NAMESPACE
+          value: ${REPLICA_NAMESPACE}
         - name: RBAC_PSKS
           valueFrom:
             secretKeyRef:
@@ -616,6 +622,8 @@ objects:
               key: psks.json
               name: rbac-psks
               optional: false
+        - name: REPLICA_NAMESPACE
+          value: ${REPLICA_NAMESPACE}
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3
@@ -725,6 +733,8 @@ objects:
               optional: false
         - name: HOSTS_TABLE_NUM_PARTITIONS
           value: ${HOSTS_TABLE_NUM_PARTITIONS}
+        - name: REPLICA_NAMESPACE
+          value: ${REPLICA_NAMESPACE}
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3
@@ -819,6 +829,8 @@ objects:
           value: ${MQ_DB_BATCH_MAX_MESSAGES}
         - name: MQ_DB_BATCH_MAX_SECONDS
           value: ${MQ_DB_BATCH_MAX_SECONDS}
+        - name: REPLICA_NAMESPACE
+          value: ${REPLICA_NAMESPACE}
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3
@@ -917,6 +929,8 @@ objects:
               key: psks.json
               name: rbac-psks
               optional: false
+        - name: REPLICA_NAMESPACE
+          value: ${REPLICA_NAMESPACE}
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3
@@ -988,6 +1002,8 @@ objects:
           value: ${FF_LAST_CHECKIN}
         - name: UNLEASH_REFRESH_INTERVAL
           value: ${UNLEASH_REFRESH_INTERVAL}
+        - name: REPLICA_NAMESPACE
+          value: ${REPLICA_NAMESPACE}
         image: ${IMAGE}:${IMAGE_TAG}
         livenessProbe:
           failureThreshold: 3
@@ -1088,6 +1104,8 @@ objects:
                 key: psks.json
                 name: rbac-psks
                 optional: false
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_REAPER}
@@ -1152,6 +1170,8 @@ objects:
             value: ${UNLEASH_REFRESH_INTERVAL}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_STALE_HOST_NOTIFICAION}
@@ -1272,6 +1292,8 @@ objects:
             value: ${FF_LAST_CHECKIN}
           - name: UNLEASH_REFRESH_INTERVAL
             value: ${UNLEASH_REFRESH_INTERVAL}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_SP_VALIDATOR}
@@ -1393,6 +1415,8 @@ objects:
             value: ${UNLEASH_REFRESH_INTERVAL}
           - name: REBUILD_EVENTS_TIME_LIMIT
             value: ${REBUILD_EVENTS_TIME_LIMIT}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_SYNCHRONIZER}
@@ -1462,6 +1486,8 @@ objects:
             value: ${UNLEASH_REFRESH_INTERVAL}
           - name: REBUILD_EVENTS_TIME_LIMIT
             value: ${REBUILD_EVENTS_TIME_LIMIT}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_SYNCHRONIZER}
@@ -1576,6 +1602,8 @@ objects:
             value: ${UNLEASH_REFRESH_INTERVAL}
           - name: BYPASS_KESSEL_JOBS
             value: ${BYPASS_KESSEL_JOBS}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_UNGROUPED_HOSTS_JOB}
@@ -1686,6 +1714,8 @@ objects:
               secretKeyRef:
                 name: ${DELETE_HOSTS_S3_AWS_SECRET}
                 key: bucket
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_GROUPS_S3_EXPORT}
@@ -1755,6 +1785,8 @@ objects:
             value: ${BYPASS_KESSEL_JOBS}
           - name: ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE
             value: ${ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_UNGROUPED_HOSTS_JOB}
@@ -1888,6 +1920,8 @@ objects:
             value: ${UNLEASH_REFRESH_INTERVAL}
           - name: HOST_DELETE_CHUNK_SIZE
             value: ${HOST_DELETE_CHUNK_SIZE}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_HOSTS_WITHOUT_ID_FACTS_JOB}
@@ -2655,3 +2689,9 @@ parameters:
 - name: FLOORIST_DB_SECRET_NAME
   description: database secret name
   value: host-inventory-db
+
+
+# Replica namespace
+- name: REPLICA_NAMESPACE
+  description: Disable Kafka operations in the replica namespace
+  value: 'false'

--- a/inv_export_service.py
+++ b/inv_export_service.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import sys
+import time
 from functools import partial
 
 from confluent_kafka import Consumer as KafkaConsumer
@@ -20,7 +21,15 @@ def main():
     config = application.app.config["INVENTORY_CONFIG"]
 
     if config.replica_namespace:
-        logger.info("Running in replica cluster - skipping export service")
+        logger.info("Running in replica cluster - sleeping until shutdown")
+
+        shutdown_handler = ShutdownHandler()
+        shutdown_handler.register()
+
+        while not shutdown_handler.shut_down():
+            time.sleep(1)
+
+        logger.info("Shutdown signal received, exiting gracefully")
         sys.exit(0)
 
     start_http_server(config.metrics_port)

--- a/inv_export_service.py
+++ b/inv_export_service.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+import sys
 from functools import partial
 
 from confluent_kafka import Consumer as KafkaConsumer
@@ -17,6 +18,11 @@ logger = get_logger("export_sevice_mq")
 def main():
     application = create_app(RuntimeEnvironment.SERVICE)
     config = application.app.config["INVENTORY_CONFIG"]
+
+    if config.replica_namespace:
+        logger.info("Running in replica cluster - skipping export service")
+        sys.exit(0)
+
     start_http_server(config.metrics_port)
 
     consumer = KafkaConsumer(

--- a/inv_export_service.py
+++ b/inv_export_service.py
@@ -22,6 +22,7 @@ def main():
 
     if config.replica_namespace:
         logger.info("Running in replica cluster - sleeping until shutdown")
+        start_http_server(config.metrics_port)
 
         shutdown_handler = ShutdownHandler()
         shutdown_handler.register()

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -1,17 +1,17 @@
 #!/usr/bin/python
 
-from confluent_kafka import Consumer as KafkaConsumer
 from prometheus_client import start_http_server
 
 from api.cache import init_cache
 from app import create_app
 from app.environment import RuntimeEnvironment
 from app.logging import get_logger
-from app.queue.event_producer import EventProducer
+from app.queue.event_producer import create_event_producer
 from app.queue.host_mq import HBIMessageConsumerBase
 from app.queue.host_mq import IngressMessageConsumer
 from app.queue.host_mq import SystemProfileMessageConsumer
 from app.queue.host_mq import WorkspaceMessageConsumer
+from app.queue.host_mq import create_consumer
 from lib.handlers import ShutdownHandler
 from lib.handlers import register_shutdown
 
@@ -30,21 +30,14 @@ def main():
         config.workspaces_topic: WorkspaceMessageConsumer,
     }
 
-    consumer = KafkaConsumer(
-        {
-            "group.id": config.host_ingress_consumer_group,
-            "bootstrap.servers": config.bootstrap_servers,
-            "auto.offset.reset": "earliest",
-            **config.kafka_consumer,
-        }
-    )
+    consumer = create_consumer(config)
     consumer.subscribe([config.kafka_consumer_topic])
     register_shutdown(consumer.close, "Closing consumer")
 
-    event_producer = EventProducer(config, config.event_topic)
+    event_producer = create_event_producer(config, config.event_topic)
     register_shutdown(event_producer.close, "Closing producer")
 
-    notification_event_producer = EventProducer(config, config.notification_topic)
+    notification_event_producer = create_event_producer(config, config.notification_topic)
     register_shutdown(notification_event_producer.close, "Closing notification producer")
 
     shutdown_handler = ShutdownHandler()

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -94,6 +94,11 @@ def run(config, logger, session, consumer, event_producer, shutdown_handler):
 def main(logger):
     application = create_app(RuntimeEnvironment.JOB)
     config = application.app.config["INVENTORY_CONFIG"]
+
+    if config.replica_namespace:
+        logger.info("Running in replica cluster - skipping event topic rebuild")
+        sys.exit(0)
+
     Session = _init_db(config)
     session = Session()
     # TODO: Metrics

--- a/rebuild_events_topic.py
+++ b/rebuild_events_topic.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import json
 import sys
+import time
 from datetime import datetime
 from datetime import timedelta
 from functools import partial
@@ -96,7 +97,15 @@ def main(logger):
     config = application.app.config["INVENTORY_CONFIG"]
 
     if config.replica_namespace:
-        logger.info("Running in replica cluster - skipping event topic rebuild")
+        logger.info("Running in replica cluster - sleeping until shutdown")
+
+        shutdown_handler = ShutdownHandler()
+        shutdown_handler.register()
+
+        while not shutdown_handler.shut_down():
+            time.sleep(1)
+
+        logger.info("Shutdown signal received, exiting gracefully")
         sys.exit(0)
 
     Session = _init_db(config)

--- a/system_profile_validator.py
+++ b/system_profile_validator.py
@@ -176,6 +176,10 @@ def _validate_schema_for_pr_and_generate_comment(pr_number: str, config: Config)
 def main(logger):
     config = _init_config()
 
+    if config.replica_namespace:
+        logger.info("Running in replica cluster - skipping schema validation")
+        sys.exit(0)
+
     # Get list of PRs that require validation
     logger.info("Starting validation check.")
     prs_to_validate = _get_prs_that_require_validation(REPO_OWNER, REPO_NAME)

--- a/tests/test_kafka_null_implementations.py
+++ b/tests/test_kafka_null_implementations.py
@@ -1,0 +1,394 @@
+# ruff: noqa: ARG002
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from app.payload_tracker import NullProducer
+from app.queue.event_producer import NullEventProducer
+from app.queue.event_producer import create_event_producer
+from app.queue.host_mq import NullConsumer
+from app.queue.host_mq import create_consumer
+
+
+class TestNullConsumer:
+    """Test cases for NullConsumer class"""
+
+    def test_null_consumer_initialization(self):
+        """Test that NullConsumer initializes correctly"""
+        config = Mock()
+        config.replica_namespace = True
+
+        consumer = NullConsumer(config)
+
+        assert consumer.config == config
+
+    def test_null_consumer_consume_returns_empty_list(self):
+        """Test that consume method returns empty list"""
+        config = Mock()
+        consumer = NullConsumer(config)
+
+        result = consumer.consume(num_messages=10, timeout=5.0)
+
+        assert result == []
+
+    def test_null_consumer_consume_with_default_parameters(self):
+        """Test that consume method works with default parameters"""
+        config = Mock()
+        consumer = NullConsumer(config)
+
+        result = consumer.consume()
+
+        assert result == []
+
+    def test_null_consumer_subscribe_does_nothing(self):
+        """Test that subscribe method doesn't perform any action"""
+        config = Mock()
+        consumer = NullConsumer(config)
+        topics = ["topic1", "topic2"]
+
+        # Should not raise any exception
+        consumer.subscribe(topics)
+
+    def test_null_consumer_close_does_nothing(self):
+        """Test that close method doesn't perform any action"""
+        config = Mock()
+        consumer = NullConsumer(config)
+
+        # Should not raise any exception
+        consumer.close()
+
+
+class TestNullProducer:
+    """Test cases for NullProducer class"""
+
+    def test_null_producer_produce_logs_message(self, capsys):
+        """Test that produce method prints the message"""
+        producer = NullProducer()
+        topic = "test-topic"
+        msg = "test-message"
+
+        producer.produce(topic, msg)
+
+        captured = capsys.readouterr()
+        assert f"sending message: {topic} - {msg}" in captured.out
+
+    def test_null_producer_poll_does_nothing(self):
+        """Test that poll method does nothing"""
+        producer = NullProducer()
+
+        # Should not raise any exception
+        producer.poll(timeout=1.0)
+        producer.poll()  # With default timeout
+
+
+class TestNullEventProducer:
+    """Test cases for NullEventProducer class"""
+
+    def test_null_event_producer_initialization(self):
+        """Test that NullEventProducer initializes correctly"""
+        config = Mock()
+        topic = "test-topic"
+
+        producer = NullEventProducer(config, topic)
+
+        assert producer.mq_topic == topic
+
+    def test_null_event_producer_write_event_does_nothing(self):
+        """Test that write_event method doesn't perform any action"""
+        config = Mock()
+        topic = "test-topic"
+        producer = NullEventProducer(config, topic)
+
+        event = "test-event"
+        key = "test-key"
+        headers = {"header1": "value1"}
+
+        # Should not raise any exception
+        producer.write_event(event, key, headers, wait=True)
+
+    def test_null_event_producer_write_event_without_wait(self):
+        """Test that write_event method works without wait parameter"""
+        config = Mock()
+        topic = "test-topic"
+        producer = NullEventProducer(config, topic)
+
+        event = "test-event"
+        key = "test-key"
+        headers = {"header1": "value1"}
+
+        # Should not raise any exception
+        producer.write_event(event, key, headers)
+
+    def test_null_event_producer_close_does_nothing(self):
+        """Test that close method doesn't perform any action"""
+        config = Mock()
+        topic = "test-topic"
+        producer = NullEventProducer(config, topic)
+
+        # Should not raise any exception
+        producer.close()
+
+
+class TestFactoryFunctions:
+    """Test cases for factory functions that create null implementations"""
+
+    def test_create_consumer_returns_null_consumer_when_replica_namespace(self):
+        """Test that create_consumer returns NullConsumer when replica_namespace is True"""
+        config = Mock()
+        config.replica_namespace = True
+        config.host_ingress_consumer_group = "test-group"
+        config.bootstrap_servers = "localhost:9092"
+        config.kafka_consumer = {}
+
+        consumer = create_consumer(config)
+
+        assert isinstance(consumer, NullConsumer)
+        assert consumer.config == config
+
+    def test_create_consumer_returns_real_consumer_when_not_replica_namespace(self):
+        """Test that create_consumer returns real Consumer when replica_namespace is False"""
+        config = Mock()
+        config.replica_namespace = False
+        config.host_ingress_consumer_group = "test-group"
+        config.bootstrap_servers = "localhost:9092"
+        config.kafka_consumer = {}
+
+        with patch("app.queue.host_mq.Consumer") as mock_consumer_class:
+            mock_consumer = Mock()
+            mock_consumer_class.return_value = mock_consumer
+
+            consumer = create_consumer(config)
+
+            assert consumer == mock_consumer
+            mock_consumer_class.assert_called_once_with(
+                {
+                    "group.id": "test-group",
+                    "bootstrap.servers": "localhost:9092",
+                    "auto.offset.reset": "earliest",
+                    **config.kafka_consumer,
+                }
+            )
+
+    def test_create_event_producer_returns_null_producer_when_replica_namespace(self):
+        """Test that create_event_producer returns NullEventProducer when replica_namespace is True"""
+        config = Mock()
+        config.replica_namespace = True
+        topic = "test-topic"
+
+        producer = create_event_producer(config, topic)
+
+        assert isinstance(producer, NullEventProducer)
+        assert producer.mq_topic == topic
+
+    def test_create_event_producer_returns_real_producer_when_not_replica_namespace(self):
+        """Test that create_event_producer returns EventProducer when replica_namespace is False"""
+        config = Mock()
+        config.replica_namespace = False
+        config.bootstrap_servers = "localhost:9092"
+        config.kafka_producer = {}
+        topic = "test-topic"
+
+        with patch("app.queue.event_producer.EventProducer") as mock_producer_class:
+            mock_producer = Mock()
+            mock_producer_class.return_value = mock_producer
+
+            producer = create_event_producer(config, topic)
+
+            assert producer == mock_producer
+            mock_producer_class.assert_called_once_with(config, topic)
+
+
+class TestNullConsumerIntegration:
+    """Integration tests for NullConsumer with HBIMessageConsumerBase"""
+
+    def test_null_consumer_in_event_loop_returns_empty_messages(self, mocker):
+        """Test that NullConsumer works correctly in the event loop context"""
+        from app.queue.host_mq import HBIMessageConsumerBase
+
+        # Mock the consumer
+        config = Mock()
+        config.replica_namespace = True
+        null_consumer = NullConsumer(config)
+
+        # Mock flask app and other dependencies
+        flask_app = Mock()
+        flask_app.app = Mock()
+        flask_app.app.app_context = Mock()
+        flask_app.app.app_context.return_value.__enter__ = Mock()
+        flask_app.app.app_context.return_value.__exit__ = Mock()
+        event_producer = Mock()
+        notification_event_producer = Mock()
+
+        # Create a concrete implementation of HBIMessageConsumerBase for testing
+        class TestConsumer(HBIMessageConsumerBase):
+            def process_message(self, *args, **kwargs):
+                return None, None, None, None
+
+            def handle_message(self, *args, **kwargs):
+                return None
+
+        consumer = TestConsumer(null_consumer, flask_app, event_producer, notification_event_producer)
+
+        # Mock the interrupt function to return True after first iteration
+        interrupt = mocker.Mock(side_effect=[False, True])
+
+        # Mock inventory_config
+        mock_config = Mock()
+        mock_config.mq_db_batch_max_messages = 10
+        mock_config.mq_db_batch_max_seconds = 1.0
+        mocker.patch("app.queue.host_mq.inventory_config", return_value=mock_config)
+
+        # Mock session_guard and db.session
+        mock_session = Mock()
+        mock_session.no_autoflush = Mock()
+        mocker.patch("app.queue.host_mq.db.session", mock_session)
+        mocker.patch("app.queue.host_mq.session_guard", return_value=Mock())
+
+        # This should not raise any exceptions and should exit cleanly
+        consumer.event_loop(interrupt)
+
+        # The test passes if no exception is raised
+        # The NullConsumer.consume method returns an empty list, which is the expected behavior
+
+
+class TestNullProducerIntegration:
+    """Integration tests for NullProducer with payload tracker"""
+
+    def test_null_producer_with_payload_tracker(self, mocker):
+        """Test that NullProducer works correctly with payload tracker"""
+        from app.payload_tracker import get_payload_tracker
+
+        # Mock config
+        config = Mock()
+        config.payload_tracker_enabled = True
+        config.replica_namespace = True
+        config.payload_tracker_kafka_topic = "test-topic"
+        config.payload_tracker_service_name = "test-service"
+
+        # Mock the producer
+        null_producer = NullProducer()
+
+        # Mock init_payload_tracker
+        mocker.patch("app.payload_tracker._CFG", config)
+        mocker.patch("app.payload_tracker._PRODUCER", null_producer)
+
+        # Get payload tracker
+        tracker = get_payload_tracker(request_id="test-request-id")
+
+        # Should be a NullPayloadTracker when replica_namespace is True
+        from app.payload_tracker import NullPayloadTracker
+
+        assert isinstance(tracker, NullPayloadTracker)
+
+        # All methods should not raise exceptions
+        tracker.payload_received("test")
+        tracker.payload_success("test")
+        tracker.payload_error("test")
+        tracker.processing("test")
+        tracker.processing_success("test")
+        tracker.processing_error("test")
+
+        # inventory_id property should work
+        tracker.inventory_id = "test-id"
+        assert tracker.inventory_id is None  # NullPayloadTracker returns None
+
+
+class TestNullEventProducerIntegration:
+    """Integration tests for NullEventProducer with message consumers"""
+
+    def test_null_event_producer_with_message_consumer(self, mocker):
+        """Test that NullEventProducer works correctly with message consumers"""
+        from app.queue.host_mq import IngressMessageConsumer
+
+        # Mock config
+        config = Mock()
+        config.replica_namespace = True
+
+        # Create null event producer
+        null_producer = NullEventProducer(config, "test-topic")
+
+        # Mock consumer
+        mock_consumer = Mock()
+
+        # Mock flask app
+        flask_app = Mock()
+
+        # Create message consumer with null event producer
+        # Note: Using type: ignore because NullEventProducer is compatible with EventProducer interface
+        consumer = IngressMessageConsumer(mock_consumer, flask_app, null_producer, null_producer)
+
+        # Verify that the null producer is used
+        assert consumer.event_producer == null_producer
+        assert consumer.notification_event_producer == null_producer
+
+        # Test that write_event doesn't raise exceptions
+        null_producer.write_event("test-event", "test-key", {"header": "value"})
+        null_producer.close()
+
+
+class TestNullImplementationsEdgeCases:
+    """Test edge cases and error conditions for null implementations"""
+
+    def test_null_consumer_with_none_config(self):
+        """Test NullConsumer with None config"""
+        consumer = NullConsumer(None)
+        assert consumer.config is None
+
+        # Should still work without errors
+        result = consumer.consume()
+        assert result == []
+
+        consumer.subscribe(["topic"])
+        consumer.close()
+
+    def test_null_producer_with_none_values(self, capsys):
+        """Test NullProducer with None values"""
+        producer = NullProducer()
+
+        producer.produce(None, None)
+        captured = capsys.readouterr()
+        assert "sending message: None - None" in captured.out
+
+        producer.poll(0.0)  # Use 0.0 instead of None for timeout
+
+    def test_null_event_producer_with_none_values(self):
+        """Test NullEventProducer with None values"""
+        config = Mock()
+        producer = NullEventProducer(config, None)
+
+        # Should not raise any exception
+        producer.write_event(None, None, None)
+
+    def test_null_consumer_multiple_calls(self):
+        """Test that NullConsumer can be called multiple times without issues"""
+        config = Mock()
+        consumer = NullConsumer(config)
+
+        # Multiple consume calls
+        for i in range(5):
+            result = consumer.consume(num_messages=i, timeout=float(i))
+            assert result == []
+
+        # Multiple subscribe calls
+        topics_list = [["topic1"], ["topic2", "topic3"], []]
+        for topics in topics_list:
+            consumer.subscribe(topics)
+
+        # Multiple close calls
+        for _ in range(3):
+            consumer.close()
+
+    def test_null_producer_multiple_calls(self, capsys):
+        """Test that NullProducer can be called multiple times without issues"""
+        producer = NullProducer()
+
+        # Multiple produce calls
+        for i in range(5):
+            producer.produce(f"topic{i}", f"message{i}")
+
+        # Multiple poll calls
+        for i in range(3):
+            producer.poll(timeout=float(i))
+
+        captured = capsys.readouterr()
+        for i in range(5):
+            assert f"sending message: topic{i} - message{i}" in captured.out


### PR DESCRIPTION
# Overview

This PR is being created to make it possible to disable all Kafka operations on replica clusters (e.g. Prod replica)

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Disable Kafka operations in replica namespaces by propagating a REPLICA_NAMESPACE flag through deployment and application configuration, providing no-op Kafka consumer/producer implementations, and short-circuiting Kafka-dependent workflows when running in replica clusters.

New Features:
- Introduce a replica_namespace configuration flag read from the REPLICA_NAMESPACE environment variable to toggle Kafka operations off in replica clusters.
- Provide NullConsumer and NullEventProducer no-op implementations with create_consumer and create_event_producer factory methods.
- Short-circuit Kafka-dependent services (host ingestion, event production, export, rebuild jobs, schema validation, and payload tracking) to skip or exit early when replica_namespace is enabled.

Enhancements:
- Add REPLICA_NAMESPACE parameter to the clowdapp deployment configuration across all components.
- Extend application config to read and log the replica_namespace flag on startup.

Tests:
- Add unit tests for NullConsumer, NullEventProducer, factory functions, and payload tracker behavior under replica_namespace.
- Add integration tests to validate end-to-end no-op behavior of Kafka consumers, producers, and payload tracker in replica clusters.

## Summary by Sourcery

Disable Kafka operations in replica namespaces by introducing a replica_namespace flag, providing no-op Kafka implementations, and short-circuiting Kafka-dependent workflows when running in replica clusters

New Features:
- Introduce a replica_namespace configuration flag (REPLICA_NAMESPACE) to disable Kafka operations in replica clusters
- Provide NullConsumer and NullEventProducer no-op implementations with create_consumer and create_event_producer factory functions
- Short-circuit Kafka-dependent services and jobs (host ingestion, event production, export, rebuild jobs, schema validation, and payload tracking) when replica_namespace is enabled

Enhancements:
- Extend application configuration to read and log the replica_namespace flag on startup

Deployment:
- Add REPLICA_NAMESPACE environment variable to all components in the ClowdApp deployment manifest

Tests:
- Add unit and integration tests for null Kafka consumers, producers, and payload tracker behavior under replica_namespace