### PR TITLE
perf(RHINENG-25821): add gunicorn --max-requests worker recycling

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -15,6 +15,8 @@ objects:
         "gunicorn",
         "--workers=${GUNICORN_WORKERS}",
         "--threads=${GUNICORN_THREADS}",
+        "--max-requests=${GUNICORN_MAX_REQUESTS}",
+        "--max-requests-jitter=${GUNICORN_MAX_REQUESTS_JITTER}",
         "--limit-request-field_size=${GUNICORN_REQUEST_FIELD_LIMIT}",
         "--limit-request-line=${GUNICORN_REQUEST_LINE_LIMIT}",
         "--worker-tmp-dir=/gunicorn",
@@ -2531,6 +2533,10 @@ parameters:
   value: '4'
 - name: GUNICORN_THREADS
   value: '8'
+- name: GUNICORN_MAX_REQUESTS
+  value: '0' # (disabled)
+- name: GUNICORN_MAX_REQUESTS_JITTER
+  value: '0' # (disabled)
 - name: GUNICORN_REQUEST_FIELD_LIMIT
   value: '16380'
 - name: GUNICORN_REQUEST_LINE_LIMIT


### PR DESCRIPTION
**Jira**
[RHINENG-25821](https://issues.redhat.com/browse/RHINENG-25821)

**What**
Add --max-requests and --max-requests-jitter gunicorn parameters to the shared gunicornPodSpec in clowdapp.yml to enable periodic worker recycling.

**Why**
Service-reads pods are being OOM-killed every 2–3 days in production. This has been happening since at least mid-March, confirmed via container_memory_usage_bytes metrics showing a consistent sawtooth pattern across all pods. Metric retention does not go back further than mid-March, so the issue has likely been occurring for longer.

**How**
Added two new template parameters (GUNICORN_MAX_REQUESTS, GUNICORN_MAX_REQUESTS_JITTER) to the gunicorn CLI args in the shared gunicornPodSpec anchor. 
Defaults are 0 (disabled) so ephemeral and stage environments are unaffected. Production values (10000 / 2000) will be set via app-interface, causing each worker to gracefully restart after 8,000–12,000 requests (~every 6–8 hours at current traffic of ~35K requests/worker/day).

**Testing**

- --max-requests=0 is gunicorn's default and means workers never restart ([docs](https://docs.gunicorn.org/en/latest/settings.html#max-requests)). Combined with --max-requests-jitter=0, this is a no-op — no behavior change without the app-interface override.

After deploying to prod with the override, monitor:

- container_memory_usage_bytes — memory should plateau instead of the sawtooth climb
- kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} — OOM kills should stop
- inventory_http_request_duration_seconds — no latency regression

## Summary by Sourcery

Enhancements:
- Add configurable Gunicorn max-requests and max-requests-jitter options to the shared Gunicorn pod specification with defaults that keep the feature disabled.

[RHINENG-25821]: https://redhat.atlassian.net/browse/RHINENG-25821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ