### PR TITLE
add access decorator to hosts endpoints

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -176,6 +176,8 @@ def get_host_list(
 
 
 @api_operation
+@access(KesselResourceTypes.HOST.delete, writeOperation=True)
+@rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_hosts_by_filter(
     display_name=None,
@@ -287,6 +289,7 @@ def _delete_host_list(host_id_list, rbac_filter):
 
 
 @api_operation
+@access(KesselResourceTypes.HOST.delete, writeOperation=True)
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_all_hosts(confirm_delete_all=None, rbac_filter=None):
@@ -312,6 +315,7 @@ def delete_all_hosts(confirm_delete_all=None, rbac_filter=None):
 
 
 @api_operation
+@access(KesselResourceTypes.HOST.delete, id_param="host_id_list", writeOperation=True)
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_host_by_id(host_id_list, rbac_filter=None):
@@ -344,6 +348,7 @@ def get_host_by_id(host_id_list, page=1, per_page=100, order_by=None, order_how=
 
 
 @api_operation
+@access(KesselResourceTypes.HOST.view, id_param="host_id_list")
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
 def get_host_system_profile_by_id(
@@ -412,6 +417,7 @@ def patch_host_by_id(host_id_list, body, rbac_filter=None):
 
 
 @api_operation
+@access(KesselResourceTypes.HOST.write, id_param="host_id_list", writeOperation=True)
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def replace_facts(host_id_list, namespace, body, rbac_filter=None):
@@ -419,6 +425,7 @@ def replace_facts(host_id_list, namespace, body, rbac_filter=None):
 
 
 @api_operation
+@access(KesselResourceTypes.HOST.write, id_param="host_id_list", writeOperation=True)
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def merge_facts(host_id_list, namespace, body, rbac_filter=None):
@@ -488,6 +495,7 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict, rba
 
 
 @api_operation
+@access(KesselResourceTypes.HOST.view, id_param="host_id_list")
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
 def get_host_tag_count(host_id_list, page=1, per_page=100, order_by=None, order_how=None, rbac_filter=None):
@@ -499,6 +507,7 @@ def get_host_tag_count(host_id_list, page=1, per_page=100, order_by=None, order_
 
 
 @api_operation
+@access(KesselResourceTypes.HOST.view, id_param="host_id_list")
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
 def get_host_tags(host_id_list, page=1, per_page=100, order_by=None, order_how=None, search=None, rbac_filter=None):
@@ -516,6 +525,7 @@ def _build_paginated_host_tags_response(total, page, per_page, tags_list):
 
 
 @api_operation
+@access(KesselResourceTypes.HOST.write, writeOperation=True)
 @rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def host_checkin(body, rbac_filter=None):  # noqa: ARG001, required for all API endpoints, not needed for host checkins
@@ -542,6 +552,7 @@ def host_checkin(body, rbac_filter=None):  # noqa: ARG001, required for all API 
 
 
 @api_operation
+@access(KesselResourceTypes.HOST.view)
 @rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
 def get_host_exists(insights_id, rbac_filter=None):

--- a/api/host.py
+++ b/api/host.py
@@ -25,8 +25,7 @@ from api.host_query_db import get_host_list_by_id_list
 from api.host_query_db import get_host_tags_list_by_id_list
 from api.host_query_db import get_sparse_system_profile
 from api.staleness_query import get_staleness_obj
-from app import KesselResourceTypes, RbacPermission
-from app import RbacResourceType
+from app import KesselResourceTypes
 from app.auth import get_current_identity
 from app.auth.identity import IdentityType
 from app.auth.identity import to_auth_header
@@ -59,7 +58,6 @@ from lib.host_delete import delete_hosts
 from lib.host_repository import find_existing_host
 from lib.host_repository import find_non_culled_hosts
 from lib.host_repository import get_host_list_by_id_list_from_db
-from lib.middleware import rbac
 from lib.middleware import access
 
 FactOperations = Enum("FactOperations", ("merge", "replace"))
@@ -70,7 +68,6 @@ logger = get_logger(__name__)
 
 @api_operation
 @access(KesselResourceTypes.HOST.view)
-@rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
 def get_host_list(
     display_name=None,
@@ -177,7 +174,6 @@ def get_host_list(
 
 @api_operation
 @access(KesselResourceTypes.HOST.delete, writeOperation=True)
-@rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_hosts_by_filter(
     display_name=None,
@@ -290,7 +286,6 @@ def _delete_host_list(host_id_list, rbac_filter):
 
 @api_operation
 @access(KesselResourceTypes.HOST.delete, writeOperation=True)
-@rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_all_hosts(confirm_delete_all=None, rbac_filter=None):
     if not confirm_delete_all:
@@ -316,7 +311,6 @@ def delete_all_hosts(confirm_delete_all=None, rbac_filter=None):
 
 @api_operation
 @access(KesselResourceTypes.HOST.delete, id_param="host_id_list", writeOperation=True)
-@rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def delete_host_by_id(host_id_list, rbac_filter=None):
     delete_count = _delete_host_list(host_id_list, rbac_filter)
@@ -349,7 +343,6 @@ def get_host_by_id(host_id_list, page=1, per_page=100, order_by=None, order_how=
 
 @api_operation
 @access(KesselResourceTypes.HOST.view, id_param="host_id_list")
-@rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
 def get_host_system_profile_by_id(
     host_id_list, page=1, per_page=100, order_by=None, order_how=None, fields=None, rbac_filter=None
@@ -418,7 +411,6 @@ def patch_host_by_id(host_id_list, body, rbac_filter=None):
 
 @api_operation
 @access(KesselResourceTypes.HOST.write, id_param="host_id_list", writeOperation=True)
-@rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def replace_facts(host_id_list, namespace, body, rbac_filter=None):
     return update_facts_by_namespace(FactOperations.replace, host_id_list, namespace, body, rbac_filter)
@@ -426,7 +418,6 @@ def replace_facts(host_id_list, namespace, body, rbac_filter=None):
 
 @api_operation
 @access(KesselResourceTypes.HOST.write, id_param="host_id_list", writeOperation=True)
-@rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def merge_facts(host_id_list, namespace, body, rbac_filter=None):
     if not body:
@@ -496,7 +487,6 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict, rba
 
 @api_operation
 @access(KesselResourceTypes.HOST.view, id_param="host_id_list")
-@rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
 def get_host_tag_count(host_id_list, page=1, per_page=100, order_by=None, order_how=None, rbac_filter=None):
     limit, offset = pagination_params(page, per_page)
@@ -508,7 +498,6 @@ def get_host_tag_count(host_id_list, page=1, per_page=100, order_by=None, order_
 
 @api_operation
 @access(KesselResourceTypes.HOST.view, id_param="host_id_list")
-@rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
 def get_host_tags(host_id_list, page=1, per_page=100, order_by=None, order_how=None, search=None, rbac_filter=None):
     limit, offset = pagination_params(page, per_page)
@@ -526,7 +515,6 @@ def _build_paginated_host_tags_response(total, page, per_page, tags_list):
 
 @api_operation
 @access(KesselResourceTypes.HOST.write, writeOperation=True)
-@rbac(RbacResourceType.HOSTS, RbacPermission.WRITE)
 @metrics.api_request_time.time()
 def host_checkin(body, rbac_filter=None):  # noqa: ARG001, required for all API endpoints, not needed for host checkins
     current_identity = get_current_identity()
@@ -553,7 +541,6 @@ def host_checkin(body, rbac_filter=None):  # noqa: ARG001, required for all API 
 
 @api_operation
 @access(KesselResourceTypes.HOST.view)
-@rbac(RbacResourceType.HOSTS, RbacPermission.READ)
 @metrics.api_request_time.time()
 def get_host_exists(insights_id, rbac_filter=None):
     host_id = get_host_id_by_insights_id(insights_id, rbac_filter)


### PR DESCRIPTION
# Overview
This PR is being created to address [RHINENG-xxxx](https://issues.redhat.com/browse/RHINENG-xxxx).
(A description of your PR's changes, along with why/context to the PR, goes here.)


Add access decorator to remaining methods of hosts

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add fine-grained access control decorators to host management endpoints

Enhancements:
- Apply @access decorator with delete permissions to host deletion endpoints
- Apply @access decorator with view permissions to host retrieval endpoints
- Apply @access decorator with write permissions to host modification and check-in endpoints