### PR TITLE
RHINENG-20676(Staleness): Increase custom staleness deletion value to 30 days

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,7 +7,10 @@ from datetime import timedelta
 from enum import Enum
 
 from app.common import get_build_version
-from app.culling import days_to_seconds
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+from app.culling import seconds_to_days
 from app.environment import RuntimeEnvironment
 from app.logging import get_logger
 
@@ -288,24 +291,31 @@ class Config:
         self.payload_tracker_enabled = payload_tracker_enabled.lower() == "true"
 
         self.culling_stale_warning_offset_delta = timedelta(
-            days=int(os.environ.get("CULLING_STALE_WARNING_OFFSET_DAYS", "7")),
+            days=int(
+                os.environ.get(
+                    "CULLING_STALE_WARNING_OFFSET_DAYS",
+                    str(seconds_to_days(CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS)),
+                )
+            ),
             minutes=int(os.environ.get("CULLING_STALE_WARNING_OFFSET_MINUTES", "0")),
         )
         self.culling_culled_offset_delta = timedelta(
-            days=int(os.environ.get("CULLING_CULLED_OFFSET_DAYS", "14")),
+            days=int(
+                os.environ.get("CULLING_CULLED_OFFSET_DAYS", str(seconds_to_days(CONVENTIONAL_TIME_TO_DELETE_SECONDS)))
+            ),
             minutes=int(os.environ.get("CULLING_CULLED_OFFSET_MINUTES", "0")),
         )
 
         self.conventional_time_to_stale_seconds = int(
-            os.environ.get("CONVENTIONAL_TIME_TO_STALE_SECONDS", 104400)
+            os.environ.get("CONVENTIONAL_TIME_TO_STALE_SECONDS", CONVENTIONAL_TIME_TO_STALE_SECONDS)
         )  # 29 hours
 
-        self.conventional_time_to_stale_warning_seconds = os.environ.get(
-            "CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS", days_to_seconds(7)
+        self.conventional_time_to_stale_warning_seconds = int(
+            os.environ.get("CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS", CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS)
         )
 
-        self.conventional_time_to_delete_seconds = os.environ.get(
-            "CONVENTIONAL_TIME_TO_DELETE_SECONDS", days_to_seconds(14)
+        self.conventional_time_to_delete_seconds = int(
+            os.environ.get("CONVENTIONAL_TIME_TO_DELETE_SECONDS", CONVENTIONAL_TIME_TO_DELETE_SECONDS)
         )
 
         self.use_sub_man_id_for_host_id = os.environ.get("USE_SUBMAN_ID", "false").lower() == "true"

--- a/app/culling.py
+++ b/app/culling.py
@@ -7,7 +7,30 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from app.models.host import Host
 
-__all__ = ("Conditions", "Timestamps", "days_to_seconds")
+__all__ = (
+    "Conditions",
+    "Timestamps",
+    "days_to_seconds",
+    "seconds_to_days",
+    "CONVENTIONAL_TIME_TO_STALE_SECONDS",
+    "CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS",
+    "CONVENTIONAL_TIME_TO_DELETE_SECONDS",
+)
+
+# Time period of inactivity before the system becomes stale. (Hosts are
+# expected to check in nightly, but to accommodate for potential delays like a
+# randomized check-in window and overnight Kafka lag, the extra 5 hours beyond
+# the standard 24 hours provide a buffer).
+# Default: 104400 seconds (29 hours)
+CONVENTIONAL_TIME_TO_STALE_SECONDS = 104400
+
+# Time period of inactivity before the system is in "stale_warning" state.
+# Default: 604800 seconds (7 days).
+CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS = 604800
+
+# Time period of inactivity before the system is deleted from the database.
+# Default: 2592000 seconds (30 days).
+CONVENTIONAL_TIME_TO_DELETE_SECONDS = 2592000
 
 
 class _Config(namedtuple("_Config", ("stale_warning_offset_delta", "culled_offset_delta"))):
@@ -91,6 +114,11 @@ class Conditions:
 def days_to_seconds(n_days: int) -> int:
     factor = 86400
     return n_days * factor
+
+
+def seconds_to_days(n_seconds: int) -> int:
+    factor = 86400
+    return n_seconds // factor
 
 
 def should_host_stay_fresh_forever(host: "Host") -> bool:

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -14,6 +14,7 @@ from marshmallow import validate as marshmallow_validate
 from marshmallow import validates
 from marshmallow import validates_schema
 
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
 from app.models.constants import MAX_CANONICAL_FACTS_VERSION
 from app.models.constants import MIN_CANONICAL_FACTS_VERSION
 from app.models.constants import TAG_KEY_VALIDATION
@@ -343,7 +344,9 @@ class InputGroupSchema(MarshmallowSchema):
 
 
 class StalenessSchema(MarshmallowSchema):
-    conventional_time_to_stale = fields.Integer(validate=marshmallow_validate.Range(min=1, max=604800))
+    conventional_time_to_stale = fields.Integer(
+        validate=marshmallow_validate.Range(min=1, max=CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS)
+    )
     conventional_time_to_stale_warning = fields.Integer(validate=marshmallow_validate.Range(min=1, max=15552000))
     conventional_time_to_delete = fields.Integer(validate=marshmallow_validate.Range(min=1, max=63072000))
 

--- a/app/models/staleness.py
+++ b/app/models/staleness.py
@@ -4,7 +4,9 @@ from sqlalchemy import Index
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 
-from app.culling import days_to_seconds
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
 from app.exceptions import ValidationException
 from app.models.constants import INVENTORY_SCHEMA
 from app.models.database import db
@@ -44,8 +46,10 @@ class Staleness(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     org_id = db.Column(db.String(36), nullable=False)
-    conventional_time_to_stale = db.Column(db.Integer, default=104400, nullable=False)
-    conventional_time_to_stale_warning = db.Column(db.Integer, default=days_to_seconds(7), nullable=False)
-    conventional_time_to_delete = db.Column(db.Integer, default=days_to_seconds(14), nullable=False)
+    conventional_time_to_stale = db.Column(db.Integer, default=CONVENTIONAL_TIME_TO_STALE_SECONDS, nullable=False)
+    conventional_time_to_stale_warning = db.Column(
+        db.Integer, default=CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS, nullable=False
+    )
+    conventional_time_to_delete = db.Column(db.Integer, default=CONVENTIONAL_TIME_TO_DELETE_SECONDS, nullable=False)
     created_on = db.Column(db.DateTime(timezone=True), default=_time_now)
     modified_on = db.Column(db.DateTime(timezone=True), default=_time_now, onupdate=_time_now)

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -21,6 +21,9 @@ import dateutil.parser
 from requests import Response
 
 from app.auth.identity import IdentityType
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
 from app.models import Host
 from app.utils import HostWrapper
 from tests.helpers.test_utils import now
@@ -176,9 +179,9 @@ RBAC_ADMIN_PROHIBITED_RBAC_RESPONSE_FILES = (
 )
 
 DEFAULT_STALENESS_SETTINGS = {
-    "stale": 104400,
-    "stale_warning": 604800,
-    "delete": 1209600,
+    "stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
+    "stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
+    "delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
 }
 _INPUT_DATA = {
     "conventional_time_to_stale": DEFAULT_STALENESS_SETTINGS["stale"],

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -11,6 +11,9 @@ from confluent_kafka import TopicPartition
 
 from app.auth.identity import Identity
 from app.auth.identity import to_auth_header
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
 from app.serialization import serialize_facts
 from app.utils import Tag
 from tests.helpers.test_utils import SYSTEM_IDENTITY
@@ -239,9 +242,15 @@ def assert_patch_event_is_valid(
     reporter=None,
     identity=USER_IDENTITY,
 ):
-    stale_timestamp = (host.last_check_in.astimezone(UTC) + timedelta(seconds=104400)).isoformat()
-    stale_warning_timestamp = (host.last_check_in.astimezone(UTC) + timedelta(seconds=604800)).isoformat()
-    culled_timestamp = (host.last_check_in.astimezone(UTC) + timedelta(seconds=1209600)).isoformat()
+    stale_timestamp = (
+        host.last_check_in.astimezone(UTC) + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_SECONDS)
+    ).isoformat()
+    stale_warning_timestamp = (
+        host.last_check_in.astimezone(UTC) + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS)
+    ).isoformat()
+    culled_timestamp = (
+        host.last_check_in.astimezone(UTC) + timedelta(seconds=CONVENTIONAL_TIME_TO_DELETE_SECONDS)
+    ).isoformat()
 
     reporter = reporter or host.reporter
 

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -2272,7 +2272,7 @@ def test_query_by_staleness_using_columns(
         "fresh": now(),
         "stale": now() - timedelta(days=3),
         "stale_warning": now() - timedelta(days=10),
-        "culled": now() - timedelta(days=20),
+        "culled": now() - timedelta(days=35),
     }
     staleness_to_host_ids_map = dict()
 

--- a/tests/test_api_staleness_create.py
+++ b/tests/test_api_staleness_create.py
@@ -1,15 +1,13 @@
 import pytest
 
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
 from tests.helpers.api_utils import _INPUT_DATA
 from tests.helpers.api_utils import STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import create_mock_rbac_response
-
-
-def _days_to_seconds(n_days):
-    factor = 86400
-    return n_days * factor
 
 
 def test_create_staleness(api_create_staleness, db_get_staleness_culling):
@@ -35,8 +33,8 @@ def test_create_staleness_with_only_one_data(api_create_staleness, db_get_stalen
     saved_data = db_get_staleness_culling(saved_org_id)
 
     assert saved_data.conventional_time_to_stale == input_data["conventional_time_to_stale"]
-    assert saved_data.conventional_time_to_stale_warning == _days_to_seconds(7)
-    assert saved_data.conventional_time_to_delete == _days_to_seconds(14)
+    assert saved_data.conventional_time_to_stale_warning == CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+    assert saved_data.conventional_time_to_delete == CONVENTIONAL_TIME_TO_DELETE_SECONDS
 
 
 def test_create_same_staleness(api_create_staleness):
@@ -89,19 +87,19 @@ def test_create_staleness_rbac_denied(subtests, mocker, api_create_staleness):
     "input_data",
     (
         {
-            "conventional_time_to_stale": 104400,
+            "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
             "conventional_time_to_stale_warning": 1,
-            "conventional_time_to_delete": 1209600,
+            "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
         },
         {
-            "conventional_time_to_stale": 104400,
-            "conventional_time_to_stale_warning": 604800,
+            "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
+            "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
             "conventional_time_to_delete": 1,
         },
         {
-            "conventional_time_to_stale": 104400,
-            "conventional_time_to_stale_warning": 2000000,
-            "conventional_time_to_delete": 1209600,
+            "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
+            "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_DELETE_SECONDS + 1,
+            "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
         },
     ),
 )
@@ -115,25 +113,25 @@ def test_create_improper_staleness(api_create_staleness, input_data):
     "input_data",
     (
         {
-            "conventional_time_to_stale": 104400,
-            "conventional_time_to_stale_warning": 604800,
-            "conventional_time_to_delete": 1209600,
+            "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
+            "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
+            "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
             "immutable_time_to_stale": 172800,
             "immutable_time_to_stale_warning": 1,
             "immutable_time_to_delete": 63072000,
         },
         {
-            "conventional_time_to_stale": 104400,
-            "conventional_time_to_stale_warning": 604800,
-            "conventional_time_to_delete": 1209600,
+            "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
+            "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
+            "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
             "immutable_time_to_stale": 172800,
             "immutable_time_to_stale_warning": 15552000,
             "immutable_time_to_delete": 1,
         },
         {
-            "conventional_time_to_stale": 104400,
-            "conventional_time_to_stale_warning": 604800,
-            "conventional_time_to_delete": 1209600,
+            "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
+            "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
+            "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
             "immutable_time_to_stale": 172800,
             "immutable_time_to_stale_warning": 64000000,
             "immutable_time_to_delete": 63072000,

--- a/tests/test_api_staleness_delete.py
+++ b/tests/test_api_staleness_delete.py
@@ -10,7 +10,7 @@ def test_delete_existing_staleness(db_create_staleness_culling, api_delete_stale
     saved_staleness = db_create_staleness_culling(
         conventional_time_to_stale=1,
         conventional_time_to_stale_warning=7,
-        conventional_time_to_delete=14,
+        conventional_time_to_delete=30,
     )
 
     response_status, _ = api_delete_staleness()
@@ -39,7 +39,7 @@ def test_delete_staleness_rbac_allowed(subtests, mocker, api_delete_staleness, d
             db_create_staleness_culling(
                 conventional_time_to_stale=1,
                 conventional_time_to_stale_warning=7,
-                conventional_time_to_delete=14,
+                conventional_time_to_delete=30,
             )
 
             response_status, _ = api_delete_staleness()

--- a/tests/test_custom_staleness.py
+++ b/tests/test_custom_staleness.py
@@ -1,4 +1,5 @@
 import time
+from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 from unittest import mock
@@ -6,6 +7,9 @@ from unittest.mock import patch
 
 import pytest
 
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
 from app.logging import threadctx
 from app.models import db
 from jobs.host_reaper import run as host_reaper_run
@@ -14,21 +18,21 @@ from tests.helpers.api_utils import build_staleness_url
 from tests.helpers.test_utils import now
 
 CUSTOM_STALENESS_DELETE = {
-    "conventional_time_to_stale": 104400,
-    "conventional_time_to_stale_warning": 604800,
+    "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
+    "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
     "conventional_time_to_delete": 1,
 }
 
 CUSTOM_STALENESS_NO_HOSTS_TO_DELETE = {
-    "conventional_time_to_stale": 104400,
-    "conventional_time_to_stale_warning": 604800,
-    "conventional_time_to_delete": 1209600,
+    "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
+    "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
+    "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
 }
 
 CUSTOM_STALENESS_HOST_BECAME_STALE = {
     "conventional_time_to_stale": 1,
-    "conventional_time_to_stale_warning": 604800,
-    "conventional_time_to_delete": 1209600,
+    "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
+    "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
 }
 
 
@@ -44,7 +48,7 @@ def test_delete_all_type_of_hosts(
     db_create_staleness_culling(**CUSTOM_STALENESS_DELETE)
 
     with patch("app.models.utils.datetime") as mock_datetime:
-        mock_datetime.now.return_value = datetime.now() - timedelta(minutes=1)
+        mock_datetime.now.return_value = datetime.now(UTC) - timedelta(minutes=1)
         immutable_hosts = db_create_multiple_hosts(
             how_many=2, extra_data={"system_profile_facts": {"host_type": "edge"}, "reporter": "puptoo"}
         )

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -1,5 +1,6 @@
 import io
 import json
+from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 from unittest import mock
@@ -201,7 +202,7 @@ def test_do_not_export_culled_hosts(flask_app, db_create_host, db_create_stalene
         }
 
         with mock.patch("app.models.utils.datetime") as mock_datetime:
-            mock_datetime.now.return_value = datetime.now() - timedelta(minutes=1)
+            mock_datetime.now.return_value = datetime.now(UTC) - timedelta(minutes=1)
             db_create_staleness_culling(**CUSTOM_STALENESS_DELETE)
             db_create_host()
 

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -20,6 +20,9 @@ from sqlalchemy.orm.exc import StaleDataError
 
 from app.auth.identity import Identity
 from app.auth.identity import create_mock_identity_with_org_id
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
 from app.exceptions import InventoryException
 from app.exceptions import ValidationException
 from app.logging import threadctx
@@ -1352,12 +1355,16 @@ def test_add_host_stale_timestamp(mq_create_or_update_host):
     key, event, _ = mq_create_or_update_host(host, return_all_data=True)
     updated_timestamp = datetime.fromisoformat(event["host"]["last_check_in"])
 
-    host.stale_timestamp = (updated_timestamp + timedelta(seconds=104400)).isoformat()
+    host.stale_timestamp = (updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_SECONDS)).isoformat()
     expected_results = {
         "host": {
             **host.data(),
-            "stale_warning_timestamp": (updated_timestamp + timedelta(seconds=604800)).isoformat(),
-            "culled_timestamp": (updated_timestamp + timedelta(seconds=1209600)).isoformat(),
+            "stale_warning_timestamp": (
+                updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS)
+            ).isoformat(),
+            "culled_timestamp": (
+                updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_DELETE_SECONDS)
+            ).isoformat(),
         }
     }
 
@@ -1384,9 +1391,13 @@ def test_add_host_without_stale_timestamp(mq_create_or_update_host):
     expected_results = {
         "host": {
             **host.data(),
-            "stale_timestamp": (updated_timestamp + timedelta(seconds=104400)).isoformat(),
-            "stale_warning_timestamp": (updated_timestamp + timedelta(seconds=604800)).isoformat(),
-            "culled_timestamp": (updated_timestamp + timedelta(seconds=1209600)).isoformat(),
+            "stale_timestamp": (updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_SECONDS)).isoformat(),
+            "stale_warning_timestamp": (
+                updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS)
+            ).isoformat(),
+            "culled_timestamp": (
+                updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_DELETE_SECONDS)
+            ).isoformat(),
         }
     }
 
@@ -1415,9 +1426,13 @@ def test_add_host_with_stale_timestamp_ignore(mq_create_or_update_host):
     expected_results = {
         "host": {
             **host.data(),
-            "stale_timestamp": (updated_timestamp + timedelta(seconds=104400)).isoformat(),  # default stale_timestamp
-            "stale_warning_timestamp": (updated_timestamp + timedelta(seconds=604800)).isoformat(),
-            "culled_timestamp": (updated_timestamp + timedelta(seconds=1209600)).isoformat(),
+            "stale_timestamp": (updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_SECONDS)).isoformat(),
+            "stale_warning_timestamp": (
+                updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS)
+            ).isoformat(),
+            "culled_timestamp": (
+                updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_DELETE_SECONDS)
+            ).isoformat(),
         }
     }
 


### PR DESCRIPTION
- Increase the custom staleness deletion default value from 14 to 30 days.
- Replace hardcoded staleness values with shared constants throughout config, models, schemas, and tests
- Add CONVENTIONAL_TIME_TO_DELETE_SECONDS, CONVENTIONAL_TIME_TO_STALE_SECONDS and
  CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS to culling module exports
- Update validation ranges and default values to use constants
- Improve maintainability and consistency of staleness logic

# Overview

This PR is being created to address [RHINENG-20676](https://issues.redhat.com/browse/RHINENG-20676).

## PR Checklist

- [X] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [x] Tests: validate optimal/expected output
- [x] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices

## Summary by Sourcery

Centralize staleness thresholds into shared constants and increase the default deletion window from 14 to 30 days

Enhancements:
- Define and export CONVENTIONAL_TIME_TO_STALE_SECONDS, CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS, and CONVENTIONAL_TIME_TO_DELETE_SECONDS in the culling module
- Replace hardcoded staleness offsets in configuration, ORM models, schemas, business logic, and helpers with the new constants
- Update marshmallow validation ranges and environment settings to reference shared constants
- Bump the default staleness deletion threshold from 14 to 30 days across the application

Tests:
- Update unit, integration, and API tests to use the new constants and validate the 30-day deletion threshold
- Normalize datetime mocking in tests to use UTC for consistent behavior

## Summary by Sourcery

Centralize staleness thresholds into shared constants, extend the default deletion window to 30 days, and replace hard-coded timing values throughout the application and tests

New Features:
- Introduce shared constants for standard stale, stale_warning, and delete timeouts in culling module exports
- Add seconds_to_days utility function for time conversions

Enhancements:
- Centralize all staleness timing logic using shared constants and remove hard-coded offsets
- Increase default custom staleness deletion window from 14 to 30 days and update config defaults accordingly
- Update marshmallow schema and validation ranges to reference shared constants instead of literal values

Tests:
- Refactor unit, integration, and API tests to use shared staleness constants and adjust expectations for the 30-day deletion threshold
- Normalize datetime mocking in tests to use UTC for consistent timestamp calculations