### PR TITLE
fix(RHINENG-20633) Swap Outbox metric threshold colors in Grafana

### DIFF
--- a/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-inventory-general.configmap.yaml
@@ -1789,11 +1789,11 @@ data:
                 "steps": [
                   {
                     "value": null,
-                    "color": "#299c46"
+                    "color": "rgba(237, 129, 40, 0.89)"
                   },
                   {
                     "value": 0.1,
-                    "color": "rgba(237, 129, 40, 0.89)"
+                    "color": "#299c46"
                   },
                   {
                     "color": "#d44a3a"


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20633](https://issues.redhat.com/browse/RHINENG-20633).
Swaps the threshold colors for the "Outbox successes" panel in Grafana. Now it should be orange when there are 0 successes, and green when there are more than 0.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Invert color assignments for the first two threshold steps in the Outbox successes metric