### PR TITLE
hotfix: Create index only if it does not exist

### DIFF
--- a/migrations/versions/6714f3063d90_logical_replication_prerequisites.py
+++ b/migrations/versions/6714f3063d90_logical_replication_prerequisites.py
@@ -68,7 +68,7 @@ def upgrade():
             with op.get_context().autocommit_block():
                 op.execute(
                     text(f"""
-                        CREATE UNIQUE INDEX CONCURRENTLY {index_name}
+                        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS {index_name}
                         ON {partition_name} (org_id, id, insights_id);
                     """)
                 )
@@ -100,7 +100,7 @@ def upgrade():
         # Step 3: Create the parent index (will take a lock briefly)
         op.execute(
             text(f"""
-                CREATE UNIQUE INDEX hosts_replica_identity_idx
+                CREATE UNIQUE INDEX IF NOT EXISTS hosts_replica_identity_idx
                 ON {INVENTORY_SCHEMA}.hosts (org_id, id, insights_id);
             """)
         )


### PR DESCRIPTION
# Overview

This PR is being created to fix an issue when running a migration to create indexes.

It will only try to create the index if it doesn't exist.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Prevent migration failures by only creating indexes if they do not already exist

Bug Fixes:
- Add IF NOT EXISTS to the partitioned table’s CREATE UNIQUE INDEX CONCURRENTLY statement
- Add IF NOT EXISTS to the hosts table’s CREATE UNIQUE INDEX statement