### PR TITLE
chore(RHINENG-19959): Automate the updates of hermetic build lockfiles

### DIFF
--- a/.github/workflows/hermetic-updates.yaml
+++ b/.github/workflows/hermetic-updates.yaml
@@ -1,0 +1,75 @@
+name: Hermetic Updates
+
+on:
+  schedule:
+    - cron: '0 3 * * 0' # Runs weekly at 3:00 AM UTC on Sunday
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+env:
+  COMMIT_TITLE: "build: Update hermetic lockfiles"
+  PR_TITLE: "build: Update hermetic lockfiles"
+  PR_BODY: "Automated hermetic lockfile update"
+
+jobs:
+  hermetic-updates:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.access.redhat.com/ubi9/python-312
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Subscribe to Red Hat
+        run: |
+          subscription-manager register \
+            --org="${{ secrets.BUILD_RH_ORG_ID }}" \
+            --activationkey="${{ secrets.BUILD_RH_ACTIVATION_KEY }}"
+
+      - name: Run the hermetic lockfile updates
+        run: make generate-hermetic-lockfiles
+
+      - name: Commit and push changes with gh
+        id: commit-changes
+        run: |
+          git config --global user.name "insights-inventory-bot[bot]"
+          git config --global user.email "insights-inventory-bot[bot]@users.noreply.github.com"
+          git add .
+
+          git commit -m "$COMMIT_TITLE"
+          changes_made=$?
+          echo "changes_made=$changes_made" >> $GITHUB_OUTPUT
+
+          if [ $changes_made -gt 1 ]; then
+            echo "Error checking for changes"
+            exit 1
+          fi
+
+      - name: Generate token
+        id: app-token
+        if: steps.commit-changes.outputs.changes_made == '0'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AUTOMERGE_APP_ID }}
+          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+
+      - name: Push changes and create PR
+        if: steps.commit-changes.outputs.changes_made == '0'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh repo set-default ${{ github.repository }}
+
+          # Push to hermetic_updates branch, force overwrite
+          git push --force https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }} HEAD:hermetic_updates
+
+          # Check if PR exists from hermetic_updates to default branch, if not, create one
+          if ! gh pr list --base ${{ github.ref_name }} --head hermetic_updates --state open | grep .; then
+            gh pr create --base ${{ github.ref_name }} --head hermetic_updates \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY";
+          fi;
+
+      - name: Unsubscribe (cleanup)
+        if: always()
+        run: |
+          subscription-manager unregister || true


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19959](https://issues.redhat.com/browse/RHINENG-19959).

Automates an update to hermetic build lockfiles through GH action.

## Summary by Sourcery

Introduce a GitHub Actions workflow to automatically regenerate hermetic build lockfiles on a weekly schedule (with manual dispatch support) and open a pull request if updates are detected.

CI:
- Add .github/workflows/hermetic-updates.yaml workflow triggered weekly and on demand running in a Python 3.12 UBI9 container.
- Use make generate-hermetic-lockfiles, GitHub CLI, and a GitHub App token to commit changes, push to a branch, and create a PR when updates occur, with Red Hat subscription setup and cleanup.