### PR TITLE
fix: add missing REPLICA_NAMESPACE env vars

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1228,6 +1228,8 @@ objects:
             value: "${INVENTORY_DB_SCHEMA}"
           - name: PROMETHEUS_PUSHGATEWAY
             value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_SYNDICATOR}
@@ -1374,6 +1376,8 @@ objects:
             value: ${FF_LAST_CHECKIN}
           - name: UNLEASH_REFRESH_INTERVAL
             value: ${UNLEASH_REFRESH_INTERVAL}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_PENDO_SYNCHER}
@@ -1642,6 +1646,8 @@ objects:
             value: ${BYPASS_KESSEL_JOBS}
           - name: CREATE_UNGROUPED_GROUPS_BATCH_SIZE
             value: ${CREATE_UNGROUPED_GROUPS_BATCH_SIZE}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_UNGROUPED_HOSTS_JOB}
@@ -1761,6 +1767,8 @@ objects:
                 key: bucket
           - name: BYPASS_KESSEL_JOBS
             value: ${BYPASS_KESSEL_JOBS}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_GROUPS_S3_EXPORT}
@@ -1941,6 +1949,8 @@ objects:
                 fieldPath: metadata.namespace
           - name: CLOWDER_ENABLED
             value: "true"
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_HOSTS_LAST_CHECK_IN}
@@ -1975,6 +1985,8 @@ objects:
                 fieldPath: metadata.namespace
           - name: CLOWDER_ENABLED
             value: "true"
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_EDGE_HOSTS_PRS}
@@ -2105,6 +2117,8 @@ objects:
             value: ${REMOVE_DUPLICATES_DRY_RUN}
           - name: SUSPEND_JOB
             value: ${SUSPEND_DUPLICATE_HOSTS_REMOVER}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_DUPLICATE_HOSTS_REMOVER_JOB}


### PR DESCRIPTION
# Overview

This PR is being created to add the missing `REPLICA_NAMESPACE` env vars in the jobs definition.
Even though not all jobs interact with Kafka, I think is prudent to have this env var set for all of them just in case.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Include the REPLICA_NAMESPACE env var in multiple job specs within deploy/clowdapp.yml to prevent missing configuration issues.