### PR TITLE
chore(RHINENG-19364) Remove use-cached-insights-client-system feature flag

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -10,7 +10,6 @@ from app.logging import get_logger
 UNLEASH = Unleash()
 logger = get_logger(__name__)
 
-FLAG_INVENTORY_USE_CACHED_INSIGHTS_CLIENT_SYSTEM = "hbi.api.use-cached-insights-client-system"
 FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION = "hbi.api.kessel-workspace-migration"
 FLAG_INVENTORY_API_READ_ONLY = "hbi.api.read-only"
 FLAG_INVENTORY_KESSEL_PHASE_1 = "hbi.api.kessel-phase-1"
@@ -22,7 +21,6 @@ FLAG_INVENTORY_FILTER_STALENESS_USING_COLUMNS = "hbi.filter_staleness_using_colu
 ENV_FLAG_LAST_CHECKIN_PER_REPORTER_STALENESS = os.getenv("FF_LAST_CHECKIN", "false").lower() == "true"
 
 FLAG_FALLBACK_VALUES = {
-    FLAG_INVENTORY_USE_CACHED_INSIGHTS_CLIENT_SYSTEM: False,
     FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION: False,
     FLAG_INVENTORY_API_READ_ONLY: False,
     FLAG_INVENTORY_KESSEL_PHASE_1: False,


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19364](https://issues.redhat.com/browse/RHINENG-19364).
Removes the `hbi.api.use-cached-insights-client-system` feature flag from the repo. We've left this feature flag enabled in both Stage and Prod for a long time, and have no plans to disable it. So, I'm removing these references to reduce complexity.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Remove the obsolete use-cached-insights-client-system feature flag and simplify related code paths to always apply system caching.

Enhancements:
- Eliminate feature flag declaration and fallback configuration from feature_flags.py
- Unconditionally apply cached insights client system logic in write_add_update_event_message
- Always update last check-in date and staleness timestamps in host_checkin
- Remove conditional paths and logging in get_host_list associated with the deleted feature flag