### PR TITLE
chore: Use dnf over microdnf in non-minimal images

### DIFF
--- a/.github/workflows/hermetic-updates.yaml
+++ b/.github/workflows/hermetic-updates.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install prerequisites
         run: |
-          microdnf install -y dnf-plugins-core python3-dnf
+          dnf install -y dnf-plugins-core python3-dnf
           python3 -m pip install https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/heads/main.zip
 
       - name: Run the hermetic lockfile updates


### PR DESCRIPTION
SSIA

## Summary by Sourcery

CI:
- Replace microdnf with dnf in the Install prerequisites step of the hermetic-updates workflow