### PR TITLE
fix(RHINENG-25804): Don't delete group if HBI receives 404 from RBAC

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -463,6 +463,8 @@ def delete_groups(group_id_list, rbac_filter=None):
     found_groups = get_groups_by_id_list_from_db(group_id_list, identity.org_id)
     check_all_ids_found(group_id_list, found_groups, "group")
 
+    delete_count = 0
+
     if not inventory_config().bypass_kessel:
         # Write is not allowed for the ungrouped through API requests
         ungrouped_group = get_ungrouped_group(identity)
@@ -471,8 +473,6 @@ def delete_groups(group_id_list, rbac_filter=None):
         for group_id in group_id_list:
             if ungrouped_group_id == group_id:
                 abort(HTTPStatus.BAD_REQUEST, f"Ungrouped workspace {group_id} can not be deleted.")
-
-        delete_count = 0
 
         # Attempt to delete the RBAC workspaces
         for group_id in group_id_list:

--- a/api/group.py
+++ b/api/group.py
@@ -472,7 +472,6 @@ def delete_groups(group_id_list, rbac_filter=None):
             if ungrouped_group_id == group_id:
                 abort(HTTPStatus.BAD_REQUEST, f"Ungrouped workspace {group_id} can not be deleted.")
 
-        group_ids_to_delete = []
         delete_count = 0
 
         # Attempt to delete the RBAC workspaces
@@ -481,12 +480,7 @@ def delete_groups(group_id_list, rbac_filter=None):
                 delete_rbac_workspace(group_id)
                 delete_count += 1
             except ResourceNotFoundException:
-                # For workspaces that are missing from RBAC,
-                # we'll attempt to delete the groups on our side
-                group_ids_to_delete.append(group_id)
-
-        # Attempt to delete the "not found" groups on our side
-        delete_count += delete_group_list(group_ids_to_delete, identity, current_app.event_producer)
+                continue
     else:
         delete_count = delete_group_list(group_id_list, identity, current_app.event_producer)
 

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
@@ -171,11 +171,7 @@ class TestRBACGranularGroupsWritePermission:
           title: Test that users with only granular RBAC access can't create new groups
         """
         group_name = generate_display_name()
-        with raises_apierror(
-            403,
-            "Unfiltered inventory:groups:write RBAC permission is required "
-            "in order to create new groups.",
-        ):
+        with raises_apierror(403):
             host_inventory_non_org_admin.apis.groups.create_group(
                 group_name, wait_for_created=False
             )

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_groups_read_permission.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_groups_read_permission.py
@@ -8,6 +8,8 @@ import logging
 import pytest
 from pytest_lazy_fixtures import lf
 
+from iqe_host_inventory import ApplicationHostInventory
+from iqe_host_inventory.utils.api_utils import FORBIDDEN_OR_NOT_FOUND
 from iqe_host_inventory.utils.api_utils import raises_apierror
 
 pytestmark = [
@@ -101,7 +103,8 @@ class TestRBACGroupsNoReadPermission:
         self,
         no_read_permission_user_setup,
         rbac_setup_resources,
-        host_inventory_non_org_admin,
+        host_inventory: ApplicationHostInventory,
+        host_inventory_non_org_admin: ApplicationHostInventory,
     ):
         """
         https://issues.redhat.com/browse/ESSNTL-4499
@@ -113,12 +116,16 @@ class TestRBACGroupsNoReadPermission:
           negative: true
           title: Test that users without "groups:read" permission can't get a list of groups
         """
-        with raises_apierror(
-            403,
-            "You don't have the permission to access the requested resource. "
-            "It is either read-protected or not readable by the server.",
-        ):
-            host_inventory_non_org_admin.apis.groups.get_groups()
+        if host_inventory.unleash.is_kessel_groups_enabled():
+            response = host_inventory_non_org_admin.apis.groups.get_groups()
+            assert len(response) == 0
+        else:
+            with raises_apierror(
+                403,
+                "You don't have the permission to access the requested resource. "
+                "It is either read-protected or not readable by the server.",
+            ):
+                host_inventory_non_org_admin.apis.groups.get_groups()
 
     def test_rbac_groups_no_read_permission_get_groups_by_id(
         self,
@@ -139,9 +146,5 @@ class TestRBACGroupsNoReadPermission:
         groups = rbac_setup_resources[1]
 
         for group in groups:
-            with raises_apierror(
-                403,
-                "You don't have the permission to access the requested resource. "
-                "It is either read-protected or not readable by the server.",
-            ):
+            with raises_apierror(FORBIDDEN_OR_NOT_FOUND):
                 host_inventory_non_org_admin.apis.groups.get_groups_by_id(group)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_groups_write_permission.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_groups_write_permission.py
@@ -12,6 +12,7 @@ from pytest_lazy_fixtures import lf
 from pytest_lazy_fixtures.lazy_fixture import LazyFixtureWrapper
 
 from iqe_host_inventory import ApplicationHostInventory
+from iqe_host_inventory.utils.api_utils import FORBIDDEN_OR_NOT_FOUND
 from iqe_host_inventory.utils.api_utils import raises_apierror
 from iqe_host_inventory.utils.datagen_utils import TagDict
 from iqe_host_inventory.utils.datagen_utils import generate_display_name
@@ -236,11 +237,7 @@ class TestRBACGroupsNoWritePermission:
           title: Test that users without "groups:write" permission can't create a group
         """
         group_name = generate_display_name()
-        with raises_apierror(
-            403,
-            "You don't have the permission to access the requested resource. "
-            "It is either read-protected or not readable by the server.",
-        ):
+        with raises_apierror(403):
             host_inventory_non_org_admin.apis.groups.create_group(
                 group_name, wait_for_created=False
             )
@@ -302,11 +299,7 @@ class TestRBACGroupsNoWritePermission:
         groups = rbac_setup_resources[1]
 
         for group in groups:
-            with raises_apierror(
-                403,
-                "You don't have the permission to access the requested resource. "
-                "It is either read-protected or not readable by the server.",
-            ):
+            with raises_apierror(FORBIDDEN_OR_NOT_FOUND):
                 host_inventory_non_org_admin.apis.groups.delete_groups_raw(group)
 
             host_inventory.apis.groups.verify_not_deleted(group)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/service_accounts/test_rbac_sa_groups_read_permission.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/service_accounts/test_rbac_sa_groups_read_permission.py
@@ -8,6 +8,7 @@ import logging
 import pytest
 
 from iqe_host_inventory import ApplicationHostInventory
+from iqe_host_inventory.utils.api_utils import FORBIDDEN_OR_NOT_FOUND
 from iqe_host_inventory.utils.api_utils import raises_apierror
 from iqe_host_inventory.utils.datagen_utils import TagDict
 from iqe_host_inventory_api import GroupOut
@@ -71,6 +72,7 @@ class TestRBACSAGroupsNoReadPermission:
     @pytest.mark.usefixtures("rbac_setup_resources")
     def test_rbac_sa_groups_no_read_permission_get_groups_list(
         self,
+        host_inventory: ApplicationHostInventory,
         host_inventory_sa_2: ApplicationHostInventory,
     ):
         """
@@ -84,12 +86,16 @@ class TestRBACSAGroupsNoReadPermission:
           title: Test that service accounts users without "groups:read" permission
                  can't get a list of groups
         """
-        with raises_apierror(
-            403,
-            "You don't have the permission to access the requested resource. "
-            "It is either read-protected or not readable by the server.",
-        ):
-            host_inventory_sa_2.apis.groups.get_groups()
+        if host_inventory.unleash.is_kessel_groups_enabled():
+            response = host_inventory_sa_2.apis.groups.get_groups()
+            assert len(response) == 0
+        else:
+            with raises_apierror(
+                403,
+                "You don't have the permission to access the requested resource. "
+                "It is either read-protected or not readable by the server.",
+            ):
+                host_inventory_sa_2.apis.groups.get_groups()
 
     def test_rbac_sa_groups_no_read_permission_get_groups_by_id(
         self,
@@ -109,9 +115,5 @@ class TestRBACSAGroupsNoReadPermission:
         groups = rbac_setup_resources[1]
 
         for group in groups:
-            with raises_apierror(
-                403,
-                "You don't have the permission to access the requested resource. "
-                "It is either read-protected or not readable by the server.",
-            ):
+            with raises_apierror(FORBIDDEN_OR_NOT_FOUND):
                 host_inventory_sa_2.apis.groups.get_groups_by_id(group)

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -494,6 +494,39 @@ def test_delete_existing_group_missing_workspace(api_delete_groups_kessel, db_cr
 @pytest.mark.usefixtures("event_producer")
 @pytest.mark.usefixtures("enable_kessel")
 @pytest.mark.usefixtures("enable_rbac")
+def test_delete_group_not_deleted_from_hbi_when_rbac_returns_404(
+    api_delete_groups_kessel, db_create_group, db_get_group_by_id, mocker
+):
+    """When RBAC returns 404 for a workspace, HBI must NOT delete the group from its own DB.
+
+    RBAC v2 returns 404 both when a workspace doesn't exist and when the user lacks
+    permission to delete it. Deleting from HBI on 404 would bypass permission checks.
+    """
+    from app.exceptions import ResourceNotFoundException
+
+    group_id = db_create_group("test group").id
+
+    # Enable RBAC v2 for groups so the @rbac decorator skips v1 permission checks
+    mocker.patch("lib.middleware.is_rbac_v2_groups_enabled", return_value=True)
+
+    # Mock delete_rbac_workspace to raise ResourceNotFoundException (RBAC returns 404)
+    mocker.patch(
+        "api.group.delete_rbac_workspace",
+        side_effect=ResourceNotFoundException("Workspace not found"),
+    )
+
+    response_status, _ = api_delete_groups_kessel([group_id])
+
+    # The API should NOT return 204 — the workspace was not deleted
+    assert_response_status(response_status, expected_status=404)
+
+    # The group must still exist in HBI's database
+    assert db_get_group_by_id(group_id) is not None
+
+
+@pytest.mark.usefixtures("event_producer")
+@pytest.mark.usefixtures("enable_kessel")
+@pytest.mark.usefixtures("enable_rbac")
 @mock.patch("requests.Session.delete", new=mocked_delete_workspace_empty_response)
 def test_delete_existing_group_kessel_empty_response(api_delete_groups_kessel, db_create_group, mocker):
     """

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -567,61 +567,6 @@ def test_delete_host_from_nonexistent_group(
     assert "Group" in response_data["detail"] and "not found" in response_data["detail"]
 
 
-@pytest.mark.usefixtures("event_producer")
-@pytest.mark.usefixtures("enable_kessel")
-@pytest.mark.usefixtures("enable_rbac")
-@mock.patch("requests.Session.delete", new=mocked_post_workspace_not_found)
-def test_delete_group_with_hosts_not_in_rbac_after_workspace_event(
-    api_delete_groups_kessel, db_create_group, db_create_group_with_hosts, mocker
-):
-    """Regression test: deleting a group with hosts that exists in HBI but not in RBAC.
-
-    Before the fix, wait_for_workspace_event contaminated the SQLAlchemy connection
-    pool by setting ISOLATION_LEVEL_AUTOCOMMIT on the session's underlying psycopg2
-    connection. When a subsequent request tried to delete a group (with hosts) that
-    didn't exist in RBAC, db.session.begin_nested() in _remove_all_hosts_from_group
-    would fail with 'SAVEPOINT can only be used in transaction blocks'.
-    """
-    from app.queue.events import EventType
-    from lib.group_repository import wait_for_workspace_event
-
-    # Step 1: Create a "seed" group so wait_for_workspace_event can find it
-    # in the DB and return early (without needing actual LISTEN/NOTIFY).
-    seed_group = db_create_group("seed_group")
-
-    # Step 2: Call wait_for_workspace_event. With the old code
-    # (db.session.connection().connection), this would set ISOLATION_LEVEL_AUTOCOMMIT
-    # on the session's underlying connection, contaminating it permanently.
-    # With the fix (psycopg2.connect()), a separate connection is used.
-    wait_for_workspace_event(str(seed_group.id), EventType.created, org_id=seed_group.org_id)
-
-    # Step 3: Create a group WITH hosts. The begin_nested() SAVEPOINT issue only
-    # manifests in _remove_all_hosts_from_group when moving hosts to ungrouped.
-    group_with_hosts = db_create_group_with_hosts("group_to_delete", num_hosts=2)
-
-    # Step 4: Mock RBAC permissions to allow the request.
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-    mock_rbac_response = create_mock_rbac_response(
-        "tests/helpers/rbac-mock-data/inv-groups-write-resource-defs-template.json"
-    )
-    get_rbac_permissions_mock.return_value = mock_rbac_response
-
-    # Mock ungrouped workspace creation (RBAC API call).
-    mocker.patch("lib.group_repository.rbac_create_ungrouped_hosts_workspace", return_value=generate_uuid())
-
-    # Mock the metrics context manager.
-    with mock.patch("lib.middleware.outbound_http_response_time") as mock_metric:
-        mock_metric.labels.return_value.time.return_value = contextlib.nullcontext()
-
-        # Step 5: Delete the group. RBAC returns 404 (workspace not found), so HBI
-        # should delete it from its own DB, moving hosts to the ungrouped group.
-        response_status, _ = api_delete_groups_kessel([group_with_hosts.id])
-
-        # Before the fix, this would fail with HTTP 500:
-        # InternalError('SAVEPOINT can only be used in transaction blocks')
-        assert_response_status(response_status, expected_status=204)
-
-
 @pytest.mark.usefixtures("enable_rbac")
 def test_delete_hosts_from_diff_groups_rbac_v2_success(
     mocker,


### PR DESCRIPTION
## Jira
[RHINENG-25804](https://issues.redhat.com/browse/RHINENG-25804)
[RHINENG-25474](https://issues.redhat.com/browse/RHINENG-25474)

## What
Stop deleting a group if HBI receives HTTP 404 from RBAC v2.

Update a few IQE tests to stop them from failing when RBAC v2 is enabled.

## Why
RBAC v2 returns 404 even if the user doesn't have permissions for deleting
workspaces, so when HBI deletes a group after RBAC returns 404, it can
delete a group even if the user doesn't have permissions for it.

## How
Remove the logic that checked for 404 in the RBAC response and then deleted the groups from HBI DB.

## Testing
I will test this in ephemeral with enabled Kessel.


[RHINENG-25804]: https://redhat.atlassian.net/browse/RHINENG-25804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHINENG-25474]: https://redhat.atlassian.net/browse/RHINENG-25474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure groups are not deleted in HBI when RBAC v2 returns 404 and align RBAC permission tests with the new behavior.

Bug Fixes:
- Prevent deletion of groups from HBI when RBAC returns HTTP 404 for the corresponding workspace.

Enhancements:
- Simplify group deletion logic by ignoring RBAC 404 responses instead of attempting local deletion.
- Relax IQE RBAC tests to accept either 403 or 404 responses (or empty results when Kessel groups are enabled) where appropriate, using shared constants and feature checks.