### PR TITLE
fix(RHINENG-20409) Fix failing Outbox test

### DIFF
--- a/tests/test_outbox_end_to_end_cases.py
+++ b/tests/test_outbox_end_to_end_cases.py
@@ -893,7 +893,10 @@ class TestOutboxE2ECases:
                 pass
 
         # Use the mock event producer to test outbox entry creation without cleanup
-        with patch("api.host.current_app.event_producer", MockEventProducerNoCleanup()):
+        with (
+            patch("api.host.current_app.event_producer", MockEventProducerNoCleanup()),
+            patch("lib.host_delete.kafka_available", return_value=True),
+        ):
             # Make DELETE request to delete the host
             response_status, _ = api_delete_host(host.id)
 

--- a/tests/test_outbox_end_to_end_cases.py
+++ b/tests/test_outbox_end_to_end_cases.py
@@ -859,12 +859,13 @@ class TestOutboxE2ECases:
             assert updated_host.display_name == "updated-host-name"
             assert updated_host.ansible_host == "updated.ansible.host"
 
-    @pytest.mark.usefixtures("event_producer", "notification_event_producer")
+    @pytest.mark.usefixtures("notification_event_producer")
     def test_host_delete_via_api_endpoint_with_actual_outbox_validation(
         self,
         api_delete_host,
         db_create_host,
         db_get_host,
+        event_producer,
     ):
         """
         Test that deleting a host via DELETE API endpoint triggers actual outbox entry creation and
@@ -929,8 +930,14 @@ class TestOutboxE2ECases:
         assert db_get_host(host2.id) is not None
         assert host2.display_name == "host-to-delete-2"
 
-        # Make DELETE request to delete the second host (using real event producer)
-        response_status, _ = api_delete_host(host2.id)
+        # We want to use the real event producer, but we need to mock the kafka functions
+        event_producer._kafka_producer.flush = Mock(return_value=True)
+        event_producer._kafka_producer.poll = Mock(return_value=True)
+        event_producer._kafka_producer.produce = Mock(return_value=True)
+
+        with patch("lib.host_delete.kafka_available", return_value=True):
+            # Make DELETE request to delete the second host (using real event producer)
+            response_status, _ = api_delete_host(host2.id)
 
         # Verify the API request was successful
         assert response_status == 200


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20409](https://issues.redhat.com/browse/RHINENG-20409). It fixes `tests.test_outbox_end_to_end_cases.TestOutboxE2ECases.test_host_delete_via_api_endpoint_with_actual_outbox_validation`, which was failing due to Kafka not being available. This was occurring because instead of using `event_producer_mock`, which automatically patches the `kafka_available()` check, the test is using a mock made specifically for it. I just added the patch to this new mock producer.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Mock Kafka availability in the outbox end-to-end test to fix the failing host delete validation

Bug Fixes:
- Fix TestOutboxE2ECases.test_host_delete_via_api_endpoint_with_actual_outbox_validation by patching kafka_available to True

Tests:
- Add patch for lib.host_delete.kafka_available return value in the outbox test context