### PR TITLE
test(RHINENG-25474): RBAC v2 followups

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
@@ -15,6 +15,7 @@ from iqe_rbac_api import GroupOut as RBACGroupOut
 from iqe_rbac_api import GroupWithPrincipalsAndRoles
 from iqe_rbac_api import RoleWithAccess
 from iqe_rbac_v2_api import ApiException as RBACV2ApiException
+from iqe_rbac_v2_api import ResourceType
 from iqe_rbac_v2_api import Role as RBACV2Role
 from iqe_rbac_v2_api import RoleBindingsBatchCreateRoleBindingsRequest
 from iqe_rbac_v2_api import RoleBindingsBatchCreateRoleBindingsResponse
@@ -23,6 +24,7 @@ from iqe_rbac_v2_api import RoleBindingsCreateRoleBindingsRequestResource
 from iqe_rbac_v2_api import RoleBindingsCreateRoleBindingsRequestRole
 from iqe_rbac_v2_api import RoleBindingsCreateRoleBindingsRequestSubject
 from iqe_rbac_v2_api import RoleBindingsSubjectType
+from iqe_rbac_v2_api import RoleBindingsUpdateRoleBindingsRequest
 from iqe_rbac_v2_api import RolesBatchDeleteRolesRequest
 from iqe_rbac_v2_api import RolesCreateOrUpdateRoleRequest
 
@@ -220,20 +222,31 @@ class RBACAPIWrapper(BaseEntity):
             self.delete_role_v1(role_id)
 
     def reset_role_bindings(self, group_uuid: str) -> None:
-        """Remove all role bindings for a group by deleting the bound IQE-created roles.
+        """Remove all role bindings for a group.
 
         In RBAC V2 a group cannot be deleted while role bindings reference it.
-        There is no "delete role binding" API, so the only way to remove
-        bindings is to delete the roles they reference.
+        Uses PUT /role-bindings/by-subject/ with an empty roles list to clear
+        bindings for each (resource, subject) combination.
         """
         response = self.raw_api_v2.role_bindings_api.role_bindings_list(
             subject_type=RoleBindingsSubjectType.GROUP,
             subject_id=group_uuid,
             limit=10000,
         )
-        role_ids_to_delete = {binding.role.id for binding in response.data}
-        for role_id in role_ids_to_delete:
-            self.delete_role_v2(role_id)
+        logger.info(response.data)
+        # Clear bindings for each unique resource by sending an empty roles list.
+        # model_construct bypasses the client-side min_length=1 validation;
+        # the API itself accepts an empty list and removes all bindings.
+        empty_request = RoleBindingsUpdateRoleBindingsRequest.model_construct(roles=[])
+        for binding in response.data:
+            resource = binding.resource
+            self.raw_api_v2.role_bindings_api.role_bindings_update_without_preload_content(
+                resource_id=resource.id,
+                resource_type=ResourceType.WORKSPACE,
+                subject_id=group_uuid,
+                subject_type=RoleBindingsSubjectType.GROUP,
+                role_bindings_update_role_bindings_request=empty_request,
+            )
 
     def reset_user_groups(
         self, username: str, group_name: str | None = "iqe-hbi", delete_groups: bool = True

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
@@ -233,7 +233,6 @@ class RBACAPIWrapper(BaseEntity):
             subject_id=group_uuid,
             limit=10000,
         )
-        logger.info(response.data)
         # Clear bindings for each unique resource by sending an empty roles list.
         # model_construct bypasses the client-side min_length=1 validation;
         # the API itself accepts an empty list and removes all bindings.
@@ -242,7 +241,9 @@ class RBACAPIWrapper(BaseEntity):
             resource = binding.resource
             self.raw_api_v2.role_bindings_api.role_bindings_update_without_preload_content(
                 resource_id=resource.id,
-                resource_type=ResourceType.WORKSPACE,
+                resource_type=(
+                    ResourceType(resource.type) if resource.type else ResourceType.WORKSPACE
+                ),
                 subject_id=group_uuid,
                 subject_type=RoleBindingsSubjectType.GROUP,
                 role_bindings_update_role_bindings_request=empty_request,

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/conftest.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/conftest.py
@@ -180,6 +180,8 @@ def _flush_kafka(host_inventory: ApplicationHostInventory) -> Generator[None, No
 def enable_kessel_backend_flags(
     request: FixtureRequest,
     host_inventory: ApplicationHostInventory,
+    # https://redhat.atlassian.net/browse/IQE-3975
+    hbi_setup_ephemeral_accounts: None,  # ensure accounts are set up first
 ) -> None:
     if request.config.getoption("--kessel"):
         host_inventory.unleash.toggle_feature_flag(


### PR DESCRIPTION
## Jira
[RHINENG-25474](https://issues.redhat.com/browse/RHINENG-25474)

## What

1. Setup ephemeral users first, before enabling feature flags
2. Delete RBAC v2 role-bindings during RBAC cleanup, instead of deleting the roles

## Why

1. If we first enable the RBAC v2 flag, then the UserProvider, which sets up our ephemeral users, doesn't work: https://redhat.atlassian.net/browse/IQE-3975
2. Some roles are not possible to delete (the default, pre-configured ones). So, if we couldn't delete the role, then the role-bindings were kept, and we couldn't delete the RBAC group (there is a restriction in RBAC v2 - we can't delete group if it has existing role-binding)

## How

1. Use `hbi_setup_ephemeral_accounts` as a dependency of `enable_kessel_backend_flags`
2. Use RBAC's PUT endpoint on role-bindings, specifying 0 roles for each existing binding. This deletes the role-binding. Unfortunately, there isn't a dedicated DELETE endpoint for role bindings, so this is the only way how to do it: https://redhat-internal.slack.com/archives/C0233N2MBU6/p1775812452190729?thread_ts=1775741027.293369&cid=C0233N2MBU6

## Testing
I ran a couple tests against Stage and they worked


[RHINENG-25474]: https://redhat.atlassian.net/browse/RHINENG-25474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Adjust RBAC v2 group cleanup and feature-flag setup ordering to avoid failures with ephemeral users and undeletable default roles.

Bug Fixes:
- Change RBAC v2 role-binding cleanup to remove bindings via the role-bindings API instead of deleting roles, allowing groups to be deleted even when roles are undeletable.
- Ensure ephemeral user accounts are created before enabling Kessel backend feature flags to prevent user provisioning failures.