### PR TITLE
feat(RHINENG-20411): Add job to update canonical facts columns

### DIFF
--- a/deploy/cji.yml
+++ b/deploy/cji.yml
@@ -83,6 +83,16 @@ objects:
     appName: host-inventory
     jobs:
       - delete-host-bios-uuid
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    labels:
+      app: host-inventory
+    name: canonical-facts-migration-${CANONICAL_FACTS_MIGRATION_RUN_NUMBER}
+  spec:
+    appName: host-inventory
+    jobs:
+      - canonical-facts-migration
 parameters:
 - name: SYNCHRONIZER_RUN_NUMBER
   value: '1'
@@ -99,4 +109,6 @@ parameters:
 - name: HOSTS_TABLE_MIGRATION_SWITCH_RUN_NUMBER
   value: '1'
 - name: DELETE_HOST_BIOS_UUID_RUN_NUMBER
+  value: '1'
+- name: CANONICAL_FACTS_MIGRATION_RUN_NUMBER
   value: '1'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1819,6 +1819,44 @@ objects:
           requests:
             cpu: ${CPU_REQUEST_DELETE_HOST_BIOS_UUID_JOB}
             memory: ${MEMORY_REQUEST_DELETE_HOST_BIOS_UUID_JOB}
+    - name: canonical-facts-migration
+      restartPolicy: Never
+      suspend: ${{SUSPEND_CANONICAL_FACTS_MIGRATION}}
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        args: [ "./jobs/canonical_facts_migration.py" ]
+        env:
+          - name: PYTHONPATH
+            value: '/opt/app-root/src'
+          - name: INVENTORY_LOG_LEVEL
+            value: ${LOG_LEVEL}
+          - name: INVENTORY_DB_SSL_MODE
+            value: ${INVENTORY_DB_SSL_MODE}
+          - name: INVENTORY_DB_SSL_CERT
+            value: ${INVENTORY_DB_SSL_CERT}
+          - name: INVENTORY_DB_SCHEMA
+            value: "${INVENTORY_DB_SCHEMA}"
+          - name: PROMETHEUS_PUSHGATEWAY
+            value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CLOWDER_ENABLED
+            value: "true"
+          - name: CANONICAL_FACTS_MIGRATION_BATCH_SIZE
+            value: ${CANONICAL_FACTS_MIGRATION_BATCH_SIZE}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
+          - name: SUSPEND_CANONICAL_FACTS_MIGRATION
+            value: ${SUSPEND_CANONICAL_FACTS_MIGRATION}
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_CANONICAL_FACTS_MIGRATION}
+            memory: ${MEMORY_LIMIT_CANONICAL_FACTS_MIGRATION}
+          requests:
+            cpu: ${CPU_REQUEST_CANONICAL_FACTS_MIGRATION}
+            memory: ${MEMORY_REQUEST_CANONICAL_FACTS_MIGRATION}
     database:
       name: ${DB_NAME}
       version: 16
@@ -2613,3 +2651,19 @@ parameters:
 - name: TARGET_HOST_ID
   description: The host ID to target for bios_uuid deletion
   value: ''
+
+# Canonical Facts Migration Job
+- name: CPU_REQUEST_CANONICAL_FACTS_MIGRATION
+  value: 250m
+- name: CPU_LIMIT_CANONICAL_FACTS_MIGRATION
+  value: 500m
+- name: MEMORY_REQUEST_CANONICAL_FACTS_MIGRATION
+  value: 256Mi
+- name: MEMORY_LIMIT_CANONICAL_FACTS_MIGRATION
+  value: 512Mi
+- name: SUSPEND_CANONICAL_FACTS_MIGRATION
+  description: If set to true, the canonical-facts-migration job will immediately exit upon running.
+  value: 'true'
+- name: CANONICAL_FACTS_MIGRATION_BATCH_SIZE
+  description: The batch size to use for the canonical facts migration.
+  value: '5000'

--- a/jobs/canonical_facts_migration.py
+++ b/jobs/canonical_facts_migration.py
@@ -1,0 +1,175 @@
+#!/usr/bin/python3
+# ruff: noqa: E501
+import os
+import sys
+import time
+from functools import partial
+from logging import Logger
+
+from connexion import FlaskApp
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.environment import RuntimeEnvironment
+from app.logging import get_logger
+from app.models.constants import INVENTORY_SCHEMA
+from jobs.common import excepthook
+from jobs.common import job_setup
+
+PROMETHEUS_JOB = "canonical-facts-migration"
+LOGGER_NAME = "canonical_facts_migration"
+RUNTIME_ENVIRONMENT = RuntimeEnvironment.JOB
+SUSPEND_JOB = os.environ.get("SUSPEND_CANONICAL_FACTS_MIGRATION", "true").lower() == "true"
+
+"""
+This job updates the canonical facts columns in the hosts table by extracting
+values from the canonical_facts JSONB column. It processes data in batches
+to manage memory and avoid long-running transactions.
+
+This script can be run safely on a live system as it only performs UPDATE operations.
+"""
+
+# Single Source of Truth for Index DDL
+INDEX_DEFINITIONS = {
+    "hosts_replica_identity_idx": "CREATE UNIQUE INDEX {index_name} ON {schema}.hosts (org_id, id, insights_id);",
+    "idx_hosts_insights_id": "CREATE INDEX {index_name} ON {schema}.hosts (insights_id);",
+    "idx_hosts_subscription_manager_id": "CREATE INDEX {index_name} ON {schema}.hosts (subscription_manager_id);",
+}
+
+
+def drop_indexes(session: Session, logger: Logger):
+    """Drops all non-primary key indexes from the target tables to speed up inserts."""
+    logger.warning("Dropping all non-PK indexes from target tables to optimize data copy...")
+    for index_name in INDEX_DEFINITIONS.keys():
+        logger.info(f"  Dropping index: {index_name}")
+        session.execute(text(f"DROP INDEX IF EXISTS {INVENTORY_SCHEMA}.{index_name};"))
+    session.commit()
+    logger.info("All non-PK indexes have been dropped.")
+
+
+def recreate_indexes(session: Session, logger: Logger):
+    """Recreates all indexes using a data-driven approach after the data copy is complete."""
+    logger.info("Data copy finished. Recreating all indexes (this may take a long time)...")
+    try:
+        for index_name, index_ddl in INDEX_DEFINITIONS.items():
+            logger.info(f"  Recreating index: {index_name}")
+            session.execute(text(index_ddl.format(index_name=index_name, schema=INVENTORY_SCHEMA)))
+
+        logger.info("Committing index creation transaction...")
+        session.commit()
+        logger.info("All indexes have been recreated successfully.")
+    except Exception:
+        logger.error("An error occurred during index recreation. Rolling back.")
+        session.rollback()
+        raise
+
+
+def update_canonical_facts_in_batches(session: Session, logger: Logger):
+    """Updates canonical facts columns from the canonical_facts JSONB column using batched processing."""
+    batch_size = int(os.getenv("CANONICAL_FACTS_MIGRATION_BATCH_SIZE", 5000))
+    # Initialize cursor for DESC pagination. These are "max" values to start from the top.
+    last_modified_on = "9999-12-31 23:59:59+00"
+    last_id = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    total_rows_updated = 0
+
+    logger.info(
+        f"Starting canonical facts migration using (last_modified_on, id) index with a batch size of {batch_size} rows."
+    )
+
+    while True:
+        batch_start_time = time.perf_counter()
+        logger.info(f"Fetching next batch of hosts with last_modified_on before: {last_modified_on} - {last_id}")
+
+        # Step 1: Fetch the next batch using the descending index.
+        # The ORDER BY clause must match the index definition for efficiency.
+        batch_to_process = session.execute(
+            text(
+                f"""
+                SELECT id, modified_on FROM {INVENTORY_SCHEMA}.hosts
+                WHERE (modified_on, id) < (:last_modified_on, :last_id)
+                    AND canonical_facts IS NOT NULL
+                ORDER BY last_check_in DESC, id DESC
+                LIMIT :batch_size;
+                """
+            ),
+            {"last_modified_on": last_modified_on, "last_id": last_id, "batch_size": batch_size},
+        ).fetchall()
+
+        if not batch_to_process:
+            logger.info("No more hosts to process. Canonical facts migration complete.")
+            break
+
+        id_list = [row[0] for row in batch_to_process]
+        logger.info(f"Processing batch of {len(id_list)} hosts...")
+
+        # Step 2: Update canonical facts columns for the current batch
+        # Convert UUID list to string format for the query
+        id_list_str = [str(host_id) for host_id in id_list]
+
+        update_sql = f"""
+            UPDATE {INVENTORY_SCHEMA}.hosts
+            SET
+                insights_id = COALESCE((canonical_facts->>'insights_id')::uuid, '00000000-0000-0000-0000-000000000000'),
+                subscription_manager_id = canonical_facts ->> 'subscription_manager_id',
+                satellite_id = canonical_facts ->> 'satellite_id',
+                fqdn = canonical_facts ->> 'fqdn',
+                bios_uuid = canonical_facts ->> 'bios_uuid',
+                ip_addresses = canonical_facts -> 'ip_addresses',
+                mac_addresses = canonical_facts -> 'mac_addresses',
+                provider_id = canonical_facts ->> 'provider_id',
+                provider_type = canonical_facts ->> 'provider_type'
+            WHERE id IN :id_list
+                AND canonical_facts IS NOT NULL;
+        """
+
+        result = session.execute(text(update_sql), {"id_list": tuple(id_list_str)})
+        rows_affected = result.rowcount
+
+        # Update loop variables with the last row from the processed batch
+        last_row = batch_to_process[-1]
+        last_modified_on = last_row[1]
+        last_id = last_row[0]
+
+        total_rows_updated += rows_affected
+        batch_duration = time.perf_counter() - batch_start_time
+
+        logger.info(
+            f"Batch complete in {batch_duration:.2f}s. "
+            f"Updated {rows_affected} rows in this batch. "
+            f"Total rows updated so far: {total_rows_updated}. "
+            f"Next batch starts before: {last_modified_on}"
+        )
+
+        session.commit()
+
+    logger.info(f"Successfully finished updating canonical facts. Total rows updated: {total_rows_updated}.")
+
+
+def run(logger: Logger, session: Session, application: FlaskApp):
+    """Main execution function."""
+    try:
+        with application.app.app_context():
+            drop_indexes(session, logger)
+            update_canonical_facts_in_batches(session, logger)
+            recreate_indexes(session, logger)
+    except Exception:
+        logger.exception("A critical error occurred during the canonical facts migration job.")
+        raise
+    finally:
+        logger.info("Closing database session.")
+        session.close()
+
+
+if __name__ == "__main__":
+    logger = get_logger(LOGGER_NAME)
+
+    if SUSPEND_JOB:
+        logger.info("SUSPEND_CANONICAL_FACTS_MIGRATION is set to true; exiting job.")
+        sys.exit(0)
+
+    job_type = "Canonical facts migration"
+    sys.excepthook = partial(excepthook, logger, job_type)
+
+    _, session, _, _, _, application = job_setup((), PROMETHEUS_JOB)
+
+    run(logger, session, application)

--- a/tests/test_canonical_facts_migration.py
+++ b/tests/test_canonical_facts_migration.py
@@ -1,0 +1,65 @@
+from unittest import mock
+
+import pytest
+from connexion import FlaskApp
+from sqlalchemy import text
+
+from app.logging import get_logger
+from app.models import db
+from jobs.canonical_facts_migration import run as canonical_facts_migration_run
+from tests.helpers.db_utils import minimal_db_host
+from tests.helpers.test_utils import generate_uuid
+
+logger = get_logger(__name__)
+
+
+@pytest.mark.canonical_facts_migration
+def test_canonical_facts_migration_runs_successfully(
+    flask_app: FlaskApp,
+    db_create_host,
+    db_get_host,
+):
+    """
+    Test that the canonical facts migration job correctly updates NULL canonical facts columns
+    from the canonical_facts JSONB column.
+    """
+    # Create a host with canonical facts data
+    insights_id = generate_uuid()
+    bios_uuid = generate_uuid()
+
+    canonical_facts = {
+        "insights_id": insights_id,
+        "fqdn": "test-host.example.com",
+        "bios_uuid": bios_uuid,
+        "provider_type": "aws",
+    }
+
+    host_data = minimal_db_host(canonical_facts=canonical_facts)
+    created_host = db_create_host(host=host_data)
+
+    # Set bios_uuid to NULL to create a migration scenario
+    # (insights_id has a NOT NULL constraint so we can't set it to NULL)
+    update_sql = text("""
+        UPDATE hbi.hosts
+        SET bios_uuid = NULL
+        WHERE id = :host_id
+    """)
+    db.session.execute(update_sql, {"host_id": created_host.id})
+    db.session.commit()
+
+    # Verify setup: bios_uuid is NULL but canonical_facts contains data
+    host_before = db_get_host(created_host.id)
+    assert host_before.bios_uuid is None
+    assert host_before.canonical_facts["bios_uuid"] == bios_uuid
+
+    # Run the migration job
+    logger_mock = mock.Mock()
+
+    with mock.patch.dict("os.environ", {"CANONICAL_FACTS_MIGRATION_BATCH_SIZE": "1"}):
+        with flask_app.app.app_context():
+            canonical_facts_migration_run(logger_mock, db.session, flask_app)
+
+    # Verify the job completed successfully and found hosts to update
+    log_messages = [str(call) for call in logger_mock.info.call_args_list]
+    assert any("Successfully finished updating canonical facts" in msg for msg in log_messages)
+    assert any("Total rows updated: 1" in msg for msg in log_messages)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20411](https://issues.redhat.com/browse/RHINENG-20411).
Adds a job to update the canonical facts columns, in order to maintain it updated.
This is needed because there was found a bug where the canonical facts columns were not being updated, but the canonical_facts JSONB was.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [x] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add a new batch job to extract and update canonical facts columns from the JSONB field in the hosts table, configure its deployment and invocation, and include tests for validation.

New Features:
- Introduce jobs/canonical_facts_migration.py to process hosts in batches and populate individual canonical facts columns from the JSONB value

Bug Fixes:
- Address missing updates to canonical facts columns by synchronizing them from the canonical_facts JSONB

Deployment:
- Add ClowdApp and ClowdJobInvocation entries in deploy/clowdapp.yml and deploy/cji.yml with resource, environment, and scheduling parameters for the migration job

Tests:
- Add tests to verify the migration job correctly updates null canonical facts columns and logs the expected summary