### PR TITLE
Host group sync fix

### DIFF
--- a/app/serialization.py
+++ b/app/serialization.py
@@ -135,7 +135,7 @@ def serialize_host(
     system_profile_fields=None,
 ):
     # Ensure additional_fields is a tuple
-    additional_fields = additional_fields or tuple()
+    additional_fields = additional_fields or ()
 
     timestamps = get_staleness_timestamps(host, staleness_timestamps, staleness)
 
@@ -177,7 +177,7 @@ def serialize_host(
     }
 
     # Process each field dynamically
-    serialized_host.update({key: func() for key, func in field_mapping.items() if key in fields})
+    serialized_host |= {key: func() for key, func in field_mapping.items() if key in fields}
 
     # Handle system_profile separately due to its complexity
     if "system_profile" in fields:
@@ -232,6 +232,18 @@ def serialize_host_for_export_svc(
 
     serialized_host = {key: serialized_host[key] for key in _EXPORT_SERVICE_FIELDS}
     return serialized_host
+
+
+def serialize_group_without_host_count(group: Group) -> dict:
+    return {
+        "id": _serialize_uuid(group.id),
+        "org_id": group.org_id,
+        "account": group.account,
+        "name": group.name,
+        "ungrouped": group.ungrouped,
+        "created": _serialize_datetime(group.created_on),
+        "updated": _serialize_datetime(group.modified_on),
+    }
 
 
 def serialize_group_with_host_count(group: Group, host_count: int) -> dict:

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -247,9 +247,7 @@ def serialize_group_without_host_count(group: Group) -> dict:
 
 
 def serialize_group_with_host_count(group: Group, host_count: int) -> dict:
-    serialized_group = serialize_group_without_host_count(group)
-    serialized_group["host_count"] = host_count
-    return serialized_group
+    return {**serialize_group_without_host_count(group), "host_count": host_count}
 
 
 def serialize_host_system_profile(host):

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -247,16 +247,9 @@ def serialize_group_without_host_count(group: Group) -> dict:
 
 
 def serialize_group_with_host_count(group: Group, host_count: int) -> dict:
-    return {
-        "id": _serialize_uuid(group.id),
-        "org_id": group.org_id,
-        "account": group.account,
-        "name": group.name,
-        "host_count": host_count,
-        "ungrouped": group.ungrouped,
-        "created": _serialize_datetime(group.created_on),
-        "updated": _serialize_datetime(group.modified_on),
-    }
+    serialized_group = serialize_group_without_host_count(group)
+    serialized_group["host_count"] = host_count
+    return serialized_group
 
 
 def serialize_host_system_profile(host):

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -470,11 +470,7 @@ def _update_group_update_time(group_id: str, org_id: str):
 
 def get_group_using_host_id(host_id: str, org_id: str):
     assoc = db.session.query(HostGroupAssoc).filter(HostGroupAssoc.host_id == host_id).one_or_none()
-    if assoc:
-        # check current identity against db
-        return get_group_by_id_from_db(str(assoc.group_id), org_id)
-    else:
-        return None
+    return get_group_by_id_from_db(str(assoc.group_id), org_id) if assoc else None
 
 
 def get_or_create_ungrouped_hosts_group_for_identity(identity: Identity) -> Group:

--- a/lib/host_synchronize.py
+++ b/lib/host_synchronize.py
@@ -78,6 +78,7 @@ def sync_group_data(select_hosts_query, chunk_size, interrupt=lambda: False):
     num_failed = 0
 
     while len(host_list) > 0 and not interrupt():
+        logger.info(f"Processing batch of {len(host_list)}")
         for host in host_list:
             # If host.groups says it's empty,
             # Get the host's associated Group (if any) and store it in the "groups" field
@@ -90,6 +91,7 @@ def sync_group_data(select_hosts_query, chunk_size, interrupt=lambda: False):
         try:
             query.session.flush()
             num_updated += len(host_list)
+            logger.info(f"Changes flushed; {num_updated} updated so far.")
         except Exception as exc:
             logger.exception("Failed to sync host.groups data for batch.", exc_info=exc)
             num_failed += len(host_list)

--- a/lib/host_synchronize.py
+++ b/lib/host_synchronize.py
@@ -7,11 +7,11 @@ from app.models import Host
 from app.queue.events import EventType
 from app.queue.events import build_event
 from app.queue.events import message_headers
+from app.serialization import serialize_group_without_host_count
 from app.serialization import serialize_host
 from app.serialization import serialize_staleness_to_dict
 from app.staleness_serialization import get_sys_default_staleness
 from lib.group_repository import get_group_using_host_id
-from lib.group_repository import serialize_group
 from lib.metrics import synchronize_host_count
 
 logger = get_logger(__name__)
@@ -84,7 +84,7 @@ def sync_group_data(select_hosts_query, chunk_size, interrupt=lambda: False):
             if (host.groups is None or host.groups == []) and (
                 group := get_group_using_host_id(str(host.id), host.org_id)
             ):
-                host.groups = [serialize_group(group)]
+                host.groups = [serialize_group_without_host_count(group)]
 
         # flush changes, and then load next chunk using keyset pagination
         try:


### PR DESCRIPTION
# Overview

This PR changes the host-group-sync code so it doesn't include the host_count. This allows it to bypass some code that takes a long time to execute.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Refactor host-group serialization to omit the expensive host_count during host sync and streamline related utility methods

Bug Fixes:
- Exclude host_count from host.groups during synchronization by introducing serialize_group_without_host_count

Enhancements:
- Refactor serialize_group_with_host_count to delegate to the new serialize_group_without_host_count
- Simplify get_group_using_host_id with a single-line conditional
- Use tuple literal for default additional_fields and dict union operator for merging
- Add informational logging around batch processing in sync_group_data