### PR TITLE
chore(RHINENG-20197): Update replica identity on all table partitions

### DIFF
--- a/migrations/helpers.py
+++ b/migrations/helpers.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import contextmanager
 
 from alembic import op
@@ -5,7 +6,11 @@ from sqlalchemy.orm.session import Session
 
 from app.logging import get_logger
 
-__all__ = ("logger", "session")
+__all__ = ("logger", "session", "validate_num_partitions", "TABLE_NUM_PARTITIONS", "MIGRATION_MODE")
+
+
+TABLE_NUM_PARTITIONS = int(os.getenv("HOSTS_TABLE_NUM_PARTITIONS", 1))
+MIGRATION_MODE = os.getenv("MIGRATION_MODE", "automated")
 
 
 def logger(name):
@@ -23,3 +28,8 @@ def session():
         raise
     else:
         session.commit()
+
+
+def validate_num_partitions(num_partitions: int):
+    if not 1 <= num_partitions <= 32:
+        raise ValueError(f"Invalid number of partitions: {num_partitions}. Must be between 1 and 32.")

--- a/migrations/versions/595dbad97e20_update_replica_identity_on_table_.py
+++ b/migrations/versions/595dbad97e20_update_replica_identity_on_table_.py
@@ -1,0 +1,75 @@
+"""Update replica identity on table partitions
+
+Revision ID: 595dbad97e20
+Revises: 6714f3063d90
+Create Date: 2025-08-14 15:41:29.851439
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+from app.models.constants import INVENTORY_SCHEMA
+from migrations.helpers import MIGRATION_MODE
+from migrations.helpers import TABLE_NUM_PARTITIONS
+from migrations.helpers import validate_num_partitions
+
+# revision identifiers, used by Alembic.
+revision = "595dbad97e20"
+down_revision = "6714f3063d90"
+branch_labels = None
+depends_on = None
+
+"""
+This migration updates the replica identity on table partitions
+to use the composite unique index (org_id, id/host_id, insights_id),
+which is required for logical replication.
+
+Previous migrations updated the replica identity on the parent tables,
+but we later discovered that these changes do not automatically
+cascade to child partitions, so each partition must be updated individually.
+"""
+
+
+def upgrade():
+    validate_num_partitions(TABLE_NUM_PARTITIONS)
+
+    for i in range(TABLE_NUM_PARTITIONS):
+        # Determine the hosts index name based on environment
+        if MIGRATION_MODE == "managed":
+            # In managed environments, this index was created concurrently on the hosts table partitions,
+            # unlike automated environments, where index creation cascades automatically from the parent table.
+            # This is why the partition indexes for the hosts table ended up having two different naming schemes.
+            hosts_index_name = f"hosts_p{i}_replica_identity_idx"
+        else:
+            hosts_index_name = f"hosts_p{i}_org_id_id_insights_id_idx"
+
+        hosts_partition_name = f"{INVENTORY_SCHEMA}.hosts_p{i}"
+        op.execute(text(f"ALTER TABLE {hosts_partition_name} REPLICA IDENTITY USING INDEX {hosts_index_name};"))
+
+        # Update replica identity for system_profiles_static partition
+        sp_static_index_name = f"system_profiles_static_p{i}_org_id_host_id_insights_id_idx"
+        sp_static_partition_name = f"{INVENTORY_SCHEMA}.system_profiles_static_p{i}"
+        op.execute(
+            text(f"ALTER TABLE {sp_static_partition_name} REPLICA IDENTITY USING INDEX {sp_static_index_name};")
+        )
+
+        # Update replica identity for system_profiles_dynamic partition
+        sp_dynamic_index_name = f"system_profiles_dynamic_p{i}_org_id_host_id_insights_id_idx"
+        sp_dynamic_partition_name = f"{INVENTORY_SCHEMA}.system_profiles_dynamic_p{i}"
+        op.execute(
+            text(f"ALTER TABLE {sp_dynamic_partition_name} REPLICA IDENTITY USING INDEX {sp_dynamic_index_name};")
+        )
+
+
+def downgrade():
+    validate_num_partitions(TABLE_NUM_PARTITIONS)
+
+    for i in range(TABLE_NUM_PARTITIONS):
+        hosts_partition_name = f"{INVENTORY_SCHEMA}.hosts_p{i}"
+        op.execute(text(f"ALTER TABLE {hosts_partition_name} REPLICA IDENTITY DEFAULT;"))
+
+        sp_static_partition_name = f"{INVENTORY_SCHEMA}.system_profiles_static_p{i}"
+        op.execute(text(f"ALTER TABLE {sp_static_partition_name} REPLICA IDENTITY DEFAULT;"))
+
+        sp_dynamic_partition_name = f"{INVENTORY_SCHEMA}.system_profiles_dynamic_p{i}"
+        op.execute(text(f"ALTER TABLE {sp_dynamic_partition_name} REPLICA IDENTITY DEFAULT;"))

--- a/migrations/versions/595dbad97e20_update_replica_identity_on_table_.py
+++ b/migrations/versions/595dbad97e20_update_replica_identity_on_table_.py
@@ -33,29 +33,46 @@ cascade to child partitions, so each partition must be updated individually.
 def upgrade():
     validate_num_partitions(TABLE_NUM_PARTITIONS)
 
-    for i in range(TABLE_NUM_PARTITIONS):
-        if MIGRATION_MODE == "managed":
-            # In managed environments, this index was created concurrently on the hosts table partitions,
-            # unlike automated environments, where index creation cascades automatically from the parent table.
-            # This is why the partition indexes for the hosts table ended up having two different naming schemes.
-            hosts_index_name = f"hosts_p{i}_replica_identity_idx"
+    def set_replica_identity_if_index_exists(schema: str, table: str, index: str):
+        result = (
+            op.get_bind()
+            .execute(
+                text("""
+                SELECT 1
+                FROM pg_indexes
+                WHERE schemaname = :schema
+                  AND tablename = :table
+                  AND indexname = :index
+            """),
+                {"schema": schema, "table": table, "index": index},
+            )
+            .fetchone()
+        )
+
+        if result:
+            op.execute(text(f"ALTER TABLE {schema}.{table} REPLICA IDENTITY USING INDEX {index};"))
         else:
-            hosts_index_name = f"hosts_p{i}_org_id_id_insights_id_idx"
+            print(f"Index '{index}' does not exist on table '{schema}.{table}'. Skipping replica identity update.")
 
-        hosts_partition_name = f"{INVENTORY_SCHEMA}.hosts_p{i}"
-        op.execute(text(f"ALTER TABLE {hosts_partition_name} REPLICA IDENTITY USING INDEX {hosts_index_name};"))
-
-        sp_static_index_name = f"system_profiles_static_p{i}_org_id_host_id_insights_id_idx"
-        sp_static_partition_name = f"{INVENTORY_SCHEMA}.system_profiles_static_p{i}"
-        op.execute(
-            text(f"ALTER TABLE {sp_static_partition_name} REPLICA IDENTITY USING INDEX {sp_static_index_name};")
+    for i in range(TABLE_NUM_PARTITIONS):
+        # In managed environments, this index was created concurrently on the hosts table partitions,
+        # unlike automated environments, where index creation cascades automatically from the parent table.
+        # This is why the partition indexes for the hosts table ended up having two different naming schemes.
+        hosts_index_name = (
+            f"hosts_p{i}_replica_identity_idx"
+            if MIGRATION_MODE == "managed"
+            else f"hosts_p{i}_org_id_id_insights_id_idx"
         )
+        hosts_table = f"hosts_p{i}"
+        set_replica_identity_if_index_exists(INVENTORY_SCHEMA, hosts_table, hosts_index_name)
 
-        sp_dynamic_index_name = f"system_profiles_dynamic_p{i}_org_id_host_id_insights_id_idx"
-        sp_dynamic_partition_name = f"{INVENTORY_SCHEMA}.system_profiles_dynamic_p{i}"
-        op.execute(
-            text(f"ALTER TABLE {sp_dynamic_partition_name} REPLICA IDENTITY USING INDEX {sp_dynamic_index_name};")
-        )
+        sp_static_table = f"system_profiles_static_p{i}"
+        sp_static_index = f"{sp_static_table}_org_id_host_id_insights_id_idx"
+        set_replica_identity_if_index_exists(INVENTORY_SCHEMA, sp_static_table, sp_static_index)
+
+        sp_dynamic_table = f"system_profiles_dynamic_p{i}"
+        sp_dynamic_index = f"{sp_dynamic_table}_org_id_host_id_insights_id_idx"
+        set_replica_identity_if_index_exists(INVENTORY_SCHEMA, sp_dynamic_table, sp_dynamic_index)
 
 
 def downgrade():

--- a/migrations/versions/595dbad97e20_update_replica_identity_on_table_.py
+++ b/migrations/versions/595dbad97e20_update_replica_identity_on_table_.py
@@ -34,7 +34,6 @@ def upgrade():
     validate_num_partitions(TABLE_NUM_PARTITIONS)
 
     for i in range(TABLE_NUM_PARTITIONS):
-        # Determine the hosts index name based on environment
         if MIGRATION_MODE == "managed":
             # In managed environments, this index was created concurrently on the hosts table partitions,
             # unlike automated environments, where index creation cascades automatically from the parent table.
@@ -46,14 +45,12 @@ def upgrade():
         hosts_partition_name = f"{INVENTORY_SCHEMA}.hosts_p{i}"
         op.execute(text(f"ALTER TABLE {hosts_partition_name} REPLICA IDENTITY USING INDEX {hosts_index_name};"))
 
-        # Update replica identity for system_profiles_static partition
         sp_static_index_name = f"system_profiles_static_p{i}_org_id_host_id_insights_id_idx"
         sp_static_partition_name = f"{INVENTORY_SCHEMA}.system_profiles_static_p{i}"
         op.execute(
             text(f"ALTER TABLE {sp_static_partition_name} REPLICA IDENTITY USING INDEX {sp_static_index_name};")
         )
 
-        # Update replica identity for system_profiles_dynamic partition
         sp_dynamic_index_name = f"system_profiles_dynamic_p{i}_org_id_host_id_insights_id_idx"
         sp_dynamic_partition_name = f"{INVENTORY_SCHEMA}.system_profiles_dynamic_p{i}"
         op.execute(


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20197](https://issues.redhat.com/browse/RHINENG-20197).

It updates the replica identity on all table partitions. In previous migrations, we updated the replica identity on the parent table, expecting it to cascade to the child partitions as index creation does. However, this does not happen automatically in PostgreSQL; each partition must be updated individually.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Ensure replica identity is explicitly updated on each partition of hosts and system_profiles tables by introducing partition count validation and a new Alembic migration that applies the correct index per partition.

New Features:
- Add Alembic migration that iterates through all table partitions to set replica identity using the appropriate index on hosts and system_profiles tables.
- Implement downgrade logic to revert replica identity settings back to default for all partitions.

Enhancements:
- Introduce TABLE_NUM_PARTITIONS and MIGRATION_MODE environment variables in migrations.helpers to drive partition logic.
- Add validate_num_partitions helper to enforce partition count between 1 and 32 before running migrations.