### PR TITLE
chore(RHINENG-19885) Update grafana metrics

### DIFF
--- a/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
@@ -579,7 +579,7 @@ data:
           ],
           "targets": [
             {
-              "expr": "sum(increase(kafka_consumergroup_group_offset{topic=~'(platform-mq-stage.|platform-mq-prod)?platform.inventory.host-ingress.*'}[5m])) by (topic)",
+              "expr": "sum(increase(inventory_ingress_add_host_successes_total[1m])) + sum(increase(inventory_ingress_add_host_failures_total[1m]))",
               "instant": true,
               "interval": "1s",
               "legendFormat": "{{topic}}",
@@ -1374,7 +1374,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "$datasource",
+          "datasource": "$datasource_awskafka",
           "fieldConfig": {
             "defaults": {
               "custom": {},
@@ -1419,7 +1419,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(kafka_consumergroup_group_lag{topic=~'(platform-mq-stage.|platform-mq-prod)?platform.inventory.host-ingress.*'}) by (topic)",
+              "expr": "sum(aws_kafka_sum_offset_lag_sum{consumer_group='inventory-mq') by (topic)",
               "interval": "1m",
               "legendFormat": "{{topic}}",
               "refId": "A"
@@ -2731,7 +2731,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "$datasource",
+          "datasource": "$datasource_awskafka",
           "fieldConfig": {
             "defaults": {
               "custom": {},
@@ -2776,7 +2776,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(kafka_consumergroup_group_lag{topic=~'(platform-mq-stage.|platform-mq-prod)?platform.inventory.host-ingress.*'}) by (topic)",
+              "expr": "sum(aws_kafka_sum_offset_lag_sum{consumer_group='inventory-mq'}) by (topic)",
               "interval": "1m",
               "legendFormat": "{{topic}}",
               "refId": "A"
@@ -2873,7 +2873,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(increase(kafka_consumergroup_group_offset{topic=~'(platform-mq-stage.|platform-mq-prod)?platform.inventory.host-ingress.*'}[1m])) by (topic)",
+              "expr": "(sum(increase(inventory_ingress_add_host_successes_total[1m])) by (container) + sum(increase(inventory_ingress_add_host_failures_total[1m])) by (container))",
               "interval": "1m",
               "legendFormat": "{{topic}}",
               "refId": "A"
@@ -4291,6 +4291,24 @@ data:
             "query": "prometheus",
             "refresh": 1,
             "regex": "/.*appsre.*/",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "appsrep11ue1-prometheus",
+              "value": "appsrep11ue1-prometheus"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource - AWS Kafka",
+            "multi": false,
+            "name": "datasource_awskafka",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "(appsrep11ue1-prometheus|appsres11ue1-prometheus)",
             "skipUrlSync": false,
             "type": "datasource"
           },

--- a/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
@@ -579,7 +579,7 @@ data:
           ],
           "targets": [
             {
-              "expr": "sum(increase(inventory_ingress_add_host_successes_total[1m])) + sum(increase(inventory_ingress_add_host_failures_total[1m]))",
+              "expr": "sum(increase(inventory_ingress_add_host_successes_total[5m])) + sum(increase(inventory_ingress_add_host_failures_total[5m]))",
               "instant": true,
               "interval": "1s",
               "legendFormat": "{{topic}}",


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19885](https://issues.redhat.com/browse/RHINENG-19885).
Updates our Grafana dashboard to use the new AWS lag metrics. These metrics required a new datasource to be added to the page. Additionally, there is no exact replacement for tracking the consumed message counts, so I substituted those panels with the sum of message successes and failures over time.

After this merges, I will test the panels in Stage Grafana, and then make an app-interface MR to update Prod Grafana.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Update the Grafana dashboard to leverage new AWS Kafka metrics and replace deprecated Kafka consumer metrics

Enhancements:
- Add a new AWS Kafka datasource variable for the Grafana dashboard
- Switch consumer lag panels to use aws_kafka_sum_offset_lag_sum metric with the new datasource
- Replace consumed message count panels with the sum of inventory_ingress_add_host_successes_total and failures over time