### PR TITLE
Default hbi.filter_staleness_using_columns flag to True

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -102,7 +102,7 @@
             "type": "release",
             "project": "default",
             "stale": false,
-            "enabled": false,
+            "enabled": true,
             "createdAt": "2025-05-05T22:31:19.466Z",
             "strategies": [
                 {

--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -19,7 +19,7 @@ FLAG_FALLBACK_VALUES = {
     FLAG_INVENTORY_API_READ_ONLY: False,
     FLAG_INVENTORY_KESSEL_PHASE_1: False,
     # Use when all hosts are populated with stale_warning/deletion_timestamps
-    FLAG_INVENTORY_FILTER_STALENESS_USING_COLUMNS: False,
+    FLAG_INVENTORY_FILTER_STALENESS_USING_COLUMNS: True,
 }
 
 

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -2320,7 +2320,6 @@ def test_fresh_staleness_with_only_rhsm_system_profile_bridge(api_get, db_create
         )
         host_id = str(host.id)
 
-    # Set FLAG_INVENTORY_FILTER_STALENESS_USING_COLUMNS to true
     url = build_hosts_url(query="?staleness=fresh")
     response_status, response_data = api_get(url=url)
 

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -2321,9 +2321,8 @@ def test_fresh_staleness_with_only_rhsm_system_profile_bridge(api_get, db_create
         host_id = str(host.id)
 
     # Set FLAG_INVENTORY_FILTER_STALENESS_USING_COLUMNS to true
-    with patch("api.filtering.db_filters.get_flag_value", return_value=True):
-        url = build_hosts_url(query="?staleness=fresh")
-        response_status, response_data = api_get(url=url)
+    url = build_hosts_url(query="?staleness=fresh")
+    response_status, response_data = api_get(url=url)
 
     assert response_status == 200
     # The host should be present in the results


### PR DESCRIPTION
# Overview

This PR is being created to set the fallback value for the `hbi.filter_staleness_using_columns` feature flag to True. Slack context [here](https://redhat-internal.slack.com/archives/CQFKM031T/p1755091874787949?thread_ts=1753797713.831199&cid=CQFKM031T). 

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enable the inventory staleness filtering feature by default and clean up tests to rely on the new default flag value.

Enhancements:
- Set the FLAG_INVENTORY_FILTER_STALENESS_USING_COLUMNS feature flag default to true
- Remove explicit patching of get_flag_value in the staleness filtering API test
- Update unleash flags configuration to reflect the new default setting

Tests:
- Update host API test to assume staleness filtering is enabled by default