### PR TITLE
fix(RHINENG-19958): Drop obsolete foreign key from hosts_groups_old table

### DIFF
--- a/migrations/versions/96e12ae08c05_remove_fk_from_the_hosts_groups_old_.py
+++ b/migrations/versions/96e12ae08c05_remove_fk_from_the_hosts_groups_old_.py
@@ -1,0 +1,56 @@
+"""Drop obsolete foreign key from hosts_groups_old table
+
+Revision ID: 96e12ae08c05
+Revises: 3b60b7daf0f2
+Create Date: 2025-08-07 14:24:21.101543
+
+"""
+
+from alembic import op
+
+from app.models.constants import INVENTORY_SCHEMA
+
+# revision identifiers, used by Alembic.
+revision = "96e12ae08c05"
+down_revision = "3b60b7daf0f2"
+branch_labels = None
+depends_on = None
+
+OLD_TABLE_NAME = "hosts_groups_old"
+FK_NAME = "hosts_groups_group_id_fkey"
+
+
+def upgrade():
+    op.execute(f"""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT FROM pg_tables
+                WHERE schemaname = '{INVENTORY_SCHEMA}' AND tablename = '{OLD_TABLE_NAME}'
+            ) THEN
+                IF EXISTS (
+                    SELECT 1
+                    FROM pg_constraint con
+                    JOIN pg_class rel ON rel.oid = con.conrelid
+                    WHERE rel.relname = '{OLD_TABLE_NAME}'
+                      AND con.conname = '{FK_NAME}'
+                      AND con.connamespace = (
+                          SELECT oid FROM pg_namespace WHERE nspname = '{INVENTORY_SCHEMA}'
+                      )
+                ) THEN
+                    RAISE NOTICE 'Foreign key "{FK_NAME}" found on table "{OLD_TABLE_NAME}". Dropping it.';
+                    ALTER TABLE {INVENTORY_SCHEMA}.{OLD_TABLE_NAME} DROP CONSTRAINT {FK_NAME};
+                ELSE
+                    RAISE NOTICE 'Foreign key "{FK_NAME}" not found on table "{OLD_TABLE_NAME}". No action needed.';
+                END IF;
+            ELSE
+                RAISE NOTICE 'Table "{OLD_TABLE_NAME}" not found. No action needed.';
+            END IF;
+        END;
+        $$;
+    """)
+
+
+def downgrade():
+    # DO NOTHING. We don't want to re-create a FK on an unused table.
+    pass


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19958](https://issues.redhat.com/browse/RHINENG-19958).

There is a bug affecting specific workspaces that cannot be deleted because a FK that exists on a table that is no longer used.

Assisted by: Google Gemini

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Drop the unused foreign key constraint from the hosts_groups_old table through a new migration to fix workspace cleanup failures.

Bug Fixes:
- Remove obsolete foreign key constraint from hosts_groups_old table to resolve workspace deletion issues

Enhancements:
- Add Alembic migration that conditionally drops the hosts_groups_group_id_fkey if present