### PR TITLE
chore: Allow running the commands locally for hermetic lockfiles

### DIFF
--- a/.github/workflows/hermetic-updates.yaml
+++ b/.github/workflows/hermetic-updates.yaml
@@ -27,7 +27,7 @@ jobs:
             --activationkey='${{ secrets.BUILD_RH_ORG_ACTIVATION_KEY }}'
 
       - name: Run the hermetic lockfile updates
-        run: make generate-hermetic-lockfiles
+        run: make generate-hermetic-lockfiles BASE_IMAGE=local
 
       - name: Commit and push changes with gh
         id: commit-changes


### PR DESCRIPTION
if we are already in correct container, the commands can run locally.
We need this for GitHub actions, which already do run in a container environment and doesn't allow running nested containerization.