### PR TITLE
Add ability to suspend 2 jobs

### DIFF
--- a/delete_hosts_s3.py
+++ b/delete_hosts_s3.py
@@ -25,6 +25,8 @@ LOGGER_NAME = "delete_hosts_s3"
 RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
 S3_OBJECT_KEY = "host_ids.csv"
 BATCH_SIZE = int(os.getenv("DELETE_HOSTS_S3_BATCH_SIZE", 500))
+SUSPEND_JOB = os.environ.get("SUSPEND_JOB", "true").lower() == "true"
+
 
 # Vars to keep track of the number of hosts deleted, not deleted, and not found
 deleted_count = 0
@@ -169,6 +171,9 @@ def run(
 
 if __name__ == "__main__":
     logger = get_logger(LOGGER_NAME)
+    if SUSPEND_JOB:
+        logger.info("SUSPEND_JOB set to true; exiting.")
+
     job_type = "Delete host IDs via S3"
     sys.excepthook = partial(excepthook, logger, job_type)
 

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1716,6 +1716,8 @@ objects:
                 key: bucket
           - name: REPLICA_NAMESPACE
             value: ${REPLICA_NAMESPACE}
+          - name: SUSPEND_JOB
+            value: ${SUSPEND_DELETE_HOSTS_S3}
         resources:
           limits:
             cpu: ${CPU_LIMIT_GROUPS_S3_EXPORT}
@@ -1977,6 +1979,8 @@ objects:
             value: ${SCRIPT_CHUNK_SIZE}
           - name: DRY_RUN
             value: ${REMOVE_DUPLICATES_DRY_RUN}
+          - name: SUSPEND_JOB
+            value: ${SUSPEND_DUPLICATE_HOSTS_REMOVER}
         resources:
           limits:
             cpu: ${CPU_LIMIT_DUPLICATE_HOSTS_REMOVER_JOB}
@@ -2698,6 +2702,12 @@ parameters:
 - name: HOSTS_TABLE_NUM_PARTITIONS
   description: The number of partitions for the hosts table
   value: '1'
+- name: SUSPEND_DELETE_HOSTS_S3
+  description: If set to true, the delete-hosts-s3 job will immediately exit upon running.
+  value: 'true'
+- name: SUSPEND_DUPLICATE_HOSTS_REMOVER
+  description: If set to true, the duplicate-hosts-remover job will immediately exit upon running.
+  value: 'true'
 
 # NGINX
 - displayName: Minimum replicas

--- a/host_delete_duplicates.py
+++ b/host_delete_duplicates.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from functools import partial
 from logging import Logger
@@ -27,6 +28,7 @@ PROMETHEUS_JOB = "duplicate-hosts-remover"
 LOGGER_NAME = "duplicate-hosts-remover"
 COLLECTED_METRICS = (delete_duplicate_host_count,)
 RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
+SUSPEND_JOB = os.environ.get("SUSPEND_JOB", "true").lower() == "true"
 
 
 def run(
@@ -75,6 +77,9 @@ def run(
 
 if __name__ == "__main__":
     logger = get_logger(LOGGER_NAME)
+    if SUSPEND_JOB:
+        logger.info("SUSPEND_JOB set to true; exiting.")
+
     job_type = "Delete duplicate hosts"
     sys.excepthook = partial(excepthook, logger, job_type)
 


### PR DESCRIPTION
# Overview

This PR is being created to unblock the Prod release. Adds `SUSPEND_DELETE_HOSTS_S3` and `SUSPEND_DUPLICATE_HOSTS_REMOVER` template params; these control the `SUSPEND_JOB` env var for their respective jobs. When this var is set to "true", these jobs will exit immediately upon starting up.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
