### PR TITLE
chore(RHINENG-19488): disable host reaper when HBI is on read-only mode

### DIFF
--- a/host_reaper.py
+++ b/host_reaper.py
@@ -19,6 +19,8 @@ from app.queue.metrics import event_producer_success
 from app.queue.metrics import event_serialization_time
 from jobs.common import excepthook
 from jobs.common import job_setup as host_reaper_job_setup
+from lib.feature_flags import FLAG_INVENTORY_API_READ_ONLY
+from lib.feature_flags import get_flag_value
 from lib.host_delete import delete_hosts
 from lib.host_repository import find_hosts_by_staleness_job
 from lib.host_repository import find_hosts_sys_default_staleness
@@ -143,4 +145,10 @@ if __name__ == "__main__":
     config, session, event_producer, notification_event_producer, shutdown_handler, application = (
         host_reaper_job_setup(COLLECTED_METRICS, PROMETHEUS_JOB)
     )
+
+    with application.app.app_context():
+        if get_flag_value(FLAG_INVENTORY_API_READ_ONLY):
+            logger.info("Inventory API is currently in read-only mode. Exiting.")
+            sys.exit(0)
+
     run(config, logger, session, event_producer, notification_event_producer, shutdown_handler, application)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19488](https://issues.redhat.com/browse/RHINENG-19488).

We need to disable host reaper job execution when HBI is on read-only mode to prevent database write operations.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Disable host reaper execution when the inventory API is in read-only mode to prevent unintended database writes.

Bug Fixes:
- Add a check for the read-only feature flag to exit the host reaper job early when enabled

Enhancements:
- Log an informational message when the reaper exits due to read-only mode