### PR TITLE
RHINENG-24457: Implement sorting IQE tests for /beta/hosts-view endpoint

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/conf/requirements.yaml
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/conf/requirements.yaml
@@ -796,6 +796,14 @@ inv-host-views-filter:
   summary: Users can filter data through the `GET /beta/hosts-view` endpoint
   priority: high
 
+inv-host-views-sorting:
+  summary: Users can sort results by app data fields on the `GET /beta/hosts-view` endpoint
+  description: >
+    Users should be able to sort hosts by application data fields (e.g. advisor:recommendations,
+    vulnerability:critical_cves) in ASC or DESC order. Hosts without app data should appear
+    last (NULLS LAST semantics). Sorting and filtering can target different applications independently.
+  priority: high
+
 inv-host-views-sparse-fields:
   summary: Users can request specific fields through the `GET /beta/hosts-view` endpoint using sparse fieldsets
   priority: high

--- a/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/host_views_fixtures.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/host_views_fixtures.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from iqe_host_inventory import ApplicationHostInventory
+from iqe_host_inventory.modeling.wrappers import HostWrapper
 from iqe_host_inventory.utils.datagen_utils import generate_host_app_data
 
 logger = logging.getLogger(__name__)
@@ -46,3 +47,24 @@ def setup_host_with_app_data(host_inventory: ApplicationHostInventory):
         return host
 
     return _setup
+
+
+def add_app_data_to_host(
+    host_inventory: ApplicationHostInventory,
+    host: HostWrapper,
+    app_name: str,
+    data_overrides: dict[str, Any] | None = None,
+):
+    """Add app data to an existing host via Kafka and wait for it to appear."""
+    app_data = generate_host_app_data(app_name)
+    if data_overrides:
+        app_data.update(data_overrides)
+
+    host_inventory.kafka.produce_host_app_message(
+        application=app_name,
+        org_id=host.org_id,
+        hosts_app_data=[{"id": host.id, "data": app_data}],
+    )
+    host_inventory.apis.host_views.wait_for_host_view_app_data(
+        insights_id=host.insights_id, app_name=app_name
+    )

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_host_views_sort.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_host_views_sort.py
@@ -1,0 +1,171 @@
+"""Integration tests for sorting on the /beta/hosts-view endpoint.
+
+These tests cover end-to-end sort behaviour that unit tests cannot verify:
+actual HTTP response ordering by app data fields, NULLS LAST semantics,
+and cross-app sort + filter combinations.
+
+Field-map completeness, resolve_app_sort logic, validation errors, pagination,
+and standard host-field sorting are already covered in unit tests
+(test_filtering_app_data_sorting.py, test_api_host_views.py).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+from iqe_host_inventory.fixtures.host_views_fixtures import add_app_data_to_host
+
+if TYPE_CHECKING:
+    from iqe_host_inventory import ApplicationHostInventory
+
+logger = logging.getLogger(__name__)
+pytestmark = [pytest.mark.backend, pytest.mark.ephemeral]
+
+
+class TestHostViewAppDataSort:
+    """E2E sort ordering by app data fields on /beta/hosts-view."""
+
+    @pytest.mark.parametrize(
+        "app_name,field,low_val,high_val",
+        [
+            pytest.param("advisor", "recommendations", 2, 20, id="advisor"),
+            pytest.param("vulnerability", "critical_cves", 1, 10, id="vulnerability"),
+        ],
+    )
+    @pytest.mark.parametrize("order_how", ["ASC", "DESC"])
+    def test_sort_by_app_field(
+        self,
+        host_inventory: ApplicationHostInventory,
+        setup_host_with_app_data,
+        app_name: str,
+        field: str,
+        low_val: int,
+        high_val: int,
+        order_how: str,
+    ):
+        """Two hosts with distinct values appear in the expected order.
+
+        metadata:
+            requirements: inv-host-views-sorting
+            assignee: adubey
+            importance: high
+            title: Test sort by app data field ASC/DESC
+        """
+        host_low = setup_host_with_app_data(app_name, {field: low_val})
+        host_high = setup_host_with_app_data(app_name, {field: high_val})
+
+        response = host_inventory.apis.host_views.get_host_views_response(
+            order_by=f"{app_name}:{field}",
+            order_how=order_how,
+        )
+        result_ids = [h.id for h in response.results]
+
+        idx_low = result_ids.index(host_low.id)
+        idx_high = result_ids.index(host_high.id)
+
+        if order_how == "ASC":
+            assert idx_low < idx_high, f"ASC: {field}={low_val} should precede {field}={high_val}"
+        else:
+            assert idx_high < idx_low, f"DESC: {field}={high_val} should precede {field}={low_val}"
+
+    def test_sort_three_hosts(
+        self,
+        host_inventory: ApplicationHostInventory,
+        setup_host_with_app_data,
+    ):
+        """Three hosts with distinct values are fully ordered.
+
+        metadata:
+            requirements: inv-host-views-sorting
+            assignee: adubey
+            importance: high
+            title: Test full sort ordering with three hosts
+        """
+        host_a = setup_host_with_app_data("advisor", {"recommendations": 5})
+        host_b = setup_host_with_app_data("advisor", {"recommendations": 15})
+        host_c = setup_host_with_app_data("advisor", {"recommendations": 10})
+
+        response = host_inventory.apis.host_views.get_host_views_response(
+            order_by="advisor:recommendations",
+            order_how="ASC",
+        )
+        result_ids = [h.id for h in response.results]
+
+        idx_a = result_ids.index(host_a.id)
+        idx_b = result_ids.index(host_b.id)
+        idx_c = result_ids.index(host_c.id)
+
+        assert idx_a < idx_c < idx_b, (
+            f"Expected 5 < 10 < 15, got indices {idx_a}, {idx_c}, {idx_b}"
+        )
+
+    @pytest.mark.parametrize("order_how", ["ASC", "DESC"])
+    def test_nulls_last(
+        self,
+        host_inventory: ApplicationHostInventory,
+        setup_host_with_app_data,
+        order_how: str,
+    ):
+        """Hosts without app data appear after those with data (NULLS LAST).
+
+        metadata:
+            requirements: inv-host-views-sorting
+            assignee: adubey
+            importance: high
+            title: Test NULLS LAST for app data sorting
+        """
+        host_with = setup_host_with_app_data("advisor", {"recommendations": 10})
+        host_without = host_inventory.kafka.create_host()
+
+        response = host_inventory.apis.host_views.get_host_views_response(
+            order_by="advisor:recommendations",
+            order_how=order_how,
+        )
+        result_ids = [h.id for h in response.results]
+
+        assert host_with.id in result_ids, "Host with app data not found in results"
+        assert host_without.id in result_ids, "Host without app data not found in results"
+        assert result_ids.index(host_with.id) < result_ids.index(host_without.id), (
+            f"{order_how}: Host with data should appear before host without (NULLS LAST)"
+        )
+
+    def test_sort_one_app_filter_another(
+        self,
+        host_inventory: ApplicationHostInventory,
+        setup_host_with_app_data,
+    ):
+        """Filter by advisor but sort by vulnerability — independent operations.
+
+        metadata:
+            requirements: inv-host-views-sorting, inv-host-views-filter
+            assignee: adubey
+            importance: high
+            title: Test cross-app sort + filter
+        """
+        host_a = setup_host_with_app_data("advisor", {"recommendations": 10})
+        add_app_data_to_host(host_inventory, host_a, "vulnerability", {"critical_cves": 20})
+
+        host_b = setup_host_with_app_data("advisor", {"recommendations": 8})
+        add_app_data_to_host(host_inventory, host_b, "vulnerability", {"critical_cves": 5})
+
+        # This host should be filtered out (recommendations < 5)
+        host_c = setup_host_with_app_data("advisor", {"recommendations": 1})
+        add_app_data_to_host(host_inventory, host_c, "vulnerability", {"critical_cves": 50})
+
+        response = host_inventory.apis.host_views.get_host_views_response(
+            filter=["[advisor][recommendations][gte]=5"],
+            order_by="vulnerability:critical_cves",
+            order_how="DESC",
+        )
+        result_ids = [h.id for h in response.results]
+
+        assert host_c.id not in result_ids, "host_c should be filtered out"
+        assert host_a.id in result_ids
+        assert host_b.id in result_ids
+
+        assert result_ids.index(host_a.id) < result_ids.index(host_b.id), (
+            "DESC by critical_cves: host_a(20) before host_b(5)"
+        )

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_host_views_sparse_fields.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_host_views_sparse_fields.py
@@ -18,29 +18,13 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from iqe_host_inventory.utils.datagen_utils import generate_host_app_data
+from iqe_host_inventory.fixtures.host_views_fixtures import add_app_data_to_host
 
 if TYPE_CHECKING:
     from iqe_host_inventory import ApplicationHostInventory
 
 logger = logging.getLogger(__name__)
 pytestmark = [pytest.mark.backend, pytest.mark.ephemeral]
-
-
-def _add_app_data_to_host(host_inventory, host, app_name: str, data_overrides: dict | None = None):
-    """Helper to add app data to an existing host."""
-    app_data = generate_host_app_data(app_name)
-    if data_overrides:
-        app_data.update(data_overrides)
-
-    host_inventory.kafka.produce_host_app_message(
-        application=app_name,
-        org_id=host.org_id,
-        hosts_app_data=[{"id": host.id, "data": app_data}],
-    )
-    host_inventory.apis.host_views.wait_for_host_view_app_data(
-        insights_id=host.insights_id, app_name=app_name
-    )
 
 
 class TestSparseFieldsSingleApp:
@@ -60,7 +44,7 @@ class TestSparseFieldsSingleApp:
             title: Test sparse fields - single app all fields
         """
         host = setup_host_with_app_data("advisor", {"recommendations": 5, "incidents": 2})
-        _add_app_data_to_host(host_inventory, host, "vulnerability")
+        add_app_data_to_host(host_inventory, host, "vulnerability")
 
         response = host_inventory.apis.host_views.get_host_views_response(
             insights_id=host.insights_id,
@@ -129,10 +113,10 @@ class TestSparseFieldsMultipleApps:
             title: Test sparse fields - multiple apps all fields
         """
         host = setup_host_with_app_data("advisor", {"recommendations": 5, "incidents": 2})
-        _add_app_data_to_host(
+        add_app_data_to_host(
             host_inventory, host, "vulnerability", {"total_cves": 10, "critical_cves": 2}
         )
-        _add_app_data_to_host(host_inventory, host, "patch")
+        add_app_data_to_host(host_inventory, host, "patch")
 
         response = host_inventory.apis.host_views.get_host_views_response(
             insights_id=host.insights_id,
@@ -160,7 +144,7 @@ class TestSparseFieldsMultipleApps:
             title: Test sparse fields - multiple apps specific fields
         """
         host = setup_host_with_app_data("advisor", {"recommendations": 5, "incidents": 2})
-        _add_app_data_to_host(
+        add_app_data_to_host(
             host_inventory, host, "vulnerability", {"total_cves": 10, "critical_cves": 2}
         )
 
@@ -204,7 +188,7 @@ class TestSparseFieldsMetaKey:
         host = setup_host_with_app_data("advisor", {"recommendations": 5, "incidents": 2})
 
         for app_name in ["vulnerability", "remediations"]:
-            _add_app_data_to_host(host_inventory, host, app_name)
+            add_app_data_to_host(host_inventory, host, app_name)
 
         response = host_inventory.apis.host_views.get_host_views_response(
             insights_id=host.insights_id,
@@ -238,7 +222,7 @@ class TestSparseFieldsMetaKey:
             title: Test sparse fields - app_data meta-key with app-specific fields
         """
         host = setup_host_with_app_data("advisor", {"recommendations": 5, "incidents": 2})
-        _add_app_data_to_host(
+        add_app_data_to_host(
             host_inventory, host, "vulnerability", {"total_cves": 10, "critical_cves": 2}
         )
 
@@ -477,12 +461,12 @@ class TestSparseFieldsWithFiltering:
             title: Test filter on one app with sparse fields on another
         """
         host1 = setup_host_with_app_data("advisor", {"recommendations": 10, "incidents": 5})
-        _add_app_data_to_host(
+        add_app_data_to_host(
             host_inventory, host1, "vulnerability", {"total_cves": 20, "critical_cves": 3}
         )
 
         host2 = setup_host_with_app_data("advisor", {"recommendations": 2, "incidents": 1})
-        _add_app_data_to_host(
+        add_app_data_to_host(
             host_inventory, host2, "vulnerability", {"total_cves": 5, "critical_cves": 1}
         )
 
@@ -603,7 +587,7 @@ class TestSparseFieldsDefaultBehavior:
             title: Test default behavior without fields parameter
         """
         host = setup_host_with_app_data("advisor", {"recommendations": 5, "incidents": 2})
-        _add_app_data_to_host(
+        add_app_data_to_host(
             host_inventory, host, "vulnerability", {"total_cves": 10, "critical_cves": 2}
         )
 


### PR DESCRIPTION
## Jira
[RHINENG-24457](https://issues.redhat.com/browse/RHINENG-24457)

## What
Add IQE integration tests for sorting on the `/beta/hosts-view` endpoint by application data fields (e.g., `advisor:recommendations`, `vulnerability:critical_cves`).

## Why
Unit tests validate the sort field resolution logic (`resolve_app_sort`) and field map completeness, but they cannot verify actual HTTP response ordering, NULLS LAST SQL behavior, or cross-app sort + filter interactions end-to-end. These 7 IQE test cases fill that gap.

## How
New test file `test_host_views_sort.py` in the IQE plugin's REST test suite. Uses the existing `setup_host_with_app_data` fixture to create hosts with controlled app data values via Kafka, then queries `/beta/hosts-view` with `order_by` / `order_how` parameters and asserts result ordering.


[RHINENG-24457]: https://redhat.atlassian.net/browse/RHINENG-24457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add end-to-end IQE integration tests validating /beta/hosts-view sorting behavior on application data fields, including NULL handling and cross-application interactions.

Tests:
- Introduce REST integration tests that verify sorting by advisor and vulnerability application fields in both ascending and descending order on /beta/hosts-view.
- Add coverage for multi-host ordering, ensuring full ordering across three distinct application data values.
- Validate NULLS LAST behavior by asserting hosts without app data appear after those with data when sorting by app fields.
- Test cross-application behavior where results are filtered by one app’s data while being sorted by another app’s data.