### PR TITLE
fix(migrations): update down_revision ID in outbox table migration

### DIFF
--- a/migrations/versions/38324a692109_add_outbox_table.py
+++ b/migrations/versions/38324a692109_add_outbox_table.py
@@ -1,7 +1,7 @@
 """add outbox table
 
 Revision ID: 38324a692109
-Revises: 595dbad97e20
+Revises: e54048e82617
 Create Date: 2025-08-19 12:39:56.582711
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "38324a692109"
-down_revision = "595dbad97e20"
+down_revision = "e54048e82617"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
- Corrected the `down_revision` ID in the migration script to ensure proper dependency resolution in the Alembic migration chain.

# Overview

This PR is being created to address [RHINENG-xxxx](https://issues.redhat.com/browse/RHINENG-xxxx).
(A description of your PR's changes, along with why/context to the PR, goes here.)

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Update down_revision value to e54048e82617 in the outbox table migration script