### PR TITLE
fix: populate canonical facts columns on host creation

### DIFF
--- a/app/models/host.py
+++ b/app/models/host.py
@@ -313,6 +313,7 @@ class Host(LimitedHost):
             self._update_per_reporter_staleness(reporter)
 
         self.update_canonical_facts(canonical_facts)
+        self.update_canonical_facts_columns(canonical_facts)
 
     def save(self):
         self._cleanup_tags()


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19775](https://issues.redhat.com/browse/RHINENG-19775).

- populate the new canonical facts columns when new hosts are being created.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enhancements:
- Populate new canonical fact columns during host creation by invoking update_canonical_facts_columns in the Host initializer