### PR TITLE
Fix: Filter group host-count query on org_id

### DIFF
--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -427,7 +427,7 @@ def get_non_culled_hosts_count_in_group(group: Group, org_id: str) -> int:
         query = (
             db.session.query(Host)
             .join(HostGroupAssoc)
-            .filter(HostGroupAssoc.group_id == group.id)
+            .filter(HostGroupAssoc.group_id == group.id, HostGroupAssoc.org_id == org_id)
             .group_by(Host.id, Host.org_id)
         )
 


### PR DESCRIPTION
# Overview

This PR is being created to address a perf issue in Prod. This query was not filtering on org_id, so it had to search all partitions rather than just 1. This fix makes it so it only looks through one partition.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Include org_id filter in the HostGroupAssoc query to restrict the search to a single partition