### PR TITLE
feat(RHINENG-20633) Add outbox successes and failures to Grafana dashboard

### DIFF
--- a/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
@@ -1819,7 +1819,6 @@ data:
               "range": true
             }
           ],
-          "maxDataPoints": 100,
           "datasource": {
             "uid": "$datasource"
           },
@@ -1901,7 +1900,6 @@ data:
               "range": true
             }
           ],
-          "maxDataPoints": 100,
           "datasource": {
             "uid": "$datasource"
           },

--- a/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
@@ -1761,6 +1761,170 @@ data:
           "valueName": "current"
         },
         {
+          "id": 93,
+          "type": "stat",
+          "title": "Outbox successes",
+          "gridPos": {
+            "x": 12,
+            "y": 18,
+            "h": 2,
+            "w": 3
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "0",
+                      "index": 0
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "value": null,
+                    "color": "#299c46"
+                  },
+                  {
+                    "value": 0.1,
+                    "color": "rgba(237, 129, 40, 0.89)"
+                  },
+                  {
+                    "color": "#d44a3a"
+                  }
+                ]
+              },
+              "unit": "locale",
+              "decimals": 0,
+              "noValue": "0"
+            },
+            "overrides": []
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "expr": "sum(increase(inventory_outbox_save_successes_total[$__range]))",
+              "interval": "5m",
+              "refId": "A",
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "maxDataPoints": 100,
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "options": {
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "wideLayout": true,
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "showPercentChange": false,
+            "percentChangeColorMode": "standard"
+          },
+          "links": []
+        },
+        {
+          "id": 94,
+          "type": "stat",
+          "title": "Outbox failures",
+          "gridPos": {
+            "x": 15,
+            "y": 18,
+            "h": 2,
+            "w": 3
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "0",
+                      "index": 0
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "value": null,
+                    "color": "#299c46"
+                  },
+                  {
+                    "value": 0.1,
+                    "color": "rgba(237, 129, 40, 0.89)"
+                  },
+                  {
+                    "color": "#d44a3a"
+                  }
+                ]
+              },
+              "unit": "locale",
+              "decimals": 0,
+              "noValue": "0"
+            },
+            "overrides": []
+          },
+          "pluginVersion": "11.6.3",
+          "targets": [
+            {
+              "expr": "sum(increase(inventory_outbox_save_failures_total[$__range]))",
+              "interval": "5m",
+              "refId": "A",
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "maxDataPoints": 100,
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "options": {
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "orientation": "horizontal",
+            "textMode": "auto",
+            "wideLayout": true,
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "showPercentChange": false,
+            "percentChangeColorMode": "standard"
+          },
+          "links": []
+        },
+        {
           "cacheTimeout": null,
           "colorBackground": false,
           "colorValue": false,


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20633](https://issues.redhat.com/browse/RHINENG-20633).
Adds the Outbox success and failure rates to our Grafana dashboard. In context, it looks like this:

<img width="951" height="158" alt="image" src="https://github.com/user-attachments/assets/c50ef316-b526-4f34-a18a-2265fadf9b72" />

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Add stat panels for Outbox successes and failures to the Grafana inventory dashboard

New Features:
- Add Outbox successes stat panel displaying sum of successful outbox save events
- Add Outbox failures stat panel displaying sum of failed outbox save events