### PR TITLE
fix(RHINENG-17234): Fix remove_unique_group_name_restriction' DB migration

### DIFF
--- a/migrations/versions/5baf9b7b3166_remove_unique_group_name_restriction.py
+++ b/migrations/versions/5baf9b7b3166_remove_unique_group_name_restriction.py
@@ -34,6 +34,7 @@ def upgrade():
             schema="hbi",
             postgresql_concurrently=True,
         )
+        op.execute("SELECT 1")
 
 
 def downgrade():
@@ -54,3 +55,4 @@ def downgrade():
             schema="hbi",
             postgresql_concurrently=True,
         )
+        op.execute("SELECT 1")

--- a/migrations/versions/5baf9b7b3166_remove_unique_group_name_restriction.py
+++ b/migrations/versions/5baf9b7b3166_remove_unique_group_name_restriction.py
@@ -17,38 +17,40 @@ depends_on = None
 
 
 def upgrade():
-    op.create_index(
-        "idx_groups_org_id_name_ignorecase",
-        "groups",
-        [text("lower(name)"), "org_id"],
-        if_not_exists=True,
-        unique=False,
-        schema="hbi",
-        postgresql_concurrently=True,
-    )
-    op.drop_index(
-        "idx_groups_org_id_name_nocase",
-        table_name="groups",
-        if_exists=True,
-        schema="hbi",
-        postgresql_concurrently=True,
-    )
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "idx_groups_org_id_name_ignorecase",
+            "groups",
+            [text("lower(name)"), "org_id"],
+            if_not_exists=True,
+            unique=False,
+            schema="hbi",
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            "idx_groups_org_id_name_nocase",
+            table_name="groups",
+            if_exists=True,
+            schema="hbi",
+            postgresql_concurrently=True,
+        )
 
 
 def downgrade():
-    op.drop_index(
-        "idx_groups_org_id_name_ignorecase",
-        "groups",
-        if_exists=True,
-        schema="hbi",
-        postgresql_concurrently=True,
-    )
-    op.create_index(
-        "idx_groups_org_id_name_nocase",
-        "groups",
-        [text("lower(name)"), "org_id"],
-        if_not_exists=True,
-        unique=True,
-        schema="hbi",
-        postgresql_concurrently=True,
-    )
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "idx_groups_org_id_name_ignorecase",
+            "groups",
+            if_exists=True,
+            schema="hbi",
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "idx_groups_org_id_name_nocase",
+            "groups",
+            [text("lower(name)"), "org_id"],
+            if_not_exists=True,
+            unique=True,
+            schema="hbi",
+            postgresql_concurrently=True,
+        )


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17234](https://issues.redhat.com/browse/RHINENG-17234).
It fixes a DB migration introduced in https://github.com/RedHatInsights/insights-host-inventory/pull/2743

Slack thread: https://redhat-internal.slack.com/archives/CQFKM031T/p1752571067242319

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Remove postgresql_concurrently parameter from op.create_index and op.drop_index calls in both upgrade and downgrade