### PR TITLE
feat(RHINENG-20046) Add the ability to configure connexion log level

### DIFF
--- a/app/logging.py
+++ b/app/logging.py
@@ -30,7 +30,7 @@ def configure_logging():
 
     # Allows for the log level of certain loggers to be redefined with an env variable
     # e.g. SQLALCHEMY_ENGINE_LOG_LEVEL=DEBUG
-    for component in ("sqlalchemy.engine", "urllib3"):
+    for component in ("sqlalchemy.engine", "urllib3", "connexion"):
         env_key = component.replace(".", "_").upper()
         level = os.getenv(f"{env_key}_LOG_LEVEL")
         if level:

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -115,6 +115,8 @@ objects:
           value: ${LOG_LEVEL}
         - name: URLLIB3_LOG_LEVEL
           value: ${URLLIB3_LOG_LEVEL}
+        - name: CONNEXION_LOG_LEVEL
+          value: ${CONNEXION_LOG_LEVEL}
         - name: INVENTORY_DB_SSL_MODE
           value: ${INVENTORY_DB_SSL_MODE}
         - name: PAYLOAD_TRACKER_SERVICE_NAME
@@ -275,6 +277,8 @@ objects:
           value: ${LOG_LEVEL}
         - name: URLLIB3_LOG_LEVEL
           value: ${URLLIB3_LOG_LEVEL}
+        - name: CONNEXION_LOG_LEVEL
+          value: ${CONNEXION_LOG_LEVEL}
         - name: INVENTORY_DB_SSL_MODE
           value: ${INVENTORY_DB_SSL_MODE}
         - name: PAYLOAD_TRACKER_SERVICE_NAME
@@ -435,6 +439,8 @@ objects:
           value: ${LOG_LEVEL}
         - name: URLLIB3_LOG_LEVEL
           value: ${URLLIB3_LOG_LEVEL}
+        - name: CONNEXION_LOG_LEVEL
+          value: ${CONNEXION_LOG_LEVEL}
         - name: INVENTORY_DB_SSL_MODE
           value: ${INVENTORY_DB_SSL_MODE}
         - name: PAYLOAD_TRACKER_SERVICE_NAME
@@ -550,6 +556,8 @@ objects:
           value: ${CONSOLEDOT_HOSTNAME}
         - name: INVENTORY_LOG_LEVEL
           value: ${LOG_LEVEL}
+        - name: CONNEXION_LOG_LEVEL
+          value: ${CONNEXION_LOG_LEVEL}
         - name: INVENTORY_DB_SSL_MODE
           value: ${INVENTORY_DB_SSL_MODE}
         - name: INVENTORY_DB_SSL_CERT
@@ -661,6 +669,8 @@ objects:
           value: ${CONSOLEDOT_HOSTNAME}
         - name: INVENTORY_LOG_LEVEL
           value: ${LOG_LEVEL}
+        - name: CONNEXION_LOG_LEVEL
+          value: ${CONNEXION_LOG_LEVEL}
         - name: INVENTORY_DB_SSL_MODE
           value: ${INVENTORY_DB_SSL_MODE}
         - name: INVENTORY_DB_SSL_CERT
@@ -769,6 +779,8 @@ objects:
           value: ${CONSOLEDOT_HOSTNAME}
         - name: INVENTORY_LOG_LEVEL
           value: ${LOG_LEVEL}
+        - name: CONNEXION_LOG_LEVEL
+          value: ${CONNEXION_LOG_LEVEL}
         - name: INVENTORY_DB_SSL_MODE
           value: ${INVENTORY_DB_SSL_MODE}
         - name: INVENTORY_DB_SSL_CERT
@@ -865,6 +877,8 @@ objects:
           value: ${CONSOLEDOT_HOSTNAME}
         - name: INVENTORY_LOG_LEVEL
           value: ${LOG_LEVEL}
+        - name: CONNEXION_LOG_LEVEL
+          value: ${CONNEXION_LOG_LEVEL}
         - name: INVENTORY_DB_SSL_MODE
           value: ${INVENTORY_DB_SSL_MODE}
         - name: INVENTORY_DB_SSL_CERT
@@ -1128,6 +1142,8 @@ objects:
             value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
+          - name: CONNEXION_LOG_LEVEL
+            value: ${CONNEXION_LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
             value: ${INVENTORY_DB_SSL_MODE}
           - name: INVENTORY_DB_SSL_CERT
@@ -2300,6 +2316,8 @@ parameters:
 - name: CONSOLEDOT_HOSTNAME
   value: localhost
 - name: URLLIB3_LOG_LEVEL
+  value: WARNING
+- name: CONNEXION_LOG_LEVEL
   value: WARNING
 - description: SSL validation mode for the DB
   name: INVENTORY_DB_SSL_MODE


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20046](https://issues.redhat.com/browse/RHINENG-20046).
It adds the ability to configure the log level for Connexion, defaulting to WARNING.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enable customizing the Connexion log level by introducing a CONNEXION_LOG_LEVEL environment variable and integrating it into the deployment manifests and logging configuration.

New Features:
- Introduce a CONNEXION_LOG_LEVEL environment variable for configuring Connexion logger level

Enhancements:
- Add CONNEXION_LOG_LEVEL entries to multiple deploy/clowdapp.yml environments
- Extend configure_logging to apply the CONNEXION_LOG_LEVEL setting to the Connexion logger