### PR TITLE
feat(RHINENG-19769): Add 'discovery' to valid 'provider_type' values

### DIFF
--- a/app/models/constants.py
+++ b/app/models/constants.py
@@ -29,6 +29,7 @@ class ProviderType(str, Enum):
     ALIBABA = "alibaba"
     AWS = "aws"
     AZURE = "azure"
+    DISCOVERY = "discovery"
     GCP = "gcp"
     IBM = "ibm"
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1037,6 +1037,7 @@ components:
           - alibaba
           - aws
           - azure
+          - discovery
           - gcp
           - ibm
       description: Filter by provider_type

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1714,6 +1714,7 @@
             "alibaba",
             "aws",
             "azure",
+            "discovery",
             "gcp",
             "ibm"
           ]

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -121,7 +121,7 @@ def wrap_message(host_data, operation="add_host", platform_metadata=None, operat
     return message
 
 
-def assert_mq_host_data(actual_id, actual_event, expected_results, host_keys_to_check):
+def assert_mq_host_data(actual_id: str, actual_event: dict, expected_results: dict, host_keys_to_check: list[str]):
     assert actual_event["host"]["id"] == actual_id
 
     for key in host_keys_to_check:

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -2588,3 +2588,49 @@ def test_write_add_update_event_message(mocker):
     # Assert that all group fields were present when calling mock_set_cached_system
     cached_group = mock_set_cached_system.call_args[0][1]["groups"][0]
     assert cached_group == serialized_group
+
+
+@pytest.mark.parametrize("provider_type", ["alibaba", "aws", "azure", "discovery", "gcp", "ibm"])
+def test_add_host_with_provider_types(
+    mq_create_or_update_host: Callable,
+    db_get_host: Callable[[str], Host],
+    provider_type: str,
+) -> None:
+    """
+    Tests adding a host with various provider_type values via Kafka message
+    and validates that the host is successfully created in the database.
+    """
+    provider_id = generate_uuid()
+
+    host = minimal_host(provider_type=provider_type, provider_id=provider_id)
+
+    expected_results = {"host": {**host.data()}}
+    host_keys_to_check = ["provider_type", "provider_id"]
+
+    key, event, _ = mq_create_or_update_host(host, return_all_data=True)
+    assert_mq_host_data(key, event, expected_results, host_keys_to_check)
+
+    # Verify host was created in database with correct provider_type
+    created_host: Host = db_get_host(key)
+    assert created_host.canonical_facts["provider_type"] == provider_type
+    assert created_host.canonical_facts["provider_id"] == provider_id
+
+
+@pytest.mark.parametrize("invalid_provider_type", ["invalid_provider", "discovery-system", "unknown", ""])
+def test_add_host_with_invalid_provider_type(
+    mocker: MockerFixture,
+    mq_create_or_update_host: Callable,
+    invalid_provider_type: str,
+) -> None:
+    """
+    Tests that adding a host with invalid provider_type via Kafka message
+    raises ValidationException and sends notification event.
+    """
+    host = minimal_host(insights_id=generate_uuid(), provider_type=invalid_provider_type, provider_id=generate_uuid())
+
+    mock_notification_event_producer = mocker.Mock()
+    with pytest.raises(ValidationException):
+        mq_create_or_update_host(host, notification_event_producer=mock_notification_event_producer)
+
+    # Verify that notification event was sent for the validation failure
+    mock_notification_event_producer.write_event.assert_called_once()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -744,6 +744,7 @@ def test_canonical_facts_version_toohigh():
         {"provider_type": "alibaba", "provider_id": generate_uuid()},
         {"provider_type": "aws", "provider_id": "i-05d2313e6b9a42b16"},
         {"provider_type": "azure", "provider_id": generate_uuid()},
+        {"provider_type": "discovery", "provider_id": generate_uuid()},
         {"provider_type": "gcp", "provider_id": generate_uuid()},
         {"provider_type": "ibm", "provider_id": generate_uuid()},
         #
@@ -768,6 +769,13 @@ def test_canonical_facts_version_toohigh():
             "is_virtual": True,
             "mac_addresses": ["c2:00:d0:c8:61:01", "aa:bb:cc:dd:ee:ff"],
             "provider_type": "azure",
+            "provider_id": generate_uuid(),
+        },
+        {
+            "canonical_facts_version": 1,
+            "is_virtual": True,
+            "mac_addresses": ["c2:00:d0:c8:61:01", "aa:bb:cc:dd:ee:ff"],
+            "provider_type": "discovery",
             "provider_id": generate_uuid(),
         },
         {


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19769](https://issues.redhat.com/browse/RHINENG-19769).

When we recently made changes to our deduplication process, requiring "provider_id", "subscription_manager_id", and "insights_id", the Discovery payloads started to fail. This is because the Discovery is used to find systems that are not yet registered to Insights or Red Hat via RHSM, so they don't have any of these IDs.

Since this is a critical issue for them, we decided that Discovery will temporarily populate the "provider_id" with their own ID and set the "provider_type" to "discovery". This can potentially lead to duplicates, if the systems get registered to Insights later via standard ways, but since we don't expect this to happen often and the old hosts will be deleted in 2 weeks since they are reported by Discovery, this shouldn't be too big an issue.

This is just a temporary hot-fix, and we are trying to come up with a long-term solution for Discovery in the meantime.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add support for 'discovery' provider type to allow discovery payloads to be ingested as a temporary hotfix

New Features:
- Allow 'discovery' as a valid provider_type in the service models, API validation, and documentation

Enhancements:
- Add precise type hints for assert_mq_host_data in mq_utils

Documentation:
- Include 'discovery' in the provider_type enum in swagger and OpenAPI specifications

Tests:
- Add parameterized tests to validate hosts with 'discovery' provider_type and ensure invalid provider types raise validation errors and emit notifications