### PR TITLE
feat(RHINENG-20360) Make the inv_publish_hosts script configurable

### DIFF
--- a/app/models/host.py
+++ b/app/models/host.py
@@ -201,7 +201,7 @@ class LimitedHost(db.Model):
     canonical_facts = db.Column(JSONB)
 
     # canonical facts
-    insights_id = db.Column(UUID(as_uuid=True), default="00000000-0000-0000-0000-000000000000")
+    insights_id = db.Column(UUID(as_uuid=True), nullable=False, default="00000000-0000-0000-0000-000000000000")
     subscription_manager_id = db.Column(db.String(36))
     satellite_id = db.Column(db.String(255))
     fqdn = db.Column(db.String(255))

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1210,6 +1210,14 @@ objects:
             value: ${PROMETHEUS_PUSHGATEWAY}
           - name: REPLICA_NAMESPACE
             value: ${REPLICA_NAMESPACE}
+          - name: CREATE_PUBLICATIONS
+            value: ${SYNDICATOR_CREATE_PUBLICATIONS}
+          - name: DROP_PUBLICATIONS
+            value: ${SYNDICATOR_DROP_PUBLICATIONS}
+          - name: DROP_REPLICATION_SLOTS
+            value: ${SYNDICATOR_DROP_REPLICATION_SLOTS}
+          - name: REPLICA_IDENTITY_MODE
+            value: ${SYNDICATOR_REPLICA_IDENTITY_MODE}
         resources:
           limits:
             cpu: ${CPU_LIMIT_SYNDICATOR}
@@ -2624,6 +2632,20 @@ parameters:
 - name: FLOORIST_DB_SECRET_NAME
   description: database secret name
   value: host-inventory-db
+
+  # Logical replication
+- name: SYNDICATOR_CREATE_PUBLICATIONS
+  description: Publications to create
+  value: ''
+- name: SYNDICATOR_DROP_PUBLICATIONS
+  description: Publications to drop
+  value: ''
+- name: SYNDICATOR_DROP_REPLICATION_SLOTS
+  description: Replication slots to drop
+  value: ''
+- name: SYNDICATOR_REPLICA_IDENTITY_MODE
+  description: Replica Identity Mode to set in the published tables (and their partitions)
+  value: ''
 
 # Replica namespace
 - name: REPLICA_NAMESPACE

--- a/dev.yml
+++ b/dev.yml
@@ -3,6 +3,7 @@ services:
     db:
       container_name: hbi-db
       image: docker.io/library/postgres:16.4
+      command: postgres -c wal_level=logical
       restart: always
       environment:
           POSTGRES_PASSWORD: insights

--- a/docs/inv_publish_hosts_configuration.md
+++ b/docs/inv_publish_hosts_configuration.md
@@ -1,0 +1,137 @@
+# inv_publish_hosts.py Configuration
+
+This document describes the configuration options available for the `jobs/inv_publish_hosts.py` script.
+
+## Environment Variables
+
+### CREATE_PUBLICATIONS
+- **Type**: Comma-separated string
+- **Default**: `""` (empty - no publications created by default)
+- **Description**: List of PostgreSQL publications to create.
+- **Example**: `"hbi_hosts_pub_v1_0_2,hbi_hosts_pub_v2_0_0"`
+- **Note**: Each publication must exist as a key in the internal `PUBLICATION_CONFIG` structure
+- **Control**: Use empty string to skip publication creation entirely
+
+### DROP_PUBLICATIONS
+- **Type**: Comma-separated string
+- **Default**: `""` (empty - no publications dropped by default)
+- **Description**: List of legacy publication names to drop before creating new ones.
+- **Example**: `"old_pub1,legacy_pub2,deprecated_pub3"`
+- **Control**: Use empty string to skip publication dropping entirely
+
+### DROP_REPLICATION_SLOTS
+- **Type**: Comma-separated string
+- **Default**: `""` (empty - no replication slots dropped by default)
+- **Description**: List of replication slot names to drop if they are inactive.
+- **Example**: `"slot1,slot2,slot3"`
+- **Note**: Empty string or unset means no replication slots will be dropped
+
+### REPLICA_IDENTITY_MODE
+- **Type**: String
+- **Default**: `""` (empty - no changes will be made to the replica identity)
+- **Valid values**: `"default"`, `"index"`, `""` (empty string)
+- **Description**: Sets the replica identity mode for all tables and their partitions.
+  - `"default"`: Uses PostgreSQL's default replica identity (usually primary key)
+  - `"index"`: Uses a unique index for replica identity
+  - `""` (empty string): Skip replica identity configuration entirely
+- **Smart Detection**: The script efficiently checks each table's current replica identity using PostgreSQL's `regclass` functionality before making changes. Tables already in the desired mode are skipped, reducing unnecessary operations.
+
+## Tables Managed
+
+All tables are configured in the `PUBLICATION_CONFIG` variable within the script, which includes:
+- Publication name (as top-level key)
+- Tables list for each publication containing:
+  - Table name
+  - Schema name
+  - Partition information
+  - Publication columns
+  - Publication filter (WHERE clause for selective replication)
+
+This structure supports multiple publications and makes it easy to modify table configurations, add new publications, update schemas, change publication columns, or customize replication filters as needed.
+
+### Adding New Publications
+
+To add a new publication, simply add a new key to `PUBLICATION_CONFIG` in the script:
+
+```python
+PUBLICATION_CONFIG = {
+    "hbi_hosts_pub_v1_0_2": {
+        "tables": [
+            # ... existing tables
+        ]
+    },
+    "hbi_hosts_pub_v2_0_0": {  # New publication
+        "tables": [
+            {
+                "name": "hosts",
+                "schema": INVENTORY_SCHEMA,
+                "has_partitions": True,
+                "publication_columns": ["org_id", "id", "display_name"],  # Different columns
+                "publication_filter": "created_on > '2024-01-01'"  # Different filter
+            },
+            # ... other tables with different configurations
+        ]
+    }
+}
+```
+
+Then specify both publications in the environment variable:
+```bash
+CREATE_PUBLICATIONS="hbi_hosts_pub_v1_0_2,hbi_hosts_pub_v2_0_0"
+```
+
+## Control Mechanism
+
+The script uses **empty values** to control whether operations are performed:
+
+- **`CREATE_PUBLICATIONS=""` (empty)**: Skip publication creation entirely
+- **`DROP_PUBLICATIONS=""` (empty)**: Skip publication dropping entirely
+- **`DROP_REPLICATION_SLOTS=""` (empty)**: Skip replication slot cleanup entirely
+- **`REPLICA_IDENTITY_MODE=""` (empty)**: Skip replica identity configuration entirely
+
+This provides fine-grained control without needing separate enable/disable flags. You can selectively enable/disable each type of operation independently.
+
+## Usage Examples
+
+### Basic usage (default configuration)
+```bash
+python jobs/inv_publish_hosts.py
+```
+
+### Skip replica identity configuration
+```bash
+REPLICA_IDENTITY_MODE="" python jobs/inv_publish_hosts.py
+```
+
+### Skip all operations (publications and replica identity)
+```bash
+CREATE_PUBLICATIONS="" DROP_PUBLICATIONS="" DROP_REPLICATION_SLOTS="" REPLICA_IDENTITY_MODE="" python jobs/inv_publish_hosts.py
+```
+
+### Full custom configuration
+```bash
+CREATE_PUBLICATIONS="hbi_hosts_pub_v1_0_2" \
+REPLICA_IDENTITY_MODE=index \
+DROP_PUBLICATIONS="hbi_hosts_pub_v1_0_0,hbi_hosts_pub_v1_0_1" \
+DROP_REPLICATION_SLOTS="roadmap_hosts_sub" \
+python jobs/inv_publish_hosts.py
+```
+
+## What the Script Does
+
+1. **Replica Identity Configuration**: Sets replica identity for all tables and partitions according to `REPLICA_IDENTITY_MODE`
+   - **Smart Detection**: Checks current replica identity before making changes
+   - **Skip Unchanged**: Tables already in the desired mode are skipped
+   - **Efficient Updates**: Only modifies tables that need changes
+   - **Skip Entirely**: Use empty string (`""`) to skip replica identity configuration completely
+2. **Publication Management**:
+   - Drops legacy publications (if `DROP_PUBLICATIONS` is not empty)
+   - Creates each publication from `CREATE_PUBLICATIONS` list if it doesn't exist (if `CREATE_PUBLICATIONS` is not empty)
+3. **Replication Slot Cleanup**: Drops inactive replication slots listed in `DROP_REPLICATION_SLOTS`
+
+
+## Error Handling
+
+- If replica identity mode is invalid, the script logs an error and skips replica identity configuration
+- If publication or replication slot operations fail, the transaction is rolled back
+- All database changes are committed only if all operations succeed

--- a/jobs/inv_publish_hosts.py
+++ b/jobs/inv_publish_hosts.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import os
 import sys
 from functools import partial
 
@@ -12,6 +13,7 @@ from app import create_app
 from app.config import Config
 from app.environment import RuntimeEnvironment
 from app.logging import get_logger
+from app.models.constants import INVENTORY_SCHEMA
 from lib.handlers import ShutdownHandler
 from lib.handlers import register_shutdown
 from lib.metrics import hosts_syndication_fail_count
@@ -24,72 +26,91 @@ LOGGER_NAME = "hosts-syndicator"
 PROMETHEUS_JOB = "hosts-syndicator"
 RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
 
-# Publications and columns
-PUBLICATION_NAME = "hbi_hosts_pub_v1_0_2"
-HOSTS_PUBLICATION_COLUMNS = [
-    "org_id",
-    "id",
-    "account",
-    "display_name",
-    "ansible_host",
-    "created_on",
-    "modified_on",
-    "facts",
-    "tags_alt",
-    "groups",
-    "last_check_in",
-    "stale_timestamp",
-    "deletion_timestamp",
-    "stale_warning_timestamp",
-    "reporter",
-    "per_reporter_staleness",
-    "insights_id",
-    "subscription_manager_id",
-    "satellite_id",
-    "fqdn",
-    "bios_uuid",
-    "ip_addresses",
-    "mac_addresses",
-    "provider_id",
-    "provider_type",
-]
-SP_DYNAMIC_PUBLICATION_COLUMNS = [
-    "org_id",
-    "host_id",
-    "insights_id",
-    "installed_packages",
-    "installed_products",
-    "workloads",
-]
-SP_STATIC_PUBLICATION_COLUMNS = (
-    "org_id",
-    "host_id",
-    "insights_id",
-    "arch",
-    "bootc_status",
-    "dnf_modules",
-    "host_type",
-    "image_builder",
-    "operating_system",
-    "owner_id",
-    "releasever",
-    "rhc_client_id",
-    "rhsm",
-    "satellite_managed",
-    "system_update_method",
-    "yum_repos",
-)
+# Configuration from environment variables
+CREATE_PUBLICATIONS = [pub.strip() for pub in os.getenv("CREATE_PUBLICATIONS", "").split(",") if pub.strip()]
+DROP_PUBLICATIONS = [pub.strip() for pub in os.getenv("DROP_PUBLICATIONS", "").split(",") if pub.strip()]
+DROP_REPLICATION_SLOTS = [slot.strip() for slot in os.getenv("DROP_REPLICATION_SLOTS", "").split(",") if slot.strip()]
+REPLICA_IDENTITY_MODE = os.getenv("REPLICA_IDENTITY_MODE", "").lower()
 
-# Publications to drop
-DROP_PUBLICATIONS = [
-    "hbi_hosts_pub",
-    "hbi_hosts_pub_v1_0_0",
-    "hbi_hosts_pub_v1_0_1",
-    "hbi_hosts_pub_v1_0_2",
-]
 
-# Replication slots to drop
-DROP_REPLICATION_SLOTS = ["roadmap_hosts_sub"]
+# Publication configurations for replica identity management and publication setup
+PUBLICATION_CONFIG = {
+    "hbi_hosts_pub_v1_0_2": {
+        "tables": [
+            {
+                "name": "hosts",
+                "schema": INVENTORY_SCHEMA,
+                "has_partitions": True,
+                "publication_columns": [
+                    "org_id",
+                    "id",
+                    "account",
+                    "display_name",
+                    "ansible_host",
+                    "created_on",
+                    "modified_on",
+                    "facts",
+                    "tags_alt",
+                    "groups",
+                    "last_check_in",
+                    "stale_timestamp",
+                    "deletion_timestamp",
+                    "stale_warning_timestamp",
+                    "reporter",
+                    "per_reporter_staleness",
+                    "insights_id",
+                    "subscription_manager_id",
+                    "satellite_id",
+                    "fqdn",
+                    "bios_uuid",
+                    "ip_addresses",
+                    "mac_addresses",
+                    "provider_id",
+                    "provider_type",
+                ],
+                "publication_filter": "insights_id != '00000000-0000-0000-0000-000000000000'",
+            },
+            {
+                "name": "system_profiles_dynamic",
+                "schema": INVENTORY_SCHEMA,
+                "has_partitions": True,
+                "publication_columns": [
+                    "org_id",
+                    "host_id",
+                    "insights_id",
+                    "installed_packages",
+                    "installed_products",
+                    "workloads",
+                ],
+                "publication_filter": "insights_id != '00000000-0000-0000-0000-000000000000'",
+            },
+            {
+                "name": "system_profiles_static",
+                "schema": INVENTORY_SCHEMA,
+                "has_partitions": True,
+                "publication_columns": [
+                    "org_id",
+                    "host_id",
+                    "insights_id",
+                    "arch",
+                    "bootc_status",
+                    "dnf_modules",
+                    "host_type",
+                    "image_builder",
+                    "operating_system",
+                    "owner_id",
+                    "releasever",
+                    "rhc_client_id",
+                    "rhsm",
+                    "satellite_managed",
+                    "system_update_method",
+                    "yum_repos",
+                ],
+                "publication_filter": "insights_id != '00000000-0000-0000-0000-000000000000'",
+            },
+        ]
+    }
+}
 
 CHECK_PUBLICATION_SQL = sa_text("""
     SELECT EXISTS(
@@ -98,21 +119,41 @@ CHECK_PUBLICATION_SQL = sa_text("""
 """)
 CHECK_REPLICATION_SLOTS_SQL = sa_text("SELECT slot_name, active FROM pg_replication_slots")
 
-CREATE_PUBLICATION_SQL = sa_text(f"""
-    CREATE PUBLICATION {PUBLICATION_NAME}
-    FOR TABLE
-      hbi.hosts ({",".join(HOSTS_PUBLICATION_COLUMNS)})
-        WHERE (insights_id != '00000000-0000-0000-0000-000000000000'),
-      hbi.system_profiles_dynamic ({",".join(SP_DYNAMIC_PUBLICATION_COLUMNS)})
-        WHERE (insights_id != '00000000-0000-0000-0000-000000000000'),
-      hbi.system_profiles_static ({",".join(SP_STATIC_PUBLICATION_COLUMNS)})
-        WHERE (insights_id != '00000000-0000-0000-0000-000000000000')
-    WITH (publish_via_partition_root = true);
-""")
-
 DROP_PUBLICATION_SQL = "DROP PUBLICATION IF EXISTS "
 
 DROP_REPLICATION_SLOTS_SQL = sa_text("SELECT pg_drop_replication_slot(:slot_name)")
+
+REPLICA_IDENTITY_DEFAULT_SQL = sa_text("ALTER TABLE {schema}.{table_name} REPLICA IDENTITY DEFAULT")
+REPLICA_IDENTITY_INDEX_SQL = sa_text("ALTER TABLE {schema}.{table_name} REPLICA IDENTITY USING INDEX {index_name}")
+
+GET_PARTITIONS_SQL = sa_text("""
+    SELECT schemaname, tablename
+    FROM pg_tables
+    WHERE schemaname = :schema
+    AND tablename ~ :table_pattern
+    AND tablename != :table_name
+    ORDER BY tablename
+""")
+
+GET_CURRENT_REPLICA_IDENTITY_SQL = sa_text("""
+    SELECT relreplident
+    FROM pg_class
+    WHERE oid = (:qualified_table_name)::regclass
+""")
+
+# Get the unique index for replica identity
+GET_UNIQUE_INDEXES_SQL = sa_text("""
+    SELECT indexname
+    FROM pg_indexes
+    WHERE schemaname = :schema
+    AND tablename = :table_name
+    AND indexdef LIKE '%UNIQUE%'
+    AND (indexname LIKE '%replica_identity%'
+         OR indexname LIKE '%org_id_id_insights_id_idx%'
+         OR indexname LIKE '%org_id_host_id_insights_id_idx%')
+    ORDER BY indexname
+    LIMIT 1
+""")
 
 COLLECTED_METRICS = (
     hosts_syndication_fail_count,
@@ -140,53 +181,225 @@ def _excepthook(logger, exc_type, value, traceback):
     logger.exception("Inventory migration failed", exc_info=(exc_type, value, traceback))
 
 
-def setup_publication(session, logger):
-    # 1) drop any legacy publications
-    for pub in DROP_PUBLICATIONS:
-        logger.info(f"Dropping publication: {pub}")
-        session.execute(sa_text(DROP_PUBLICATION_SQL + pub))
+def _build_create_publication_sql(publication_name):
+    """Build CREATE PUBLICATION SQL dynamically from PUBLICATION_CONFIG."""
+    if publication_name not in PUBLICATION_CONFIG:
+        raise ValueError(f"Publication '{publication_name}' not found in PUBLICATION_CONFIG")
 
-    # 2) check if the publication already exists
-    exists = session.execute(CHECK_PUBLICATION_SQL, {"pubname": PUBLICATION_NAME}).scalar()
-    if exists:
-        logger.info(f'Publication "{PUBLICATION_NAME}" already exists.')
+    publication_config = PUBLICATION_CONFIG[publication_name]
+    table_specs = []
+
+    for table_config in publication_config["tables"]:
+        table_name = table_config["name"]
+        schema = table_config["schema"]
+        columns = ",".join(table_config["publication_columns"])
+        publication_filter = table_config.get("publication_filter", "")
+
+        if publication_filter:
+            table_spec = f"""      {schema}.{table_name} ({columns})
+        WHERE ({publication_filter})"""
+        else:
+            table_spec = f"""      {schema}.{table_name} ({columns})"""
+
+        table_specs.append(table_spec)
+
+    return sa_text(f"""
+    CREATE PUBLICATION {publication_name}
+    FOR TABLE
+{",\n".join(table_specs)}
+    WITH (publish_via_partition_root = true);
+""")
+
+
+def set_replica_identity_for_table(session, logger, table_config, mode="index"):
+    """Set replica identity for a table and its partitions."""
+    table_name = table_config["name"]
+    schema = table_config["schema"]
+    has_partitions = table_config["has_partitions"]
+
+    logger.info(f"Setting replica identity to '{mode}' for table {schema}.{table_name}")
+
+    # Set replica identity for the main table
+    _set_replica_identity_single_table(session, logger, schema, table_name, mode)
+
+    # Set replica identity for partitions if they exist
+    if has_partitions:
+        partitions = session.execute(
+            GET_PARTITIONS_SQL,
+            {"schema": schema, "table_name": table_name, "table_pattern": f"^{table_name}_p[0-9]+$"},
+        ).fetchall()
+
+        for partition_schema, partition_name in partitions:
+            _set_replica_identity_single_table(session, logger, partition_schema, partition_name, mode)
+
+
+def _get_current_replica_identity_mode(session, schema, table_name):
+    """
+    Get the current replica identity mode for a table.
+    Returns: 'default', 'index', or 'unknown'
+    """
+    qualified_table_name = f"{schema}.{table_name}"
+
+    try:
+        replica_identity_result = session.execute(
+            GET_CURRENT_REPLICA_IDENTITY_SQL, {"qualified_table_name": qualified_table_name}
+        ).fetchone()
+
+        if not replica_identity_result:
+            return "unknown"
+
+        relreplident = replica_identity_result[0]
+
+        # Map PostgreSQL replica identity codes to our modes
+        # 'd' = default, 'i' = index, 'f' = full, 'n' = nothing
+        if relreplident == "d":
+            return "default"
+        elif relreplident == "i":
+            return "index"
+        return "unknown"
+    except Exception:
+        # If table doesn't exist or any other error, return unknown
+        return "unknown"
+
+
+def _set_replica_identity_single_table(session, logger, schema, table_name, mode):
+    """Set replica identity for a single table."""
+    try:
+        current_mode = _get_current_replica_identity_mode(session, schema, table_name)
+
+        if current_mode == mode:
+            logger.info(f"Table {schema}.{table_name} already has replica identity {mode.upper()} - skipping")
+            return
+
+        logger.info(
+            f"Changing replica identity for {schema}.{table_name} from {current_mode.upper()} to {mode.upper()}"
+        )
+
+        if mode == "default":
+            sql = REPLICA_IDENTITY_DEFAULT_SQL.text.format(schema=schema, table_name=table_name)
+            session.execute(sa_text(sql))
+            logger.info(f"Set replica identity DEFAULT for {schema}.{table_name}")
+
+        elif mode == "index":
+            index_result = session.execute(
+                GET_UNIQUE_INDEXES_SQL, {"schema": schema, "table_name": table_name}
+            ).fetchone()
+
+            if index_result:
+                index_name = index_result[0]
+                sql = REPLICA_IDENTITY_INDEX_SQL.text.format(
+                    schema=schema, table_name=table_name, index_name=index_name
+                )
+                session.execute(sa_text(sql))
+                logger.info(f"Set replica identity USING INDEX {index_name} for {schema}.{table_name}")
+            else:
+                # Fallback to default if no suitable index found
+                logger.warning(f"No suitable unique index found for {schema}.{table_name}, using DEFAULT")
+                sql = REPLICA_IDENTITY_DEFAULT_SQL.text.format(schema=schema, table_name=table_name)
+                session.execute(sa_text(sql))
+
+        else:
+            raise ValueError(f"Invalid replica identity mode: {mode}. Use 'default' or 'index'")
+    except Exception as e:
+        logger.error(f"Failed to set replica identity for {schema}.{table_name}: {e}")
+        raise
+
+
+def configure_replica_identities(session, logger):
+    """Configure replica identities for all tables across all publications in PUBLICATION_CONFIG."""
+    if REPLICA_IDENTITY_MODE == "":
+        logger.info("Replica identity configuration skipped (REPLICA_IDENTITY_MODE is empty)")
         return
 
-    # 3) create the publication
-    logger.info(f'Creating publication "{PUBLICATION_NAME}".')
-    # session.execute(CREATE_PUBLICATION_SQL)
+    if REPLICA_IDENTITY_MODE not in ["default", "index"]:
+        logger.error(
+            f"Invalid REPLICA_IDENTITY_MODE: {REPLICA_IDENTITY_MODE}. Must be 'default', 'index', or empty string"
+        )
+        return
 
-    # 4) sanity-check replication slots
-    bad = []
-    for slot_name, active in session.execute(CHECK_REPLICATION_SLOTS_SQL):
-        if not active:
-            if slot_name in DROP_REPLICATION_SLOTS:
-                logger.info(f"Dropping inactive slot: {slot_name}")
-                session.execute(DROP_REPLICATION_SLOTS_SQL, {"slot_name": slot_name})
+    logger.info(f"Configuring replica identities with mode: {REPLICA_IDENTITY_MODE}")
+
+    # Collect all unique tables across all publication configurations
+    unique_tables = {}
+    for publication_config in PUBLICATION_CONFIG.values():
+        for table_config in publication_config["tables"]:
+            table_key = f"{table_config['schema']}.{table_config['name']}"
+            if table_key not in unique_tables:
+                unique_tables[table_key] = table_config
+
+    # Configure replica identity for each unique table
+    for table_config in unique_tables.values():
+        set_replica_identity_for_table(session, logger, table_config, REPLICA_IDENTITY_MODE)
+
+
+def setup_publication(session, logger):
+    """Setup publications and manage replication slots based on configuration."""
+
+    if DROP_PUBLICATIONS:
+        logger.info(f"Dropping publications: {DROP_PUBLICATIONS}")
+        for pub in DROP_PUBLICATIONS:
+            logger.info(f"Dropping publication: {pub}")
+            session.execute(sa_text(DROP_PUBLICATION_SQL + pub))
+    else:
+        logger.info("No publications configured for dropping")
+
+    if CREATE_PUBLICATIONS:
+        logger.info(f"Creating publications: {CREATE_PUBLICATIONS}")
+        for publication_name in CREATE_PUBLICATIONS:
+            exists = session.execute(CHECK_PUBLICATION_SQL, {"pubname": publication_name}).scalar()
+            if exists:
+                logger.info(f'Publication "{publication_name}" already exists.')
             else:
-                bad.append(slot_name)
-    if bad:
-        raise RuntimeError(f"Inactive slots left open: {bad}")
+                logger.info(f'Creating publication "{publication_name}".')
+                create_sql = _build_create_publication_sql(publication_name)
+                session.execute(create_sql)
+                logger.info(f'Publication "{publication_name}" created!')
+    else:
+        logger.info("No publications configured for creation")
 
-    logger.info(f'Publication "{PUBLICATION_NAME}" created!')
+    # sanity-check replication slots
+    if DROP_REPLICATION_SLOTS:
+        logger.info(f"Checking replication slots to drop: {DROP_REPLICATION_SLOTS}")
+        bad = []
+        for slot_name, active in session.execute(CHECK_REPLICATION_SLOTS_SQL):
+            if not active:
+                if slot_name in DROP_REPLICATION_SLOTS:
+                    logger.info(f"Dropping inactive slot: {slot_name}")
+                    session.execute(DROP_REPLICATION_SLOTS_SQL, {"slot_name": slot_name})
+                else:
+                    bad.append(slot_name)
+        if bad:
+            raise RuntimeError(f"Inactive slots left open: {bad}")
+    else:
+        logger.info("No replication slots configured for cleanup")
 
 
 def run(logger, session, application):
     with application.app.app_context():
         try:
+            logger.info("Configuring replica identities...")
+            configure_replica_identities(session, logger)
+
+            logger.info("Setting up publications...")
             setup_publication(session, logger)
         except Exception as e:
             session.rollback()
             hosts_syndication_fail_count.inc()
-            logger.error(f"Error during publication setup: {e}")
+            logger.error(f"Error during setup: {e}")
             raise
         else:
             session.commit()
             hosts_syndication_success_count.inc()
-            logger.info("Publication setup completed successfully.")
+            logger.info("Setup completed successfully.")
 
 
 def main(logger):
+    logger.info("Starting hosts syndicator with configuration:")
+    logger.info(f"  CREATE_PUBLICATIONS: {CREATE_PUBLICATIONS}")
+    logger.info(f"  DROP_PUBLICATIONS: {DROP_PUBLICATIONS}")
+    logger.info(f"  DROP_REPLICATION_SLOTS: {DROP_REPLICATION_SLOTS}")
+    logger.info(f"  REPLICA_IDENTITY_MODE: {REPLICA_IDENTITY_MODE}")
+
     config = _init_config()
     application = create_app(RUNTIME_ENVIRONMENT)
 

--- a/jobs/inv_publish_hosts.py
+++ b/jobs/inv_publish_hosts.py
@@ -196,19 +196,18 @@ def _build_create_publication_sql(publication_name):
         publication_filter = table_config.get("publication_filter", "")
 
         if publication_filter:
-            table_spec = f"""      {schema}.{table_name} ({columns})
-        WHERE ({publication_filter})"""
+            table_spec = f"""{schema}.{table_name} ({columns}) WHERE ({publication_filter})"""
         else:
-            table_spec = f"""      {schema}.{table_name} ({columns})"""
+            table_spec = f"""{schema}.{table_name} ({columns})"""
 
         table_specs.append(table_spec)
 
     return sa_text(f"""
-    CREATE PUBLICATION {publication_name}
-    FOR TABLE
-{",\n".join(table_specs)}
-    WITH (publish_via_partition_root = true);
-""")
+        CREATE PUBLICATION {publication_name}
+        FOR TABLE
+        {",\n".join(table_specs)}
+        WITH (publish_via_partition_root = true);
+    """)
 
 
 def set_replica_identity_for_table(session, logger, table_config, mode="index"):

--- a/tests/test_inv_publish_hosts.py
+++ b/tests/test_inv_publish_hosts.py
@@ -1,0 +1,1012 @@
+#!/usr/bin/env python
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text as sa_text
+
+from app.models import db
+from app.models.constants import INVENTORY_SCHEMA
+from jobs.inv_publish_hosts import PUBLICATION_CONFIG
+from jobs.inv_publish_hosts import _build_create_publication_sql
+from jobs.inv_publish_hosts import _get_current_replica_identity_mode
+from jobs.inv_publish_hosts import _set_replica_identity_single_table
+from jobs.inv_publish_hosts import configure_replica_identities
+from jobs.inv_publish_hosts import set_replica_identity_for_table
+from jobs.inv_publish_hosts import setup_publication
+
+
+def get_first_available_publication():
+    """Helper function to get the first available publication name from PUBLICATION_CONFIG.
+
+    Returns:
+        str: The name of the first publication in PUBLICATION_CONFIG
+
+    Raises:
+        AssertionError: If no publications are configured
+    """
+    assert len(PUBLICATION_CONFIG) > 0, "At least one publication should be configured"
+    return next(iter(PUBLICATION_CONFIG.keys()))
+
+
+def get_unique_table_count():
+    """Helper function to get the number of unique tables across all publications.
+
+    Returns:
+        int: The number of unique (schema, table_name) combinations across all publications
+    """
+    unique_tables = set()
+    for pub_config in PUBLICATION_CONFIG.values():
+        for table in pub_config["tables"]:
+            unique_tables.add((table["schema"], table["name"]))
+    return len(unique_tables)
+
+
+def get_table_info():
+    """Helper function to get the table's schema and name to be used for testing.
+
+    Returns:
+        tuple: (schema, table_name)
+    """
+    return "hbi", "hosts"
+
+
+def get_sample_table_config():
+    """Helper function to get a sample table configuration for testing.
+
+    Returns:
+        dict: A sample table configuration based on the first table in PUBLICATION_CONFIG
+    """
+    first_pub = next(iter(PUBLICATION_CONFIG.values()))
+    first_table = first_pub["tables"][0]
+
+    return {
+        "name": first_table["name"],
+        "schema": first_table["schema"],
+        "publication_columns": first_table["publication_columns"][:3],  # Use first 3 columns
+        "publication_filter": first_table.get("publication_filter"),
+    }
+
+
+class TestBuildCreatePublicationSql:
+    """Tests for _build_create_publication_sql function."""
+
+    def test_build_create_publication_sql_success(self):
+        """Test building CREATE PUBLICATION SQL for valid publication name."""
+
+        publication_name = get_first_available_publication()
+
+        result = _build_create_publication_sql(publication_name)
+
+        sql_text = str(result)
+
+        assert f"CREATE PUBLICATION {publication_name}" in sql_text
+        assert "FOR TABLE" in sql_text
+        assert "WITH (publish_via_partition_root = true)" in sql_text
+
+        publication_config = PUBLICATION_CONFIG[publication_name]
+        for table_config in publication_config["tables"]:
+            table_name = table_config["name"]
+            schema = table_config["schema"]
+            publication_filter = table_config.get("publication_filter", "")
+
+            assert f"{schema}.{table_name}" in sql_text
+            if publication_filter:
+                assert publication_filter in sql_text
+
+    def test_build_create_publication_sql_invalid_name(self):
+        """Test building CREATE PUBLICATION SQL for invalid publication name."""
+        with pytest.raises(ValueError, match="Publication 'invalid_pub' not found in PUBLICATION_CONFIG"):
+            _build_create_publication_sql("invalid_pub")
+
+    def test_build_create_publication_sql_includes_all_columns(self):
+        """Test that all configured columns are included in the SQL."""
+
+        publication_name = get_first_available_publication()
+
+        result = _build_create_publication_sql(publication_name)
+        sql_text = str(result)
+
+        publication_config = PUBLICATION_CONFIG[publication_name]
+        for table_config in publication_config["tables"]:
+            for column in table_config["publication_columns"]:
+                assert column in sql_text, f"Column '{column}' missing from SQL for table '{table_config['name']}'"
+
+    def test_build_create_publication_sql_all_publications(self):
+        """Test that SQL can be generated successfully for ALL publication configurations."""
+
+        # Test SQL generation for ALL publications
+        for pub_name in PUBLICATION_CONFIG.keys():
+            result = _build_create_publication_sql(pub_name)
+            sql_text = str(result)
+
+            # Basic SQL structure validation
+            assert f"CREATE PUBLICATION {pub_name}" in sql_text, f"Publication '{pub_name}' missing CREATE statement"
+            assert "FOR TABLE" in sql_text, f"Publication '{pub_name}' missing FOR TABLE clause"
+            assert "WITH (publish_via_partition_root = true)" in sql_text, (
+                f"Publication '{pub_name}' missing WITH clause"
+            )
+
+            # Verify all configured tables and columns are present
+            publication_config = PUBLICATION_CONFIG[pub_name]
+            for table_config in publication_config["tables"]:
+                table_name = table_config["name"]
+                schema = table_config["schema"]
+                qualified_table_name = f"{schema}.{table_name}"
+
+                assert qualified_table_name in sql_text, (
+                    f"Publication '{pub_name}' missing table '{qualified_table_name}'"
+                )
+
+                # Check publication columns
+                for column in table_config["publication_columns"]:
+                    assert column in sql_text, (
+                        f"Publication '{pub_name}', table '{table_name}' missing column '{column}'"
+                    )
+
+                # Check filter if present
+                table_filter = table_config.get("publication_filter", "")
+                if table_filter:
+                    assert table_filter in sql_text, (
+                        f"Publication '{pub_name}', table '{table_name}' missing filter '{table_filter}'"
+                    )
+
+
+class TestReplicaIdentityIntegration:
+    """Tests for replica identity configuration functions."""
+
+    def reset_replica_identity(self, table_name):
+        """Reset replica identity to default for cleanup."""
+        schema, _ = get_table_info()
+        try:
+            db.session.execute(sa_text(f"ALTER TABLE {schema}.{table_name} REPLICA IDENTITY DEFAULT"))
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+
+    def test_get_current_replica_identity_mode_default(self, flask_app):
+        """Test getting current replica identity mode when set to default."""
+        schema, table_name = get_table_info()
+
+        try:
+            with flask_app.app.app_context():
+                # Set to default replica identity
+                db.session.execute(sa_text(f"ALTER TABLE {schema}.{table_name} REPLICA IDENTITY DEFAULT"))
+                db.session.commit()
+
+                result = _get_current_replica_identity_mode(db.session, schema, table_name)
+                assert result == "default"
+        finally:
+            with flask_app.app.app_context():
+                self.reset_replica_identity(table_name)
+
+    def test_get_current_replica_identity_mode_index(self, flask_app):
+        """Test getting current replica identity mode when set to index."""
+        schema, table_name = get_table_info()
+
+        with flask_app.app.app_context():
+            # Set to index replica identity
+            db.session.execute(
+                sa_text(
+                    f"""
+                    CREATE UNIQUE INDEX IF NOT EXISTS hosts_replica_identity_idx
+                    ON {schema}.{table_name} (org_id, id);
+                    """
+                )
+            )
+            db.session.execute(
+                sa_text(f"ALTER TABLE {schema}.{table_name} REPLICA IDENTITY USING INDEX hosts_replica_identity_idx;")
+            )
+            db.session.commit()
+
+            result = _get_current_replica_identity_mode(db.session, schema, table_name)
+            assert result == "index"
+
+    def test_get_current_replica_identity_mode_no_result(self, flask_app):
+        """Test getting current replica identity mode when table doesn't exist."""
+        schema, _ = get_table_info()
+        with flask_app.app.app_context():
+            # When table doesn't exist, PostgreSQL throws an exception
+            # The function should handle this and return "unknown"
+            result = _get_current_replica_identity_mode(db.session, schema, "nonexistent_table")
+            assert result == "unknown"
+
+    def test_set_replica_identity_single_table_already_set(self, flask_app):
+        """Test setting replica identity when already set to desired mode."""
+        schema, table_name = get_table_info()
+        mock_logger = Mock()
+
+        try:
+            with flask_app.app.app_context():
+                # Set to default first
+                db.session.execute(sa_text(f"ALTER TABLE {schema}.{table_name} REPLICA IDENTITY DEFAULT"))
+                db.session.commit()
+
+                # Try to set to default again - should skip
+                _set_replica_identity_single_table(db.session, mock_logger, schema, table_name, "default")
+
+                expected_msg = f"Table {schema}.{table_name} already has replica identity DEFAULT - skipping"
+                mock_logger.info.assert_called_with(expected_msg)
+        finally:
+            with flask_app.app.app_context():
+                self.reset_replica_identity(table_name)
+
+    def test_set_replica_identity_single_table_to_default(self, flask_app):
+        """Test setting replica identity to default mode."""
+        schema, table_name = get_table_info()
+        mock_logger = Mock()
+
+        with flask_app.app.app_context():
+            # Test setting to default mode (regardless of current state)
+            _set_replica_identity_single_table(db.session, mock_logger, schema, table_name, "default")
+
+            # Check that appropriate logging occurred
+            calls = [str(call) for call in mock_logger.info.call_args_list]
+            has_relevant_logging = any(
+                "already has replica identity DEFAULT" in call
+                or "Set replica identity DEFAULT" in call
+                or "Changing replica identity" in call
+                for call in calls
+            )
+            assert has_relevant_logging, f"Expected relevant logging, got calls: {calls}"
+
+            # Verify it's actually set to default
+            result = _get_current_replica_identity_mode(db.session, schema, table_name)
+            assert result == "default"
+
+    def test_set_replica_identity_single_table_to_index_with_index(self, flask_app):
+        """Test setting replica identity to index mode when suitable index exists."""
+        schema, table_name = get_table_info()
+        mock_logger = Mock()
+
+        with flask_app.app.app_context():
+            # Test setting to index mode - behavior depends on available indexes
+            _set_replica_identity_single_table(db.session, mock_logger, schema, table_name, "index")
+
+            # Check that appropriate logging occurred
+            calls = [str(call) for call in mock_logger.info.call_args_list]
+            has_relevant_logging = any(
+                "already has replica identity INDEX" in call
+                or "Set replica identity USING INDEX" in call
+                or "Changing replica identity" in call
+                or "No suitable unique index found" in call
+                for call in calls
+            )
+            assert has_relevant_logging, f"Expected relevant logging, got calls: {calls}"
+
+            # The result should be either index (if suitable index exists) or default (fallback)
+            result = _get_current_replica_identity_mode(db.session, schema, table_name)
+            assert result in ["index", "default"], f"Expected index or default, got {result}"
+
+    def test_set_replica_identity_single_table_to_index_no_index(self, flask_app):
+        """Test setting replica identity to index mode when no suitable index exists."""
+        # Use staleness table which is not in PUBLICATION_CONFIG and doesn't have replica identity index
+        schema, _ = get_table_info()  # Get schema from config
+        table_name = "staleness"  # Use a table that doesn't have the required replica identity index
+        mock_logger = Mock()
+
+        try:
+            with flask_app.app.app_context():
+                # Try to set to index mode without suitable index - should fallback to default
+                _set_replica_identity_single_table(db.session, mock_logger, schema, table_name, "index")
+
+                expected_warning = f"No suitable unique index found for {schema}.{table_name}, using DEFAULT"
+                mock_logger.warning.assert_called_with(expected_warning)
+                expected_change = f"Changing replica identity for {schema}.{table_name} from DEFAULT to INDEX"
+                mock_logger.info.assert_any_call(expected_change)
+
+                # Should fall back to default
+                result = _get_current_replica_identity_mode(db.session, schema, table_name)
+                assert result == "default"
+        finally:
+            with flask_app.app.app_context():
+                self.reset_replica_identity(table_name)
+
+    def test_set_replica_identity_single_table_invalid_mode(self, flask_app):
+        """Test setting replica identity with invalid mode."""
+        schema, table_name = get_table_info()
+        mock_logger = Mock()
+
+        with flask_app.app.app_context():
+            with pytest.raises(ValueError, match="Invalid replica identity mode: invalid"):
+                _set_replica_identity_single_table(db.session, mock_logger, schema, table_name, "invalid")
+
+    def test_set_replica_identity_for_table_without_partitions(self, flask_app):
+        """Test setting replica identity for table without partitions."""
+        schema, table_name = get_table_info()
+        mock_logger = Mock()
+
+        try:
+            with flask_app.app.app_context():
+                table_config = {"name": table_name, "schema": schema, "has_partitions": False}
+
+                set_replica_identity_for_table(db.session, mock_logger, table_config, "default")
+
+                # Should set replica identity on the main table
+                result = _get_current_replica_identity_mode(db.session, schema, table_name)
+                assert result == "default"
+        finally:
+            with flask_app.app.app_context():
+                self.reset_replica_identity(table_name)
+
+    def test_set_replica_identity_for_table_with_partitions(self, flask_app):
+        """Test setting replica identity for table with partitions."""
+        schema, table_name = get_table_info()
+        mock_logger = Mock()
+
+        try:
+            with flask_app.app.app_context():
+                table_config = {"name": table_name, "schema": schema, "has_partitions": True}
+
+                set_replica_identity_for_table(db.session, mock_logger, table_config, "default")
+
+                # Verify replica identity is set on main table
+                result = _get_current_replica_identity_mode(db.session, schema, table_name)
+                assert result == "default"
+
+                # Verify replica identity is also set on partitions (migrations always create at least _p0)
+                partition_name = f"{table_name}_p0"
+                partition_result = _get_current_replica_identity_mode(db.session, schema, partition_name)
+                if partition_result != "unknown":  # Only check if partition exists
+                    assert partition_result == "default", (
+                        f"Partition {partition_name} should have default replica identity"
+                    )
+                    mock_logger.info.assert_any_call(
+                        f"Setting replica identity to 'default' for table {schema}.{partition_name}"
+                    )
+
+                # Verify the function logged setting replica identity for the main table
+                mock_logger.info.assert_any_call(
+                    f"Setting replica identity to 'default' for table {schema}.{table_name}"
+                )
+        finally:
+            with flask_app.app.app_context():
+                self.reset_replica_identity(table_name)
+                # Also reset partitions if they exist
+                partition_name = f"{table_name}_p0"
+                self.reset_replica_identity(partition_name)
+
+
+class TestConfigureReplicaIdentities:
+    """Tests for configure_replica_identities function."""
+
+    @patch("jobs.inv_publish_hosts.REPLICA_IDENTITY_MODE", "")
+    @patch("jobs.inv_publish_hosts.set_replica_identity_for_table")
+    def test_configure_replica_identities_empty_mode(self, mock_set_replica):
+        """Test configure_replica_identities with empty mode."""
+        mock_session = Mock()
+        mock_logger = Mock()
+
+        configure_replica_identities(mock_session, mock_logger)
+
+        mock_logger.info.assert_called_with("Replica identity configuration skipped (REPLICA_IDENTITY_MODE is empty)")
+        mock_set_replica.assert_not_called()
+
+    @patch("jobs.inv_publish_hosts.REPLICA_IDENTITY_MODE", "invalid")
+    @patch("jobs.inv_publish_hosts.set_replica_identity_for_table")
+    def test_configure_replica_identities_invalid_mode(self, mock_set_replica):
+        """Test configure_replica_identities with invalid mode."""
+        mock_session = Mock()
+        mock_logger = Mock()
+
+        configure_replica_identities(mock_session, mock_logger)
+
+        mock_logger.error.assert_called_with(
+            "Invalid REPLICA_IDENTITY_MODE: invalid. Must be 'default', 'index', or empty string"
+        )
+        mock_set_replica.assert_not_called()
+
+    @patch("jobs.inv_publish_hosts.REPLICA_IDENTITY_MODE", "default")
+    @patch("jobs.inv_publish_hosts.set_replica_identity_for_table")
+    def test_configure_replica_identities_default_mode(self, mock_set_replica):
+        """Test configure_replica_identities with default mode."""
+        mock_session = Mock()
+        mock_logger = Mock()
+
+        configure_replica_identities(mock_session, mock_logger)
+
+        mock_logger.info.assert_called_with("Configuring replica identities with mode: default")
+        # Should be called for each unique table in PUBLICATION_CONFIG
+        expected_call_count = get_unique_table_count()
+        assert mock_set_replica.call_count == expected_call_count
+
+
+class TestSetupPublication:
+    """Tests for setup_publication function."""
+
+    @patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", ["old_pub1", "old_pub2"])
+    @patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", [])
+    @patch("jobs.inv_publish_hosts.DROP_REPLICATION_SLOTS", [])
+    def test_setup_publication_drop_only(self):
+        """Test setup_publication with only drop publications configured."""
+        mock_session = Mock()
+        mock_logger = Mock()
+
+        setup_publication(mock_session, mock_logger)
+
+        mock_logger.info.assert_any_call("Dropping publications: ['old_pub1', 'old_pub2']")
+        mock_logger.info.assert_any_call("Dropping publication: old_pub1")
+        mock_logger.info.assert_any_call("Dropping publication: old_pub2")
+        mock_logger.info.assert_any_call("No publications configured for creation")
+        assert mock_session.execute.call_count == 2  # Two drop statements
+
+    def test_setup_publication_create_new(self):
+        """Test setup_publication creating new publication."""
+
+        publication_name = get_first_available_publication()
+
+        with (
+            patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", []),
+            patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", [publication_name]),
+            patch("jobs.inv_publish_hosts.DROP_REPLICATION_SLOTS", []),
+        ):
+            mock_session = Mock()
+            mock_logger = Mock()
+
+            # Mock publication doesn't exist
+            mock_session.execute.return_value.scalar.return_value = False
+
+            setup_publication(mock_session, mock_logger)
+
+            mock_logger.info.assert_any_call(f"Creating publications: ['{publication_name}']")
+            mock_logger.info.assert_any_call(f'Creating publication "{publication_name}".')
+            mock_logger.info.assert_any_call(f'Publication "{publication_name}" created!')
+            assert mock_session.execute.call_count == 2  # Check existence + create
+
+    def test_setup_publication_create_existing(self):
+        """Test setup_publication when publication already exists."""
+
+        publication_name = get_first_available_publication()
+
+        with (
+            patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", []),
+            patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", [publication_name]),
+            patch("jobs.inv_publish_hosts.DROP_REPLICATION_SLOTS", []),
+        ):
+            mock_session = Mock()
+            mock_logger = Mock()
+
+            # Mock publication already exists
+            mock_session.execute.return_value.scalar.return_value = True
+
+            setup_publication(mock_session, mock_logger)
+
+            mock_logger.info.assert_any_call(f'Publication "{publication_name}" already exists.')
+            assert mock_session.execute.call_count == 1  # Only check existence
+
+    @patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", [])
+    @patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", [])
+    @patch("jobs.inv_publish_hosts.DROP_REPLICATION_SLOTS", ["inactive_slot1", "inactive_slot2"])
+    def test_setup_publication_drop_inactive_slots(self):
+        """Test setup_publication dropping inactive replication slots."""
+        mock_session = Mock()
+        mock_logger = Mock()
+
+        # Mock replication slots query
+        mock_session.execute.return_value = [
+            ("inactive_slot1", False),
+            ("active_slot1", True),
+            ("inactive_slot2", False),
+        ]
+
+        setup_publication(mock_session, mock_logger)
+
+        mock_logger.info.assert_any_call("Dropping inactive slot: inactive_slot1")
+        mock_logger.info.assert_any_call("Dropping inactive slot: inactive_slot2")
+        # Should execute: check slots + drop slot1 + drop slot2
+        assert mock_session.execute.call_count == 3
+
+    @patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", [])
+    @patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", [])
+    @patch("jobs.inv_publish_hosts.DROP_REPLICATION_SLOTS", ["should_drop"])
+    def test_setup_publication_inactive_slots_error(self):
+        """Test setup_publication with inactive slots that shouldn't exist."""
+        mock_session = Mock()
+        mock_logger = Mock()
+
+        # Mock replication slots query - inactive slot not in drop list
+        mock_session.execute.return_value = [
+            ("unwanted_inactive", False),
+        ]
+
+        with pytest.raises(RuntimeError, match="Inactive slots left open: \\['unwanted_inactive'\\]"):
+            setup_publication(mock_session, mock_logger)
+
+
+class TestPublicationIntegration:
+    """Integration tests for publication creation and deletion in real database."""
+
+    def cleanup_publication(self, publication_name):
+        """Helper to clean up publications."""
+        try:
+            with db.session.begin():
+                db.session.execute(sa_text(f"DROP PUBLICATION IF EXISTS {publication_name}"))
+        except Exception:
+            db.session.rollback()
+
+    def publication_exists(self, publication_name):
+        """Helper to check if publication exists."""
+        result = db.session.execute(
+            sa_text("SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_publication WHERE pubname = :pubname)"),
+            {"pubname": publication_name},
+        ).scalar()
+        return result
+
+    def create_replication_slot(self, slot_name):
+        """Helper to create a logical replication slot."""
+        try:
+            db.session.execute(sa_text(f"SELECT pg_create_logical_replication_slot('{slot_name}', 'pgoutput')"))
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+            # Slot might already exist, that's okay for tests
+
+    def cleanup_replication_slot(self, slot_name):
+        """Helper to clean up replication slots."""
+        try:
+            result = db.session.execute(
+                sa_text("SELECT COUNT(*) FROM pg_replication_slots WHERE slot_name = :slot_name"),
+                {"slot_name": slot_name},
+            ).scalar()
+            if result > 0:
+                db.session.execute(sa_text(f"SELECT pg_drop_replication_slot('{slot_name}')"))
+                db.session.commit()
+        except Exception:
+            db.session.rollback()
+
+    def replication_slot_exists(self, slot_name):
+        """Helper to check if replication slot exists."""
+        result = db.session.execute(
+            sa_text("SELECT COUNT(*) FROM pg_replication_slots WHERE slot_name = :slot_name"), {"slot_name": slot_name}
+        ).scalar()
+        return result > 0
+
+    def get_replication_slot_status(self, slot_name):
+        """Helper to get replication slot status (active/inactive)."""
+        result = db.session.execute(
+            sa_text("SELECT active FROM pg_replication_slots WHERE slot_name = :slot_name"), {"slot_name": slot_name}
+        ).scalar()
+        return result
+
+    def test_create_publication(self, flask_app):
+        """Test creating a publication in the real database."""
+        publication_name = "test_hosts_publication"
+        mock_logger = Mock()
+
+        # Create a custom publication config for testing using dynamic table info
+        sample_config = get_sample_table_config()
+        test_config = {"test_hosts_publication": {"tables": [sample_config]}}
+
+        try:
+            with flask_app.app.app_context():
+                with (
+                    patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", [publication_name]),
+                    patch("jobs.inv_publish_hosts.PUBLICATION_CONFIG", test_config),
+                ):
+                    # Ensure publication doesn't exist initially
+                    self.cleanup_publication(publication_name)
+                    assert not self.publication_exists(publication_name)
+
+                    # Create publication
+                    setup_publication(db.session, mock_logger)
+                    db.session.commit()
+
+                    # Verify publication was created
+                    assert self.publication_exists(publication_name)
+
+                    # Verify logging
+                    mock_logger.info.assert_any_call(f"Creating publications: ['{publication_name}']")
+                    mock_logger.info.assert_any_call(f'Creating publication "{publication_name}".')
+                    mock_logger.info.assert_any_call(f'Publication "{publication_name}" created!')
+
+        finally:
+            with flask_app.app.app_context():
+                self.cleanup_publication(publication_name)
+
+    def test_create_existing_publication(self, flask_app):
+        """Test attempting to create a publication that already exists."""
+        publication_name = "test_existing_publication"
+        mock_logger = Mock()
+
+        # Create a simple test config using dynamic table info
+        sample_config = get_sample_table_config()
+        test_config = {"test_existing_publication": {"tables": [sample_config]}}
+
+        try:
+            with flask_app.app.app_context():
+                with (
+                    patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", [publication_name]),
+                    patch("jobs.inv_publish_hosts.PUBLICATION_CONFIG", test_config),
+                ):
+                    # Create publication first
+                    self.cleanup_publication(publication_name)
+                    create_sql = _build_create_publication_sql(publication_name)
+                    db.session.execute(create_sql)
+                    db.session.commit()
+
+                    assert self.publication_exists(publication_name)
+
+                    setup_publication(db.session, mock_logger)
+
+                    # Verify it detected existing publication
+                    mock_logger.info.assert_any_call(f'Publication "{publication_name}" already exists.')
+
+        finally:
+            with flask_app.app.app_context():
+                self.cleanup_publication(publication_name)
+
+    @patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", ["test_publication_drop"])
+    def test_drop_publication(self, flask_app):
+        """Test dropping a publication from the real database."""
+        publication_name = "test_publication_drop"
+        mock_logger = Mock()
+
+        try:
+            with flask_app.app.app_context():
+                # Create publication first - simple publication for testing drop functionality
+                sample_config = get_sample_table_config()
+                qualified_table = f"{sample_config['schema']}.{sample_config['name']}"
+                columns_str = ", ".join(sample_config["publication_columns"])
+                where_clause = (
+                    f"WHERE ({sample_config['publication_filter']})" if sample_config["publication_filter"] else ""
+                )
+
+                self.cleanup_publication(publication_name)
+                db.session.execute(
+                    sa_text(f"""
+                    CREATE PUBLICATION {publication_name}
+                    FOR TABLE {qualified_table} ({columns_str})
+                    {where_clause}
+                    WITH (publish_via_partition_root = true)
+                """)
+                )
+                db.session.commit()
+
+                assert self.publication_exists(publication_name)
+
+                # Test publication deletion
+                setup_publication(db.session, mock_logger)
+                db.session.commit()
+
+                # Verify publication was dropped
+                assert not self.publication_exists(publication_name)
+
+                # Verify logging
+                mock_logger.info.assert_any_call("Dropping publications: ['test_publication_drop']")
+                mock_logger.info.assert_any_call("Dropping publication: test_publication_drop")
+
+        finally:
+            with flask_app.app.app_context():
+                self.cleanup_publication(publication_name)
+
+    def test_create_and_drop_multiple_publications(self, flask_app):
+        """Test creating and dropping publications in same operation."""
+        create_pub = "test_create_pub"
+        drop_pub = "test_drop_pub"
+        mock_logger = Mock()
+
+        # Create test config using dynamic table info
+        sample_config = get_sample_table_config()
+        test_config = {"test_create_pub": {"tables": [sample_config]}}
+
+        try:
+            with flask_app.app.app_context():
+                with (
+                    patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", [create_pub]),
+                    patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", [drop_pub]),
+                    patch("jobs.inv_publish_hosts.PUBLICATION_CONFIG", test_config),
+                ):
+                    # Setup: clean all publications and create the one to be dropped
+                    sample_config = get_sample_table_config()
+                    qualified_table = f"{sample_config['schema']}.{sample_config['name']}"
+                    columns_str = ", ".join(sample_config["publication_columns"])
+                    where_clause = (
+                        f"WHERE ({sample_config['publication_filter']})" if sample_config["publication_filter"] else ""
+                    )
+
+                    for pub in [create_pub, drop_pub]:
+                        self.cleanup_publication(pub)
+
+                    db.session.execute(
+                        sa_text(f"""
+                        CREATE PUBLICATION {drop_pub}
+                        FOR TABLE {qualified_table} ({columns_str})
+                        {where_clause}
+                        WITH (publish_via_partition_root = true)
+                    """)
+                    )
+                    db.session.commit()
+
+                    assert self.publication_exists(drop_pub)
+                    assert not self.publication_exists(create_pub)
+
+                    setup_publication(db.session, mock_logger)
+                    db.session.commit()
+
+                    # Verify results
+                    assert not self.publication_exists(drop_pub)  # Should be dropped
+                    assert self.publication_exists(create_pub)  # Should be created
+
+                    # Verify logging for drops
+                    mock_logger.info.assert_any_call(f"Dropping publications: ['{drop_pub}']")
+
+                    # Verify logging for creates
+                    mock_logger.info.assert_any_call(f"Creating publications: ['{create_pub}']")
+
+        finally:
+            with flask_app.app.app_context():
+                for pub in [create_pub, drop_pub]:
+                    self.cleanup_publication(pub)
+
+    @patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", [])
+    @patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", [])
+    @patch("jobs.inv_publish_hosts.DROP_REPLICATION_SLOTS", [])
+    def test_no_publications_configured(self, flask_app):
+        """Test when no publications are configured for creation or deletion."""
+        mock_logger = Mock()
+
+        with flask_app.app.app_context():
+            setup_publication(db.session, mock_logger)
+
+            mock_logger.info.assert_any_call("No publications configured for dropping")
+            mock_logger.info.assert_any_call("No publications configured for creation")
+            mock_logger.info.assert_any_call("No replication slots configured for cleanup")
+
+    def test_publication_sql_generation_real_config(self, flask_app):
+        """Test that generated SQL works with real database using actual config."""
+
+        publication_name = get_first_available_publication()
+
+        with flask_app.app.app_context():
+            sql = _build_create_publication_sql(publication_name)
+
+            # Verify the SQL is well-formed by checking for required elements
+            sql_str = str(sql)
+            assert "CREATE PUBLICATION" in sql_str
+            assert publication_name in sql_str
+            assert "FOR TABLE" in sql_str
+            assert "WITH (publish_via_partition_root = true)" in sql_str
+
+            # Verify that at least one table from the configuration is in the SQL
+            publication_config = PUBLICATION_CONFIG[publication_name]
+            table_found = False
+            for table_config in publication_config["tables"]:
+                table_name = f"{table_config['schema']}.{table_config['name']}"
+                if table_name in sql_str:
+                    table_found = True
+                    break
+            assert table_found, f"No configured tables found in SQL: {sql_str}"
+
+            # The SQL should not be empty
+            assert len(sql_str.strip()) > 0
+
+    def test_drop_inactive_replication_slots(self, flask_app):
+        """Test dropping inactive replication slots that are configured for cleanup."""
+        slot_name = "test_inactive_slot"
+        mock_logger = Mock()
+
+        try:
+            with flask_app.app.app_context():
+                with (
+                    patch("jobs.inv_publish_hosts.DROP_REPLICATION_SLOTS", [slot_name]),
+                    patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", []),
+                    patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", []),
+                ):
+                    # Clean up any existing slot first
+                    self.cleanup_replication_slot(slot_name)
+
+                    # Create an inactive replication slot
+                    self.create_replication_slot(slot_name)
+                    assert self.replication_slot_exists(slot_name)
+
+                    # Slot should be inactive (newly created slots are inactive)
+                    assert self.get_replication_slot_status(slot_name) is False
+
+                    # Test setup_publication - should drop the inactive slot
+                    setup_publication(db.session, mock_logger)
+                    db.session.commit()
+
+                    # Verify slot was dropped
+                    assert not self.replication_slot_exists(slot_name)
+
+                    # Verify logging
+                    mock_logger.info.assert_any_call(f"Checking replication slots to drop: ['{slot_name}']")
+                    mock_logger.info.assert_any_call(f"Dropping inactive slot: {slot_name}")
+
+        finally:
+            with flask_app.app.app_context():
+                self.cleanup_replication_slot(slot_name)
+
+    def test_error_on_unwanted_inactive_slots(self, flask_app):
+        """Test error when there are inactive slots not configured for cleanup."""
+        wanted_slot = "test_wanted_slot"
+        unwanted_slot = "test_unwanted_slot"
+        mock_logger = Mock()
+
+        try:
+            with flask_app.app.app_context():
+                # Configure one slot for cleanup, but create an additional unwanted slot
+                with (
+                    patch("jobs.inv_publish_hosts.DROP_REPLICATION_SLOTS", [wanted_slot]),
+                    patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", []),
+                    patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", []),
+                ):
+                    # Clean up any existing slots first
+                    self.cleanup_replication_slot(wanted_slot)
+                    self.cleanup_replication_slot(unwanted_slot)
+
+                    # Create the unwanted inactive replication slot
+                    self.create_replication_slot(unwanted_slot)
+                    assert self.replication_slot_exists(unwanted_slot)
+
+                    # Slot should be inactive
+                    assert self.get_replication_slot_status(unwanted_slot) is False
+
+                    # Test setup_publication - should raise error about unwanted slot
+                    with pytest.raises(RuntimeError, match=f"Inactive slots left open: \\['{unwanted_slot}'\\]"):
+                        setup_publication(db.session, mock_logger)
+
+                    # Slot should still exist (not dropped)
+                    assert self.replication_slot_exists(unwanted_slot)
+
+        finally:
+            with flask_app.app.app_context():
+                self.cleanup_replication_slot(wanted_slot)
+                self.cleanup_replication_slot(unwanted_slot)
+
+    def test_drop_multiple_replication_slots(self, flask_app):
+        """Test dropping multiple inactive replication slots."""
+        slot_names = ["test_slot_1", "test_slot_2"]
+        unwanted_slot = "test_unwanted_slot"
+        mock_logger = Mock()
+
+        try:
+            with flask_app.app.app_context():
+                with (
+                    patch("jobs.inv_publish_hosts.DROP_REPLICATION_SLOTS", slot_names),
+                    patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", []),
+                    patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", []),
+                ):
+                    # Clean up any existing slots first
+                    for slot in slot_names + [unwanted_slot]:
+                        self.cleanup_replication_slot(slot)
+
+                    # Create slots configured for cleanup
+                    for slot in slot_names:
+                        self.create_replication_slot(slot)
+                        assert self.replication_slot_exists(slot)
+                        assert self.get_replication_slot_status(slot) is False
+
+                    # Create unwanted slot
+                    self.create_replication_slot(unwanted_slot)
+                    assert self.replication_slot_exists(unwanted_slot)
+
+                    # Should raise error due to unwanted slot
+                    with pytest.raises(RuntimeError, match=f"Inactive slots left open: \\['{unwanted_slot}'\\]"):
+                        setup_publication(db.session, mock_logger)
+
+                    # The configured slots should be dropped (they get processed first)
+                    for slot in slot_names:
+                        assert not self.replication_slot_exists(slot)
+                    # The unwanted slot should still exist (it caused the error)
+                    assert self.replication_slot_exists(unwanted_slot)
+
+        finally:
+            with flask_app.app.app_context():
+                for slot in slot_names + [unwanted_slot]:
+                    self.cleanup_replication_slot(slot)
+
+    def test_active_replication_slots_left_alone(self, flask_app):
+        """Test that active replication slots are not dropped even if configured."""
+        slot_name = "test_active_slot"
+        mock_logger = Mock()
+
+        try:
+            with flask_app.app.app_context():
+                with (
+                    patch("jobs.inv_publish_hosts.DROP_REPLICATION_SLOTS", [slot_name]),
+                    patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", []),
+                    patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", []),
+                ):
+                    # Clean up any existing slot first
+                    self.cleanup_replication_slot(slot_name)
+
+                    # For this test, we'll simulate what happens when there are active slots
+                    # by not creating any slots at all - if there are no inactive slots,
+                    # the logic should pass without errors
+                    setup_publication(db.session, mock_logger)
+                    db.session.commit()
+
+                    # Verify logging shows it checked for slots to drop
+                    mock_logger.info.assert_any_call(f"Checking replication slots to drop: ['{slot_name}']")
+
+        finally:
+            with flask_app.app.app_context():
+                self.cleanup_replication_slot(slot_name)
+
+    def test_no_replication_slots_configured(self, flask_app):
+        """Test when no replication slots are configured for cleanup."""
+        mock_logger = Mock()
+
+        with flask_app.app.app_context():
+            with (
+                patch("jobs.inv_publish_hosts.DROP_REPLICATION_SLOTS", []),
+                patch("jobs.inv_publish_hosts.CREATE_PUBLICATIONS", []),
+                patch("jobs.inv_publish_hosts.DROP_PUBLICATIONS", []),
+            ):
+                setup_publication(db.session, mock_logger)
+
+                # Verify appropriate logging
+                mock_logger.info.assert_any_call("No replication slots configured for cleanup")
+
+
+class TestPublicationConfig:
+    """Tests for PUBLICATION_CONFIG validation."""
+
+    def test_publication_config_structure(self):
+        """Test that ALL publications in PUBLICATION_CONFIG have the expected structure."""
+
+        assert len(PUBLICATION_CONFIG) > 0, "At least one publication should be configured"
+
+        for pub_name, pub_config in PUBLICATION_CONFIG.items():
+            assert "tables" in pub_config, f"Publication '{pub_name}' missing 'tables' key"
+            assert len(pub_config["tables"]) > 0, f"Publication '{pub_name}' should have at least one table"
+
+            for table in pub_config["tables"]:
+                table_name = table.get("name", "unknown")
+                context = f"Publication '{pub_name}', table '{table_name}'"
+
+                assert "name" in table, f"{context} missing 'name' key"
+                assert "schema" in table, f"{context} missing 'schema' key"
+                assert "has_partitions" in table, f"{context} missing 'has_partitions' key"
+                assert "publication_columns" in table, f"{context} missing 'publication_columns' key"
+                assert "publication_filter" in table, f"{context} missing 'publication_filter' key"
+                assert table["schema"] == INVENTORY_SCHEMA, f"{context} has invalid schema '{table['schema']}'"
+                assert isinstance(table["publication_columns"], list), f"{context} publication_columns must be a list"
+                assert len(table["publication_columns"]) > 0, f"{context} should have at least one publication column"
+
+    def test_publication_config_required_columns(self):
+        """Test that required columns are present in ALL publication configurations."""
+
+        assert len(PUBLICATION_CONFIG) > 0, "At least one publication should be configured"
+
+        for pub_name, pub_config in PUBLICATION_CONFIG.items():
+            for table in pub_config["tables"]:
+                table_name = table["name"]
+                columns = table["publication_columns"]
+                context = f"Publication '{pub_name}', table '{table_name}'"
+
+                # Every inventory table should have org_id for tenant isolation
+                assert "org_id" in columns, f"{context} missing required 'org_id' column"
+
+                # Each table should have some form of identifier column
+                id_columns = [col for col in columns if col.endswith("_id") or col == "id"]
+                assert len(id_columns) > 0, f"{context} should have at least one ID column"
+
+                # Ensure publication_columns list is not empty
+                assert len(columns) > 0, f"{context} should have at least one publication column"
+
+                # If table has a filter, ensure filtered columns are in publication_columns
+                table_filter = table.get("publication_filter")
+                if table_filter and table_filter.strip():
+                    # Extract column names from filter
+                    import re
+
+                    # Match column names
+                    filter_columns = re.findall(r"\b([a-zA-Z_][a-zA-Z0-9_]*)\b", table_filter)
+                    # Filter out common SQL keywords and operators
+                    sql_keywords = {"and", "or", "not", "is", "null", "where"}
+                    actual_columns = [col for col in filter_columns if col.lower() not in sql_keywords]
+
+                    for filter_col in actual_columns:
+                        if filter_col not in columns:
+                            raise AssertionError(
+                                f"{context} filter references column '{filter_col}' "
+                                f"which is not in publication_columns: {columns}"
+                            )
+
+
+@pytest.fixture
+def mock_logger():
+    """Fixture to provide a mock logger."""
+    return Mock()

--- a/tests/test_inv_publish_hosts.py
+++ b/tests/test_inv_publish_hosts.py
@@ -198,7 +198,7 @@ class TestReplicaIdentityIntegration:
                 sa_text(
                     f"""
                     CREATE UNIQUE INDEX IF NOT EXISTS hosts_replica_identity_idx
-                    ON {schema}.{table_name} (org_id, id);
+                    ON {schema}.{table_name} (org_id, id, insights_id);
                     """
                 )
             )
@@ -296,7 +296,10 @@ class TestReplicaIdentityIntegration:
                 # Create multiple unique indexes
                 db.session.execute(
                     sa_text(
-                        f"CREATE UNIQUE INDEX IF NOT EXISTS hosts_replica_identity_idx ON {schema}.{table_name} (id)"
+                        f"""
+                        CREATE UNIQUE INDEX IF NOT EXISTS hosts_replica_identity_idx
+                        ON {schema}.{table_name} (org_id, id, insights_id)
+                        """
                     )
                 )
                 db.session.execute(

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -47,7 +47,8 @@ DB_CONTAINER_ID=$(podman run -d \
     -e POSTGRESQL_USER="inventory-test" \
     -e POSTGRESQL_PASSWORD="inventory-test" \
     -e POSTGRESQL_DATABASE="inventory-test" \
-    "$POSTGRES_IMAGE" || echo "0")
+    "$POSTGRES_IMAGE" \
+    -c wal_level=logical || echo "0")
 
 if [[ "$DB_CONTAINER_ID" == "0" ]]; then
     echo "Failed to start DB container"

--- a/unit_test.sh
+++ b/unit_test.sh
@@ -29,7 +29,7 @@ fi
 # run unit tests in containers
 DB_CONTAINER_NAME="inventory-db-${IMAGE_TAG}"
 NETWORK="inventory-test-${IMAGE_TAG}"
-POSTGRES_IMAGE="quay.io/cloudservices/postgresql-rds:cyndi-13"
+POSTGRES_IMAGE="quay.io/cloudservices/postgresql-rds:cyndi-16"
 
 function teardown_podman {
     podman rm -f "$DB_CONTAINER_ID" || true
@@ -41,14 +41,16 @@ trap "teardown_podman" EXIT SIGINT SIGTERM
 
 podman network create --driver bridge "$NETWORK"
 
+echo "wal_level = logical" > 99-wal-level.conf
+
 DB_CONTAINER_ID=$(podman run -d \
     --name "$DB_CONTAINER_NAME" \
     --network "$NETWORK" \
     -e POSTGRESQL_USER="inventory-test" \
     -e POSTGRESQL_PASSWORD="inventory-test" \
     -e POSTGRESQL_DATABASE="inventory-test" \
-    "$POSTGRES_IMAGE" \
-    -c wal_level=logical || echo "0")
+    -v ./99-wal-level.conf:/etc/postgresql/conf.d/99-wal-level.conf:Z \
+    "$POSTGRES_IMAGE" || echo "0")
 
 if [[ "$DB_CONTAINER_ID" == "0" ]]; then
     echo "Failed to start DB container"


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20360](https://issues.redhat.com/browse/RHINENG-20360).

It introduces 4 new environment variables that allow to set the publications that will be created and dropped. It also allows to set the replica identity mode for the replicated tables.

This will allow us to continue the logical replication tests on stage environment and be able to run this job in production when we fell that we are ready to give it another try to update the replica identity and rollback to default if needed.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [x] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enable dynamic configuration of PostgreSQL publications, replication slot cleanup, and replica identity settings in the inv_publish_hosts script via environment variables; refactor core logic into reusable functions; update deployment manifest; and add documentation and extensive tests.

New Features:
- Drive publication creation, deletion, and replication slot cleanup via environment variables (CREATE_PUBLICATIONS, DROP_PUBLICATIONS, DROP_REPLICATION_SLOTS).
- Support setting replica identity mode (default or index) for tables and their partitions via REPLICA_IDENTITY_MODE.
- Generate CREATE PUBLICATION SQL dynamically from a central PUBLICATION_CONFIG structure.

Enhancements:
- Refactor inv_publish_hosts.py to modularize publication and replica identity setup into reusable functions with improved logging and configuration handling.

Build:
- Expose new environment variables for publication and replica identity settings in the clowdapp deployment manifest.

Documentation:
- Add user-facing documentation describing inv_publish_hosts.py configuration via environment variables.

Tests:
- Add comprehensive unit and integration tests covering publication SQL generation, publication setup, replication slot cleanup, and replica identity management.