### PR TITLE
chore: Add gh cli through mount to a container

### DIFF
--- a/.github/workflows/hermetic-updates.yaml
+++ b/.github/workflows/hermetic-updates.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: registry.access.redhat.com/ubi9/python-39
-      options: "--user root:root"
+      options: "--user root:root -v /usr/bin:/mnt/usrbin"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -68,6 +68,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          PATH=$PATH:/mnt/usrbin
           gh repo set-default ${{ github.repository }}
 
           # Push to hermetic_updates branch, force overwrite


### PR DESCRIPTION
The container doesn't have the gh installed.
We mount host bin to the container to get access to it.

## Summary by Sourcery

Make GitHub CLI available inside the hermetic-updates workflow container by mounting the host’s /usr/bin directory and updating PATH accordingly.

CI:
- Mount the host’s /usr/bin directory into the container at /mnt/usrbin
- Extend PATH to include /mnt/usrbin so the gh CLI is accessible