### PR TITLE
test(RHINENG-25474): Workaround for RBAC v2 issues

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/rbac_fixtures.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/rbac_fixtures.py
@@ -51,9 +51,9 @@ def hbi_non_org_admin_user_rbac_setup(
     yield _rbac_inventory_user_setup
 
     for rbac_setup in to_delete:
-        host_inventory.apis.rbac.delete_group(rbac_setup[0])
         for role_id in rbac_setup[1]:
             host_inventory.apis.rbac.delete_role(role_id)
+        host_inventory.apis.rbac.delete_group(rbac_setup[0])
 
 
 @pytest.fixture(scope="class")
@@ -80,9 +80,9 @@ def hbi_non_org_admin_user_rbac_setup_class(
     yield _rbac_inventory_user_setup
 
     for rbac_setup in to_delete:
-        host_inventory.apis.rbac.delete_group(rbac_setup[0])
         for role_id in rbac_setup[1]:
             host_inventory.apis.rbac.delete_role(role_id)
+        host_inventory.apis.rbac.delete_group(rbac_setup[0])
 
 
 @pytest.fixture(scope="class")

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
@@ -105,7 +105,8 @@ class RBACAPIWrapper(BaseEntity):
         try:
             self.raw_api.group_api.delete_principal_from_group(group_uuid, usernames=username)
         except RBACApiException as exc:
-            assert exc.status == 404
+            if exc.status != 404:
+                raise
 
     def delete_group(self, group_uuid: str) -> None:
         if self._host_inventory.unleash.is_rbac_workspaces_enabled:
@@ -113,7 +114,8 @@ class RBACAPIWrapper(BaseEntity):
         try:
             self.raw_api.group_api.delete_group(group_uuid)
         except RBACApiException as exc:
-            assert exc.status == 404
+            if exc.status != 404:
+                raise
 
     def create_role_v1(
         self,
@@ -205,7 +207,8 @@ class RBACAPIWrapper(BaseEntity):
         try:
             self.raw_api.role_api.delete_role(role_uuid)
         except RBACApiException as exc:
-            assert exc.status == 404
+            if exc.status != 404:
+                raise
 
     def delete_role_v2(self, role_id: str) -> None:
         try:
@@ -213,7 +216,8 @@ class RBACAPIWrapper(BaseEntity):
                 RolesBatchDeleteRolesRequest(ids=[role_id])
             )
         except RBACV2ApiException as exc:
-            assert exc.status == 404
+            if exc.status != 404:
+                raise
 
     def delete_role(self, role_id: str) -> None:
         if self._host_inventory.unleash.is_rbac_workspaces_enabled:
@@ -228,7 +232,7 @@ class RBACAPIWrapper(BaseEntity):
         Uses PUT /role-bindings/by-subject/ with an empty roles list to clear
         bindings for each (resource, subject) combination.
         """
-        response = self.raw_api_v2.role_bindings_api.role_bindings_list(
+        get_response = self.raw_api_v2.role_bindings_api.role_bindings_list(
             subject_type=RoleBindingsSubjectType.GROUP,
             subject_id=group_uuid,
             limit=10000,
@@ -237,17 +241,24 @@ class RBACAPIWrapper(BaseEntity):
         # model_construct bypasses the client-side min_length=1 validation;
         # the API itself accepts an empty list and removes all bindings.
         empty_request = RoleBindingsUpdateRoleBindingsRequest.model_construct(roles=[])
-        for binding in response.data:
+        for binding in get_response.data:
             resource = binding.resource
-            self.raw_api_v2.role_bindings_api.role_bindings_update_without_preload_content(
-                resource_id=resource.id,
-                resource_type=(
-                    ResourceType(resource.type) if resource.type else ResourceType.WORKSPACE
-                ),
-                subject_id=group_uuid,
-                subject_type=RoleBindingsSubjectType.GROUP,
-                role_bindings_update_role_bindings_request=empty_request,
+            put_response = (
+                self.raw_api_v2.role_bindings_api.role_bindings_update_without_preload_content(
+                    resource_id=resource.id,
+                    resource_type=(
+                        ResourceType(resource.type) if resource.type else ResourceType.WORKSPACE
+                    ),
+                    subject_id=group_uuid,
+                    subject_type=RoleBindingsSubjectType.GROUP,
+                    role_bindings_update_role_bindings_request=empty_request,
+                )
             )
+            # Remove these logs when https://redhat.atlassian.net/browse/RHCLOUD-46719 is fixed
+            logger.info(f"{put_response.status}: {put_response.data}")
+
+            # Enable this assert when https://redhat.atlassian.net/browse/RHCLOUD-46719 is fixed
+            # assert 200 <= put_response.status <= 299, f"{put_response.status}: {put_response.data}"  # noqa: E501
 
     def reset_user_groups(
         self, username: str, group_name: str | None = "iqe-hbi", delete_groups: bool = True
@@ -259,7 +270,17 @@ class RBACAPIWrapper(BaseEntity):
                 # This is a platform_default group and principal assignments can't be modified
                 continue
             if delete_groups:
-                self.delete_group(group.uuid)
+                # Remove the try/except workaround when
+                # https://redhat.atlassian.net/browse/RHCLOUD-46719 is fixed
+                try:
+                    self.delete_group(group.uuid)
+                except RBACApiException as exc:
+                    if exc.status == 400:
+                        logger.info(f"Wasn't able to delete RBAC group: {exc.status}: {exc.body}")
+                        logger.info("Removing user from the RBAC group")
+                        self.remove_user_from_group(username, group.uuid)
+                    else:
+                        raise
             else:
                 self.remove_user_from_group(username, group.uuid)
 


### PR DESCRIPTION
## Jira
[RHINENG-25474](https://issues.redhat.com/browse/RHINENG-25474)

## What
Create a workaround in IQE tests for this RBAC v2 issue: https://redhat.atlassian.net/browse/RHCLOUD-46719

## Why
The RBAC issue is preventing us from removing role bindings, which in turn prevents us from deleting RBAC groups, which prevents us from creating a proper RBAC setup for our users to run the permission tests.

## How
This workaround checks if the RBAC group deletion was successful, and if it wasn't, instead of failing it just removes the user from the group. This will make it possible to do the required RBAC setup for the tests, but it will leave uncleaned RBAC groups in our account. But, it's better to have uncleaned resources temporarily (until they fix the issue), than not being able to run the tests.

## Testing
I ran a few permission tests with this PR on both RBAC v2 and RBAC v1 accounts against Stage, and they passed.


[RHINENG-25474]: https://redhat.atlassian.net/browse/RHINENG-25474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce a temporary workaround in RBAC-related IQE test helpers to cope with RBAC v2 role-binding deletion issues while preserving testability.

Bug Fixes:
- Handle non-404 RBAC API exceptions by re-raising instead of asserting to avoid masking unexpected failures.

Enhancements:
- Adjust RBAC role-binding reset logic to log responses from RBAC v2 updates and prepare for stricter success assertions once the upstream issue is fixed.
- Update user group reset logic to fall back to removing the user from a group when group deletion fails with a known RBAC 400 error.
- Tweak RBAC test fixtures to delete roles before groups during teardown to align with the new cleanup flow.

Tests:
- Refine RBAC test teardown order to ensure consistent cleanup under the new RBAC v2 workaround behavior.