### PR TITLE
chore(RHINENG-25529): add check for num of lines changes to PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -12,3 +12,11 @@
 
 ## Testing
 <!-- How was this tested? -->
+
+## PR Guideline
+
+You can find the documentation of the guideline [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)
+
+## PR Guideline checks
+
+- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -13,9 +13,9 @@
 ## Testing
 <!-- How was this tested? -->
 
-## PR Guideline
+## PR Guidelines
 
-You can find the documentation of the guideline [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)
+You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)
 
 ## PR Guideline checks
 


### PR DESCRIPTION
## Jira
[RHINENG-3984](https://github.com/RedHatInsights/insights-host-inventory/pull/3984)
## What
Update PR template to include a check for the number of line changes in the PR

## Why
As part of the agreement we made last week with the team for backed code review guide

## How
Changing the PR template and adding a check

## Testing
No tests required

## Summary by Sourcery

Documentation:
- Add links and sections in the PR template describing PR guidelines and expected line count limits for changes.

[RHINENG-3984]: https://redhat.atlassian.net/browse/RHINENG-3984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ