### PR TITLE
fix(RHINENG-18150) Disable LZ4 compression

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -271,7 +271,6 @@ class Config:
                 os.environ.get("KAFKA_PRODUCER_MAX.IN.FLIGHT.REQUESTS.PER.CONNECTION", "5")
             ),
             "enable.idempotence": os.environ.get("KAFKA_PRODUCER_ENABLE_IDEMPOTENCE", "true").lower() == "true",
-            "compression.type": os.environ.get("KAFKA_PRODUCER_COMPRESSION_TYPE", "lz4"),
             **self.kafka_ssl_configs,
         }
 


### PR DESCRIPTION
# Overview

Addresses a fix related to [RHINENG-18150](https://issues.redhat.com/browse/RHINENG-18150). LZ4 compression is one of the performance tweaks I included as part of #3046, but I didn't realize that it would cause compatibility issues with downstream apps. I'm reverting that particular change.

## PR Checklist

- [x] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [x] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Disable default LZ4 compression for the Kafka producer to restore compatibility with downstream applications