### PR TITLE
chore(RHINENG-20292) Cleanup HBI application dual mode feature flag

### DIFF
--- a/api/host.py
+++ b/api/host.py
@@ -439,12 +439,7 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict, rba
         Host.facts.has_key(namespace),
     )
 
-    if inventory_config().hbi_db_refactoring_use_old_table:
-        # Old code: use single column GROUP BY
-        query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.id)
-    else:
-        # New code: use composite GROUP BY
-        query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.org_id, Host.id)
+    query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.org_id, Host.id)
 
     if rbac_filter and "groups" in rbac_filter:
         count_before_rbac_filter = find_non_culled_hosts(
@@ -452,12 +447,7 @@ def update_facts_by_namespace(operation, host_id_list, namespace, fact_dict, rba
         ).count()
         filters += (HostGroupAssoc.group_id.in_(rbac_filter["groups"]),)
 
-        if inventory_config().hbi_db_refactoring_use_old_table:
-            # Old code: use single column GROUP BY
-            query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.id)
-        else:
-            # New code: use composite GROUP BY
-            query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.org_id, Host.id)
+        query = Host.query.join(HostGroupAssoc, isouter=True).filter(*filters).group_by(Host.org_id, Host.id)
 
         if (
             count_before_rbac_filter

--- a/app/config.py
+++ b/app/config.py
@@ -366,10 +366,6 @@ class Config:
         if self.replica_namespace:
             self.logger.info("***PROD REPLICA NAMESPACE DETECTED - Kafka operations will be disabled ***")
 
-        self.hbi_db_refactoring_use_old_table = (
-            os.environ.get("HBI_DB_REFACTORING_USE_OLD_TABLE", "false").lower() == "true"
-        )
-
     def _build_base_url_path(self):
         app_name = os.getenv("APP_NAME", "inventory")
         path_prefix = os.getenv("PATH_PREFIX", "api")

--- a/app/models/host_group_assoc.py
+++ b/app/models/host_group_assoc.py
@@ -1,34 +1,22 @@
-import os
-
 from sqlalchemy import ForeignKey
 from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy import Index
-from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 
-from app.common import inventory_config
 from app.models.constants import INVENTORY_SCHEMA
 from app.models.database import db
 
 
 class HostGroupAssoc(db.Model):
     __tablename__ = "hosts_groups"
-    if os.environ.get("HBI_DB_REFACTORING_USE_OLD_TABLE", "false").lower() != "true":
-        __table_args__ = (
-            Index("idxhostsgroups", "host_id", "group_id"),
-            Index("idxgroups_hosts", "group_id", "host_id"),
-            ForeignKeyConstraint(
-                ["org_id", "host_id"], [f"{INVENTORY_SCHEMA}.hosts.org_id", f"{INVENTORY_SCHEMA}.hosts.id"]
-            ),
-            {"schema": INVENTORY_SCHEMA},
-        )
-    else:
-        __table_args__ = (
-            Index("idxhostsgroups", "host_id", "group_id"),
-            Index("idxgroups_hosts", "group_id", "host_id"),
-            UniqueConstraint("host_id", name="hosts_groups_unique_host_id"),
-            {"schema": INVENTORY_SCHEMA},
-        )
+    __table_args__ = (
+        Index("idxhostsgroups", "host_id", "group_id"),
+        Index("idxgroups_hosts", "group_id", "host_id"),
+        ForeignKeyConstraint(
+            ["org_id", "host_id"], [f"{INVENTORY_SCHEMA}.hosts.org_id", f"{INVENTORY_SCHEMA}.hosts.id"]
+        ),
+        {"schema": INVENTORY_SCHEMA},
+    )
 
     def __init__(
         self,
@@ -38,14 +26,8 @@ class HostGroupAssoc(db.Model):
     ):
         self.host_id = host_id
         self.group_id = group_id
+        self.org_id = org_id
 
-        if not inventory_config().hbi_db_refactoring_use_old_table:
-            self.org_id = org_id
-
-    if os.environ.get("HBI_DB_REFACTORING_USE_OLD_TABLE", "false").lower() != "true":
-        host_id = db.Column(UUID(as_uuid=True), primary_key=True)
-        org_id = db.Column(db.String(36), primary_key=True)
-    else:
-        host_id = db.Column(UUID(as_uuid=True), ForeignKey(f"{INVENTORY_SCHEMA}.hosts.id"), primary_key=True)
-
+    host_id = db.Column(UUID(as_uuid=True), primary_key=True)
+    org_id = db.Column(db.String(36), primary_key=True)
     group_id = db.Column(UUID(as_uuid=True), ForeignKey(f"{INVENTORY_SCHEMA}.groups.id"), primary_key=True)

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -13,7 +13,6 @@ from marshmallow import validate as marshmallow_validate
 from marshmallow import validates
 from marshmallow import validates_schema
 
-from app.common import inventory_config
 from app.models.constants import MAX_CANONICAL_FACTS_VERSION
 from app.models.constants import MIN_CANONICAL_FACTS_VERSION
 from app.models.constants import TAG_KEY_VALIDATION
@@ -235,43 +234,27 @@ class LimitedHostSchema(CanonicalFactsSchema):
 
     @staticmethod
     def build_model(data, canonical_facts, facts, tags, tags_alt=None):
-        if inventory_config().hbi_db_refactoring_use_old_table:
-            # Old code: constructor without canonical facts parameters
-            return LimitedHost(
-                canonical_facts=canonical_facts,
-                display_name=data.get("display_name"),
-                ansible_host=data.get("ansible_host"),
-                account=data.get("account"),
-                org_id=data.get("org_id"),
-                facts=facts,
-                tags=tags,
-                tags_alt=tags_alt if tags_alt else [],
-                system_profile_facts=data.get("system_profile", {}),
-                groups=data.get("groups", []),
-            )
-        else:
-            # New code: constructor with canonical facts parameters
-            return LimitedHost(
-                canonical_facts=canonical_facts,
-                display_name=data.get("display_name"),
-                ansible_host=data.get("ansible_host"),
-                account=data.get("account"),
-                org_id=data.get("org_id"),
-                facts=facts,
-                tags=tags,
-                tags_alt=tags_alt if tags_alt else [],
-                system_profile_facts=data.get("system_profile", {}),
-                groups=data.get("groups", []),
-                insights_id=canonical_facts.get("insights_id"),
-                subscription_manager_id=canonical_facts.get("subscription_manager_id"),
-                satellite_id=canonical_facts.get("satellite_id"),
-                fqdn=canonical_facts.get("fqdn"),
-                bios_uuid=canonical_facts.get("bios_uuid"),
-                ip_addresses=canonical_facts.get("ip_addresses"),
-                mac_addresses=canonical_facts.get("mac_addresses"),
-                provider_id=canonical_facts.get("provider_id"),
-                provider_type=canonical_facts.get("provider_type"),
-            )
+        return LimitedHost(
+            canonical_facts=canonical_facts,
+            display_name=data.get("display_name"),
+            ansible_host=data.get("ansible_host"),
+            account=data.get("account"),
+            org_id=data.get("org_id"),
+            facts=facts,
+            tags=tags,
+            tags_alt=tags_alt if tags_alt else [],
+            system_profile_facts=data.get("system_profile", {}),
+            groups=data.get("groups", []),
+            insights_id=canonical_facts.get("insights_id"),
+            subscription_manager_id=canonical_facts.get("subscription_manager_id"),
+            satellite_id=canonical_facts.get("satellite_id"),
+            fqdn=canonical_facts.get("fqdn"),
+            bios_uuid=canonical_facts.get("bios_uuid"),
+            ip_addresses=canonical_facts.get("ip_addresses"),
+            mac_addresses=canonical_facts.get("mac_addresses"),
+            provider_id=canonical_facts.get("provider_id"),
+            provider_type=canonical_facts.get("provider_type"),
+        )
 
     @pre_load
     def coerce_system_profile_types(self, data, **kwargs):
@@ -306,47 +289,29 @@ class HostSchema(LimitedHostSchema):
     def build_model(data, canonical_facts, facts, tags, tags_alt=None):
         if tags_alt is None:
             tags_alt = []
-        if inventory_config().hbi_db_refactoring_use_old_table:
-            # Old code: constructor without canonical facts parameters
-            return Host(
-                canonical_facts,
-                data.get("display_name"),
-                data.get("ansible_host"),
-                data.get("account"),
-                data.get("org_id"),
-                facts,
-                tags,
-                tags_alt,
-                data.get("system_profile", {}),
-                data["stale_timestamp"],
-                data["reporter"],
-                data.get("groups", []),
-            )
-        else:
-            # New code: constructor with canonical facts parameters
-            return Host(
-                canonical_facts,
-                data.get("display_name"),
-                data.get("ansible_host"),
-                data.get("account"),
-                data.get("org_id"),
-                facts,
-                tags,
-                tags_alt,
-                data.get("system_profile", {}),
-                data["stale_timestamp"],
-                data["reporter"],
-                data.get("groups", []),
-                insights_id=canonical_facts.get("insights_id"),
-                subscription_manager_id=canonical_facts.get("subscription_manager_id"),
-                satellite_id=canonical_facts.get("satellite_id"),
-                fqdn=canonical_facts.get("fqdn"),
-                bios_uuid=canonical_facts.get("bios_uuid"),
-                ip_addresses=canonical_facts.get("ip_addresses"),
-                mac_addresses=canonical_facts.get("mac_addresses"),
-                provider_id=canonical_facts.get("provider_id"),
-                provider_type=canonical_facts.get("provider_type"),
-            )
+        return Host(
+            canonical_facts,
+            data.get("display_name"),
+            data.get("ansible_host"),
+            data.get("account"),
+            data.get("org_id"),
+            facts,
+            tags,
+            tags_alt,
+            data.get("system_profile", {}),
+            data["stale_timestamp"],
+            data["reporter"],
+            data.get("groups", []),
+            insights_id=canonical_facts.get("insights_id"),
+            subscription_manager_id=canonical_facts.get("subscription_manager_id"),
+            satellite_id=canonical_facts.get("satellite_id"),
+            fqdn=canonical_facts.get("fqdn"),
+            bios_uuid=canonical_facts.get("bios_uuid"),
+            ip_addresses=canonical_facts.get("ip_addresses"),
+            mac_addresses=canonical_facts.get("mac_addresses"),
+            provider_id=canonical_facts.get("provider_id"),
+            provider_type=canonical_facts.get("provider_type"),
+        )
 
 
 class PatchHostSchema(MarshmallowSchema):

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -425,12 +425,7 @@ class IngressMessageConsumer(HostMessageConsumer):
                 db.session.flush()  # Flush so that we can retrieve the created host's ID
                 # Get org's "ungrouped hosts" group (create if not exists) and assign host to it
                 group = get_or_create_ungrouped_hosts_group_for_identity(identity)
-                if inventory_config().hbi_db_refactoring_use_old_table:
-                    # Old code: constructor without org_id
-                    assoc = HostGroupAssoc(host_row.id, group.id)
-                else:
-                    # New code: constructor with org_id
-                    assoc = HostGroupAssoc(host_row.id, group.id, identity.org_id)
+                assoc = HostGroupAssoc(host_row.id, group.id, identity.org_id)
                 db.session.add(assoc)
                 host_row.groups = [serialize_group(group)]
                 db.session.flush()

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -99,8 +99,6 @@ objects:
           "run:app"
         ]
         env:
-        - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-          value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
         - name: APP_NAME
           value: ${APP_NAME}
         - name: PATH_PREFIX
@@ -261,8 +259,6 @@ objects:
           "run:app"
         ]
         env:
-        - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-          value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
         - name: APP_NAME
           value: ${APP_NAME}
         - name: PATH_PREFIX
@@ -423,8 +419,6 @@ objects:
           "run:app"
         ]
         env:
-        - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-          value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
         - name: APP_NAME
           value: ${APP_NAME}
         - name: PATH_PREFIX
@@ -550,8 +544,6 @@ objects:
       podSpec:
         args: ["./inv_mq_service.py"]
         env:
-        - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-          value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
         - name: CONSOLEDOT_HOSTNAME
           value: ${CONSOLEDOT_HOSTNAME}
         - name: INVENTORY_LOG_LEVEL
@@ -661,8 +653,6 @@ objects:
           inheritEnv: true
         args: ["./inv_mq_service.py"]
         env:
-        - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-          value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
         - name: MIGRATION_MODE
           value: ${MIGRATION_MODE}
         - name: CONSOLEDOT_HOSTNAME
@@ -773,8 +763,6 @@ objects:
       podSpec:
         args: ["./inv_mq_service.py"]
         env:
-        - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-          value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
         - name: CONSOLEDOT_HOSTNAME
           value: ${CONSOLEDOT_HOSTNAME}
         - name: INVENTORY_LOG_LEVEL
@@ -871,8 +859,6 @@ objects:
       podSpec:
         args: ["./inv_mq_service.py"]
         env:
-        - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-          value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
         - name: CONSOLEDOT_HOSTNAME
           value: ${CONSOLEDOT_HOSTNAME}
         - name: INVENTORY_LOG_LEVEL
@@ -978,8 +964,6 @@ objects:
       podSpec:
         args: ["./inv_export_service.py"]
         env:
-        - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-          value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
         - name: INVENTORY_LOG_LEVEL
           value: DEBUG
         - name: INVENTORY_DB_SSL_MODE
@@ -1052,8 +1036,6 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         args: ["./jobs/host_reaper.py"]
         env:
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -1140,8 +1122,6 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         args: ["./jobs/generate_stale_host_notifications.py"]
         env:
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: CONNEXION_LOG_LEVEL
@@ -1210,8 +1190,6 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         args: ["./jobs/inv_publish_hosts.py"]
         env:
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -1250,8 +1228,6 @@ objects:
         env:
           - name: PYTHONPATH
             value: '/opt/app-root/src'
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: GIT_TOKEN
@@ -1341,8 +1317,6 @@ objects:
         env:
           - name: PYTHONPATH
             value: '/opt/app-root/src'
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -1395,8 +1369,6 @@ objects:
         env:
           - name: PYTHONPATH
             value: '/opt/app-root/src'
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -1468,8 +1440,6 @@ objects:
         env:
           - name: PYTHONPATH
             value: '/opt/app-root/src'
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -1541,8 +1511,6 @@ objects:
         env:
           - name: PYTHONPATH
             value: '/opt/app-root/src'
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -1614,8 +1582,6 @@ objects:
         env:
           - name: PYTHONPATH
             value: '/opt/app-root/src'
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -1686,8 +1652,6 @@ objects:
         env:
           - name: PYTHONPATH
             value: '/opt/app-root/src'
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: INVENTORY_LOG_LEVEL
             value: ${LOG_LEVEL}
           - name: INVENTORY_DB_SSL_MODE
@@ -1750,8 +1714,6 @@ objects:
         env:
           - name: PYTHONPATH
             value: '/opt/app-root/src'
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: PYTHONPATH
             value: '/opt/app-root/src'
           - name: INVENTORY_LOG_LEVEL
@@ -1790,8 +1752,6 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         args: [ "./jobs/hosts_table_migration_switch.py" ]
         env:
-          - name: HBI_DB_REFACTORING_USE_OLD_TABLE
-            value: ${HBI_DB_REFACTORING_USE_OLD_TABLE}
           - name: PYTHONPATH
             value: '/opt/app-root/src'
           - name: INVENTORY_LOG_LEVEL
@@ -2601,8 +2561,3 @@ parameters:
   description: Choose migration mode to run DB refactoring tables transition
   required: true
   value: automated
-
-# Skip DB refactoring changes in prod
-- name: HBI_DB_REFACTORING_USE_OLD_TABLE
-  description: Skip DB refactoring changes in prod
-  value: 'false'

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -57,16 +57,9 @@ def _update_hosts_for_group_changes(host_id_list: list[str], group_id_list: list
     ]
 
     # Update groups data on each host record
-    if inventory_config().hbi_db_refactoring_use_old_table:
-        # Old code: filter by ID only
-        db.session.query(Host).filter(Host.id.in_(host_id_list)).update(
-            {"groups": serialized_groups}, synchronize_session="fetch"
-        )
-    else:
-        # New code: filter by ID and org_id
-        db.session.query(Host).filter(Host.id.in_(host_id_list), Host.org_id == identity.org_id).update(
-            {"groups": serialized_groups}, synchronize_session="fetch"
-        )
+    db.session.query(Host).filter(Host.id.in_(host_id_list), Host.org_id == identity.org_id).update(
+        {"groups": serialized_groups}, synchronize_session="fetch"
+    )
     db.session.commit()
 
     return serialized_groups, host_id_list
@@ -167,20 +160,11 @@ def _add_hosts_to_group(group_id: str, host_id_list: list[str], org_id: str):
         synchronize_session="fetch"
     )
 
-    if inventory_config().hbi_db_refactoring_use_old_table:
-        # Old code: constructor without org_id
-        host_group_assoc = [
-            HostGroupAssoc(host_id=host_id, group_id=group_id)
-            for host_id in host_id_list
-            if host_id not in ids_already_in_this_group
-        ]
-    else:
-        # New code: constructor with org_id
-        host_group_assoc = [
-            HostGroupAssoc(host_id=host_id, group_id=group_id, org_id=org_id)
-            for host_id in host_id_list
-            if host_id not in ids_already_in_this_group
-        ]
+    host_group_assoc = [
+        HostGroupAssoc(host_id=host_id, group_id=group_id, org_id=org_id)
+        for host_id in host_id_list
+        if host_id not in ids_already_in_this_group
+    ]
     db.session.add_all(host_group_assoc)
 
     _update_group_update_time(group_id, org_id)
@@ -483,16 +467,11 @@ def _update_group_update_time(group_id: str, org_id: str):
 
 
 def get_group_using_host_id(host_id: str, org_id: str):
-    if inventory_config().hbi_db_refactoring_use_old_table:
-        # Old code: filter by host_id only
-        assoc = db.session.query(HostGroupAssoc).filter(HostGroupAssoc.host_id == host_id).one_or_none()
-    else:
-        # New code: filter by org_id and host_id
-        assoc = (
-            db.session.query(HostGroupAssoc)
-            .filter(HostGroupAssoc.org_id == org_id, HostGroupAssoc.host_id == host_id)
-            .one_or_none()
-        )
+    assoc = (
+        db.session.query(HostGroupAssoc)
+        .filter(HostGroupAssoc.org_id == org_id, HostGroupAssoc.host_id == host_id)
+        .one_or_none()
+    )
     return get_group_by_id_from_db(str(assoc.group_id), org_id) if assoc else None
 
 

--- a/lib/host_delete.py
+++ b/lib/host_delete.py
@@ -10,7 +10,6 @@ from sqlalchemy.orm import Session
 
 from app.auth.identity import Identity
 from app.auth.identity import to_auth_header
-from app.common import inventory_config
 from app.instrumentation import log_host_delete_succeeded
 from app.logging import get_logger
 from app.models import Host
@@ -96,18 +95,10 @@ def delete_hosts(
 def _delete_host(session: Session, host: Host, identity: Identity | None, control_rule: str | None) -> OperationResult:
     sp_fields_to_log = extract_host_model_sp_to_log(host)
     org_id = identity.org_id if identity else host.org_id
-
-    if inventory_config().hbi_db_refactoring_use_old_table:
-        # Old code: filter by ID only
-        assoc_delete_query = session.query(HostGroupAssoc).filter(HostGroupAssoc.host_id == host.id)
-        host_delete_query = session.query(Host).filter(Host.id == host.id)
-    else:
-        # New code: filter by org_id and ID
-        assoc_delete_query = session.query(HostGroupAssoc).filter(
-            HostGroupAssoc.org_id == org_id, HostGroupAssoc.host_id == host.id
-        )
-        host_delete_query = session.query(Host).filter(Host.org_id == org_id, Host.id == host.id)
-
+    assoc_delete_query = session.query(HostGroupAssoc).filter(
+        HostGroupAssoc.org_id == org_id, HostGroupAssoc.host_id == host.id
+    )
+    host_delete_query = session.query(Host).filter(Host.org_id == org_id, Host.id == host.id)
     assoc_delete_query.delete(synchronize_session="fetch")
     host_delete_query.delete(synchronize_session="fetch")
     return OperationResult(

--- a/lib/host_remove_duplicates.py
+++ b/lib/host_remove_duplicates.py
@@ -5,7 +5,6 @@ from typing import Any
 from flask_sqlalchemy.query import Query
 from sqlalchemy.orm import Session
 
-from app.common import inventory_config
 from app.models import Host
 from app.queue.event_producer import EventProducer
 from lib.host_delete import delete_hosts
@@ -97,14 +96,9 @@ def delete_duplicate_hosts(
             logger.info(f"Found {len(duplicate_host_ids)} duplicates for org_id: {actual_org_id}")
             total_deleted += len(duplicate_host_ids)
         else:
-            if inventory_config().hbi_db_refactoring_use_old_table:
-                # Old code: filter by ID only
-                hosts_by_ids_query = misc_session.query(Host).filter(Host.id.in_(duplicate_host_ids))
-            else:
-                # New code: filter by org_id and ID
-                hosts_by_ids_query = misc_session.query(Host).filter(
-                    Host.org_id == actual_org_id, Host.id.in_(duplicate_host_ids)
-                )
+            hosts_by_ids_query = misc_session.query(Host).filter(
+                Host.org_id == actual_org_id, Host.id.in_(duplicate_host_ids)
+            )
             deleted_count = len(
                 list(
                     delete_hosts(

--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -19,7 +19,6 @@ from api.filtering.db_filters import staleness_to_conditions
 from api.filtering.db_filters import update_query_for_owner_id
 from api.staleness_query import get_staleness_obj
 from app.auth.identity import Identity
-from app.common import inventory_config
 from app.config import ALL_STALENESS_STATES
 from app.config import COMPOUND_ID_FACTS
 from app.config import COMPOUND_ID_FACTS_MAP
@@ -398,37 +397,23 @@ def get_host_list_by_id_list_from_db(host_id_list, identity, rbac_filter=None, c
 
         filters += (or_(*rbac_group_filters),)
 
-    if inventory_config().hbi_db_refactoring_use_old_table:
-        # Old code: use single column GROUP BY
-        query = (
-            Host.query.join(HostGroupAssoc, isouter=True).join(Group, isouter=True).filter(*filters).group_by(Host.id)
-        )
-    else:
-        # New code: use composite GROUP BY
-        query = (
-            Host.query.join(HostGroupAssoc, isouter=True)
-            .join(Group, isouter=True)
-            .filter(*filters)
-            .group_by(Host.id, Host.org_id)
-        )
+    query = (
+        Host.query.join(HostGroupAssoc, isouter=True)
+        .join(Group, isouter=True)
+        .filter(*filters)
+        .group_by(Host.id, Host.org_id)
+    )
     if columns:
         query = query.with_entities(*columns)
     return find_non_culled_hosts(update_query_for_owner_id(identity, query), identity.org_id)
 
 
 def get_non_culled_hosts_count_in_group(group: Group, org_id: str) -> int:
-    if inventory_config().hbi_db_refactoring_use_old_table:
-        # Old code: use single column GROUP BY
-        query = (
-            db.session.query(Host).join(HostGroupAssoc).filter(HostGroupAssoc.group_id == group.id).group_by(Host.id)
-        )
-    else:
-        # New code: use composite GROUP BY
-        query = (
-            db.session.query(Host)
-            .join(HostGroupAssoc)
-            .filter(HostGroupAssoc.group_id == group.id, HostGroupAssoc.org_id == org_id)
-            .group_by(Host.id, Host.org_id)
-        )
+    query = (
+        db.session.query(Host)
+        .join(HostGroupAssoc)
+        .filter(HostGroupAssoc.group_id == group.id, HostGroupAssoc.org_id == org_id)
+        .group_by(Host.id, Host.org_id)
+    )
 
     return find_non_culled_hosts(query, org_id).count()

--- a/migrations/versions/61c1b152246a_partitioned_tables_transition.py
+++ b/migrations/versions/61c1b152246a_partitioned_tables_transition.py
@@ -125,61 +125,61 @@ def upgrade():
 
     # This safety check verifies that the table migration was successful before stamping.
     # It runs for ALL modes to ensure consistency.
-    # op.execute("""
-    #        DO $$
-    #        BEGIN
-    #            -- Check if the hosts table is partitioned by HASH
-    #            IF NOT EXISTS (
-    #                SELECT 1
-    #                FROM pg_partitioned_table pt
-    #                JOIN pg_class c ON c.oid = pt.partrelid
-    #                JOIN pg_namespace n ON n.oid = c.relnamespace
-    #                WHERE n.nspname = 'hbi' AND c.relname = 'hosts' AND pt.partstrat = 'h'
-    #            ) THEN
-    #                RAISE EXCEPTION 'MIGRATION ERROR: The hosts table is not partitioned as expected. Aborting.';
-    #            END IF;
+    op.execute("""
+        DO $$
+        BEGIN
+            -- Check if the hosts table is partitioned by HASH
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_partitioned_table pt
+                JOIN pg_class c ON c.oid = pt.partrelid
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'hbi' AND c.relname = 'hosts' AND pt.partstrat = 'h'
+            ) THEN
+                RAISE EXCEPTION
+                'MIGRATION ERROR: The hosts table is not partitioned as expected. Aborting.';
+            END IF;
 
+            -- Check if the hosts primary key is composite (has 2 columns)
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint con
+                JOIN pg_class rel ON rel.oid = con.conrelid
+                JOIN pg_namespace n ON n.oid = rel.relnamespace
+                WHERE n.nspname = 'hbi' AND rel.relname = 'hosts'
+                  AND con.contype = 'p' AND array_length(con.conkey, 1) = 2
+            ) THEN
+                RAISE EXCEPTION
+                'MIGRATION ERROR: Expected a composite primary key on the hosts table. Aborting.';
+            END IF;
 
-#
-#            -- Check if the hosts primary key is composite (has 2 columns)
-#            IF NOT EXISTS (
-#                SELECT 1
-#                FROM pg_constraint con
-#                JOIN pg_class rel ON rel.oid = con.conrelid
-#                JOIN pg_namespace n ON n.oid = rel.relnamespace
-#                WHERE n.nspname = 'hbi' AND rel.relname = 'hosts'
-#                AND con.contype = 'p' AND array_length(con.conkey, 1) = 2
-#            ) THEN
-#                RAISE EXCEPTION 'MIGRATION ERROR: Expected a composite primary key on the hosts table. Aborting.';
-#            END IF;
-#
-#            -- Check if the hosts_groups table is partitioned by HASH
-#            IF NOT EXISTS (
-#                SELECT 1
-#                FROM pg_partitioned_table pt
-#                JOIN pg_class c ON c.oid = pt.partrelid
-#                JOIN pg_namespace n ON n.oid = c.relnamespace
-#                WHERE n.nspname = 'hbi' AND c.relname = 'hosts_groups' AND pt.partstrat = 'h'
-#            ) THEN
-#                RAISE EXCEPTION
-#                'MIGRATION ERROR: The hosts_groups table is not partitioned as expected. Aborting.';
-#            END IF;
-#
-#            -- Check if the hosts_groups primary key is composite (has 3 columns)
-#            IF NOT EXISTS (
-#                SELECT 1
-#                FROM pg_constraint con
-#                JOIN pg_class rel ON rel.oid = con.conrelid
-#                JOIN pg_namespace n ON n.oid = rel.relnamespace
-#                WHERE n.nspname = 'hbi' AND rel.relname = 'hosts_groups'
-#                AND con.contype = 'p' AND array_length(con.conkey, 1) = 3
-#            ) THEN
-#                RAISE EXCEPTION
-#                'MIGRATION ERROR: Expected a composite primary key on the hosts_groups table. Aborting.';
-#            END IF;
-#        END;
-#        $$;
-#    """)
+            -- Check if the hosts_groups table is partitioned by HASH
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_partitioned_table pt
+                JOIN pg_class c ON c.oid = pt.partrelid
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'hbi' AND c.relname = 'hosts_groups' AND pt.partstrat = 'h'
+            ) THEN
+                RAISE EXCEPTION
+                'MIGRATION ERROR: The hosts_groups table is not partitioned as expected. Aborting.';
+            END IF;
+
+            -- Check if the hosts_groups primary key is composite (has 3 columns)
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint con
+                JOIN pg_class rel ON rel.oid = con.conrelid
+                JOIN pg_namespace n ON n.oid = rel.relnamespace
+                WHERE n.nspname = 'hbi' AND rel.relname = 'hosts_groups'
+                  AND con.contype = 'p' AND array_length(con.conkey, 1) = 3
+            ) THEN
+                RAISE EXCEPTION
+                'MIGRATION ERROR: Expected a composite primary key on the hosts_groups table. Aborting.';
+            END IF;
+        END;
+        $$;
+    """)
 
 
 def downgrade():

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -13,7 +13,6 @@ from sqlalchemy_utils import create_database
 from sqlalchemy_utils import database_exists
 from sqlalchemy_utils import drop_database
 
-from app.common import inventory_config
 from app.config import Config
 from app.environment import RuntimeEnvironment
 from app.models import Group
@@ -60,12 +59,7 @@ def database(database_name: None) -> Generator[str]:  # noqa: ARG001
 def db_get_host(flask_app: FlaskApp) -> Callable[[UUID], Host | None]:  # noqa: ARG001
     def _db_get_host(host_id: UUID, org_id: str | None = None) -> Host | None:
         org_id = org_id or SYSTEM_IDENTITY["org_id"]
-        if inventory_config().hbi_db_refactoring_use_old_table:
-            # Old code: filter by ID only
-            return Host.query.filter(Host.id == host_id).one_or_none()
-        else:
-            # New code: filter by org_id and ID
-            return Host.query.filter(Host.org_id == org_id, Host.id == host_id).one_or_none()
+        return Host.query.filter(Host.org_id == org_id, Host.id == host_id).one_or_none()
 
     return _db_get_host
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20292](https://issues.redhat.com/browse/RHINENG-20292).

It removes all the code that we have implemented to handle the application dual mode (using old and new hosts table)

Related PR: https://github.com/RedHatInsights/insights-host-inventory/pull/2808


## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Eliminate the dual-mode feature flag for the HBI application and clean up all old-table conditionals by defaulting to the new partitioned hosts tables with canonical facts and composite keys

Enhancements:
- Remove legacy HBI_DB_REFACTORING_USE_OLD_TABLE feature flag and associated conditional logic across the codebase
- Simplify Host and HostGroupAssoc models to always include canonical facts fields and enforce composite primary keys
- Uncomment and enforce migration safety checks for partitioned hosts and hosts_groups tables

Deployment:
- Remove HBI_DB_REFACTORING_USE_OLD_TABLE environment variable from Clowd app manifests

Tests:
- Update test fixtures to remove old-table filtering and default to composite key behavior