### PR TITLE
test(RHINENG-25474): Use RBAC v2 on enabled accounts

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/rbac_fixtures.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/rbac_fixtures.py
@@ -17,6 +17,7 @@ from iqe_host_inventory.utils.datagen_utils import gen_tag
 from iqe_host_inventory.utils.datagen_utils import generate_display_name
 from iqe_host_inventory.utils.rbac_utils import RBACInventoryPermission
 from iqe_host_inventory.utils.rbac_utils import RBACRoles
+from iqe_host_inventory.utils.rbac_utils import get_role_id
 from iqe_host_inventory.utils.rbac_utils import update_group_with_roles
 from iqe_host_inventory.utils.rbac_utils import wait_for_kessel_sync
 from iqe_host_inventory_api import GroupOutWithHostCount
@@ -45,20 +46,14 @@ def hbi_non_org_admin_user_rbac_setup(
             hbi_non_org_admin_user_username, permissions, hbi_groups=hbi_groups
         )
 
-        to_delete.append((group.uuid, [role.uuid for role in roles]))
-
-        host_inventory.apis.rbac.check_inventory_user_permission(
-            hbi_non_org_admin_user_username,
-            permissions,
-            hbi_groups=hbi_groups,
-        )
+        to_delete.append((group.uuid, [get_role_id(role) for role in roles]))
 
     yield _rbac_inventory_user_setup
 
     for rbac_setup in to_delete:
         host_inventory.apis.rbac.delete_group(rbac_setup[0])
-        for uuid in rbac_setup[1]:
-            host_inventory.apis.rbac.delete_role(uuid)
+        for role_id in rbac_setup[1]:
+            host_inventory.apis.rbac.delete_role(role_id)
 
 
 @pytest.fixture(scope="class")
@@ -80,25 +75,14 @@ def hbi_non_org_admin_user_rbac_setup_class(
         group, roles = host_inventory.apis.rbac.setup_rbac_user(
             hbi_non_org_admin_user_username, permissions, hbi_groups=hbi_groups
         )
-        to_delete.append((group.uuid, [role.uuid for role in roles]))
-
-        # If we set up permissions for a group/workspace that has child workspaces, then RBAC is
-        # going to return all child workspaces as well
-        if expected_hbi_groups is None:
-            expected_hbi_groups = hbi_groups
-
-        host_inventory.apis.rbac.check_inventory_user_permission(
-            hbi_non_org_admin_user_username,
-            permissions,
-            hbi_groups=expected_hbi_groups,
-        )
+        to_delete.append((group.uuid, [get_role_id(role) for role in roles]))
 
     yield _rbac_inventory_user_setup
 
     for rbac_setup in to_delete:
         host_inventory.apis.rbac.delete_group(rbac_setup[0])
-        for uuid in rbac_setup[1]:
-            host_inventory.apis.rbac.delete_role(uuid)
+        for role_id in rbac_setup[1]:
+            host_inventory.apis.rbac.delete_role(role_id)
 
 
 @pytest.fixture(scope="class")
@@ -114,8 +98,15 @@ def rbac_non_org_admin_rbac_admin_setup_class(
 
     group = host_inventory.apis.rbac.create_group(RBACInventoryPermission.RBAC_ADMIN)
     host_inventory.apis.rbac.add_user_to_a_group(hbi_non_org_admin_user_username, group.uuid)
+
     role = host_inventory.apis.rbac.get_rbac_admin_role()
-    host_inventory.apis.rbac.add_roles_to_a_group([role], group.uuid)
+    if host_inventory.unleash.is_rbac_workspaces_enabled:
+        workspace_id = host_inventory.apis.workspaces.root_workspace.id
+        host_inventory.apis.rbac.create_role_bindings(
+            [get_role_id(role)], group.uuid, [workspace_id]
+        )
+    else:
+        host_inventory.apis.rbac.add_roles_to_a_group([role], group.uuid)
 
     wait_for_kessel_sync(host_inventory)
 
@@ -591,16 +582,21 @@ def rbac_setup_granular_hosts_permissions_for_sa(
 ):
     inv_group = rbac_setup_resources_for_granular_rbac.groups[0]
     rbac_group = host_inventory.apis.rbac.get_group_by_name(RBAC_GROUP_SERVICE_ACCOUNT_REGULAR)
-    role = host_inventory.apis.rbac.create_role(
-        RBACInventoryPermission.HOSTS_ALL, hbi_groups=[inv_group]
-    )
-    host_inventory.apis.rbac.add_roles_to_a_group([role], rbac_group.uuid)
+
+    if host_inventory.unleash.is_rbac_workspaces_enabled:
+        role = host_inventory.apis.rbac.create_role_v2(RBACInventoryPermission.HOSTS_ALL)
+        host_inventory.apis.rbac.create_role_bindings([role.id], rbac_group.uuid, [inv_group.id])
+    else:
+        role = host_inventory.apis.rbac.create_role_v1(
+            RBACInventoryPermission.HOSTS_ALL, hbi_groups=[inv_group]
+        )
+        host_inventory.apis.rbac.add_roles_to_a_group([role], rbac_group.uuid)
 
     wait_for_kessel_sync(host_inventory)
 
     yield
 
-    host_inventory.apis.rbac.delete_role(role.uuid)
+    host_inventory.apis.rbac.delete_role(get_role_id(role))
 
 
 @pytest.fixture

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
@@ -226,9 +226,7 @@ class RBACAPIWrapper(BaseEntity):
 
         In RBAC V2 a group cannot be deleted while role bindings reference it.
         There is no "delete role binding" API, so the only way to remove
-        bindings is to delete the roles they reference.  Only IQE-created roles
-        (name prefix ``iqe-hbi-role_``) are deleted; system/pre-configured
-        roles are left untouched.
+        bindings is to delete the roles they reference.
         """
         response = self.raw_api_v2.role_bindings_api.role_bindings_list(
             subject_type=RoleBindingsSubjectType.GROUP,
@@ -249,8 +247,6 @@ class RBACAPIWrapper(BaseEntity):
                 # This is a platform_default group and principal assignments can't be modified
                 continue
             if delete_groups:
-                if self._host_inventory.unleash.is_rbac_workspaces_enabled:
-                    self.reset_role_bindings(group.uuid)
                 self.delete_group(group.uuid)
             else:
                 self.remove_user_from_group(username, group.uuid)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
@@ -70,6 +70,8 @@ class RBACAPIWrapper(BaseEntity):
 
     @cached_property
     def raw_api_v2(self) -> RBACRestClientV2:
+        if not self._host_inventory.unleash.is_rbac_workspaces_enabled:
+            raise RuntimeError("RBAC v2 can be used only on v2 enabled accounts")
         return self._rbac.rest_client_v2
 
     def create_group(
@@ -158,11 +160,7 @@ class RBACAPIWrapper(BaseEntity):
         permission_v = permission.value
 
         name = f"iqe-hbi-role_{generate_uuid()}" if name is None else name
-        description = (
-            f"Inventory role for {permission_v} permission tests"
-            if description is None
-            else description
-        )
+        description = description or f"Inventory role for {permission_v} permission tests"
 
         v2_permission = permission_to_v2(permission)
         return self.raw_api_v2.roles_api.roles_create(

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ast
 import logging
 from collections.abc import Sequence
 from copy import deepcopy
@@ -15,12 +14,26 @@ from iqe_rbac_api import ApiException as RBACApiException
 from iqe_rbac_api import GroupOut as RBACGroupOut
 from iqe_rbac_api import GroupWithPrincipalsAndRoles
 from iqe_rbac_api import RoleWithAccess
+from iqe_rbac_v2_api import ApiException as RBACV2ApiException
+from iqe_rbac_v2_api import Role as RBACV2Role
+from iqe_rbac_v2_api import RoleBindingsBatchCreateRoleBindingsRequest
+from iqe_rbac_v2_api import RoleBindingsBatchCreateRoleBindingsResponse
+from iqe_rbac_v2_api import RoleBindingsCreateRoleBindingsRequest
+from iqe_rbac_v2_api import RoleBindingsCreateRoleBindingsRequestResource
+from iqe_rbac_v2_api import RoleBindingsCreateRoleBindingsRequestRole
+from iqe_rbac_v2_api import RoleBindingsCreateRoleBindingsRequestSubject
+from iqe_rbac_v2_api import RoleBindingsSubjectType
+from iqe_rbac_v2_api import RolesBatchDeleteRolesRequest
+from iqe_rbac_v2_api import RolesCreateOrUpdateRoleRequest
 
+from iqe_host_inventory import ApplicationHostInventory
 from iqe_host_inventory.modeling.groups_api import GROUP_OR_ID
 from iqe_host_inventory.modeling.groups_api import _ids_from_groups
 from iqe_host_inventory.schemas import RBACRestClient
+from iqe_host_inventory.schemas import RBACRestClientV2
 from iqe_host_inventory.utils.datagen_utils import generate_uuid
 from iqe_host_inventory.utils.rbac_utils import RBACInventoryPermission
+from iqe_host_inventory.utils.rbac_utils import permission_to_v2
 from iqe_host_inventory.utils.rbac_utils import wait_for_kessel_sync
 
 logger = logging.getLogger(__name__)
@@ -44,12 +57,20 @@ def _hbi_groups_to_ids(hbi_groups: Sequence[GROUP_OR_ID | None] | None) -> Seque
 @attr.s
 class RBACAPIWrapper(BaseEntity):
     @cached_property
+    def _host_inventory(self) -> ApplicationHostInventory:
+        return self.application.host_inventory
+
+    @cached_property
     def _rbac(self) -> ApplicationRBAC:
         return self.application.rbac
 
     @cached_property
     def raw_api(self) -> RBACRestClient:
         return self._rbac.rest_client
+
+    @cached_property
+    def raw_api_v2(self) -> RBACRestClientV2:
+        return self._rbac.rest_client_v2
 
     def create_group(
         self,
@@ -71,7 +92,26 @@ class RBACAPIWrapper(BaseEntity):
 
         return self.raw_api.group_api.create_group({"name": name, "description": description})
 
-    def create_role(
+    def add_user_to_a_group(self, username: str, group_uuid: str) -> GroupWithPrincipalsAndRoles:
+        return self.raw_api.group_api.add_principal_to_group(
+            group_uuid, {"principals": [{"username": username}]}
+        )
+
+    def remove_user_from_group(self, username: str, group_uuid: str) -> None:
+        try:
+            self.raw_api.group_api.delete_principal_from_group(group_uuid, usernames=username)
+        except RBACApiException as exc:
+            assert exc.status == 404
+
+    def delete_group(self, group_uuid: str) -> None:
+        if self._host_inventory.unleash.is_rbac_workspaces_enabled:
+            self.reset_role_bindings(group_uuid)
+        try:
+            self.raw_api.group_api.delete_group(group_uuid)
+        except RBACApiException as exc:
+            assert exc.status == 404
+
+    def create_role_v1(
         self,
         permission: RBACInventoryPermission,
         *,
@@ -108,32 +148,96 @@ class RBACAPIWrapper(BaseEntity):
             "applications": [application],
         })
 
-    def add_user_to_a_group(self, username: str, group_uuid: str) -> GroupWithPrincipalsAndRoles:
-        return self.raw_api.group_api.add_principal_to_group(
-            group_uuid, {"principals": [{"username": username}]}
+    def create_role_v2(
+        self,
+        permission: RBACInventoryPermission,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> RBACV2Role:
+        permission_v = permission.value
+
+        name = f"iqe-hbi-role_{generate_uuid()}" if name is None else name
+        description = (
+            f"Inventory role for {permission_v} permission tests"
+            if description is None
+            else description
         )
 
-    def remove_user_from_group(self, username: str, group_uuid: str) -> None:
-        try:
-            self.raw_api.group_api.delete_principal_from_group(group_uuid, usernames=username)
-        except RBACApiException as exc:
-            assert exc.status == 404
-
-    def delete_group(self, group_uuid: str) -> None:
-        try:
-            self.raw_api.group_api.delete_group(group_uuid)
-        except RBACApiException as exc:
-            assert exc.status == 404
+        v2_permission = permission_to_v2(permission)
+        return self.raw_api_v2.roles_api.roles_create(
+            RolesCreateOrUpdateRoleRequest(
+                name=name,
+                description=description,
+                permissions=[v2_permission],
+            )
+        )
 
     def add_roles_to_a_group(self, roles: list[RoleWithAccess], group_uuid: str) -> None:
         role_uuids = [role.uuid for role in roles]
         self.raw_api.group_api.add_role_to_group(group_uuid, {"roles": role_uuids})
 
-    def delete_role(self, role_uuid: str) -> None:
+    def create_role_bindings(
+        self,
+        role_ids: Sequence[str],
+        group_uuid: str,
+        workspace_ids: Sequence[str],
+    ) -> RoleBindingsBatchCreateRoleBindingsResponse:
+        requests = []
+        for role_id in role_ids:
+            for workspace_id in workspace_ids:
+                requests.append(
+                    RoleBindingsCreateRoleBindingsRequest(
+                        resource=RoleBindingsCreateRoleBindingsRequestResource(
+                            id=workspace_id, type="workspace"
+                        ),
+                        subject=RoleBindingsCreateRoleBindingsRequestSubject(
+                            id=group_uuid, type=RoleBindingsSubjectType.GROUP
+                        ),
+                        role=RoleBindingsCreateRoleBindingsRequestRole(id=role_id),
+                    )
+                )
+        return self.raw_api_v2.role_bindings_api.role_bindings_batch_create(
+            RoleBindingsBatchCreateRoleBindingsRequest(requests=requests)
+        )
+
+    def delete_role_v1(self, role_uuid: str) -> None:
         try:
             self.raw_api.role_api.delete_role(role_uuid)
         except RBACApiException as exc:
             assert exc.status == 404
+
+    def delete_role_v2(self, role_id: str) -> None:
+        try:
+            self.raw_api_v2.roles_api.roles_batch_delete(
+                RolesBatchDeleteRolesRequest(ids=[role_id])
+            )
+        except RBACV2ApiException as exc:
+            assert exc.status == 404
+
+    def delete_role(self, role_id: str) -> None:
+        if self._host_inventory.unleash.is_rbac_workspaces_enabled:
+            self.delete_role_v2(role_id)
+        else:
+            self.delete_role_v1(role_id)
+
+    def reset_role_bindings(self, group_uuid: str) -> None:
+        """Remove all role bindings for a group by deleting the bound IQE-created roles.
+
+        In RBAC V2 a group cannot be deleted while role bindings reference it.
+        There is no "delete role binding" API, so the only way to remove
+        bindings is to delete the roles they reference.  Only IQE-created roles
+        (name prefix ``iqe-hbi-role_``) are deleted; system/pre-configured
+        roles are left untouched.
+        """
+        response = self.raw_api_v2.role_bindings_api.role_bindings_list(
+            subject_type=RoleBindingsSubjectType.GROUP,
+            subject_id=group_uuid,
+            limit=10000,
+        )
+        role_ids_to_delete = {binding.role.id for binding in response.data}
+        for role_id in role_ids_to_delete:
+            self.delete_role_v2(role_id)
 
     def reset_user_groups(
         self, username: str, group_name: str | None = "iqe-hbi", delete_groups: bool = True
@@ -145,52 +249,11 @@ class RBACAPIWrapper(BaseEntity):
                 # This is a platform_default group and principal assignments can't be modified
                 continue
             if delete_groups:
+                if self._host_inventory.unleash.is_rbac_workspaces_enabled:
+                    self.reset_role_bindings(group.uuid)
                 self.delete_group(group.uuid)
             else:
                 self.remove_user_from_group(username, group.uuid)
-
-    def check_inventory_user_permission(
-        self,
-        username: str,
-        permissions: list[RBACInventoryPermission],
-        *,
-        hbi_groups: Sequence[GROUP_OR_ID | None] | None = None,
-    ) -> None:
-        hbi_group_ids = _hbi_groups_to_ids(hbi_groups)
-
-        # Parse the input into a dict of app:[perms] entries so that we limit the
-        # rbac calls to one per application
-        perms: dict[str, list[str]] = {}
-        perm_values = [perm.value for perm in permissions]
-        for perm_v in perm_values:
-            app = perm_v.split(":")[0]
-            if app in perms:
-                perms[app].append(perm_v)
-            else:
-                perms[app] = [perm_v]
-
-        # Verify that the user has all expected permissions
-        for app, perm_values in perms.items():
-            response = self.raw_api.access_api.get_principal_access(
-                application=app, username=username
-            )
-            assert len(response.data) == len(perm_values)
-            for perm_v in perm_values:
-                entry = next(
-                    (entry for entry in response.data if entry.permission == perm_v), None
-                )
-                assert entry, f"Permission {perm_v} not found for user {username}"
-                assert len(entry.resource_definitions) == (1 if hbi_group_ids else 0)
-                if hbi_group_ids:
-                    # Parse the string representation back to a list and compare as sets
-                    # for order-independent comparison
-                    actual_value = ast.literal_eval(
-                        entry.resource_definitions[0].attribute_filter.value
-                    )
-                    expected_value = list(hbi_group_ids)
-                    assert set(actual_value) == set(expected_value), (
-                        f"Expected groups {expected_value}, but got {actual_value}"
-                    )
 
     def setup_rbac_user(
         self,
@@ -198,16 +261,31 @@ class RBACAPIWrapper(BaseEntity):
         permissions: list[RBACInventoryPermission],
         *,
         hbi_groups: Sequence[GROUP_OR_ID | None] | None = None,
-    ) -> tuple[RBACGroupOut, list[RoleWithAccess]]:
+    ) -> tuple[RBACGroupOut, list[RoleWithAccess] | list[RBACV2Role]]:
         self.reset_user_groups(username)
 
         group = self.create_group(permissions[0], hbi_groups=hbi_groups)
         self.add_user_to_a_group(username, group.uuid)
-        roles = [self.create_role(perm, hbi_groups=hbi_groups) for perm in permissions]
 
-        self.add_roles_to_a_group(roles, group.uuid)
+        if self._host_inventory.unleash.is_rbac_workspaces_enabled:
+            roles: list[RoleWithAccess] | list[RBACV2Role] = [
+                self.create_role_v2(perm) for perm in permissions
+            ]
+            if hbi_groups:
+                ungrouped_ws_id = self._host_inventory.apis.workspaces.ungrouped_workspace.id
+                workspace_ids = [
+                    ws_id if ws_id is not None else ungrouped_ws_id
+                    for ws_id in _hbi_groups_to_ids(hbi_groups)
+                ]
+            else:
+                workspace_ids = [self._host_inventory.apis.workspaces.root_workspace.id]
+            role_ids = [role.id for role in roles]
+            self.create_role_bindings(role_ids, group.uuid, workspace_ids)
+        else:
+            roles = [self.create_role_v1(perm, hbi_groups=hbi_groups) for perm in permissions]
+            self.add_roles_to_a_group(roles, group.uuid)
 
-        wait_for_kessel_sync(self.application.host_inventory)
+        wait_for_kessel_sync(self._host_inventory)
 
         return group, roles
 

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/unleash.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/unleash.py
@@ -118,3 +118,7 @@ class HBIUnleash(BaseEntity):
 
     def is_kessel_groups_enabled(self) -> bool:
         return self.is_flag_enabled(self.kessel_groups_flag)
+
+    @cached_property
+    def is_rbac_workspaces_enabled(self) -> bool:
+        return self.is_flag_enabled(self.rbac_workspaces_flag)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/workspaces_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/workspaces_api.py
@@ -300,6 +300,13 @@ class WorkspacesAPIWrapper(BaseEntity):
             type=WorkspacesWorkspaceTypesQueryParam.ROOT,
         )[0]
 
+    @cached_property
+    def root_workspace(self) -> WorkspacesWorkspace:
+        """
+        A cached property for getting the root workspace.
+        """
+        return self.get_root_workspace()
+
     def get_ungrouped_workspace(self) -> WorkspacesWorkspace:
         """
         Get the ungrouped workspace.  This is a special pre-defined workspace per account.
@@ -307,6 +314,13 @@ class WorkspacesAPIWrapper(BaseEntity):
         return self.get_workspaces(
             type=WorkspacesWorkspaceTypesQueryParam.UNGROUPED_MINUS_HOSTS,
         )[0]
+
+    @cached_property
+    def ungrouped_workspace(self) -> WorkspacesWorkspace:
+        """
+        A cached property for getting the ungrouped workspace.
+        """
+        return self.get_ungrouped_workspace()
 
     def get_default_workspace(self) -> WorkspacesWorkspace:
         """

--- a/iqe-host-inventory-plugin/iqe_host_inventory/schemas.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/schemas.py
@@ -7,6 +7,9 @@ from typing import Protocol
 from iqe_rbac_api import AccessApi
 from iqe_rbac_api import GroupApi
 from iqe_rbac_api import RoleApi
+from iqe_rbac_v2_api import RoleBindingsApi
+from iqe_rbac_v2_api import RolesApi
+from iqe_rbac_v2_api import WorkspacesApi
 
 from iqe_host_inventory_api.models import PerReporterStaleness
 
@@ -17,6 +20,12 @@ class RBACRestClient(Protocol):
     access_api: AccessApi
     group_api: GroupApi
     role_api: RoleApi
+
+
+class RBACRestClientV2(Protocol):
+    roles_api: RolesApi
+    role_bindings_api: RoleBindingsApi
+    workspaces_api: WorkspacesApi
 
 
 def reporter_staleness_from_db(

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
@@ -19,6 +19,7 @@ from iqe_host_inventory.utils.api_utils import raises_apierror
 from iqe_host_inventory.utils.api_utils import ungrouped_host_groups
 from iqe_host_inventory.utils.datagen_utils import generate_display_name
 from iqe_host_inventory.utils.rbac_utils import RBACInventoryPermission
+from iqe_host_inventory.utils.rbac_utils import get_role_id
 from iqe_host_inventory.utils.rbac_utils import wait_for_kessel_sync
 from iqe_host_inventory_api import GroupOutWithHostCount
 from iqe_host_inventory_api import HostOut
@@ -1014,16 +1015,10 @@ def setup_all_permissions(
         hbi_non_org_admin_user_username, permissions, hbi_groups=hbi_groups
     )
 
-    host_inventory.apis.rbac.check_inventory_user_permission(
-        hbi_non_org_admin_user_username,
-        permissions,
-        hbi_groups=hbi_groups,
-    )
-
     yield
 
     for role in roles:
-        host_inventory.apis.rbac.delete_role(role.uuid)
+        host_inventory.apis.rbac.delete_role(get_role_id(role))
     host_inventory.apis.rbac.delete_group(group.uuid)
 
 
@@ -1138,7 +1133,10 @@ def setup_permissions_with_and_without_resource_definitions(
     hbi_non_org_admin_user_username: str,
 ):
     """Creates 2 roles, one with and one without resource definitions.
-    User should have access to all resources."""
+    User should have access to all resources.
+
+    V2 equivalent: one role bound to a specific workspace, one bound to root workspace.
+    """
     hbi_groups = [rbac_setup_resources_for_granular_rbac[1][0]]
     host_inventory.apis.rbac.reset_user_groups(hbi_non_org_admin_user_username)
 
@@ -1147,28 +1145,46 @@ def setup_permissions_with_and_without_resource_definitions(
     )
     host_inventory.apis.rbac.add_user_to_a_group(hbi_non_org_admin_user_username, group.uuid)
 
-    if request.param == "first_with":
-        roles = [
-            host_inventory.apis.rbac.create_role(
-                RBACInventoryPermission.ALL_READ, hbi_groups=hbi_groups
-            ),
-            host_inventory.apis.rbac.create_role(RBACInventoryPermission.ALL_READ),
-        ]
-    else:
-        roles = [
-            host_inventory.apis.rbac.create_role(RBACInventoryPermission.ALL_READ),
-            host_inventory.apis.rbac.create_role(
-                RBACInventoryPermission.ALL_READ, hbi_groups=hbi_groups
-            ),
-        ]
+    if host_inventory.unleash.is_rbac_workspaces_enabled:
+        role_with = host_inventory.apis.rbac.create_role_v2(RBACInventoryPermission.ALL_READ)
+        role_without = host_inventory.apis.rbac.create_role_v2(RBACInventoryPermission.ALL_READ)
 
-    host_inventory.apis.rbac.add_roles_to_a_group(roles, group.uuid)
+        workspace_ids = [g.id for g in hbi_groups]
+        root_workspace_id = host_inventory.apis.workspaces.root_workspace.id
+
+        if request.param == "first_with":
+            roles = [role_with, role_without]
+        else:
+            roles = [role_without, role_with]
+
+        host_inventory.apis.rbac.create_role_bindings([role_with.id], group.uuid, workspace_ids)
+        host_inventory.apis.rbac.create_role_bindings(
+            [role_without.id], group.uuid, [root_workspace_id]
+        )
+    else:
+        if request.param == "first_with":
+            roles = [
+                host_inventory.apis.rbac.create_role_v1(
+                    RBACInventoryPermission.ALL_READ, hbi_groups=hbi_groups
+                ),
+                host_inventory.apis.rbac.create_role_v1(RBACInventoryPermission.ALL_READ),
+            ]
+        else:
+            roles = [
+                host_inventory.apis.rbac.create_role_v1(RBACInventoryPermission.ALL_READ),
+                host_inventory.apis.rbac.create_role_v1(
+                    RBACInventoryPermission.ALL_READ, hbi_groups=hbi_groups
+                ),
+            ]
+
+        host_inventory.apis.rbac.add_roles_to_a_group(roles, group.uuid)
+
     wait_for_kessel_sync(host_inventory)
 
     yield
 
     for role in roles:
-        host_inventory.apis.rbac.delete_role(role.uuid)
+        host_inventory.apis.rbac.delete_role(get_role_id(role))
     host_inventory.apis.rbac.delete_group(group.uuid)
 
 
@@ -1229,7 +1245,10 @@ def setup_resource_definitions_in_multiple_roles(
     hbi_non_org_admin_user_username: str,
 ):
     """Setup 2 roles with the same permission, but with different resourceDefinitions.
-    User should have access to resources in both resourceDefinitions."""
+    User should have access to resources in both resourceDefinitions.
+
+    V2 equivalent: 2 roles each bound to a different workspace.
+    """
     hbi_groups = rbac_setup_resources_for_granular_rbac[1][:2]
     host_inventory.apis.rbac.reset_user_groups(hbi_non_org_admin_user_username)
 
@@ -1238,22 +1257,34 @@ def setup_resource_definitions_in_multiple_roles(
     )
     host_inventory.apis.rbac.add_user_to_a_group(hbi_non_org_admin_user_username, group.uuid)
 
-    roles = [
-        host_inventory.apis.rbac.create_role(
-            RBACInventoryPermission.ADMIN, hbi_groups=[hbi_groups[0]]
-        ),
-        host_inventory.apis.rbac.create_role(
-            RBACInventoryPermission.ADMIN, hbi_groups=[hbi_groups[1]]
-        ),
-    ]
+    if host_inventory.unleash.is_rbac_workspaces_enabled:
+        roles = [
+            host_inventory.apis.rbac.create_role_v2(RBACInventoryPermission.ADMIN),
+            host_inventory.apis.rbac.create_role_v2(RBACInventoryPermission.ADMIN),
+        ]
+        host_inventory.apis.rbac.create_role_bindings(
+            [roles[0].id], group.uuid, [hbi_groups[0].id]
+        )
+        host_inventory.apis.rbac.create_role_bindings(
+            [roles[1].id], group.uuid, [hbi_groups[1].id]
+        )
+    else:
+        roles = [
+            host_inventory.apis.rbac.create_role_v1(
+                RBACInventoryPermission.ADMIN, hbi_groups=[hbi_groups[0]]
+            ),
+            host_inventory.apis.rbac.create_role_v1(
+                RBACInventoryPermission.ADMIN, hbi_groups=[hbi_groups[1]]
+            ),
+        ]
+        host_inventory.apis.rbac.add_roles_to_a_group(roles, group.uuid)
 
-    host_inventory.apis.rbac.add_roles_to_a_group(roles, group.uuid)
     wait_for_kessel_sync(host_inventory)
 
     yield
 
     for role in roles:
-        host_inventory.apis.rbac.delete_role(role.uuid)
+        host_inventory.apis.rbac.delete_role(get_role_id(role))
     host_inventory.apis.rbac.delete_group(group.uuid)
 
 
@@ -1489,7 +1520,12 @@ def setup_rbac_bad_key(
     host_inventory: ApplicationHostInventory,
     hbi_non_org_admin_user_username: str,
 ):
-    """Use wrong attributeFilter.key"""
+    """Use wrong attributeFilter.key.
+    attributeFilter is a RBAC V1 concept, not applicable to V2.
+    """
+    if host_inventory.unleash.is_rbac_workspaces_enabled:
+        pytest.skip("attributeFilter is a RBAC V1 concept, not applicable to V2")
+
     hbi_groups = [rbac_setup_resources_for_granular_rbac[1][0]]
     hosts = rbac_setup_resources_for_granular_rbac[0][0]
     host_inventory.apis.rbac.reset_user_groups(hbi_non_org_admin_user_username)
@@ -1501,7 +1537,7 @@ def setup_rbac_bad_key(
 
     key = request.param.split("-")[0]
     value = [host.id for host in hosts] if request.param == "host.id-with-host-id" else hbi_groups
-    role = host_inventory.apis.rbac.create_role(
+    role = host_inventory.apis.rbac.create_role_v1(
         RBACInventoryPermission.ADMIN, hbi_groups=value, key=key
     )
     host_inventory.apis.rbac.add_roles_to_a_group([role], group.uuid)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
@@ -7,6 +7,9 @@ from time import sleep
 from iqe.base.application import Application
 from iqe.base.application.implementations.rest import ViaREST
 from iqe_rbac.entities.group import Group
+from iqe_rbac_api import RoleWithAccess
+from iqe_rbac_v2_api import Permission as RBACV2Permission
+from iqe_rbac_v2_api import Role as RBACV2Role
 
 from iqe_host_inventory import ApplicationHostInventory
 
@@ -40,6 +43,17 @@ class RBACRoles:
     STALENESS_VIEWER = "Organization Staleness and Deletion Viewer"
     STALENESS_ADMIN = "Organization Staleness and Deletion Administrator"
     USER_ACCESS = "User Access administrator"
+
+
+def get_role_id(role: RoleWithAccess | RBACV2Role) -> str:
+    """Get role ID from either V1 (RoleWithAccess.uuid) or V2 (Role.id) role object."""
+    return getattr(role, "uuid", None) or role.id
+
+
+def permission_to_v2(permission: RBACInventoryPermission) -> RBACV2Permission:
+    """Convert an RBACInventoryPermission enum to a V2 Permission model."""
+    app, resource_type, operation = permission.value.split(":")
+    return RBACV2Permission(application=app, resource_type=resource_type, operation=operation)
 
 
 def update_group_with_roles(app: Application, group: Group, roles: list[str]) -> None:


### PR DESCRIPTION
## Jira
[RHINENG-25474](https://issues.redhat.com/browse/RHINENG-25474)

## What
Use RBAC v2 in permission tests on Kessel enabled accounts.

## Why
RBAC v1 is disabled on those accounts, so we can't use it anymore.

## How
Create new methods for RBAC v2, and use them if `platform.rbac.workspaces` feature flag is enabled.

## Testing
In progress...  I'll run the tests against Stage locally, and I'll make sure of 2 things:
- RBAC v1 is not used on our main testing account (`insights-inventory-qe`)
- RBAC v2 is not used in our new testing account (`insights-inventory-test`) - we have to be absolutely sure about this, otherwise v1 will get disabled on the account.


[RHINENG-25474]: https://redhat.atlassian.net/browse/RHINENG-25474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update RBAC test and helper logic to support RBAC v2 via workspaces while keeping RBAC v1 behavior for non-workspace accounts, gated by the rbac.workspaces feature flag.

New Features:
- Introduce RBAC v2 role and role binding management helpers, including role creation, batch role binding creation, and workspace-aware group cleanup.
- Add cached accessors for root and ungrouped workspaces and an Unleash flag helper for RBAC workspaces enablement.

Enhancements:
- Refactor RBAC user setup and fixtures to choose between RBAC v1 role assignments and RBAC v2 workspace bindings based on the RBAC workspaces feature flag.
- Unify role identifier handling across RBAC versions through a helper that abstracts v1 and v2 role ID fields.
- Improve group deletion behavior under RBAC v2 by removing associated role bindings via role deletion when necessary.

Tests:
- Adjust granular RBAC tests and fixtures to exercise both RBAC v1 (attribute filters) and RBAC v2 (workspace bindings), skipping v1-only scenarios when workspaces are enabled.