### PR TITLE
refactor(api): migrate SAP queries to HostDynamicSystemProfile table

### DIFF
--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -960,7 +960,8 @@ def test_add_host_with_sap_system(mq_create_or_update_host):
     expected_insights_id = generate_uuid()
 
     system_profile = valid_system_profile()
-    system_profile["sap_system"] = True
+    # Update to use workloads structure for SAP data (stored in system_profiles_dynamic)
+    system_profile["workloads"] = {"sap": {"sap_system": True}}
     system_profile["owner_id"] = OWNER_ID
 
     host = minimal_host(

--- a/tests/test_system_profile.py
+++ b/tests/test_system_profile.py
@@ -334,10 +334,10 @@ def test_system_profile_operating_system(mq_create_or_update_host, api_get):
 
 
 def test_system_profile_sap_system_with_missing_workloads(mq_create_or_update_host, api_get):
-    # Create some sap systems
+    # Create host without dynamic system profile workloads - should return no results
     host = minimal_host(
         insights_id=generate_uuid(),
-        system_profile={},  # Missing 'workloads' key
+        system_profile={},  # Missing 'workloads' key - no dynamic system profile created
     )
     _ = mq_create_or_update_host(host)
     url = build_system_profile_sap_system_url()
@@ -347,10 +347,10 @@ def test_system_profile_sap_system_with_missing_workloads(mq_create_or_update_ho
 
 
 def test_system_profile_sap_system_with_missing_sap(mq_create_or_update_host, api_get):
-    # Create some sap systems
+    # Create host with workloads but missing SAP data in dynamic system profile
     host = minimal_host(
         insights_id=generate_uuid(),
-        system_profile={"workloads": {}},  # Missing 'sap' key
+        system_profile={"workloads": {}},  # Missing 'sap' key in dynamic system profile
     )
     _ = mq_create_or_update_host(host)
     url = build_system_profile_sap_system_url()
@@ -360,10 +360,10 @@ def test_system_profile_sap_system_with_missing_sap(mq_create_or_update_host, ap
 
 
 def test_system_profile_sap_system_with_missing_sap_system(mq_create_or_update_host, api_get):
-    # Create one host with workloads but missing sap_system key
+    # Create one host with SAP workloads but missing sap_system key in dynamic system profile
     host = minimal_host(
         insights_id=generate_uuid(),
-        system_profile={"workloads": {"sap": {}}},  # Missing 'sap_system' key
+        system_profile={"workloads": {"sap": {}}},  # Missing 'sap_system' key in dynamic system profile
     )
 
     _ = mq_create_or_update_host(host)
@@ -375,14 +375,14 @@ def test_system_profile_sap_system_with_missing_sap_system(mq_create_or_update_h
 
 
 def test_system_profile_sap_system(mq_create_or_update_host, api_get):
-    # Create some sap systems
+    # Create some SAP systems - workloads data goes to system_profiles_dynamic table
     ordered_sap_system_data = [True, True, False, False, True, False]
     ordered_insights_ids = [generate_uuid() for _ in range(len(ordered_sap_system_data))]
 
     # Create an association between the insights IDs
     ordered_host_data = dict(zip(ordered_insights_ids, ordered_sap_system_data, strict=False))
 
-    # Create hosts for the above host data
+    # Create hosts with SAP data - this will be stored in system_profiles_dynamic table
     _ = [
         mq_create_or_update_host(
             minimal_host(
@@ -417,13 +417,13 @@ def test_system_profile_sap_system(mq_create_or_update_host, api_get):
 
 
 def test_system_profile_sap_sids(mq_create_or_update_host, api_get):
-    # Create some sap systems
+    # Create some SAP systems with SIDS - workloads data goes to system_profiles_dynamic table
     ordered_sap_sids_data = [["ABC", "HZO", "XYZ"], ["ABC"], [], [], ["XYZ"], []]
     ordered_insights_ids = [generate_uuid() for _ in range(len(ordered_sap_sids_data))]
 
     ordered_host_data = dict(zip(ordered_insights_ids, ordered_sap_sids_data, strict=False))
 
-    # Create hosts for the above host data
+    # Create hosts with SAP SIDS data - this will be stored in system_profiles_dynamic table
     _ = [
         mq_create_or_update_host(
             minimal_host(
@@ -450,13 +450,13 @@ def test_system_profile_sap_sids(mq_create_or_update_host, api_get):
 
 
 def test_system_profile_sap_sids_with_search(mq_create_or_update_host, api_get):
-    # Create some sap systems
+    # Create some SAP systems with search functionality - workloads data goes to system_profiles_dynamic table
     ordered_sap_sids_data = [["ABC", "HZO", "XYZ"], ["ABC"], [], [], ["XYZ"], []]
     ordered_insights_ids = [generate_uuid() for _ in range(len(ordered_sap_sids_data))]
 
     ordered_host_data = dict(zip(ordered_insights_ids, ordered_sap_sids_data, strict=False))
 
-    # Create hosts for the above host data
+    # Create hosts with SAP SIDS data - this will be stored in system_profiles_dynamic table
     _ = [
         mq_create_or_update_host(
             minimal_host(


### PR DESCRIPTION
- Update SAP system and SIDS queries to use HostDynamicSystemProfile
- Adjust filters and joins for new dynamic system profile structure
- Revise tests to reflect workloads data stored in dynamic profile table
- Remove legacy references to Host.system_profile_facts for SAP data

# Overview

This PR is being created to address [RHINENG-20999](https://issues.redhat.com/browse/RHINENG-20999).

The `sap_system` and `sap_sids` API Endpoints should now get the data from the new `System Profiles Dynamic` table instead of the legacy `hosts` table.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Migrate SAP workload endpoints to use the new HostDynamicSystemProfile table instead of legacy system_profile_facts, updating queries, filters, joins, and associated tests to work with the dynamic profile structure

Enhancements:
- Refactor sap_system and sap_sids query logic to join against HostDynamicSystemProfile and apply updated filtering and grouping
- Remove all legacy references to Host.system_profile_facts for SAP data

Tests:
- Update sap_system and sap_sids tests to validate data stored in the dynamic profile table and handle missing workloads cases