### PR TITLE
chore: add hosts table migration jobs - suspend logic

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2088,6 +2088,8 @@ objects:
             value: ${HOSTS_TABLE_MIGRATION_BATCH_SIZE}
           - name: REPLICA_NAMESPACE
             value: ${REPLICA_NAMESPACE}
+          - name: SUSPEND_JOB
+            value: ${HOSTS_TABLE_MIGRATION_DATA_COPY_SUSPEND}
         resources:
           limits:
             cpu: ${CPU_REQUEST_HOSTS_TABLE_MIGRATION_DATA_COPY}
@@ -2124,6 +2126,8 @@ objects:
             value: ${HOSTS_TABLE_MIGRATION_SWITCH_MODE}
           - name: REPLICA_NAMESPACE
             value: ${REPLICA_NAMESPACE}
+          - name: SUSPEND_JOB
+            value: ${HOSTS_TABLE_MIGRATION_SWITCH_SUSPEND}
         resources:
           limits:
             cpu: ${CPU_REQUEST_HOSTS_TABLE_MIGRATION_SWITCH}

--- a/hosts_table_migration_data_copy.py
+++ b/hosts_table_migration_data_copy.py
@@ -19,6 +19,7 @@ from jobs.common import job_setup
 PROMETHEUS_JOB = "hosts-table-migration-data-copy"
 LOGGER_NAME = "hosts_table_migration_data_copy"
 RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
+SUSPEND_JOB = os.environ.get("SUSPEND_JOB", "true").lower() == "true"
 
 """
 This job copies all historical data from the original 'hosts' table into the
@@ -150,6 +151,11 @@ def run(logger: Logger, session: Session, application: FlaskApp):
 
 if __name__ == "__main__":
     logger = get_logger(LOGGER_NAME)
+
+    if SUSPEND_JOB:
+        logger.info("SUSPEND_JOB set to true; exiting.")
+        sys.exit(0)
+
     job_type = "Hosts partitioned tables full data copy"
     sys.excepthook = partial(excepthook, logger, job_type)
 

--- a/hosts_table_migration_switch.py
+++ b/hosts_table_migration_switch.py
@@ -19,6 +19,7 @@ from lib.db import session_guard
 PROMETHEUS_JOB = "hosts-table-migration-switch"
 LOGGER_NAME = "hosts_table_migration_switch"
 RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
+SUSPEND_JOB = os.environ.get("SUSPEND_JOB", "true").lower() == "true"
 
 """
 This job performs the final, atomic cutover to the new partitioned tables
@@ -133,6 +134,11 @@ def run(logger: Logger, session: Session, application: FlaskApp):
 
 if __name__ == "__main__":
     logger = get_logger(LOGGER_NAME)
+
+    if SUSPEND_JOB:
+        logger.info("SUSPEND_JOB set to true; exiting.")
+        sys.exit(0)
+
     job_type = "Hosts tables switch/rollback"
     sys.excepthook = partial(excepthook, logger, job_type)
 


### PR DESCRIPTION
# Overview

This PR is being created to add a functionality to suspend the hosts data migration jobs using an env var.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
