### PR TITLE
test(RHINENG-25474): Make group timestamps checks less strict and skip resource-types endpoints tests

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_add_hosts.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_add_hosts.py
@@ -41,9 +41,7 @@ def test_groups_add_hosts_response(
     hosts = host_inventory.upload.create_hosts(3)
 
     group_name = generate_display_name()
-    time1 = datetime.now(tz=UTC)
     group = host_inventory.apis.groups.create_group(group_name, hosts=hosts[0])
-    time2 = datetime.now(tz=UTC)
 
     data = [host.id for host in hosts[1:]]
     response = (
@@ -51,7 +49,6 @@ def test_groups_add_hosts_response(
             group.id, data
         )
     )
-    time3 = datetime.now(tz=UTC)
 
     assert response[1] == 200
     updated_group: GroupOutWithHostCount = response[0]
@@ -64,8 +61,6 @@ def test_groups_add_hosts_response(
     # See https://redhat-internal.slack.com/archives/C08T01AK7U6/p1753117255488139
     # assert updated_group.account == hbi_default_account_number
     assert updated_group.ungrouped is False
-    assert time1 < updated_group.created < time2
-    assert time2 < updated_group.updated < time3
 
 
 @pytest.mark.ephemeral
@@ -93,7 +88,9 @@ def test_groups_add_hosts_check_timestamps(host_inventory: ApplicationHostInvent
 
     assert updated_group.id == group.id
     assert time1 < updated_group.created < time2
-    assert time2 < updated_group.updated < time3
+    # Using time1 instead of time2 because RBAC v2 doesn't update the workspace
+    # timestamp when hosts are added to it.
+    assert time1 < updated_group.updated < time3
 
 
 @pytest.mark.ephemeral

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_hosts.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_hosts.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 def group_to_hosts_api_dict(group: GroupOut | GroupOutWithHostCount) -> dict:
     group_dict = group.to_dict()
     group_dict.pop("host_count", None)
+    group_dict.pop("created", None)
+    group_dict.pop("updated", None)
     return group_dict
 
 
@@ -110,7 +112,7 @@ def test_groups_get_host_by_id_response(host_inventory: ApplicationHostInventory
     assert isinstance(response.groups, list)
     if in_group:
         assert len(response.groups) == 1
-        assert response.groups[0].to_dict() == group_to_hosts_api_dict(group)
+        assert group_to_hosts_api_dict(response.groups[0]) == group_to_hosts_api_dict(group)
     else:
         assert is_ungrouped_host(response)
 
@@ -136,7 +138,7 @@ def test_groups_get_hosts_list(host_inventory: ApplicationHostInventory, in_grou
     assert isinstance(response[0].groups, list)
     if in_group:
         assert len(response[0].groups) == 1
-        assert response[0].groups[0].to_dict() == group_to_hosts_api_dict(group)
+        assert group_to_hosts_api_dict(response[0].groups[0]) == group_to_hosts_api_dict(group)
     else:
         assert is_ungrouped_host(response[0])
 

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_patch.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_patch.py
@@ -48,9 +48,7 @@ def test_groups_patch_response(
     hosts = host_inventory.kafka.create_random_hosts(3)
 
     group_name = generate_display_name()
-    time1 = datetime.now(tz=UTC)
     group = host_inventory.apis.groups.create_group(group_name, hosts=hosts[0])
-    time2 = datetime.now(tz=UTC)
 
     expected_name = generate_display_name() if "name" in fields else group_name
     expected_host_ids = [host.id for host in hosts] if "host_ids" in fields else [hosts[0].id]
@@ -62,7 +60,6 @@ def test_groups_patch_response(
     response = host_inventory.apis.groups.raw_api.api_group_patch_group_by_id_with_http_info(
         group.id, data
     )
-    time3 = datetime.now(tz=UTC)
 
     assert response[1] == 200
     updated_group: GroupOutWithHostCount = response[0]
@@ -73,8 +70,6 @@ def test_groups_patch_response(
     assert updated_group.org_id == hbi_default_org_id
     assert updated_group.account == hbi_default_account_number
     assert updated_group.ungrouped is False
-    assert time1 < updated_group.created < time2
-    assert time2 < updated_group.updated < time3
 
 
 @pytest.mark.ephemeral
@@ -351,7 +346,9 @@ def test_groups_patch_check_timestamps(
 
     assert updated_group.id == group.id
     assert time1 < updated_group.created < time2
-    assert time2 < updated_group.updated < time3
+    # Using time1 instead of time2 because RBAC v2 doesn't update the workspace
+    # timestamp when hosts are added/removed.
+    assert time1 < updated_group.updated < time3
 
 
 @pytest.mark.ephemeral

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_remove_hosts.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_remove_hosts.py
@@ -75,7 +75,9 @@ def test_groups_remove_hosts_check_timestamps(host_inventory: ApplicationHostInv
     logger.info(f"created: {updated_group.created}")
     logger.info(f"updated: {updated_group.updated}")
     assert time1 < updated_group.created < time2
-    assert time2 < updated_group.updated < time3
+    # Using time1 instead of time2 because RBAC v2 doesn't update the workspace
+    # timestamp when hosts are removed from it.
+    assert time1 < updated_group.updated < time3
 
 
 @pytest.mark.ephemeral

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_remove_multiple.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_remove_multiple.py
@@ -71,7 +71,9 @@ def test_groups_remove_hosts_from_multiple_groups_check_timestamps(
     logger.info(f"created: {updated_group.created}")
     logger.info(f"updated: {updated_group.updated}")
     assert time1 < updated_group.created < time2
-    assert time2 < updated_group.updated < time3
+    # Using time1 instead of time2 because RBAC v2 doesn't update the workspace
+    # timestamp when hosts are removed from it.
+    assert time1 < updated_group.updated < time3
 
 
 @pytest.mark.ephemeral

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/test_resource_types.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/test_resource_types.py
@@ -23,6 +23,14 @@ pytestmark = [pytest.mark.backend]
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(autouse=True, scope="module")
+def _skip_if_rbac_workspaces(host_inventory: ApplicationHostInventory):
+    """Resource-types endpoints access checks are made through RBAC v1,
+    which is not available when v2 is enabled."""
+    if host_inventory.unleash.is_rbac_workspaces_enabled:
+        pytest.skip("resource-types endpoints are not supported with RBAC v2 workspaces")
+
+
 def check_resource_types_list_response(
     response: ResourceTypesQueryOutput,
     groups_count: int,

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_get.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_get.py
@@ -1260,7 +1260,7 @@ def test_get_hosts_by_group_name(host_inventory: ApplicationHostInventory, case_
     assert len(response) == 1
     assert response[0].id == hosts[0].id
     assert len(response[0].groups) == 1
-    assert response[0].groups[0].to_dict() == group_to_hosts_api_dict(group)
+    assert group_to_hosts_api_dict(response[0].groups[0]) == group_to_hosts_api_dict(group)
 
 
 @pytest.mark.ephemeral
@@ -1283,7 +1283,7 @@ def test_get_hosts_by_group_id(host_inventory: ApplicationHostInventory):
     assert len(response) == 1
     assert response[0].id == hosts[0].id
     assert len(response[0].groups) == 1
-    assert response[0].groups[0].to_dict() == group_to_hosts_api_dict(group)
+    assert group_to_hosts_api_dict(response[0].groups[0]) == group_to_hosts_api_dict(group)
 
 
 @pytest.mark.ephemeral
@@ -1383,7 +1383,7 @@ def test_get_hosts_by_group_name_not_contains(host_inventory: ApplicationHostInv
     assert len(response) == 1
     assert response[0].id == hosts[0].id
     assert len(response[0].groups) == 1
-    assert response[0].groups[0].to_dict() == group_to_hosts_api_dict(group)
+    assert group_to_hosts_api_dict(response[0].groups[0]) == group_to_hosts_api_dict(group)
 
 
 @pytest.mark.ephemeral
@@ -1406,7 +1406,7 @@ def test_get_hosts_by_group_name_multiple_hosts_in_group(host_inventory: Applica
     assert {host.id for host in response} == {host.id for host in hosts[:2]}
     for response_host in response:
         assert len(response_host.groups) == 1
-        assert response_host.groups[0].to_dict() == group_to_hosts_api_dict(group)
+        assert group_to_hosts_api_dict(response_host.groups[0]) == group_to_hosts_api_dict(group)
 
 
 @pytest.mark.ephemeral
@@ -1436,13 +1436,15 @@ def test_get_hosts_by_group_name_different_account(
     assert len(response) == 1
     assert response[0].id == host_primary.id
     assert len(response[0].groups) == 1
-    assert response[0].groups[0].to_dict() == group_to_hosts_api_dict(group_primary)
+    assert group_to_hosts_api_dict(response[0].groups[0]) == group_to_hosts_api_dict(group_primary)
 
     response = host_inventory_secondary.apis.hosts.get_hosts(group_name=[group_name])
     assert len(response) == 1
     assert response[0].id == host_secondary.id
     assert len(response[0].groups) == 1
-    assert response[0].groups[0].to_dict() == group_to_hosts_api_dict(group_secondary)
+    assert group_to_hosts_api_dict(response[0].groups[0]) == group_to_hosts_api_dict(
+        group_secondary
+    )
 
 
 @pytest.mark.ephemeral


### PR DESCRIPTION
## Jira
[RHINENG-25474](https://issues.redhat.com/browse/RHINENG-25474)

## What

1. Make group timestamps checks less strict
2. Skip resource-types endpoints tests when RBAC v2 is enabled

This should reduce the number of failing tests by about 60.

## Why

1. The groups timestamps differ slightly between HBI's DB and RBAC's workspaces
2. The resource-types endpoints use RBAC v1 access checks, which don't work when RBAC v2 is enabled. These endpoints won't be used when RBAC v2 is enabled.

## Testing
I tested this with both RBAC v2 enabled and disabled accounts.

## Summary by Sourcery

Relax group timestamp and group object equality checks in tests and make RBAC resource-types tests conditional on RBAC v2 workspaces being disabled.

Tests:
- Adjust group-to-host comparison helpers and assertions to ignore timestamp fields and rely on a normalized group dict representation.
- Loosen group timestamp expectations to allow updated timestamps to fall between the initial and final measurement window rather than strictly between intermediate checks.
- Automatically skip resource-types RBAC tests when RBAC v2 workspaces are enabled, since those endpoints rely on RBAC v1 access checks.

[RHINENG-25474]: https://redhat.atlassian.net/browse/RHINENG-25474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ