### PR TITLE
update payload file with system profile fields

### DIFF
--- a/utils/payloads.py
+++ b/utils/payloads.py
@@ -468,7 +468,7 @@ def create_system_profile():
         "cpu_flags": ["flag1", "flag2"],
         "os_release": "Red Hat EL 7.0.1",
         "os_kernel_version": "3.10.0",
-        "arch": "x86-64",
+        "arch": "x86_64",
         "last_boot_time": "2020-02-13T12:08:55Z",
         "kernel_modules": ["i915", "e1000e"],
         "running_processes": ["vim", "gcc", "python"],
@@ -477,7 +477,15 @@ def create_system_profile():
         "katello_agent_running": False,
         "satellite_managed": False,
         "is_marketplace": False,
-        "yum_repos": [{"name": "repo1", "gpgcheck": True, "enabled": True, "base_url": "http://rpms.redhat.com"}],
+        "yum_repos": [
+            {
+                "id": "repo1",
+                "name": "repo1",
+                "gpgcheck": True,
+                "enabled": True,
+                "base_url": "http://rpms.redhat.com",
+            }
+        ],
         "installed_products": [
             {"name": "eap", "id": "123", "status": "UP"},
             {"name": "jbws", "id": "321", "status": "DOWN"},
@@ -485,15 +493,90 @@ def create_system_profile():
         "insights_client_version": "12.0.12",
         "insights_egg_version": "120.0.1",
         "captured_date": "2020-02-13T12:16:00Z",
-        # "installed_packages": ["rpm1", "rpm2"],
-        # "installed_packages": subprocess.getoutput("rpm -qa").split("\n"),
-        # "installed_packages": rpm_list(),
         "installed_services": ["ndb", "krb5"],
         "enabled_services": ["ndb", "krb5"],
         "selinux_current_mode": "enforcing",
         "selinux_config_file": "enforcing",
         "operating_system": {"name": "RHEL", "major": 8, "minor": 1},
         "system_update_method": "yum",  # "dnf, rpm-ostree, yum"
+        # Static system profile extras
+        "basearch": "x86_64",
+        "bootc_status": {
+            "booted": {
+                "image": "quay.io/centos-bootc/fedora-bootc-cloud:eln",
+                "image_digest": "sha256:806d77394f96e47cf99b1233561ce970c94521244a2d8f2affa12c3261961223",
+                "cached_image": "quay.io/centos-bootc/fedora-bootc-cloud:eln",
+                "cached_image_digest": "sha256:92e476435ced1c148350c660b09c744717defbd300a15d33deda5b50ad6b21a0",
+            }
+        },
+        "cloud_provider": "aws",
+        "conversions": {"activity": True},
+        "dnf_modules": [{"name": "postgresql", "stream": "13", "status": ["default", "enabled", "installed"]}],
+        "gpg_pubkeys": ["gpg-pubkey-2fa658e0-45700c69", "gpg-pubkey-fd431d51-4ae0493b"],
+        "greenboot_fallback_detected": False,
+        "greenboot_status": "green",
+        "image_builder": {
+            "compliance_policy_id": "89b52baa-9912-4edc-9ed5-be15c06eaaa9",
+            "compliance_profile_id": "xccdf_org.ssgproject.content_profile_cis",
+        },
+        "installed_packages_delta": [
+            "openssl-0:3.0.1-1.el9.x86_64",
+            "krb5-libs-0:1.16.1-23.fc29.i686",
+        ],
+        "public_dns": ["ec2-203-0-113-12.compute-1.amazonaws.com"],
+        "public_ipv4_addresses": ["203.0.113.12"],
+        "releasever": "8",
+        "rhsm": {
+            "version": "8.1",
+            "environment_ids": ["262e621d10ae4475ab5732b39a9160b2"],
+        },
+        "rpm_ostree_deployments": [
+            {
+                "id": "rhel-9.3-1",
+                "osname": "rhel",
+                "checksum": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+                "origin": "rhel/9/x86_64/edge",
+                "booted": False,
+                "pinned": False,
+            }
+        ],
+        "system_purpose": {"role": "server", "sla": "premium", "usage": "production"},
+        "third_party_services": {
+            "crowdstrike": {
+                "falcon_aid": "44e3b7d20b434a2bb2815d9808fa3a8b",
+                "falcon_backend": "kernel",
+                "falcon_version": "7.14.16703.0",
+            }
+        },
+        "threads_per_core": 2,
+        "tuned_profile": "throughput-performance",
+        "virtual_host_uuid": "4b9a9b9c-aaaa-bbbb-cccc-2f2f2f2f2f2f",
+        # Dynamic system profile extras
+        "installed_packages": [
+            "bash-0:5.2.15-1.el9.x86_64",
+            "coreutils-0:9.1-1.el9.x86_64",
+        ],
+        "systemd": {
+            "state": "running",
+            "jobs_queued": 0,
+            "failed": 0,
+            "failed_services": [],
+        },
+        "workloads": {
+            "ansible": {
+                "controller_version": "1.2.3",
+                "hub_version": "1.2.3",
+                "catalog_worker_version": "1.2.3",
+                "sso_version": "1.2.3",
+            },
+            "rhel_ai": {
+                "variant": "RHEL AI",
+                "rhel_ai_version_id": "v1.1.3",
+                "gpu_models": [{"name": "NVIDIA A100 80GB PCIe", "vendor": "Nvidia", "memory": "80GB", "count": 1}],
+                "ai_models": ["granite-7b-redhat-lab"],
+                "free_disk_storage": "698GB",
+            },
+        },
     }
 
 


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

# Overview

This PR is being created to address [RHINENG-19788](https://issues.redhat.com/browse/RHINENG-19788).
Small PR to update payloads.py file

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Enhance the create_system_profile payload by correcting existing field formats and adding a comprehensive set of static and dynamic system profile attributes

Enhancements:
- Correct the arch format from x86-64 to x86_64
- Expand yum_repos schema to include an id field and multi-line structure
- Add a suite of static system profile fields such as basearch, bootc_status, cloud_provider, conversions, dnf_modules, gpg_pubkeys, greenboot status, image_builder, installed_packages_delta, public_dns/IPv4, releasever, rhsm, rpm_ostree_deployments, system_purpose, third_party_services, threads_per_core, tuned_profile, and virtual_host_uuid
- Add dynamic system profile fields including installed_packages, systemd state, and workloads details (ansible and rhel_ai)