### PR TITLE
fix(RHINENG-20395): Fix canonical facts updates

### DIFF
--- a/app/models/host.py
+++ b/app/models/host.py
@@ -317,6 +317,8 @@ class Host(LimitedHost):
 
         self.update_canonical_facts(input_host.canonical_facts)
 
+        self.update_canonical_facts_columns(input_host.canonical_facts)
+
         self._update_ansible_host(input_host.ansible_host)
 
         self.update_facts(input_host.facts)
@@ -364,6 +366,16 @@ class Host(LimitedHost):
         self.canonical_facts.update(canonical_facts)  # Field being removed in the future
         logger.debug("Host (id=%s) has updated canonical_facts (%s)", self.id, self.canonical_facts)
         orm.attributes.flag_modified(self, "canonical_facts")  # Field being removed in the future
+
+    def update_canonical_facts_columns(self, canonical_facts):
+        try:
+            for key, value in canonical_facts.items():
+                if getattr(self, key) != value:
+                    setattr(self, key, value)
+                    orm.attributes.flag_modified(self, key)
+        except AttributeError as e:
+            logger.warning("Error updating canonical facts column %s: %s", key, str(e))
+            raise e
 
     def update_facts(self, facts_dict):
         if facts_dict:


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20395](https://issues.redhat.com/browse/RHINENG-20395).
It fixes the canonical facts column update that was identified when investigating [RHINENG-20233](https://issues.redhat.com/browse/RHINENG-20233).

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Introduce mechanism to sync individual host columns with canonical_facts updates and extend tests to validate provider_type handling and message queue update flows.

Bug Fixes:
- Sync dedicated host attributes with canonical_facts by calling new update_canonical_facts_columns during model updates to ensure fields like bios_uuid and provider_type are updated

Enhancements:
- Add update_canonical_facts_columns helper to apply and flag modified individual canonical_facts columns based on the updated dict

Tests:
- Update duplicate hosts tests to include provider_type in canonical_facts
- Add MQ integration test to verify canonical_facts dict and dedicated columns update correctly on host create and update