### PR TITLE
chore(RHINENG-20950) Consolidate Phase 1 flags; remove obsolete flags

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -2,21 +2,6 @@
     "version": 1,
     "features": [
         {
-            "name": "edgeParity.groups-migration",
-            "description": "In the context of edge-parity, enables the migrate of edge management groups to insights inventory groups.",
-            "type": "release",
-            "project": "default",
-            "stale": false,
-            "strategies": [
-                {
-                    "name": "default",
-                    "parameters": {}
-                }
-            ],
-            "variants": [],
-            "createdAt": "2024-01-10T20:20:42.531Z"
-        },
-        {
             "name": "hbi.api.use-cached-insights-client-system",
             "description": "If active, use cached system data for requests from insights-client",
             "type": "release",
@@ -49,22 +34,6 @@
             "createdAt": "2025-02-14T16:26:57.428Z"
         },
         {
-            "name": "hbi.api.kessel-host-migration",
-            "description": "Gates the functionality for Phase 1 of the HBI Kessel migration (RHCLOUD-39540).",
-            "type": "release",
-            "project": "default",
-            "stale": false,
-            "enabled": false,
-            "strategies": [
-                {
-                    "name": "default",
-                    "parameters": {}
-                }
-            ],
-            "variants": [],
-            "createdAt": "2025-04-17T21:21:08Z"
-        },
-        {
             "name": "hbi.api.read-only",
             "description": "When turned ON, HBI's write endpoints (PUT/POST/PATCH) are disabled.",
             "type": "release",
@@ -82,7 +51,7 @@
         },
         {
             "name": "hbi.api.kessel-phase-1",
-            "description": "Enable feature flag for hbi+kessel integration Phase 1",
+            "description": "Gates the functionality for Phase 1 of the HBI Kessel migration (RHCLOUD-39540).",
             "type": "release",
             "project": "default",
             "stale": false,
@@ -97,22 +66,6 @@
             "createdAt": "2025-04-25T16:32:16.409Z"
         },
         {
-            "name": "hbi.create_last_check_in_update_per_reporter_staleness",
-            "description": "Use last_check_in field to create host staleness, and update the per_reporter_staleness field with stale_warning and culled_timestamps.",
-            "type": "release",
-            "project": "default",
-            "stale": false,
-            "enabled": false,
-            "createdAt": "2025-03-17T18:49:22.205Z",
-            "strategies": [
-                {
-                    "name": "default",
-                    "parameters": {}
-                }
-            ],
-            "variants": []
-          },
-          {
             "name": "hbi.filter_staleness_using_columns",
             "description": "Enable GET /hosts to use table columns to filter hosts.",
             "type": "release",

--- a/api/host.py
+++ b/api/host.py
@@ -53,7 +53,7 @@ from app.serialization import deserialize_canonical_facts
 from app.serialization import serialize_host
 from app.serialization import serialize_host_with_params
 from app.utils import Tag
-from lib.feature_flags import FLAG_INVENTORY_KESSEL_HOST_MIGRATION
+from lib.feature_flags import FLAG_INVENTORY_KESSEL_PHASE_1
 from lib.feature_flags import get_flag_value
 from lib.host_delete import delete_hosts
 from lib.host_repository import find_existing_host
@@ -592,7 +592,7 @@ def get_host_exists(insights_id, rbac_filter=None):
     if not host_id:
         flask.abort(404, f"No host found for Insights ID '{insights_id}'.")
     # Duplicated - I wonder if this could be factored back into middleware.py
-    if (not inventory_config().bypass_rbac) and get_flag_value(FLAG_INVENTORY_KESSEL_HOST_MIGRATION):
+    if (not inventory_config().bypass_rbac) and get_flag_value(FLAG_INVENTORY_KESSEL_PHASE_1):
         kessel_client = get_kessel_client(current_app)
         allowed, _ = get_kessel_filter(  # Kind of a duplicate Kessel call too
             kessel_client, current_identity, KesselResourceTypes.HOST.view, [host_id]

--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -9,7 +9,6 @@ UNLEASH = Unleash()
 logger = get_logger(__name__)
 
 FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION = "hbi.api.kessel-workspace-migration"
-FLAG_INVENTORY_KESSEL_HOST_MIGRATION = "hbi.api.kessel-host-migration"
 FLAG_INVENTORY_API_READ_ONLY = "hbi.api.read-only"
 FLAG_INVENTORY_KESSEL_PHASE_1 = "hbi.api.kessel-phase-1"
 FLAG_INVENTORY_FILTER_STALENESS_USING_COLUMNS = "hbi.filter_staleness_using_columns"
@@ -18,7 +17,6 @@ FLAG_INVENTORY_USE_NEW_SYSTEM_PROFILE_TABLES = "hbi.use_new_system_profile_table
 
 FLAG_FALLBACK_VALUES = {
     FLAG_INVENTORY_KESSEL_WORKSPACE_MIGRATION: False,
-    FLAG_INVENTORY_KESSEL_HOST_MIGRATION: False,
     FLAG_INVENTORY_API_READ_ONLY: False,
     FLAG_INVENTORY_KESSEL_PHASE_1: False,
     # Use when all hosts are populated with stale_warning/deletion_timestamps

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -36,7 +36,7 @@ from app.instrumentation import rbac_permission_denied
 from app.logging import get_logger
 from app.logging import threadctx
 from lib.feature_flags import FLAG_INVENTORY_API_READ_ONLY
-from lib.feature_flags import FLAG_INVENTORY_KESSEL_HOST_MIGRATION
+from lib.feature_flags import FLAG_INVENTORY_KESSEL_PHASE_1
 from lib.feature_flags import get_flag_value
 from lib.kessel import Kessel
 from lib.kessel import get_kessel_client
@@ -347,7 +347,7 @@ def access(permission: KesselPermission, id_param: str = ""):
             allowed = None
             rbac_filter = None
             if get_flag_value(
-                FLAG_INVENTORY_KESSEL_HOST_MIGRATION
+                FLAG_INVENTORY_KESSEL_PHASE_1
             ):  # Workspace permissions aren't part of HBI in V2, fallback to rbac for now.
                 kessel_client = get_kessel_client(current_app)
                 ids = permission.resource_type.get_resource_id(kwargs, id_param)


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-20950](https://issues.redhat.com/browse/RHINENG-20950).
Does the following:

- Consolidates our Kessel Phase 1 feature flags into `hbi.api.kessel-phase-1`
- Updates the `hbi.api.kessel-phase-1` description
- Removes config for the `edgeParity.groups-migration` and `hbi.create_last_check_in_update_per_reporter_staleness` feature flags, which are no longer used

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Consolidate Kessel Phase 1 feature flags under one flag, refresh its description, and clean up obsolete flag configurations and code references

Enhancements:
- Consolidate Kessel Phase 1 feature flags into a single "hbi.api.kessel-phase-1" flag and update its description
- Remove deprecated "edgeParity.groups-migration" and "hbi.create_last_check_in_update_per_reporter_staleness" flags and their configurations

Chores:
- Update host existence check and middleware to reference the unified Phase 1 flag
- Remove obsolete flag constant and default value entries from feature_flags.py