### PR TITLE
docs(RHINENG-20060): Improve description for tags filter API documentation

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1173,7 +1173,7 @@ components:
     tagsParam:
       name: tags
       in: query
-      description: filters out hosts not tagged by the given tags
+      description: 'Filters systems by tag(s). Specify multiple tags as a comma-separated list (e.g. insights-client/security=strict,env/type=prod).'
       required: false
       schema:
         type: array

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1892,7 +1892,7 @@
       "tagsParam": {
         "name": "tags",
         "in": "query",
-        "description": "filters out hosts not tagged by the given tags",
+        "description": "Filters systems by tag(s). Specify multiple tags as a comma-separated list (e.g. insights-client/security=strict,env/type=prod).",
         "required": false,
         "schema": {
           "type": "array",


### PR DESCRIPTION
This PR addresses -[ RHINENG-20060](https://issues.redhat.com/browse/RHINENG-20060)

Description of Problem
The current description for filtering inventory using the /hosts endpoint is incorrect. We should correct it and add an example

## Summary by Sourcery

Clarify the tags filter description in the Inventory API documentation by correcting its phrasing and adding an example for usage

Documentation:
- Improve the description of the `tags` query parameter to accurately reflect its function
- Add an example (`insights-client/security=strict`) to illustrate tag filtering