### PR TITLE
fix(RHINENG-19061) Fix HOSTS_TABLES_NUM_PARTITIONS migration env var

### DIFF
--- a/migrations/versions/3b60b7daf0f2_partitioned_system_profiles_tables_fix.py
+++ b/migrations/versions/3b60b7daf0f2_partitioned_system_profiles_tables_fix.py
@@ -33,7 +33,7 @@ def validate_inputs(num_partitions: int):
 
 def upgrade():
     # Get number of partitions from environment variable
-    num_partitions = int(os.getenv("HOSTS_TABLES_NUM_PARTITIONS", 1))
+    num_partitions = int(os.getenv("HOSTS_TABLE_NUM_PARTITIONS", 1))
     validate_inputs(num_partitions)
 
     # System profile tables were created using the wrong number of partitions in stage


### PR DESCRIPTION
# Overview

This PR is being created to fix a wrong env var name.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Correct environment variable name in partitioned tables migration from HOSTS_TABLES_NUM_PARTITIONS to HOSTS_TABLE_NUM_PARTITIONS