### PR TITLE
chore: Install rpm-lockfile prerequisite for rpm lockfile generation

### DIFF
--- a/.github/workflows/hermetic-updates.yaml
+++ b/.github/workflows/hermetic-updates.yaml
@@ -26,6 +26,11 @@ jobs:
             --org='${{ secrets.BUILD_RH_ORG_ID }}' \
             --activationkey='${{ secrets.BUILD_RH_ORG_ACTIVATION_KEY }}'
 
+      - name: Install prerequisites
+        run: |
+          microdnf install -y dnf-plugins-core python3-dnf
+          python3 -m pip install https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/heads/main.zip
+
       - name: Run the hermetic lockfile updates
         run: make generate-hermetic-lockfiles BASE_IMAGE=local
 

--- a/mk/hermetic_builds.mk
+++ b/mk/hermetic_builds.mk
@@ -93,7 +93,7 @@ $(hermetic_builds_dir)/rpms.in.yaml: $(CONTAINERFILE) $(hermetic_builds_dir)/ubi
 # Example: make .hermetic_builds/rpms.lock.yaml BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:latest
 #          make .hermetic_builds/rpms.lock.yaml (uses default BASE_IMAGE)
 $(hermetic_builds_dir)/rpms.lock.yaml: $(hermetic_builds_dir)/rpms.in.yaml
-	@if [ ! command -v rpm-lockfile-prototype >/dev/null 2>&1 ]; then \
+	@if [ ! "$(command -v rpm-lockfile-prototype >/dev/null 2>&1)" ]; then \
 		echo "Error: Command rpm-lockfile-prototype not found"; \
 		echo "Please install it using 'python3 -m pip install --user https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/heads/main.zip'"; \
 		echo "See https://github.com/konflux-ci/rpm-lockfile-prototype/?tab=readme-ov-file#running-in-a-container for usage in a container"; \


### PR DESCRIPTION
# Overview

Adds installation of the required rpm-lockfile-prototype dependency into the hermetic updates automation.

## Summary by Sourcery

Install the rpm-lockfile-prototype dependency in the hermetic updates workflow and update the Makefile check to handle missing commands properly

Bug Fixes:
- Fix the shell conditional in the Makefile to correctly detect when rpm-lockfile-prototype is missing

Enhancements:
- Add a workflow step to install dnf-plugins-core, python3-dnf, and rpm-lockfile-prototype before generating hermetic lockfiles