### PR TITLE
fix(RHINENG-19790): fix rhc_client_id type

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2074,7 +2074,7 @@ objects:
             "spd"."workloads"->'ansible' AS "ansible_workload",
             "spd"."workloads"->'mssql' AS "mssql_workload",
             "spd"."workloads"->'sap' AS "sap_workload",
-            "sps"."rhc_client_id" AS "rhc_client_id"
+            "sps"."rhc_client_id"::text AS "rhc_client_id"
           FROM "hbi"."hosts" AS "h"
           LEFT JOIN "hbi"."system_profiles_static" AS "sps"
             ON "h"."org_id" = "sps"."org_id" AND "h"."id" = "sps"."host_id"


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19790](https://issues.redhat.com/browse/RHINENG-19790).
After #2988 got merged, floorist produced the following error:
`pyarrow.lib.ArrowTypeError: ("Expected bytes, got a 'UUID' object", 'Conversion failed for column rhc_client_id with type object')`. This error does not happens for the `id` field, so my assumption is that null values from rhc_client_id are messing up the conversion and causing the error.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Fix pyarrow ArrowTypeError caused by rhc_client_id being a UUID by casting it to text in deploy/clowdapp.yml.