### PR TITLE
chore(RHINENG-19959): Run subscription-manager under root

### DIFF
--- a/.github/workflows/hermetic-updates.yaml
+++ b/.github/workflows/hermetic-updates.yaml
@@ -21,9 +21,9 @@ jobs:
 
       - name: Subscribe to Red Hat
         run: |
-          subscription-manager register \
-            --org="${{ secrets.BUILD_RH_ORG_ID }}" \
-            --activationkey="${{ secrets.BUILD_RH_ACTIVATION_KEY }}"
+          su -c "subscription-manager register \
+                --org='${{ secrets.BUILD_RH_ORG_ID }}' \
+                --activationkey='${{ secrets.BUILD_RH_ORG_ACTIVATION_KEY }}'" root
 
       - name: Run the hermetic lockfile updates
         run: make generate-hermetic-lockfiles
@@ -72,4 +72,4 @@ jobs:
       - name: Unsubscribe (cleanup)
         if: always()
         run: |
-          subscription-manager unregister || true
+          su -c "subscription-manager unregister || true" root


### PR DESCRIPTION
The Python UBI image defaults to USER 1001.
We need to switch user for the subscription-manager.


This PR is being created to address [RHINENG-19959](https://issues.redhat.com/browse/RHINENG-19959).

## Summary by Sourcery

CI:
- Wrap subscription-manager register and unregister commands in su to execute them as root