### PR TITLE
Hotfix: Drop logical replication publication

### DIFF
--- a/jobs/inv_publish_hosts.py
+++ b/jobs/inv_publish_hosts.py
@@ -85,6 +85,7 @@ DROP_PUBLICATIONS = [
     "hbi_hosts_pub",
     "hbi_hosts_pub_v1_0_0",
     "hbi_hosts_pub_v1_0_1",
+    "hbi_hosts_pub_v1_0_2",
 ]
 
 # Replication slots to drop
@@ -153,7 +154,7 @@ def setup_publication(session, logger):
 
     # 3) create the publication
     logger.info(f'Creating publication "{PUBLICATION_NAME}".')
-    session.execute(CREATE_PUBLICATION_SQL)
+    # session.execute(CREATE_PUBLICATION_SQL)
 
     # 4) sanity-check replication slots
     bad = []


### PR DESCRIPTION
# Overview

This PR is being created to drop the "hbi_hosts_pub_v1_0_2" publication which is causing issues in production.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Drop the problematic logical replication publication by adding it to the cleanup list and preventing its recreation.

Bug Fixes:
- Include hbi_hosts_pub_v1_0_2 in the list of replication publications to drop
- Disable the CREATE PUBLICATION execution to avoid recreating the dropped publication