### PR TITLE
[IQE-3894] Fix iqe linting, support pre-commit

### DIFF
--- a/iqe-host-inventory-plugin/.pre-commit-config.yaml
+++ b/iqe-host-inventory-plugin/.pre-commit-config.yaml
@@ -43,7 +43,8 @@ repos:
   - id: rh-pre-commit
   - id: rh-pre-commit.commit-msg # Optional for commit-msg attestation
 - repo: https://gitlab.cee.redhat.com/insights-qe/iqe-pre-commit-hooks
-  rev: v25.10.17.0
+  rev: v26.04.07.0
   hooks:
   - id: iqe-checks
   - id: iqe-tests-metadata
+    args: [--iqe-plugin-root=iqe-host-inventory-plugin]

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/validation/test_kafka_identity.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/validation/test_kafka_identity.py
@@ -1,3 +1,9 @@
+"""
+metadata:
+  requirements:
+    - inv-mq-identity-validation
+"""
+
 from __future__ import annotations
 
 import logging
@@ -224,7 +230,9 @@ def test_mq_create_system_host_all_correct(
 ):
     """Test creating host via kafka with "system" identity and correct owner_id
     metadata:
-        requirements: inv-host-create, inv-mq-identity-validation
+        requirements:
+          - inv-host-create
+          - inv-mq-identity-validation
         importance: high
         assignee: fstavela
         title: Create host via kafka with "system" identity and correct owner_id
@@ -246,7 +254,9 @@ def test_mq_update_system_host_all_correct(
 ):
     """Test updating host via kafka with "system" identity and correct owner_id
     metadata:
-        requirements: inv-host-update, inv-mq-identity-validation
+        requirements:
+          - inv-host-update
+          - inv-mq-identity-validation
         importance: high
         assignee: fstavela
         title: Update host via kafka with "system" identity and correct owner_id
@@ -273,7 +283,9 @@ def test_mq_create_non_system_host_all_correct(
 ):
     """Test creating host via kafka with "user" identity
     metadata:
-        requirements: inv-host-create, inv-mq-identity-validation
+        requirements:
+          - inv-host-create
+          - inv-mq-identity-validation
         importance: high
         assignee: fstavela
         title: Create host via kafka with "user" identity
@@ -303,7 +315,9 @@ def test_mq_update_non_system_host_all_correct(
 ):
     """Test updating host via kafka with "user" identity
     metadata:
-        requirements: inv-host-update, inv-mq-identity-validation
+        requirements:
+          - inv-host-update
+          - inv-mq-identity-validation
         importance: high
         assignee: fstavela
         title: Update host via kafka with "user" identity
@@ -350,7 +364,9 @@ def test_mq_create_system_host_rhsm_reporter(
     inventory should transform it to the canonical form (with dashes) when setting owner_id
 
     metadata:
-        requirements: inv-host-create, inv-mq-identity-exception-rhsm
+        requirements:
+          - inv-host-create
+          - inv-mq-identity-exception-rhsm
         importance: high
         assignee: fstavela
         title: Create host via kafka as rhsm reporter
@@ -381,7 +397,9 @@ def test_mq_update_system_host_rhsm_reporter(
     inventory should transform it to the canonical form (with dashes) when setting owner_id
 
     metadata:
-        requirements: inv-host-update, inv-mq-identity-exception-rhsm
+        requirements:
+          - inv-host-update
+          - inv-mq-identity-exception-rhsm
         importance: high
         assignee: fstavela
         title: Update host via kafka as rhsm reporter
@@ -422,7 +440,10 @@ def test_mq_create_system_host_rhsm_reporter_without_subscription_manager_id(
     """Test creating host via kafka as rhsm reporter without subscription_manager_id
 
     metadata:
-        requirements: inv-host-create, inv-mq-identity-exception-rhsm, inv-mq-identity-validation
+        requirements:
+          - inv-host-create
+          - inv-mq-identity-exception-rhsm
+          - inv-mq-identity-validation
         importance: medium
         assignee: fstavela
         negative: true
@@ -448,7 +469,9 @@ def test_mq_create_system_host_without_owner_id(
     """Test creating host via kafka with "system" identity without owner_id in host data
     The host should be successfully created with owner_id == identity.system.cn
     metadata:
-        requirements: inv-host-create, inv-mq-identity-validation
+        requirements:
+          - inv-host-create
+          - inv-mq-identity-validation
         importance: high
         assignee: fstavela
         title: Create host via kafka without owner_id in host data
@@ -475,7 +498,9 @@ def test_mq_update_system_host_different_owner_id(
     """Test updating host via kafka with "system" identity with wrong owner_id
     The host should be successfully created and the owner_id should be updated
     metadata:
-        requirements: inv-host-update, inv-mq-identity-validation
+        requirements:
+          - inv-host-update
+          - inv-mq-identity-validation
         importance: high
         assignee: fstavela
         title: Update host via kafka with wrong owner_id
@@ -513,7 +538,6 @@ def test_mq_create_system_host_wrong_cn(
     """Test creating host via kafka with "system" identity with different owner_id in
     identity and host data
     metadata:
-        requirements: inv-mq-identity-validation
         importance: high
         assignee: fstavela
         negative: true
@@ -542,7 +566,6 @@ def test_mq_update_system_host_wrong_cn(
     """Test updating host via kafka with "system" identity with different owner_id in
     identity and host data
     metadata:
-        requirements: inv-mq-identity-validation
         importance: high
         assignee: fstavela
         negative: true
@@ -588,7 +611,6 @@ def test_mq_create_host_wrong_org_id(
 ):
     """Test creating host via kafka with identity with wrong org_id
     metadata:
-        requirements: inv-mq-identity-validation
         importance: high
         assignee: fstavela
         negative: true
@@ -625,7 +647,6 @@ def test_mq_update_host_wrong_org_id(
 ):
     """Test updating host via kafka with identity with wrong org_id
     metadata:
-        requirements: inv-mq-identity-validation
         importance: high
         assignee: fstavela
         negative: true
@@ -661,7 +682,6 @@ def test_mq_create_host_without_metadata(
 ):
     """Test creating host via kafka without metadata
     metadata:
-        requirements: inv-mq-identity-validation
         importance: high
         assignee: fstavela
         negative: true
@@ -688,7 +708,6 @@ def test_mq_update_host_without_metadata(
 ):
     """Test updating host via kafka without metadata
     metadata:
-        requirements: inv-mq-identity-validation
         importance: high
         assignee: fstavela
         negative: true
@@ -718,7 +737,6 @@ def test_mq_create_host_without_identity(
 ):
     """Test creating host via kafka without identity
     metadata:
-        requirements: inv-mq-identity-validation
         importance: high
         assignee: fstavela
         negative: true
@@ -745,7 +763,6 @@ def test_mq_update_host_without_identity(
 ):
     """Test updating host via kafka without identity
     metadata:
-        requirements: inv-mq-identity-validation
         importance: high
         assignee: fstavela
         negative: true
@@ -877,7 +894,6 @@ def test_mq_create_host_wrong_identity(
 ):
     """Test creating host via kafka with wrong identity
     metadata:
-        requirements: inv-mq-identity-validation
         importance: medium
         assignee: fstavela
         negative: true
@@ -916,7 +932,6 @@ def test_mq_update_host_wrong_identity(
 ):
     """Test updating host via kafka with wrong identity
     metadata:
-        requirements: inv-mq-identity-validation
         importance: medium
         assignee: fstavela
         negative: true

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/__init__.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/__init__.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from box import BoxKeyError
 from dynaconf.utils.boxing import DynaBox
 from iqe.base.application import Application
+from iqe.users.user import ExplicitUser
 
 if TYPE_CHECKING:
     from iqe_host_inventory.modeling.wrappers import HostWrapper
@@ -38,7 +39,13 @@ def get_account_number(application: Application, given_account_number: str | Non
     if given_account_number is not None:
         return given_account_number
     try:
-        return str(application.user.identity.account_number)
+        user = application.user
+        if isinstance(user, ExplicitUser):
+            identity = user.identity
+            if identity is None:
+                raise BoxKeyError("identity")
+            return str(identity.account_number)
+        return str(user["identity"].account_number)
     except BoxKeyError:
         raise InvalidConfigurationParameterError(
             "Missing primary_user account_number in your settings.local.yaml file"
@@ -49,8 +56,13 @@ def get_org_id(application: Application, given_org_id: str | None = None) -> str
     if given_org_id is not None:
         return given_org_id
 
-    identity = application.user.get("identity", {})
-    org_id = identity.get("org_id") or identity.get("internal", {}).get("org_id")
+    user = application.user
+    if isinstance(user, ExplicitUser):
+        identity = user.identity
+        org_id: str | None = identity.org_id if identity is not None else None
+    else:
+        identity_data = user.get("identity", {})
+        org_id = identity_data.get("org_id") or identity_data.get("internal", {}).get("org_id")
 
     if org_id is None:
         raise InvalidConfigurationParameterError(

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/__init__.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/__init__.py
@@ -38,7 +38,7 @@ def get_account_number(application: Application, given_account_number: str | Non
     if given_account_number is not None:
         return given_account_number
     try:
-        return str(application.user.get("identity").account_number)
+        return str(application.user.identity.account_number)
     except BoxKeyError:
         raise InvalidConfigurationParameterError(
             "Missing primary_user account_number in your settings.local.yaml file"


### PR DESCRIPTION
iqe-metadata-linting supports a new argument to handle the nested python project scope.

This allows it to resolve the default from the plugin config file, where assignee and component are set.

## Jira
[IQE-3894](https://redhat.atlassian.net/browse/IQE-3894)

## What

* Update  .pre-commit-config.yml to leverage arg for iqe-metadata-linting
* Apply some mypy and metadata linting fixes

## Why
The hook can't read the defaults without this arg and an updated version of the plugin.

## Testing
`pre-commit run --all-files` from the iqe-host-inventory-plugin directory.

[IQE-3894]: https://redhat.atlassian.net/browse/IQE-3894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update IQE host inventory plugin linting support, user identity handling, and test metadata to align with the latest pre-commit hooks and ExplicitUser model.

Bug Fixes:
- Fix account number and org ID resolution when Application.user is an ExplicitUser without an identity.

Enhancements:
- Normalize and refine test metadata requirements annotations for kafka identity tests.

Build:
- Bump iqe-pre-commit-hooks version and configure iqe-tests-metadata hook with the plugin root argument to support nested project layout.