### PR TITLE
fix(RHINENG-19546): exclude ungrouped entities in groups queries

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2247,6 +2247,7 @@ objects:
             "created_on" AS "created_at",
             "modified_on" AS "updated_at"
           FROM "hbi"."groups"
+          WHERE "ungrouped" IS FALSE;
       - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/hosts_count
         query: >-
           SELECT COUNT(*) AS "hosts_count"
@@ -2254,7 +2255,8 @@ objects:
       - prefix: hms_analytics/inventory/${ENV_NAME}/groups_metrics/groups_count
         query: >-
           SELECT COUNT(*) AS "group_counts"
-          FROM "hbi"."groups";
+          FROM "hbi"."groups"
+          WHERE "ungrouped" IS FALSE;
       - prefix: hms_analytics/inventory/${ENV_NAME}/hosts_metrics/daily_created_by_reporters
         query: >-
           SELECT


### PR DESCRIPTION
- Updated SQL queries in `clowdapp.yml` to filter out ungrouped entities by adding `WHERE "ungrouped" IS FALSE` condition.
- Ensures accurate metrics for groups and hosts in analytics.

# Overview

This PR is being created to address [RHINENG-19546](https://issues.redhat.com/browse/RHINENG-19546).

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Exclude ungrouped entities from the inventory analytics by adding a WHERE "ungrouped" IS FALSE clause to groups list and count queries in clowdapp.yml.

Bug Fixes:
- Filter out ungrouped groups from the groups listing query to ensure only grouped entities are exported.
- Exclude ungrouped groups in the groups_count analytics query to correct group metrics.