### PR TITLE
kessel: hardcode UUID

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -288,21 +288,6 @@ def process_identity_header(encoded_id_header):
     return org_id, access_id
 
 
-def get_reporter_instance_id():
-    """
-    Get the current reporter instance ID for HBI.
-    
-    Returns:
-        str: The current reporter instance ID
-    """
-    #TODO: get the instance_id from the payload somehow
-    return "3c4e2382-26c1-11f0-8e5c-ce0194e9e144"
-
-
-# For backward compatibility with existing Kessel code
-reporter = type('ReporterInfo', (), {'instance_id': get_reporter_instance_id()})()
-
-
 def process_spec(spec):
     system_profile_spec_processed = {}
     for field, props in spec.items():

--- a/lib/kessel.py
+++ b/lib/kessel.py
@@ -3,7 +3,7 @@ from app.models import (
     Host,
     HostGroupAssoc
 )
-from app import Config, KesselPermission, reporter
+from app import Config, KesselPermission
 from flask import current_app
 from sqlalchemy import event
 from sqlalchemy.orm import Session
@@ -175,7 +175,7 @@ class Kessel:
             resource_id=resource_id,
             reporter=reporter_reference_pb2.ReporterReference(
                 type=permission.resource_type.namespace,  # e.g., "hbi"
-                instance_id=reporter.instance_id
+                instance_id= "3c4e2382-26c1-11f0-8e5c-ce0194e9e144"
             ),
         )
         
@@ -208,7 +208,7 @@ class Kessel:
             resource_id=resource_id,
             reporter=reporter_reference_pb2.ReporterReference(
                 type=permission.resource_type.namespace,
-                instance_id=reporter.instance_id
+                instance_id= "3c4e2382-26c1-11f0-8e5c-ce0194e9e144"
             ),
         )
         
@@ -296,7 +296,7 @@ class Kessel:
         request = report_resource_request_pb2.ReportResourceRequest(
             type="host",
             reporter_type="hbi",
-            reporter_instance_id=reporter.instance_id,
+            reporter_instance_id= "3c4e2382-26c1-11f0-8e5c-ce0194e9e144",
             representations=representations
         )
 
@@ -309,7 +309,7 @@ class Kessel:
                 resource_id=id,
                 reporter=reporter_reference_pb2.ReporterReference(
                     type="hbi",
-                    instance_id=reporter.instance_id
+                    instance_id= "3c4e2382-26c1-11f0-8e5c-ce0194e9e144"
                 )
             )
         )

--- a/lib/kessel.py
+++ b/lib/kessel.py
@@ -296,7 +296,7 @@ class Kessel:
         request = report_resource_request_pb2.ReportResourceRequest(
             type="host",
             reporter_type="hbi",
-            reporter_instance_id= "3c4e2382-26c1-11f0-8e5c-ce0194e9e144",
+            reporter_instance_id= "redhat",
             representations=representations
         )
 


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-xxxx](https://issues.redhat.com/browse/RHINENG-xxxx).
(A description of your PR's changes, along with why/context to the PR, goes here.)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Use a fixed UUID for the reporter instance instead of dynamically retrieving it

Enhancements:
- Replace all reporter.instance_id references with the hardcoded UUID "3c4e2382-26c1-11f0-8e5c-ce0194e9e144"
- Remove the get_reporter_instance_id helper and legacy ReporterInfo compatibility shim