### PR TITLE
feat(RHINENG-19514): Ignore RHSM display name updates if it is set by puptoo or API

### DIFF
--- a/app/models/host.py
+++ b/app/models/host.py
@@ -355,9 +355,14 @@ class Host(LimitedHost):
         self, input_display_name: str | None, input_reporter: str, *, input_fqdn: str | None = None
     ) -> None:
         if input_display_name:
-            if input_reporter == "rhsm-conduit" and self.display_name_reporter in ("API", "puptoo"):
+            # Ignore display_name updates from RHSM, if it has already been updated by API or insights-client
+            # https://issues.redhat.com/browse/RHINENG-19514
+            if input_reporter in ("rhsm-conduit", "rhsm-system-profile-bridge") and self.display_name_reporter in (
+                "API",
+                "puptoo",
+            ):
                 logger.debug(
-                    "Ignoring display_name update from rhsm-conduit, "
+                    f"Ignoring display_name update from {input_reporter}, "
                     f"current display_name_reporter: {self.display_name_reporter}"
                 )
                 return

--- a/migrations/versions/c1d6c41043d0_add_display_name_reporter_column.py
+++ b/migrations/versions/c1d6c41043d0_add_display_name_reporter_column.py
@@ -1,0 +1,24 @@
+"""Add display_name_reporter column
+
+Revision ID: c1d6c41043d0
+Revises: 0e3773b74542
+Create Date: 2025-08-27 11:15:25.799091
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c1d6c41043d0"
+down_revision = "0e3773b74542"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("hosts", sa.Column("display_name_reporter", sa.String(length=255), nullable=True), schema="hbi")
+
+
+def downgrade():
+    op.drop_column("hosts", "display_name_reporter", schema="hbi")

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -30,8 +30,14 @@ def api_post(flask_client):
 
 
 @pytest.fixture(scope="function")
-def api_patch(flask_client):
-    def _api_patch(url, host_data, identity=USER_IDENTITY, query_parameters=None, extra_headers=None):
+def api_patch(flask_client: TestClient) -> Callable[..., tuple[int, dict]]:
+    def _api_patch(
+        url: str,
+        host_data: dict[str, str],
+        identity: dict[str, Any] = USER_IDENTITY,
+        query_parameters: dict[str, Any] | None = None,
+        extra_headers: dict[str, Any] | None = None,
+    ) -> tuple[int, dict]:
         return do_request(flask_client.patch, url, identity, host_data, query_parameters, extra_headers)
 
     return _api_patch

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -56,8 +56,8 @@ def database(database_name: None) -> Generator[str]:  # noqa: ARG001
 
 
 @pytest.fixture(scope="function")
-def db_get_host(flask_app: FlaskApp) -> Callable[[UUID], Host | None]:  # noqa: ARG001
-    def _db_get_host(host_id: UUID, org_id: str | None = None) -> Host | None:
+def db_get_host(flask_app: FlaskApp) -> Callable[[UUID | str], Host | None]:  # noqa: ARG001
+    def _db_get_host(host_id: UUID | str, org_id: str | None = None) -> Host | None:
         org_id = org_id or SYSTEM_IDENTITY["org_id"]
         return Host.query.filter(Host.org_id == org_id, Host.id == host_id).one_or_none()
 

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -15,11 +15,14 @@ from urllib.parse import quote_plus as url_quote
 from urllib.parse import urlencode
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
+from uuid import UUID
 
 import dateutil.parser
 from requests import Response
 
 from app.auth.identity import IdentityType
+from app.models import Host
+from app.utils import HostWrapper
 from tests.helpers.test_utils import now
 
 BASE_URL = "/api/inventory/v1"
@@ -455,7 +458,9 @@ def build_fields_query_parameters(fields=None):
     return query_parameters
 
 
-def _build_url(base_url=HOST_URL, path=None, id_list=None, query=None):
+def _build_url(
+    base_url: str = HOST_URL, path: str | None = None, id_list: str | None = None, query: str | None = None
+) -> str:
     url = base_url
 
     if id_list:
@@ -470,8 +475,12 @@ def _build_url(base_url=HOST_URL, path=None, id_list=None, query=None):
     return url
 
 
-def build_hosts_url(host_list_or_id=None, path=None, query=None):
-    if host_list_or_id:
+def build_hosts_url(
+    host_list_or_id: list[str] | list[HostWrapper | Host] | str | UUID | None = None,
+    path: str | None = None,
+    query: str | None = None,
+) -> str:
+    if host_list_or_id is not None:
         host_list_or_id = build_id_list_for_url(host_list_or_id)
 
     return _build_url(id_list=host_list_or_id, path=path, query=query)
@@ -517,16 +526,13 @@ def build_facts_url(host_list_or_id, namespace, query=None):
     return build_hosts_url(path=f"/facts/{namespace}", host_list_or_id=host_list_or_id, query=query)
 
 
-def build_id_list_for_url(id_or_id_list):
-    if isinstance(id_or_id_list, dict):
-        id_or_id_list = list(id_or_id_list.values())
-
+def build_id_list_for_url(id_or_id_list: list[str] | list[HostWrapper | Host] | str | UUID) -> str:
     if isinstance(id_or_id_list, list):
         # check if the list contains hosts or strings
         if not any(isinstance(item, str) for item in id_or_id_list):
-            return ",".join(get_id_list_from_hosts(id_or_id_list))
+            return ",".join(get_id_list_from_hosts(id_or_id_list))  # type: ignore[arg-type]
         else:
-            return ",".join(id_or_id_list)
+            return ",".join(id_or_id_list)  # type: ignore[arg-type]
 
     return str(id_or_id_list)
 
@@ -543,7 +549,7 @@ def build_resource_types_groups_url(query=None):
     return _build_url(base_url=RESOURCE_TYPES_URL + "/inventory-groups", query=query)
 
 
-def get_id_list_from_hosts(host_list):
+def get_id_list_from_hosts(host_list: list[HostWrapper | Host]) -> list[str]:
     return [str(h.id) for h in host_list]
 
 

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -129,10 +129,8 @@ def set_environment(new_env=None):
 def _base_host_data(**values) -> dict[str, Any]:
     return {
         "org_id": USER_IDENTITY["org_id"],
-        "display_name": "test" + generate_random_string(),
         "stale_timestamp": (now() + timedelta(days=randint(1, 7))).isoformat(),
         "reporter": "test" + generate_random_string(),
-        "created": now().isoformat(),
         **values,
     }
 

--- a/tests/test_display_name.py
+++ b/tests/test_display_name.py
@@ -1,0 +1,376 @@
+# mypy: disallow-untyped-defs
+
+from collections.abc import Callable
+from uuid import UUID
+
+import pytest
+
+from app.models import Host
+from app.utils import HostWrapper
+from tests.helpers.api_utils import assert_response_status
+from tests.helpers.api_utils import build_hosts_url
+from tests.helpers.test_utils import generate_random_string
+from tests.helpers.test_utils import minimal_host
+
+
+@pytest.mark.parametrize("reporter", ("rhsm-conduit", "rhsm-system-profile-bridge"))
+def test_rhsm_update_display_name_ignored_after_created_by_puptoo(
+    mq_create_or_update_host: Callable[..., HostWrapper],
+    db_get_host: Callable[[UUID | str], Host | None],
+    reporter: str,
+) -> None:
+    # Create a host with display_name as puptoo
+    original_display_name = generate_random_string()
+    host_data = minimal_host(reporter="puptoo", display_name=original_display_name)
+    host = mq_create_or_update_host(host_data)
+    assert host.display_name == original_display_name
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == "puptoo"
+
+    # Try to update the display_name as RHSM
+    host_data.display_name = generate_random_string()
+    host_data.reporter = reporter
+    updated_host = mq_create_or_update_host(host_data)
+    assert updated_host.display_name == original_display_name
+    assert updated_host.reporter == reporter
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == "puptoo"
+    assert db_host.display_name == original_display_name
+    assert db_host.reporter == reporter
+
+
+@pytest.mark.parametrize("reporter", ("rhsm-conduit", "rhsm-system-profile-bridge"))
+def test_rhsm_update_display_name_ignored_after_updated_by_puptoo(
+    mq_create_or_update_host: Callable[..., HostWrapper],
+    db_get_host: Callable[[UUID | str], Host | None],
+    reporter: str,
+) -> None:
+    # Create a host without setting the display_name
+    host_data = minimal_host(reporter=reporter)
+    host = mq_create_or_update_host(host_data)
+    assert host.display_name == host.id
+    assert host.reporter == reporter
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter is None
+
+    # Update the display_name as puptoo
+    puptoo_display_name = generate_random_string()
+    host_data.display_name = puptoo_display_name
+    host_data.reporter = "puptoo"
+    updated_host = mq_create_or_update_host(host_data)
+    assert updated_host.display_name == puptoo_display_name
+    assert updated_host.reporter == "puptoo"
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == "puptoo"
+    assert db_host.display_name == puptoo_display_name
+    assert db_host.reporter == "puptoo"
+
+    # Try to update the display_name as RHSM
+    host_data.display_name = generate_random_string()
+    host_data.reporter = reporter
+    updated_host = mq_create_or_update_host(host_data)
+    assert updated_host.display_name == puptoo_display_name
+    assert updated_host.reporter == reporter
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == "puptoo"
+    assert db_host.display_name == puptoo_display_name
+    assert db_host.reporter == reporter
+
+
+@pytest.mark.parametrize("reporter", ("rhsm-conduit", "rhsm-system-profile-bridge"))
+def test_rhsm_update_display_name_ignored_after_updated_by_api(
+    mq_create_or_update_host: Callable[..., HostWrapper],
+    db_get_host: Callable[[UUID | str], Host | None],
+    api_patch: Callable[..., tuple[int, dict]],
+    reporter: str,
+) -> None:
+    # Create a host without setting the display_name
+    host_data = minimal_host(reporter="satellite")
+    host = mq_create_or_update_host(host_data)
+    assert host.display_name == host.id
+    assert host.reporter == "satellite"
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter is None
+
+    # Update the display_name via API
+    api_display_name = generate_random_string()
+    data = {"display_name": api_display_name}
+    url = build_hosts_url(host_list_or_id=host.id)
+    patch_response_status, _ = api_patch(url, data)
+    assert_response_status(patch_response_status, expected_status=200)
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == "API"
+    assert db_host.display_name == api_display_name
+    assert db_host.reporter == "satellite"
+
+    # Try to update the display_name as RHSM
+    host_data.display_name = generate_random_string()
+    host_data.reporter = reporter
+    updated_host = mq_create_or_update_host(host_data)
+    assert updated_host.display_name == api_display_name
+    assert updated_host.reporter == reporter
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == "API"
+    assert db_host.display_name == api_display_name
+    assert db_host.reporter == reporter
+
+
+@pytest.mark.parametrize(
+    "orig_reporter",
+    (
+        "yupana",
+        "yuptoo",
+        "satellite",
+        "discovery",
+        "rhsm-conduit",
+        "rhsm-system-profile-bridge",
+        "cloud-connector",
+        "test-reporter",
+    ),
+)
+@pytest.mark.parametrize("rhsm_reporter", ("rhsm-conduit", "rhsm-system-profile-bridge"))
+def test_rhsm_update_display_name_accepted(
+    mq_create_or_update_host: Callable[..., HostWrapper],
+    db_get_host: Callable[[UUID | str], Host | None],
+    orig_reporter: str,
+    rhsm_reporter: str,
+) -> None:
+    # Create a host with display_name
+    original_display_name = generate_random_string()
+    host_data = minimal_host(reporter=orig_reporter, display_name=original_display_name)
+    host = mq_create_or_update_host(host_data)
+    assert host.display_name == original_display_name
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == orig_reporter
+
+    # Check that RHSM can update the display_name, if it was not set by puptoo or API
+    new_display_name = generate_random_string()
+    host_data.display_name = new_display_name
+    host_data.reporter = rhsm_reporter
+    updated_host = mq_create_or_update_host(host_data)
+    assert updated_host.display_name == new_display_name
+    assert updated_host.reporter == rhsm_reporter
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == rhsm_reporter
+    assert db_host.display_name == new_display_name
+    assert db_host.reporter == rhsm_reporter
+
+
+@pytest.mark.parametrize(
+    "reporter",
+    (
+        "puptoo",
+        "yupana",
+        "yuptoo",
+        "satellite",
+        "discovery",
+        "rhsm-conduit",
+        "rhsm-system-profile-bridge",
+        "cloud-connector",
+        "test-reporter",
+    ),
+)
+@pytest.mark.parametrize("explicit_display_name", (True, False))
+def test_update_display_name_by_api(
+    mq_create_or_update_host: Callable[..., HostWrapper],
+    db_get_host: Callable[[UUID | str], Host | None],
+    api_patch: Callable[..., tuple[int, dict]],
+    reporter: str,
+    explicit_display_name: bool,
+) -> None:
+    # Create a host
+    host_data = minimal_host(reporter=reporter)
+    if explicit_display_name:
+        host_data.display_name = generate_random_string()
+    host = mq_create_or_update_host(host_data)
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == (reporter if explicit_display_name else None)
+
+    # Check that we can always update the display_name via API, after any reporter
+    api_display_name = generate_random_string()
+    data = {"display_name": api_display_name}
+    url = build_hosts_url(host_list_or_id=host.id)
+    patch_response_status, _ = api_patch(url, data)
+    assert_response_status(patch_response_status, expected_status=200)
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == "API"
+    assert db_host.display_name == api_display_name
+    assert db_host.reporter == reporter
+
+    # Check that we can update the display_name via API even after it was already updated by API
+    new_display_name = generate_random_string()
+    data = {"display_name": new_display_name}
+    url = build_hosts_url(host_list_or_id=host.id)
+    patch_response_status, _ = api_patch(url, data)
+    assert_response_status(patch_response_status, expected_status=200)
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == "API"
+    assert db_host.display_name == new_display_name
+    assert db_host.reporter == reporter
+
+
+@pytest.mark.parametrize(
+    "reporter",
+    (
+        "puptoo",
+        "yupana",
+        "yuptoo",
+        "satellite",
+        "discovery",
+        "cloud-connector",
+        "test-reporter",
+    ),
+)
+def test_update_display_name_by_reporter_after_puptoo(
+    mq_create_or_update_host: Callable[..., HostWrapper],
+    db_get_host: Callable[[UUID | str], Host | None],
+    reporter: str,
+) -> None:
+    # Create a host with display_name as puptoo
+    original_display_name = generate_random_string()
+    host_data = minimal_host(reporter="puptoo", display_name=original_display_name)
+    host = mq_create_or_update_host(host_data)
+    assert host.display_name == original_display_name
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == "puptoo"
+
+    # Check that we can update the display_name as any reporter except RHSM
+    new_display_name = generate_random_string()
+    host_data.display_name = new_display_name
+    host_data.reporter = reporter
+    updated_host = mq_create_or_update_host(host_data)
+    assert updated_host.display_name == new_display_name
+    assert updated_host.reporter == reporter
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == reporter
+    assert db_host.display_name == new_display_name
+    assert db_host.reporter == reporter
+
+
+@pytest.mark.parametrize(
+    "reporter",
+    (
+        "puptoo",
+        "yupana",
+        "yuptoo",
+        "satellite",
+        "discovery",
+        "cloud-connector",
+        "test-reporter",
+    ),
+)
+def test_update_display_name_by_reporter_after_api(
+    mq_create_or_update_host: Callable[..., HostWrapper],
+    db_get_host: Callable[[UUID | str], Host | None],
+    api_patch: Callable[..., tuple[int, dict]],
+    reporter: str,
+) -> None:
+    # Create a host without setting the display_name
+    host_data = minimal_host(reporter="satellite")
+    host = mq_create_or_update_host(host_data)
+    assert host.display_name == host.id
+    assert host.reporter == "satellite"
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter is None
+
+    # Update the display_name via API
+    api_display_name = generate_random_string()
+    data = {"display_name": api_display_name}
+    url = build_hosts_url(host_list_or_id=host.id)
+    patch_response_status, _ = api_patch(url, data)
+    assert_response_status(patch_response_status, expected_status=200)
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == "API"
+    assert db_host.display_name == api_display_name
+    assert db_host.reporter == "satellite"
+
+    # Check that we can update the display_name as any reporter except RHSM
+    new_display_name = generate_random_string()
+    host_data.display_name = new_display_name
+    host_data.reporter = reporter
+    updated_host = mq_create_or_update_host(host_data)
+    assert updated_host.display_name == new_display_name
+    assert updated_host.reporter == reporter
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == reporter
+    assert db_host.display_name == new_display_name
+    assert db_host.reporter == reporter
+
+
+@pytest.mark.parametrize(
+    "reporter",
+    (
+        "puptoo",
+        "yupana",
+        "yuptoo",
+        "satellite",
+        "discovery",
+        "rhsm-conduit",
+        "rhsm-system-profile-bridge",
+        "cloud-connector",
+        "test-reporter",
+    ),
+)
+def test_update_implicit_display_name_by_reporter(
+    mq_create_or_update_host: Callable[..., HostWrapper],
+    db_get_host: Callable[[UUID | str], Host | None],
+    reporter: str,
+) -> None:
+    # Create a host without setting the display_name
+    host_data = minimal_host()
+    host = mq_create_or_update_host(host_data)
+    assert host.display_name == host.id
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter is None
+
+    # Check that we can update the display_name as any reporter if it was set implicitly
+    new_display_name = generate_random_string()
+    host_data.display_name = new_display_name
+    host_data.reporter = reporter
+    updated_host = mq_create_or_update_host(host_data)
+    assert updated_host.display_name == new_display_name
+    assert updated_host.reporter == reporter
+
+    db_host = db_get_host(host.id)
+    assert db_host
+    assert db_host.display_name_reporter == reporter
+    assert db_host.display_name == new_display_name
+    assert db_host.reporter == reporter

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -468,6 +468,7 @@ def test_add_host_simple(mq_create_or_update_host):
     host = minimal_host(
         account=SYSTEM_IDENTITY["account_number"],
         insights_id=expected_insights_id,
+        display_name=generate_random_string(),
         system_profile={"owner_id": OWNER_ID},
     )
 
@@ -492,6 +493,7 @@ def test_add_host_with_system_profile(mq_create_or_update_host):
     host = minimal_host(
         account=SYSTEM_IDENTITY["account_number"],
         insights_id=expected_insights_id,
+        display_name=generate_random_string(),
         system_profile=expected_system_profile,
     )
 
@@ -727,7 +729,10 @@ def test_add_host_with_tags(mq_create_or_update_host):
     ]
 
     host = minimal_host(
-        account=SYSTEM_IDENTITY["account_number"], insights_id=expected_insights_id, tags=expected_tags
+        account=SYSTEM_IDENTITY["account_number"],
+        insights_id=expected_insights_id,
+        display_name=generate_random_string(),
+        tags=expected_tags,
     )
 
     expected_results = {"host": {**host.data()}}
@@ -958,7 +963,10 @@ def test_add_host_with_sap_system(mq_create_or_update_host):
     system_profile["owner_id"] = OWNER_ID
 
     host = minimal_host(
-        account=SYSTEM_IDENTITY["account_number"], insights_id=expected_insights_id, system_profile=system_profile
+        account=SYSTEM_IDENTITY["account_number"],
+        display_name=generate_random_string(),
+        insights_id=expected_insights_id,
+        system_profile=system_profile,
     )
 
     expected_results = {"host": {**host.data()}}


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19514](https://issues.redhat.com/browse/RHINENG-19514).

Issue: rhsm-conduit overwrites the display_name every night, even if it was explicitly set by a user via insights-client or UI (API)

This PR makes HBI ignore display_name updates from rhsm-conduit and rhsm-system-profile-bridge if the display_name has been updated by puptoo (insights-client) or API (including UI) in the past.

Question: Do we also have to create a migration for the replicated DBs? I thought we had to do that because we are adding a column to a table that is being replicated, but I noticed that we didn't do that when we added the canonical facts to the hosts table, so I skipped that step for now.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [x] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [x] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Track and respect the source of a host's display_name to prevent nightly RHSM processes from overwriting user- or API-assigned names

New Features:
- Add display_name_reporter column to hosts table
- Ignore display_name updates from rhsm-conduit and rhsm-system-profile-bridge when set by API or insights-client

Enhancements:
- Record the reporter whenever display_name is set and enforce precedence in update_display_name logic
- Update model methods and URL builder signatures with type annotations

Deployment:
- Add Alembic migration to introduce display_name_reporter column

Tests:
- Add extensive tests covering display_name update precedence for various reporters and update paths