### PR TITLE
fix: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ To install this, use the command appropriate for your system:
 ##### Fedora/Centos
 
 ```bash
-sudo dnf install libpq-devel postgresql
+sudo dnf install libpq-devel postgresql python3.12-devel
 ```
 
 ##### Debian/Ubuntu
 
 ```bash
-sudo apt-get install libpq-dev postgresql
+sudo apt-get install libpq-dev postgresql python3.12-dev
 ```
 
 ##### MacOS (using Homebrew)


### PR DESCRIPTION
# Overview

Tried installing the project from scratch and `pipenv install --dev` fails to install psycopg2 without `python3.12-devel`.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Update README installation instructions to include Python 3.12 development packages for psycopg2 installation

Documentation:
- Add python3.12-devel to Fedora/CentOS prerequisites
- Add python3.12-dev to Debian/Ubuntu prerequisites