### PR TITLE
feat(RHINENG-20672) Add "cluster" host type

### DIFF
--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -14,7 +14,6 @@ from api.filtering.filtering_common import POSTGRES_COMPARATOR_NO_EQ_LOOKUP
 from api.filtering.filtering_common import POSTGRES_DEFAULT_COMPARATOR
 from api.filtering.filtering_common import get_valid_os_names
 from app import system_profile_spec
-from app.config import HostType
 from app.exceptions import ValidationException
 from app.logging import get_logger
 from app.models import Host
@@ -308,45 +307,6 @@ def build_single_filter(filter_param: dict) -> ColumnElement:
             return target_field.contains(value)
 
         return target_field.operate(pg_op, value)
-
-
-# Standardize host_type SP filter and get its value(s)
-def get_host_types_from_filter(host_type_filter: dict) -> set[HostType]:
-    if host_type_filter:
-        host_types = set()
-
-        # Standardize the input in dict format
-        if not isinstance(host_type_filter, dict):
-            host_type_filter = {"eq": host_type_filter}
-        for key in host_type_filter.keys():
-            if key in POSTGRES_COMPARATOR_LOOKUP.keys():
-                comparator = key
-                value = host_type_filter[key]
-            else:
-                comparator = "eq"
-                value = key
-
-            # Convert single values to list format
-            if not isinstance(value, list):
-                value = [value]
-
-            for val in value:
-                if val == "not_nil":
-                    val = HostType.EDGE
-                elif val == "nil" or val == "":
-                    val = HostType.NONE
-
-                if comparator == "eq":
-                    host_types.add(val)
-                elif comparator == "neq":
-                    tmp_host_types = set(HostType.__members__.values())
-                    tmp_host_types.remove(HostType(val))
-                    host_types.update(tmp_host_types)
-
-    else:
-        host_types = set(HostType.__members__.values())
-
-    return host_types
 
 
 # Takes a System Profile filter param and turns it into sql filters.

--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -14,7 +14,7 @@ from api.filtering.filtering_common import POSTGRES_COMPARATOR_NO_EQ_LOOKUP
 from api.filtering.filtering_common import POSTGRES_DEFAULT_COMPARATOR
 from api.filtering.filtering_common import get_valid_os_names
 from app import system_profile_spec
-from app.config import HOST_TYPES
+from app.config import HostType
 from app.exceptions import ValidationException
 from app.logging import get_logger
 from app.models import Host
@@ -311,7 +311,7 @@ def build_single_filter(filter_param: dict) -> ColumnElement:
 
 
 # Standardize host_type SP filter and get its value(s)
-def get_host_types_from_filter(host_type_filter: dict) -> set[str | None]:
+def get_host_types_from_filter(host_type_filter: dict) -> set[HostType]:
     if host_type_filter:
         host_types = set()
 
@@ -332,19 +332,19 @@ def get_host_types_from_filter(host_type_filter: dict) -> set[str | None]:
 
             for val in value:
                 if val == "not_nil":
-                    val = HOST_TYPES[0]
+                    val = HostType.EDGE
                 elif val == "nil" or val == "":
-                    val = HOST_TYPES[1]
+                    val = HostType.NONE
 
                 if comparator == "eq":
                     host_types.add(val)
                 elif comparator == "neq":
-                    tmp_host_types = HOST_TYPES.copy()
-                    tmp_host_types.remove(val)
+                    tmp_host_types = set(HostType.__members__.values())
+                    tmp_host_types.remove(HostType(val))
                     host_types.update(tmp_host_types)
 
     else:
-        host_types = set(HOST_TYPES.copy())
+        host_types = set(HostType.__members__.values())
 
     return host_types
 

--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,7 @@ import json
 import os
 import tempfile
 from datetime import timedelta
+from enum import Enum
 
 from app.common import get_build_version
 from app.culling import days_to_seconds
@@ -12,7 +13,6 @@ from app.logging import get_logger
 
 PRODUCER_ACKS = {"0": 0, "1": 1, "all": "all"}
 
-HOST_TYPES = ["edge", None]
 ALL_STALENESS_STATES = ["fresh", "stale", "stale_warning"]
 
 # NOTE: The order of this tuple is important. The order defines the priority.
@@ -23,6 +23,12 @@ ID_FACTS_USE_SUBMAN_ID = ("subscription_manager_id",)
 COMPOUND_ID_FACTS_MAP = {"provider_id": "provider_type"}
 COMPOUND_ID_FACTS = tuple(COMPOUND_ID_FACTS_MAP.values())
 IMMUTABLE_ID_FACTS = ("provider_id",)
+
+
+class HostType(str, Enum):
+    EDGE = "edge"
+    CLUSTER = "cluster"
+    NONE = None
 
 
 class Config:

--- a/app/models/constants.py
+++ b/app/models/constants.py
@@ -38,3 +38,4 @@ class SystemType(str, Enum):
     CONVENTIONAL = "conventional"
     BOOTC = "bootc"
     EDGE = "edge"
+    CLUSTER = "cluster"

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1242,6 +1242,7 @@ components:
             - conventional
             - bootc
             - edge
+            - cluster
     filter_param:
       in: query
       name: filter

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -1974,7 +1974,8 @@
             "enum": [
               "conventional",
               "bootc",
-              "edge"
+              "edge",
+              "cluster"
             ]
           }
         }

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -2286,7 +2286,7 @@ def test_query_by_staleness_using_columns(
                 assert {host["id"] for host in response_data["results"]} == expected_host_ids
 
 
-@pytest.mark.parametrize("system_type", ("conventional", "bootc", "edge"))
+@pytest.mark.parametrize("system_type", ("conventional", "bootc", "edge", "cluster"))
 def test_system_type_filter_valid_types(api_get, system_type):
     url = build_hosts_url(query=f"?system_type={system_type}")
     response_status, _ = api_get(url)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20672](https://issues.redhat.com/browse/RHINENG-20672).
Does the following:

- Adds the "cluster" host type
- Adds "cluster" option to the system_type filter
- Converts the HOST_TYPES string list to an Enum
- Simplifies per-reporter-staleness filtering logic

This should result in a performance boost to GET /hosts calls, as the staleness filtering no longer has to have separate conditions for each host_type.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
