### PR TITLE
fix(RHINENG-19805): Fix db staleness filters

### DIFF
--- a/api/filtering/db_filters.py
+++ b/api/filtering/db_filters.py
@@ -177,7 +177,10 @@ def per_reporter_staleness_filter(staleness, reporter, host_type_filter, org_id)
 
 def _staleness_filter_using_columns(staleness: list[str]) -> list:
     host_staleness_states_filters = HostStalenessStatesDbFilters()
-    filters = [getattr(host_staleness_states_filters, state)() for state in staleness if state != "unknown"]
+    if staleness == ["unknown"]:
+        filters = [not_(host_staleness_states_filters.culled())]
+    else:
+        filters = [getattr(host_staleness_states_filters, state)() for state in staleness if state != "unknown"]
     return [or_(*filters)]
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -46,14 +46,12 @@ from app.models.utils import _get_staleness_obj
 from app.models.utils import _set_display_name_on_save
 from app.models.utils import _time_now
 from app.models.utils import deleted_by_this_query
-from lib.feature_flags import get_flag_value
 
 logger = get_logger(__name__)
 
 __all__ = [
     "db",
     "migrate",
-    "get_flag_value",
     "jsonschema_validate",
     "logger",
     "ProviderType",

--- a/app/staleness_states.py
+++ b/app/staleness_states.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from datetime import timezone
 
+from sqlalchemy import and_
+
 from app.models import Host
 
 
@@ -12,10 +14,10 @@ class HostStalenessStatesDbFilters:
         return self.now < Host.stale_timestamp
 
     def stale(self):
-        return self.now >= Host.stale_timestamp
+        return and_(self.now >= Host.stale_timestamp, self.now < Host.stale_warning_timestamp)
 
     def stale_warning(self):
-        return self.now >= Host.stale_warning_timestamp
+        return and_(self.now >= Host.stale_warning_timestamp, self.now < Host.deletion_timestamp)
 
     def culled(self):
         return self.now >= Host.deletion_timestamp


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19805](https://issues.redhat.com/browse/RHINENG-19805).

This PR fixes 2 issues with the DB staleness filters:
- The filters didn't have any upper boundaries, so, for example, the "stale" filter would return all stale, stale_warning, and also culled systems
- "unknown" filter didn't work properly, because it would return all hosts, including the culled hosts

This PR also updates and extends the test for these filters. The original test didn't catch these issues because it didn't patch the feature flags correctly.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
