### PR TITLE
chore: Install additional prereqisites for depsolving

### DIFF
--- a/.github/workflows/hermetic-updates.yaml
+++ b/.github/workflows/hermetic-updates.yaml
@@ -14,7 +14,7 @@ jobs:
   hermetic-updates:
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/ubi9/python-312
+      image: registry.access.redhat.com/ubi9/python-39
       options: "--user root:root"
     steps:
       - name: Checkout repository
@@ -28,15 +28,20 @@ jobs:
 
       - name: Install prerequisites
         run: |
-          dnf install -y dnf-plugins-core python3-dnf
+          sed -i 's/include-system-site-packages = false/include-system-site-packages = true/' $APP_ROOT/pyvenv.cfg
+          dnf install -y skopeo
+          python3 -m pip install pipenv
           python3 -m pip install https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/heads/main.zip
 
       - name: Run the hermetic lockfile updates
-        run: make generate-hermetic-lockfiles BASE_IMAGE=local
+        run: |
+          source $APP_ROOT/bin/activate
+          make generate-hermetic-lockfiles BASE_IMAGE=local
 
       - name: Commit and push changes with gh
         id: commit-changes
         run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           git config --global user.name "insights-inventory-bot[bot]"
           git config --global user.email "insights-inventory-bot[bot]@users.noreply.github.com"
           git add .

--- a/mk/hermetic_builds.mk
+++ b/mk/hermetic_builds.mk
@@ -99,7 +99,7 @@ $(hermetic_builds_dir)/rpms.lock.yaml: $(hermetic_builds_dir)/rpms.in.yaml
 		echo "See https://github.com/konflux-ci/rpm-lockfile-prototype/?tab=readme-ov-file#running-in-a-container for usage in a container"; \
 		exit 1; \
 	fi;
-	@rpm-lockfile-prototype --image $(BASE_IMAGE) --outfile=$@ $<
+	@rpm-lockfile-prototype --outfile=$@ $<
 	@if [ ! -f $(hermetic_builds_dir)/rpms.lock.yaml ]; then \
 		echo "Error: rpms.lock.yaml was not generated"; \
 		exit 1; \


### PR DESCRIPTION
Make sure we have all the necessary dependencies and ensure we can use them in the venv.

I found the way to test this, so this should already work 😛

## Summary by Sourcery

Adjust hermetic CI workflow to include additional prerequisites, update container runtime, and streamline RPM lockfile generation

Enhancements:
- Remove deprecated --image flag from rpm-lockfile-prototype invocation

CI:
- Switch hermetic-updates workflow container to ubi9/python-39
- Enable system site packages in the virtual environment
- Install skopeo and pipenv before running the lockfile generation
- Activate the virtual environment prior to executing make generate-hermetic-lockfiles
- Configure git safe.directory to permit commits within the workflow