### PR TITLE
DO NOT MERGE: Revert "chore: Add a new env var to allow dowgrading db migration version"

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -649,15 +649,10 @@ objects:
       replicas: ${{REPLICAS_P1}}
       podSpec:
         initContainers:
-        - command:
-            - "sh"
-            - "-c"
-            - "FLASK_APP=./manage.py flask db ${DB_MIGRATION_COMMAND}"
+        - args: ["FLASK_APP=./manage.py", "flask", "db", "upgrade"]
           inheritEnv: true
         args: ["./inv_mq_service.py"]
         env:
-        - name: DB_MIGRATION_COMMAND
-          value: ${DB_MIGRATION_COMMAND}
         - name: HBI_DB_REFACTORING_USE_OLD_TABLE
           value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
         - name: MIGRATION_MODE
@@ -2901,9 +2896,6 @@ parameters:
 - name: HOSTS_TABLE_MIGRATION_SWITCH_MODE
   description: switch or rollback to revert the hosts table switch.
   value: 'switch'
-- name: DB_MIGRATION_COMMAND
-  description: Upgrade or downgrade a database migration to a specific version.
-  value: 'upgrade'
 
 # NGINX
 - displayName: Minimum replicas


### PR DESCRIPTION
Reverts RedHatInsights/insights-host-inventory#2863

## Summary by Sourcery

Revert dynamic DB migration command support and restore fixed upgrade behavior in deployment config

Enhancements:
- Restore fixed "flask db upgrade" in init containers instead of using a variable command
- Remove DB_MIGRATION_COMMAND environment variable and parameter from the deployment configuration