### PR TITLE
fix(RHINENG-20233): Add job to fix host bios_uuid

### DIFF
--- a/deploy/cji.yml
+++ b/deploy/cji.yml
@@ -73,6 +73,16 @@ objects:
     appName: host-inventory
     jobs:
       - hosts-table-migration-switch
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    labels:
+      app: host-inventory
+    name: delete-host-bios-uuid-${DELETE_HOST_BIOS_UUID_RUN_NUMBER}
+  spec:
+    appName: host-inventory
+    jobs:
+      - delete-host-bios-uuid
 parameters:
 - name: SYNCHRONIZER_RUN_NUMBER
   value: '1'
@@ -87,4 +97,6 @@ parameters:
 - name: HOSTS_TABLE_MIGRATION_DATA_COPY_RUN_NUMBER
   value: '1'
 - name: HOSTS_TABLE_MIGRATION_SWITCH_RUN_NUMBER
+  value: '1'
+- name: DELETE_HOST_BIOS_UUID_RUN_NUMBER
   value: '1'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1783,6 +1783,42 @@ objects:
           requests:
             cpu: ${CPU_REQUEST_HOSTS_TABLE_MIGRATION_SWITCH}
             memory: ${MEMORY_REQUEST_HOSTS_TABLE_MIGRATION_SWITCH}
+    - name: delete-host-bios-uuid
+      restartPolicy: Never
+      suspend: ${{SUSPEND_DELETE_HOST_BIOS_UUID}}
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        args: [ "./jobs/delete_host_bios_uuid.py" ]
+        env:
+          - name: PYTHONPATH
+            value: '/opt/app-root/src'
+          - name: INVENTORY_LOG_LEVEL
+            value: ${LOG_LEVEL}
+          - name: INVENTORY_DB_SSL_MODE
+            value: ${INVENTORY_DB_SSL_MODE}
+          - name: INVENTORY_DB_SSL_CERT
+            value: ${INVENTORY_DB_SSL_CERT}
+          - name: INVENTORY_DB_SCHEMA
+            value: "${INVENTORY_DB_SCHEMA}"
+          - name: TARGET_HOST_ID
+            value: ${TARGET_HOST_ID}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CLOWDER_ENABLED
+            value: "true"
+          - name: SUSPEND_JOB
+            value: ${SUSPEND_DELETE_HOST_BIOS_UUID}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_DELETE_HOST_BIOS_UUID_JOB}
+            memory: ${MEMORY_LIMIT_DELETE_HOST_BIOS_UUID_JOB}
+          requests:
+            cpu: ${CPU_REQUEST_DELETE_HOST_BIOS_UUID_JOB}
+            memory: ${MEMORY_REQUEST_DELETE_HOST_BIOS_UUID_JOB}
     database:
       name: ${DB_NAME}
       version: 16
@@ -2561,3 +2597,19 @@ parameters:
   description: Choose migration mode to run DB refactoring tables transition
   required: true
   value: automated
+
+# Delete Host BIOS UUID Job
+- name: CPU_REQUEST_DELETE_HOST_BIOS_UUID_JOB
+  value: 100m
+- name: CPU_LIMIT_DELETE_HOST_BIOS_UUID_JOB
+  value: 200m
+- name: MEMORY_REQUEST_DELETE_HOST_BIOS_UUID_JOB
+  value: 128Mi
+- name: MEMORY_LIMIT_DELETE_HOST_BIOS_UUID_JOB
+  value: 256Mi
+- name: SUSPEND_DELETE_HOST_BIOS_UUID
+  description: If set to true, the delete-host-bios-uuid job will immediately exit upon running.
+  value: 'true'
+- name: TARGET_HOST_ID
+  description: The host ID to target for bios_uuid deletion
+  value: ''

--- a/jobs/delete_host_bios_uuid.py
+++ b/jobs/delete_host_bios_uuid.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python3
+"""
+Job to delete the bios_uuid field from a specific host.
+
+This script removes the bios_uuid field from a host by setting it to NULL.
+"""
+
+import os
+import sys
+import uuid
+from functools import partial
+from logging import Logger
+
+from connexion import FlaskApp
+from sqlalchemy.orm import Session
+
+from app.environment import RuntimeEnvironment
+from app.logging import get_logger
+from app.models import Host
+from jobs.common import excepthook
+from jobs.common import job_setup
+from lib.db import session_guard
+
+PROMETHEUS_JOB = "inventory-delete-host-bios-uuid"
+LOGGER_NAME = "delete-host-bios-uuid"
+RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
+
+# Host ID to target for bios_uuid deletion
+TARGET_HOST_ID = os.environ.get("TARGET_HOST_ID", "")
+
+
+def run(logger: Logger, session: Session, application: FlaskApp):
+    """Delete bios_uuid field from the specified host."""
+    with application.app.app_context():
+        # Validate that TARGET_HOST_ID is provided
+        if not TARGET_HOST_ID:
+            logger.error("TARGET_HOST_ID environment variable is required but not provided")
+            logger.error("Please set TARGET_HOST_ID to the UUID of the host to process")
+            return
+
+        logger.info(f"Starting job to delete bios_uuid field from host {TARGET_HOST_ID}")
+
+        try:
+            # Parse the target host ID to ensure it's a valid UUID
+            host_uuid = uuid.UUID(TARGET_HOST_ID)
+            logger.info(f"Target host UUID parsed successfully: {host_uuid}")
+        except ValueError as e:
+            logger.error(f"Invalid host ID format '{TARGET_HOST_ID}': {e}")
+            logger.error("TARGET_HOST_ID must be a valid UUID")
+            return
+
+        # Query for the specific host
+        host = session.query(Host).filter(Host.id == host_uuid).first()
+
+        if not host:
+            logger.warning(f"Host with ID {TARGET_HOST_ID} not found")
+            return
+
+        logger.info(f"Found host: ID={host.id}, org_id={host.org_id}, display_name={host.display_name}")
+
+        # Check current bios_uuid value
+        current_bios_uuid = host.bios_uuid
+        logger.info(f"Current bios_uuid value: {current_bios_uuid}")
+
+        if current_bios_uuid is None:
+            logger.info("bios_uuid is already NULL, no action needed")
+            return
+
+        # Delete the bios_uuid field by setting it to NULL
+        host.bios_uuid = None
+        logger.info("Set bios_uuid to NULL")
+
+        # Update the canonical_facts if it contains bios_uuid
+        if host.canonical_facts and "bios_uuid" in host.canonical_facts:
+            logger.info("Removing bios_uuid from canonical_facts")
+            del host.canonical_facts["bios_uuid"]
+            # Mark the JSONB field as modified so SQLAlchemy detects the change
+            from sqlalchemy import orm
+
+            orm.attributes.flag_modified(host, "canonical_facts")
+
+        try:
+            session.commit()
+            logger.info(f"Successfully deleted bios_uuid field from host {TARGET_HOST_ID}")
+        except Exception as e:
+            logger.error(f"Error committing changes: {e}", exc_info=True)
+            session.rollback()
+            raise
+
+
+if __name__ == "__main__":
+    logger = get_logger(LOGGER_NAME)
+    job_type = "Delete host bios_uuid field"
+    sys.excepthook = partial(excepthook, logger, job_type)
+
+    _, session, event_producer, _, _, application = job_setup(tuple(), PROMETHEUS_JOB)
+    session.expire_on_commit = False
+    with session_guard(session):
+        run(logger, session, application)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20233](https://issues.redhat.com/browse/RHINENG-20233).
Add a job to remove the bios_uuid field from the host that is raising a validation error for that field.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add a new background job to remove the bios_uuid field from a specific host, resolving validation errors by nullifying the field and cleaning it from canonical facts.

New Features:
- Add a Kubernetes job definition `delete-host-bios-uuid` with resource limits and suspend toggle in deploy/clowdapp.yml
- Implement `jobs/delete_host_bios_uuid.py` to locate the target host, set its bios_uuid to null, and remove it from canonical_facts