### PR TITLE
ci: Disable renovate updates on requirements

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,11 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
   "ignorePaths": [
-    "Pipfile"
+    "Pipfile",
+    ".hermetic_builds/**"
   ],
   "baseBranches": ["master"],
   "tekton": {
     "includePaths": ["pipelines/**"],
     "schedule": ["at any time"]
+  },
+  "pip_requirements": {
+    "enabled": false
   }
 }


### PR DESCRIPTION
Disable pip_requirements manager and disable updates for hermetic builds directory.

Renovate is sending useless PRs to update requirements of the hermetic builds, that's not what we want :)

## Summary by Sourcery

Update Renovate configuration to stop unnecessary pip requirements updates for hermetic builds.

CI:
- Disable the pip_requirements manager in the Renovate config
- Ignore the hermetic builds directory from Renovate dependency updates