### PR TITLE
feat(RHINENG-19061): New publication using the new System profile tables

### DIFF
--- a/inv_publish_hosts.py
+++ b/inv_publish_hosts.py
@@ -30,14 +30,26 @@ COLLECTED_METRICS = (
 
 RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
 
-PUBLICATION_NAME = "hbi_hosts_pub_v1_0_1"
-PUBLICATION_COLUMNS = "id,account,display_name,created_on,modified_on,facts,canonical_facts, \
-system_profile_facts,ansible_host,stale_timestamp,reporter,per_reporter_staleness,org_id, \
+PUBLICATION_NAME = "hbi_hosts_pub_v1_0_2"
+HOSTS_PUBLICATION_COLUMNS = "org_id,id,account,display_name,created_on,modified_on,facts,\
+ansible_host,insights_id,subscription_manager_id,satellite_id,fqdn,bios_uuid,ip_addresses,mac_addresses,\
+provider_id,provider_type,stale_timestamp,reporter,per_reporter_staleness,\
 groups,tags_alt,last_check_in,stale_warning_timestamp,deletion_timestamp"
+SP_DYNAMIC_PUBLICATION_COLUMNS = "org_id,host_id,installed_packages,installed_products,workloads"
+SP_STATIC_PUBLICATION_COLUMNS = "org_id,host_id,arch,bootc_status,dnf_modules,host_type,image_builder,\
+operating_system,owner_id,releasever,rhc_client_id,rhsm,satellite_managed,system_update_method,yum_repos"
 CHECK_PUBLICATION = f"SELECT EXISTS(SELECT * FROM pg_catalog.pg_publication WHERE pubname = '{PUBLICATION_NAME}')"
-CREATE_PUBLICATION = f"CREATE PUBLICATION {PUBLICATION_NAME} FOR TABLE hbi.hosts ({PUBLICATION_COLUMNS})"
+CREATE_PUBLICATION = (
+    f"CREATE PUBLICATION {PUBLICATION_NAME} "
+    f"FOR TABLE "
+    f"hbi.hosts ({HOSTS_PUBLICATION_COLUMNS}), "
+    f"hbi.system_profiles_dynamic ({SP_DYNAMIC_PUBLICATION_COLUMNS}), "
+    f"hbi.system_profiles_static ({SP_STATIC_PUBLICATION_COLUMNS}) "
+    f"WHERE (insights_id != '00000000-0000-0000-0000-000000000000') "
+    f"WITH (publish_via_partition_root = true);"
+)
 CHECK_REPLICATION_SLOTS = "SELECT slot_name, active FROM pg_replication_slots"
-DROP_PUBLICATIONS = ["hbi_hosts_pub"]
+DROP_PUBLICATIONS = ["hbi_hosts_pub", "hbi_hosts_pub_v1_0_0", "hbi_hosts_pub_v1_0_1"]
 DROP_PUBLICATION = "DROP PUBLICATION IF EXISTS "
 
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19061](https://issues.redhat.com/browse/RHINENG-19061).

It creates a new logical replication publication using the new system_profile_static and system_profile_dynamic tables filtering out hosts that have insights_id = '00000000-0000-0000-0000-000000000000'

It also only replicates system_profile fields that are required by the downstream applications.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Implement a new logical replication publication that spans hosts and system profile tables with filtered rows and tailored column sets, and clean up old publication versions.

New Features:
- Create new logical replication publication hbi_hosts_pub_v1_0_2 across hosts, system_profiles_dynamic and system_profiles_static tables
- Filter out hosts with insights_id = '00000000-0000-0000-0000-000000000000' and publish only required system profile fields

Enhancements:
- Update publication column lists to include only necessary host and system profile attributes
- Extend DROP_PUBLICATION list to remove previous publication versions