### PR TITLE
RHINENG-17234: Remove group_name unqiueness restriction

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -32,6 +32,7 @@ from app.instrumentation import log_patch_group_success
 from app.logging import get_logger
 from app.models import InputGroupSchema
 from app.queue.events import EventType
+from lib.feature_flags import FLAG_INVENTORY_KESSEL_PHASE_1
 from lib.feature_flags import FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION
 from lib.feature_flags import get_flag_value
 from lib.group_repository import add_hosts_to_group
@@ -101,16 +102,20 @@ def create_group(body, rbac_filter=None):
 
     try:
         # Create group with validated data
-        if get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION):
-            group_name = validated_create_group_data.get("name")
-            # Before waiting for workspace creation in RBAC, check that the name isn't already in use
-            if does_group_with_name_exist(group_name, get_current_identity().org_id):
-                log_create_group_failed(logger, group_name)
-                return json_error_response(
-                    "Integrity error", f"A group with name {group_name} already exists.", HTTPStatus.BAD_REQUEST
-                )
+        group_name = validated_create_group_data.get("name")
 
-            # Also, validate whether the hosts can be added to the group
+        # check the group's existence and for Kessel Phase 1
+        if (
+            not get_flag_value(FLAG_INVENTORY_KESSEL_PHASE_1)
+            or get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION)
+        ) and does_group_with_name_exist(group_name, get_current_identity().org_id):
+            log_create_group_failed(logger, group_name)
+            return json_error_response(
+                "Integrity error", f"A group with name {group_name} already exists.", HTTPStatus.BAD_REQUEST
+            )
+
+        if get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION):
+            # Validate whether the hosts can be added to the group
             if len(host_id_list := validated_create_group_data.get("host_ids", [])) > 0:
                 validate_add_host_list_to_group_for_group_create(
                     host_id_list,
@@ -175,6 +180,7 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
         return ({"status": 400, "title": "Bad Request", "detail": str(e.messages), "type": "unknown"}, 400)
 
     identity = get_current_identity()
+    new_name = validated_patch_group_data.get("name")
 
     # First, get the group and update it
     group_to_update = get_group_by_id_from_db(group_id, identity.org_id)
@@ -184,12 +190,23 @@ def patch_group_by_id(group_id, body, rbac_filter=None):
         abort(HTTPStatus.NOT_FOUND)
 
     try:
-        if get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION):
-            # Update group on Kessel
-            new_group_name = validated_patch_group_data.get("name")
+        # never allow renaming ungrouped
+        if group_to_update.ungrouped and new_name:
+            log_patch_group_failed(logger, group_id)
+            abort(HTTPStatus.BAD_REQUEST, "The 'ungrouped' group can not be modified.")
 
-            if new_group_name:
-                patch_rbac_workspace(group_id, name=new_group_name)
+        # only enforce uniqueness pre-Phase1
+        if (
+            new_name
+            and not get_flag_value(FLAG_INVENTORY_KESSEL_PHASE_1)
+            and (new_name != group_to_update.name and does_group_with_name_exist(new_name, identity.org_id))
+        ):
+            log_patch_group_failed(logger, group_id)
+            abort(HTTPStatus.BAD_REQUEST, f"Group with name '{new_name}' already exists.")
+
+        # merge both flag_paths into a single RBAC call
+        if new_name and new_name != group_to_update.name and get_flag_value(FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION):
+            patch_rbac_workspace(group_id, name=new_name)
 
         # Separate out the host IDs because they're not stored on the Group
         patch_group(group_to_update, validated_patch_group_data, identity, current_app.event_producer)

--- a/app/models/group.py
+++ b/app/models/group.py
@@ -18,7 +18,7 @@ class Group(db.Model):
     __tablename__ = "groups"
     __table_args__ = (
         Index("idxgrouporgid", "org_id"),
-        Index("idx_groups_org_id_name_nocase", "org_id", text("lower(name)"), unique=True),
+        Index("idx_groups_org_id_name_ignorecase", "org_id", text("lower(name)"), unique=False),
         Index("idxorgidungrouped", "org_id", "ungrouped"),
         {"schema": INVENTORY_SCHEMA},
     )

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -256,7 +256,7 @@ def add_group(
     session.flush()
 
     # gets the ID of the group after it has been committed
-    return session.query(Group).filter((Group.name == group_name) & (Group.org_id == org_id)).one_or_none()
+    return new_group
 
 
 def add_group_with_hosts(
@@ -272,13 +272,14 @@ def add_group_with_hosts(
     with session_guard(db.session):
         # Create group
         created_group = add_group(group_name, identity.org_id, account, group_id, ungrouped)
+        created_group_id = created_group.id
 
         # Add hosts to group
         if host_id_list:
             _add_hosts_to_group(created_group.id, host_id_list, identity.org_id)
 
     # gets the ID of the group after it has been committed
-    created_group = Group.query.filter((Group.name == group_name) & (Group.org_id == identity.org_id)).one_or_none()
+    created_group = get_group_by_id_from_db(created_group_id, identity.org_id)
 
     # Produce update messages once the DB session has been closed
     serialized_groups, host_id_list = _update_hosts_for_group_changes(

--- a/migrations/versions/91110801bc8e_remove_group_name_uniqueness.py
+++ b/migrations/versions/91110801bc8e_remove_group_name_uniqueness.py
@@ -1,0 +1,79 @@
+"""remove group name uniqueness
+
+Revision ID: 91110801bc8e
+Revises: c1d6c41043d0
+Create Date: 2025-09-02 11:46:53.861264
+
+"""
+
+import os
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = '91110801bc8e'
+down_revision = 'c1d6c41043d0'
+branch_labels = None
+depends_on = None
+
+MIGRATION_MODE = os.environ.get("MIGRATION_MODE", "automated").lower()
+
+
+def upgrade():
+    if MIGRATION_MODE == "managed":
+        with op.get_context().autocommit_block():
+            op.execute(
+                text("""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_groups_org_id_name_ignorecase
+                ON hbi.groups (lower(name), org_id);
+            """)
+            )
+            op.execute(text("DROP INDEX CONCURRENTLY IF EXISTS hbi.idx_groups_org_id_name_nocase;"))
+
+    else:
+        op.create_index(
+            "idx_groups_org_id_name_ignorecase",
+            "groups",
+            [text("lower(name)"), "org_id"],
+            if_not_exists=True,
+            unique=False,
+            schema="hbi",
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            "idx_groups_org_id_name_nocase",
+            table_name="groups",
+            if_exists=True,
+            schema="hbi",
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    if MIGRATION_MODE == "managed":
+        with op.get_context().autocommit_block():
+            op.execute(
+                text("""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_groups_org_id_name_nocase
+                ON hbi.groups (lower(name), org_id);
+            """)
+            )
+            op.execute(text("DROP INDEX CONCURRENTLY IF EXISTS hbi.idx_groups_org_id_name_ignorecase;"))
+    else:
+        op.drop_index(
+            "idx_groups_org_id_name_ignorecase",
+            "groups",
+            if_exists=True,
+            schema="hbi",
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "idx_groups_org_id_name_nocase",
+            "groups",
+            [text("lower(name)"), "org_id"],
+            if_not_exists=True,
+            unique=True,
+            schema="hbi",
+            postgresql_concurrently=True,
+        )

--- a/migrations/versions/91110801bc8e_remove_group_name_uniqueness.py
+++ b/migrations/versions/91110801bc8e_remove_group_name_uniqueness.py
@@ -12,8 +12,8 @@ from alembic import op
 from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
-revision = '91110801bc8e'
-down_revision = 'c1d6c41043d0'
+revision = "91110801bc8e"
+down_revision = "c1d6c41043d0"
 branch_labels = None
 depends_on = None
 

--- a/tests/test_api_groups_create.py
+++ b/tests/test_api_groups_create.py
@@ -6,6 +6,7 @@ from dateutil import parser
 
 from app.auth.identity import Identity
 from app.auth.identity import to_auth_header
+from lib.feature_flags import FLAG_INVENTORY_KESSEL_PHASE_1
 from tests.helpers.api_utils import GROUP_WRITE_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import assert_group_response
 from tests.helpers.api_utils import assert_response_status
@@ -108,7 +109,11 @@ def test_create_group_read_only(api_create_group, mocker):
     "new_name",
     ["test_Group", " Test_Group", "test_group ", " test_group "],
 )
-def test_create_group_taken_name(api_create_group, new_name):
+def test_create_group_taken_name(api_create_group, new_name, mocker):
+    mocker.patch(
+        "lib.feature_flags.get_flag_value",
+        side_effect=lambda name: name == FLAG_INVENTORY_KESSEL_PHASE_1,
+    )
     group_data = {"name": "test_group", "host_ids": []}
 
     api_create_group(group_data)
@@ -247,3 +252,39 @@ def test_create_group_RBAC_denied_attribute_filter(mocker, api_create_group):
 
     # Access denied because of the attributeFilter
     assert_response_status(response_status, 403)
+
+
+@pytest.mark.usefixtures("event_producer")
+def test_create_group_same_name_kessel_phase1_enabled(api_create_group, db_get_group_by_name, mocker):
+    """Test that groups with the same name can be created when FLAG_INVENTORY_KESSEL_PHASE_1 is True."""
+    # Mock FLAG_INVENTORY_KESSEL_PHASE_1 to be True and FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION to be False
+    mocker.patch(
+        "api.group.get_flag_value",
+        side_effect=lambda flag_name: flag_name == FLAG_INVENTORY_KESSEL_PHASE_1,
+    )
+
+    group_data = {"name": "duplicate_group_name", "host_ids": []}
+
+    # Create the first group
+    response_status, response_data = api_create_group(group_data)
+    assert_response_status(response_status, expected_status=201)
+
+    first_group = db_get_group_by_name(group_data["name"])
+    assert first_group is not None
+    assert_group_response(response_data, first_group, 0)
+
+    # Create the second group with the same name - should succeed when Kessel Phase 1 is enabled
+    response_status, response_data = api_create_group(group_data)
+    assert_response_status(response_status, expected_status=201)
+
+    # Verify the second group was created successfully
+    # We can't use assert_group_response here since we can't easily retrieve the second group
+    # with the same name, but we can verify the response structure
+    assert "id" in response_data
+    assert "name" in response_data
+    assert response_data["name"] == group_data["name"]
+    assert "host_count" in response_data
+    assert response_data["host_count"] == 0
+
+    # The successful 201 response indicates the second group was created
+    # without the uniqueness constraint being enforced when Kessel Phase 1 is enabled

--- a/tests/test_api_groups_update.py
+++ b/tests/test_api_groups_update.py
@@ -6,6 +6,7 @@ from dateutil import parser
 
 from app.auth.identity import Identity
 from app.auth.identity import to_auth_header
+from lib.feature_flags import FLAG_INVENTORY_KESSEL_PHASE_1
 from tests.helpers.api_utils import assert_group_response
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import create_mock_rbac_response
@@ -140,7 +141,10 @@ def test_patch_group_existing_name_different_org(
 
 
 @pytest.mark.parametrize("patch_name", ["existing_group", "EXISTING_GROUP"])
-def test_patch_group_existing_name_same_org(db_create_group, api_patch_group, patch_name):
+def test_patch_group_existing_name_same_org(db_create_group, api_patch_group, patch_name, mocker):
+    # Mock the specific modules that might be importing the flag
+    mocker.patch("api.group.get_flag_value", side_effect=lambda name: name != FLAG_INVENTORY_KESSEL_PHASE_1)
+
     # Create 2 groups
     db_create_group("existing_group")
     new_id = db_create_group("another_group").id
@@ -178,6 +182,7 @@ def test_patch_group_hosts_from_different_group(
 @pytest.mark.usefixtures("enable_rbac", "event_producer")
 def test_patch_groups_RBAC_allowed_specific_groups(mocker, db_create_group_with_hosts, api_patch_group):
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+    mocker.patch("api.group.patch_rbac_workspace")
     group_id = str(db_create_group_with_hosts("new_group", 3).id)
     # Make a list of allowed group IDs (including some mock ones)
     group_id_list = [generate_uuid(), group_id, generate_uuid()]
@@ -441,3 +446,47 @@ def test_patch_ungrouped_name_is_denied(db_create_group, db_get_group_by_id, api
     assert retrieved_group.modified_on == orig_modified_on
 
     assert event_producer.write_event.call_count == 0
+
+
+@pytest.mark.usefixtures("event_producer")
+@pytest.mark.parametrize("patch_name", ["existing_group", "EXISTING_GROUP"])
+def test_patch_group_existing_name_same_org_kessel_phase1_enabled(
+    db_create_group, db_get_group_by_id, api_patch_group, patch_name, mocker
+):
+    """
+    Test that groups can be updated to have the same name as another group when
+    FLAG_INVENTORY_KESSEL_PHASE_1 is True.
+    """
+    # Mock FLAG_INVENTORY_KESSEL_PHASE_1 to be True and FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION to be False
+    mocker.patch(
+        "api.group.get_flag_value",
+        side_effect=lambda flag_name: flag_name == FLAG_INVENTORY_KESSEL_PHASE_1,
+    )
+
+    # Create 2 groups
+    existing_group = db_create_group("existing_group")
+    existing_group_id = existing_group.id
+    group_to_update = db_create_group("another_group")
+    group_to_update_id = group_to_update.id
+    orig_modified_on = group_to_update.modified_on
+
+    # Update the second group to have the same name as the first group
+    response_status, response_data = api_patch_group(group_to_update_id, {"name": patch_name})
+
+    # Should succeed when Kessel Phase 1 is enabled
+    assert_response_status(response_status, 200)
+
+    # Verify the group was updated successfully
+    updated_group = db_get_group_by_id(group_to_update_id)
+    assert updated_group.name == patch_name
+    assert updated_group.modified_on > orig_modified_on
+
+    # Verify the response data
+    assert_group_response(response_data, updated_group, 0)
+
+    # Verify the original group is unchanged
+    original_group = db_get_group_by_id(existing_group_id)
+    assert original_group.name == "existing_group"
+
+    # Both groups should now have the same name (case-insensitive match)
+    assert updated_group.name.lower() == original_group.name.lower()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1155,14 +1155,6 @@ def test_create_group_existing_name_diff_org(db_create_group, db_get_group_by_id
     assert db_get_group_by_id(group2.id).name == group_name
 
 
-def test_create_group_existing_name_same_org(db_create_group):
-    # Make sure we can't create two groups with the same name in the same org
-    group_name = "TestGroup"
-    db_create_group(group_name)
-    with pytest.raises(IntegrityError):
-        db_create_group(group_name)
-
-
 def test_add_delete_host_group_happy(
     db_create_host,
     db_create_group,


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-17234](https://issues.redhat.com/browse/RHINENG-17234).
This PR replaces [PR #2908](https://github.com/RedHatInsights/insights-host-inventory/pull/2908), which has been approved more than once but kept running into code conflicts or build problems beyond this PR.   For background, please take a look at PR #2908, which in turn points to 2 other PRs.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Remove the uniqueness restriction on group names by dropping the unique index and conditionally enforcing name uniqueness only when relevant feature flags are unset, update create/patch endpoints, repository methods, model index, and add supporting migrations and tests

Enhancements:
- Conditionally enforce group name uniqueness based on FLAG_INVENTORY_KESSEL_PHASE_1 and FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION
- Merge RBAC workspace update logic into a single call and forbid renaming of the ungrouped group
- Update group_repository methods to return the newly created group object directly

Deployment:
- Introduce Alembic migration to drop the unique index on lower(name) and create a non-unique index concurrently

Tests:
- Add tests allowing duplicate group names under Kessel Phase 1 for both creation and updates
- Mock feature flags and RBAC patch calls in existing tests
- Remove legacy test that expected uniqueness enforcement in the same org

Chores:
- Rename the model index from idx_groups_org_id_name_nocase to idx_groups_org_id_name_ignorecase and set unique=False