### PR TITLE
chore(RHINENG-19061): Add a list of inactive replication slots to drop

### DIFF
--- a/inv_publish_hosts.py
+++ b/inv_publish_hosts.py
@@ -5,7 +5,7 @@ from functools import partial
 from prometheus_client import CollectorRegistry
 from prometheus_client import push_to_gateway
 from sqlalchemy import create_engine
-from sqlalchemy import text as sa_text
+from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 
 from app import create_app
@@ -22,35 +22,60 @@ __all__ = ("main", "run")
 
 LOGGER_NAME = "hosts-syndicator"
 PROMETHEUS_JOB = "hosts-syndicator"
+RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
+
+# Publications and columns
+PUBLICATION_NAME = "hbi_hosts_pub_v1_0_2"
+HOSTS_PUBLICATION_COLUMNS = (
+    "org_id,id,account,display_name,created_on,modified_on,facts,"
+    "ansible_host,insights_id,subscription_manager_id,satellite_id,fqdn,"
+    "bios_uuid,ip_addresses,mac_addresses,provider_id,provider_type,"
+    "stale_timestamp,reporter,per_reporter_staleness,groups,tags_alt,"
+    "last_check_in,stale_warning_timestamp,deletion_timestamp"
+)
+SP_DYNAMIC_PUBLICATION_COLUMNS = "org_id,host_id,installed_packages,installed_products,workloads"
+SP_STATIC_PUBLICATION_COLUMNS = (
+    "org_id,host_id,arch,bootc_status,dnf_modules,host_type,image_builder,"
+    "operating_system,owner_id,releasever,rhc_client_id,rhsm,satellite_managed,"
+    "system_update_method,yum_repos"
+)
+
+# Publications to drop
+DROP_PUBLICATIONS = [
+    "hbi_hosts_pub",
+    "hbi_hosts_pub_v1_0_0",
+    "hbi_hosts_pub_v1_0_1",
+]
+
+# Replication slots to drop
+DROP_REPLICATION_SLOTS = ["roadmap_hosts_sub"]
+
+CHECK_PUBLICATION_SQL = text("""
+    SELECT EXISTS(
+        SELECT 1 FROM pg_catalog.pg_publication WHERE pubname = :pubname
+    )
+""")
+CHECK_REPLICATION_SLOTS_SQL = text("SELECT slot_name, active FROM pg_replication_slots")
+
+CREATE_PUBLICATION_SQL = text(f"""
+    CREATE PUBLICATION {PUBLICATION_NAME}
+    FOR TABLE
+      hbi.hosts ({HOSTS_PUBLICATION_COLUMNS}),
+      hbi.system_profiles_dynamic ({SP_DYNAMIC_PUBLICATION_COLUMNS}),
+      hbi.system_profiles_static ({SP_STATIC_PUBLICATION_COLUMNS})
+    WHERE (insights_id != '00000000-0000-0000-0000-000000000000')
+    WITH (publish_via_partition_root = true);
+""")
+
+DROP_PUBLICATION_SQL = "DROP PUBLICATION IF EXISTS "
+
+DROP_REPLICATION_SLOTS_SQL = text("SELECT pg_drop_replication_slot(:slot_name)")
+
 COLLECTED_METRICS = (
     hosts_syndication_fail_count,
     hosts_syndication_success_count,
     hosts_syndication_time,
 )
-
-RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
-
-PUBLICATION_NAME = "hbi_hosts_pub_v1_0_2"
-HOSTS_PUBLICATION_COLUMNS = "org_id,id,account,display_name,created_on,modified_on,facts,\
-ansible_host,insights_id,subscription_manager_id,satellite_id,fqdn,bios_uuid,ip_addresses,mac_addresses,\
-provider_id,provider_type,stale_timestamp,reporter,per_reporter_staleness,\
-groups,tags_alt,last_check_in,stale_warning_timestamp,deletion_timestamp"
-SP_DYNAMIC_PUBLICATION_COLUMNS = "org_id,host_id,installed_packages,installed_products,workloads"
-SP_STATIC_PUBLICATION_COLUMNS = "org_id,host_id,arch,bootc_status,dnf_modules,host_type,image_builder,\
-operating_system,owner_id,releasever,rhc_client_id,rhsm,satellite_managed,system_update_method,yum_repos"
-CHECK_PUBLICATION = f"SELECT EXISTS(SELECT * FROM pg_catalog.pg_publication WHERE pubname = '{PUBLICATION_NAME}')"
-CREATE_PUBLICATION = (
-    f"CREATE PUBLICATION {PUBLICATION_NAME} "
-    f"FOR TABLE "
-    f"hbi.hosts ({HOSTS_PUBLICATION_COLUMNS}), "
-    f"hbi.system_profiles_dynamic ({SP_DYNAMIC_PUBLICATION_COLUMNS}), "
-    f"hbi.system_profiles_static ({SP_STATIC_PUBLICATION_COLUMNS}) "
-    f"WHERE (insights_id != '00000000-0000-0000-0000-000000000000') "
-    f"WITH (publish_via_partition_root = true);"
-)
-CHECK_REPLICATION_SLOTS = "SELECT slot_name, active FROM pg_replication_slots"
-DROP_PUBLICATIONS = ["hbi_hosts_pub", "hbi_hosts_pub_v1_0_0", "hbi_hosts_pub_v1_0_1"]
-DROP_PUBLICATION = "DROP PUBLICATION IF EXISTS "
 
 
 def _init_config():
@@ -68,47 +93,57 @@ def _prometheus_job(namespace):
     return f"{PROMETHEUS_JOB}-{namespace}" if namespace else PROMETHEUS_JOB
 
 
-def _excepthook(logger, type, value, traceback):  # noqa: ARG001, needed by sys.excepthook
+def _excepthook(logger, exc_type, value, traceback):  # noqa
     logger.exception("Inventory migration failed", exc_info=value)
+
+
+def drop_old_publications(session, logger):
+    for pub in DROP_PUBLICATIONS:
+        logger.info(f"Dropping publication: {pub}")
+        session.execute(text(DROP_PUBLICATION_SQL + pub))
+
+
+def publication_exists(session, logger):
+    found = session.execute(CHECK_PUBLICATION_SQL, {"pubname": PUBLICATION_NAME}).scalar()
+    if found:
+        logger.info(f'Publication "{PUBLICATION_NAME}" found!')
+    return found
+
+
+def create_publication(session, logger):
+    logger.info(f'Creating publication "{PUBLICATION_NAME}".')
+    session.execute(CREATE_PUBLICATION_SQL)
+    logger.info(f'Publication "{PUBLICATION_NAME}" created!')
+
+
+def check_and_drop_inactive_slots(session, logger):
+    slots = session.execute(CHECK_REPLICATION_SLOTS_SQL).all()
+    inactive_slots = [slot_name for slot_name, active in slots if not active]
+
+    for slot_name in inactive_slots:
+        if slot_name in DROP_REPLICATION_SLOTS:
+            logger.info(f"Dropping inactive replication slot: {slot_name}")
+            session.execute(DROP_REPLICATION_SLOTS_SQL, {"slot_name": slot_name})
+        else:
+            raise Exception(f"Replication slot '{slot_name}' is inactive. Aborting.")
 
 
 def run(logger, session, application):
     with application.app.app_context():
-        # Drop publications by name
-        for pub in DROP_PUBLICATIONS:
-            logger.info(f"Dropping publication using the following SQL statement:\n\t{DROP_PUBLICATION + pub}")
-            session.execute(sa_text(DROP_PUBLICATION + pub))
-
-        logger.info(f"Checking for publication using the following SQL statement:\n\t{CHECK_PUBLICATION}")
-        result = session.execute(sa_text(CHECK_PUBLICATION))
-        found = result.cursor.fetchone()[0]
-        if found:
-            logger.info(f'Publication "{PUBLICATION_NAME}" found!')
+        try:
+            drop_old_publications(session, logger)
+            if not publication_exists(session, logger):
+                create_publication(session, logger)
+                check_and_drop_inactive_slots(session, logger)
+        except Exception as e:
+            session.rollback()
+            hosts_syndication_fail_count.inc()
+            logger.error(f"Error during publication setup: {e}")
+            raise
         else:
-            logger.info(f'Creating publication "{PUBLICATION_NAME}" using \n\t{CREATE_PUBLICATION}')
-            try:
-                session.execute(sa_text(CREATE_PUBLICATION))
-
-                # check for inactive replication_slots
-                replication_slots = session.execute(sa_text(CHECK_REPLICATION_SLOTS)).all()
-                inactive = 0
-                for slot in replication_slots:
-                    slot_name, active = slot
-                    if not active:
-                        inactive += 1
-                        logger.error(f"Replication slot named {slot_name} is not active")
-                    if inactive > 0:
-                        exit(1)
-            except Exception as e:
-                session.rollback()
-                logger.error(f'Error encountered when creating the publication "{PUBLICATION_NAME}" \n\t{e}')
-                hosts_syndication_fail_count.inc()
-                raise e
-            else:
-                session.commit()
-                logger.info(f'Publication "{PUBLICATION_NAME}" created!!!')
-
-        hosts_syndication_success_count.inc()
+            session.commit()
+            hosts_syndication_success_count.inc()
+            logger.info("Publication setup completed successfully.")
 
 
 def main(logger):
@@ -118,6 +153,7 @@ def main(logger):
     registry = CollectorRegistry()
     for metric in COLLECTED_METRICS:
         registry.register(metric)
+
     job = _prometheus_job(config.kubernetes_namespace)
     prometheus_shutdown = partial(push_to_gateway, config.prometheus_pushgateway, job, registry)
     register_shutdown(prometheus_shutdown, "Pushing metrics")
@@ -128,6 +164,7 @@ def main(logger):
 
     shutdown_handler = ShutdownHandler()
     shutdown_handler.register()
+
     run(logger, session, application)
 
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19061](https://issues.redhat.com/browse/RHINENG-19061).

It introduces a new list of inactive replication slots to be removed as we discovered that we have a leftover "roadmap_hosts_sub" replication slot on stage where the Roadmap application is no longer subscribed to the publication and therefore it needs to be dropped.

It also extracts the code into separate functions for better readability.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add functionality to drop inactive replication slots and refactor publication management into modular functions, consolidating SQL definitions and constants for improved readability

New Features:
- Support dropping specified inactive replication slots, including 'roadmap_hosts_sub'

Enhancements:
- Refactor publication and replication slot management into dedicated helper functions
- Consolidate and format SQL statements and publication constants using SQLAlchemy text
- Define explicit lists of publications and replication slots to drop