### PR TITLE
ci(konflux): Disable hermetic builds temporarily

### DIFF
--- a/.tekton/insights-host-inventory-pull-request.yaml
+++ b/.tekton/insights-host-inventory-pull-request.yaml
@@ -35,9 +35,9 @@ spec:
   - name: build-source-image
     value: "true"
   - name: hermetic
-    value: "true"
-  - name: prefetch-input
-    value: '[{"type": "rpm", "path": "./.hermetic_builds"},{"type": "pip", "path": ".", "requirements_files": [".hermetic_builds/requirements.txt", ".hermetic_builds/requirements-build.txt", ".hermetic_builds/requirements-extras.txt"]}, {"type": "generic", "path": "."}]'
+    value: "false"
+  # - name: prefetch-input
+  #   value: '[{"type": "rpm", "path": "./.hermetic_builds"},{"type": "pip", "path": ".", "requirements_files": [".hermetic_builds/requirements.txt", ".hermetic_builds/requirements-build.txt", ".hermetic_builds/requirements-extras.txt"]}, {"type": "generic", "path": "."}]'
   - name: prefetch-dev-package-managers
     value: "true"
   pipelineRef:

--- a/.tekton/insights-host-inventory-push.yaml
+++ b/.tekton/insights-host-inventory-push.yaml
@@ -32,9 +32,9 @@ spec:
   - name: build-source-image
     value: "true"
   - name: hermetic
-    value: "true"
-  - name: prefetch-input
-    value: '[{"type": "rpm", "path": "./.hermetic_builds"},{"type": "pip", "path": ".", "requirements_files": [".hermetic_builds/requirements.txt", ".hermetic_builds/requirements-build.txt", ".hermetic_builds/requirements-extras.txt"]}, {"type": "generic", "path": "."}]'
+    value: "false"
+  # - name: prefetch-input
+  #   value: '[{"type": "rpm", "path": "./.hermetic_builds"},{"type": "pip", "path": ".", "requirements_files": [".hermetic_builds/requirements.txt", ".hermetic_builds/requirements-build.txt", ".hermetic_builds/requirements-extras.txt"]}, {"type": "generic", "path": "."}]'
   - name: prefetch-dev-package-managers
     value: "true"
   pipelineRef:


### PR DESCRIPTION
Disable the hermetic builds temporarily until we figure out how to speed them up.

# Overview

This PR is being created to address the terrible performance of Hermetic builds.

## Summary by Sourcery

CI:
- Temporarily disable hermetic builds in Tekton pipelines by setting the hermetic variable to false and commenting out the prefetch-input configuration.