### PR TITLE
fix(RHINENG-19785): Commit more often in update-staleness-columns job

### DIFF
--- a/update_staleness_columns.py
+++ b/update_staleness_columns.py
@@ -97,20 +97,15 @@ def run(logger: Logger, session: Session, application: FlaskApp):
                 if processed_in_current_batch >= NUM_HOSTS_UPDATE_STALENESS:
                     logger.info(f"Updating batch of {processed_in_current_batch} hosts...")
                     session.flush()  # Flush current session so we free memory
-                    logger.info(f"Flushed. Total updated so far: {total_hosts_updated}")
+                    session.commit()
+                    logger.info(f"Flushed and commited. Total updated so far: {total_hosts_updated}")
                     processed_in_current_batch = 0  # Reset counter for the next batch
 
             except Exception as e:
                 logger.error(f"Error committing batch: {e}", exc_info=True)
                 session.rollback()
 
-        if total_hosts_updated > 0:
-            try:
-                logger.info(f"Committing {total_hosts_updated} hosts.")
-                session.commit()
-                logger.info(f"Job finished. Successfully updated staleness for {total_hosts_updated} hosts.")
-            except Exception:
-                session.rollback()
+            logger.info(f"Job finished. Successfully updated staleness for {total_hosts_updated} hosts.")
         else:
             logger.info("No hosts to be updated. Finishing job")
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19785](https://issues.redhat.com/browse/RHINENG-19785).

The job is failing on a DB deadlock in Prod. If we commit more often, I hope that the chance of getting into a deadlock will decrease. And even if not, at least the changes that were already made will get commited and the next iteration of the job can continue where it left off, instead of going from the start again.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
