### PR TITLE
feat(kafka-producer): support multiple host types and enhanced CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,14 +171,55 @@ make upgrade_db
 echo "127.0.0.1   kafka" | sudo tee -a /etc/hosts
 ```
 
+To create one host(s), run the following command:
+
 ```bash
 make run_inv_mq_service_test_producer NUM_HOSTS=800
 ```
 
 - By default, it creates one host if `NUM_HOSTS` is not specified.
 - Optionally, you may need to pass `INVENTORY_HOST_ACCOUNT=5894300` to the command above to override the default `org_id` (`321`)
+- Optionally, you may want to create different types of hosts by passing `HOST_TYPE=[sap|rhsm|qpc]`. By default, it will create standard hosts with basic system profile data.
 
-### Run the export service
+#### Using the Enhanced Kafka Producer
+
+The new Kafka producer supports creating different types of hosts with various configurations:
+
+```bash
+# Create default hosts
+python utils/kafka_producer.py --num-hosts 10
+
+# Create RHSM hosts
+python utils/kafka_producer.py --host-type rhsm --num-hosts 5
+
+# Create QPC hosts
+python utils/kafka_producer.py --host-type qpc --num-hosts 3
+
+# Create SAP hosts
+python utils/kafka_producer.py --host-type sap --num-hosts 2
+
+# List available host types
+python utils/kafka_producer.py --list-types
+
+# Use custom Kafka settings
+python utils/kafka_producer.py --host-type sap --num-hosts 5 \
+  --bootstrap-servers localhost:29092 \
+  --topic platform.inventory.host-ingress
+```
+
+**Available Host Types:**
+- `default`: Standard hosts with basic system profile data
+- `rhsm`: Red Hat Subscription Manager hosts with RHSM-specific facts and metadata
+- `qpc`: Quipucords Product Catalog hosts with discovery-specific data
+- `sap`: SAP hosts with SAP workloads data in the dynamic system profile
+
+**Environment Variables:**
+- `NUM_HOSTS`: Number of hosts to create (default: 1)
+- `HOST_TYPE`: Default host type (default: "default")
+- `KAFKA_BOOTSTRAP_SERVERS`: Kafka bootstrap servers (default: "localhost:29092")
+- `KAFKA_HOST_INGRESS_TOPIC`: Kafka topic for host ingress (default: "platform.inventory.host-ingress")
+
+#### Run the Export Service
 
 ```bash
 pipenv shell

--- a/utils/kafka_producer.py
+++ b/utils/kafka_producer.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import os
 import sys
@@ -8,26 +9,102 @@ from confluent_kafka import Producer as KafkaProducer
 HOST_INGRESS_TOPIC = os.environ.get("KAFKA_HOST_INGRESS_TOPIC", "platform.inventory.host-ingress")
 BOOTSTRAP_SERVERS = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")
 NUM_HOSTS = int(os.environ.get("NUM_HOSTS", 1))
+HOST_TYPE = os.environ.get("HOST_TYPE", "default")
+
+
+# Mapping of host types to their corresponding payload builders
+HOST_TYPE_BUILDERS = {
+    "default": payloads.build_host_chunk,
+    "rhsm": payloads.build_rhsm_payload,
+    "qpc": payloads.build_qpc_payload,
+    "sap": payloads.build_sap_host_chunk,
+}
+
+# Mapping of host types to their corresponding MQ payload builders
+MQ_PAYLOAD_BUILDERS = {
+    "default": lambda: payloads.build_mq_payload(),
+    "rhsm": payloads.build_rhsm_mq_payload,
+    "qpc": payloads.build_qpc_mq_payload,
+    "sap": payloads.build_sap_mq_payload,
+}
+
+
+def get_payload_builder(host_type):
+    """Get the appropriate payload builder for the specified host type."""
+    if host_type not in MQ_PAYLOAD_BUILDERS:
+        available_types = ", ".join(MQ_PAYLOAD_BUILDERS.keys())
+        raise ValueError(f"Invalid host type '{host_type}'. Available types: {available_types}")
+
+    return MQ_PAYLOAD_BUILDERS[host_type]
+
+
+def create_payloads(num_hosts, host_type):
+    """Create a list of host payloads based on the specified type and count."""
+    payload_builder = get_payload_builder(host_type)
+
+    print(f"Creating {num_hosts} host(s) of type '{host_type}'...")
+    all_payloads = [payload_builder() for _ in range(num_hosts)]
+
+    return all_payloads
 
 
 def main():
-    # Create list of host payloads to add to the message queue
-    # payloads.build_payloads takes two optional args: number of hosts, and payload type ("default", "rhsm", "qpc")
-    all_payloads = [payloads.build_mq_payload() for _ in range(NUM_HOSTS)]
-    print("Number of hosts (payloads): ", len(all_payloads))
+    parser = argparse.ArgumentParser(description="Kafka producer for creating different types of hosts")
+    parser.add_argument(
+        "--host-type",
+        choices=list(HOST_TYPE_BUILDERS.keys()),
+        default=HOST_TYPE,
+        help="Type of hosts to create (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--num-hosts", type=int, default=NUM_HOSTS, help="Number of hosts to create (default: %(default)s)"
+    )
+    parser.add_argument(
+        "--bootstrap-servers", default=BOOTSTRAP_SERVERS, help="Kafka bootstrap servers (default: %(default)s)"
+    )
+    parser.add_argument(
+        "--topic", default=HOST_INGRESS_TOPIC, help="Kafka topic for host ingress (default: %(default)s)"
+    )
+    parser.add_argument("--list-types", action="store_true", help="List available host types and exit")
 
-    producer = KafkaProducer({"bootstrap.servers": BOOTSTRAP_SERVERS})
-    print("HOST_INGRESS_TOPIC:", HOST_INGRESS_TOPIC)
+    args = parser.parse_args()
 
-    def delivery_callback(err, msg):
-        if err:
-            sys.stderr.write(f"% Message failed delivery: {err}\n")
-        else:
-            sys.stderr.write(f"% Message delivered to {msg.topic()} [{msg.partition()}] @ {msg.offset()}\n")
+    if args.list_types:
+        print("Available host types:")
+        for host_type, builder in HOST_TYPE_BUILDERS.items():
+            description = builder.__doc__ or "No description available"
+            print(f"  {host_type}: {description.split('.')[0]}")
+        return
 
-    for payload in all_payloads:
-        producer.produce(HOST_INGRESS_TOPIC, value=payload, callback=delivery_callback)
-    producer.flush()
+    try:
+        # Create list of host payloads based on specified type
+        all_payloads = create_payloads(args.num_hosts, args.host_type)
+        print(f"Number of hosts (payloads): {len(all_payloads)}")
+        print(f"Host type: {args.host_type}")
+
+        producer = KafkaProducer({"bootstrap.servers": args.bootstrap_servers})
+        print(f"HOST_INGRESS_TOPIC: {args.topic}")
+
+        def delivery_callback(err, msg):
+            if err:
+                sys.stderr.write(f"% Message failed delivery: {err}\n")
+            else:
+                sys.stderr.write(f"% Message delivered to {msg.topic()} [{msg.partition()}] @ {msg.offset()}\n")
+
+        # Send all payloads to Kafka
+        for i, payload in enumerate(all_payloads, 1):
+            producer.produce(args.topic, value=payload, callback=delivery_callback)
+            sys.stderr.write(f"% Produced host {i}/{len(all_payloads)}\n")
+
+        producer.flush()
+        print(f"Successfully sent {len(all_payloads)} {args.host_type} host(s) to Kafka topic '{args.topic}'")
+
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add argparse-based CLI to kafka_producer.py for flexible host creation
- Support host types: default, rhsm, qpc, sap with dedicated payload builders
- Implement --list-types option to display available host types
- Update README with usage examples and environment variable documentation
- Add SAP, RHSM, QPC payload builders and MQ/HTTP helpers in payloads.py
- Include stale_timestamp and org_id in RHSM and QPC payloads for consistency

# Overview

This PR is being created to address [RHINENG-21064](https://issues.redhat.com/browse/RHINENG-21064).

Refactor the kafka producer script to be able to support multiple host type generation and enhanced the CLI

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Introduce an enhanced Kafka producer script with a flexible CLI and multiple host generation modes, add new payload builders for RHSM, QPC, and SAP hosts with consistent metadata, and update documentation with usage examples and configuration options.

New Features:
- Add argparse CLI to kafka_producer to specify host type, count, Kafka settings, and list supported types
- Support host generation for default, rhsm, qpc, and sap types with dedicated payload builders and MQ/HTTP functions
- Implement SAP payload builder injecting workloads and tags, and include org_id and stale_timestamp in RHSM/QPC payloads

Enhancements:
- Refactor kafka_producer to centralize payload creation with get_payload_builder/create_payloads and improve delivery logging and error handling

Documentation:
- Extend README with CLI usage examples, host type descriptions, and environment variable details