### PR TITLE
test(RHINENG-25474): More rbac v2 test updates

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
@@ -54,7 +54,8 @@ def read_permission_user_setup(request: pytest.FixtureRequest):
 
 @pytest.fixture(
     params=[
-        lf("rbac_inventory_groups_write_granular_user_setup_class"),
+        # TODO: Uncomment this when https://redhat.atlassian.net/browse/RHINENG-25822 is fixed
+        # lf("rbac_inventory_groups_write_granular_user_setup_class"),
         lf("rbac_inventory_groups_all_granular_user_setup_class"),
         lf("rbac_inventory_admin_granular_user_setup_class"),
     ],
@@ -660,7 +661,8 @@ class TestRBACGranularGroupsWrongPermissionReadEndpoints:
         self,
         wrong_permission_setup_read_endpoints,
         rbac_setup_resources_for_granular_rbac: RBacResources,
-        host_inventory_non_org_admin,
+        host_inventory: ApplicationHostInventory,
+        host_inventory_non_org_admin: ApplicationHostInventory,
     ):
         """
         https://issues.redhat.com/browse/ESSNTL-4961
@@ -672,12 +674,16 @@ class TestRBACGranularGroupsWrongPermissionReadEndpoints:
           negative: true
           title: Test that users with granular RBAC on wrong permission can't get a list of groups
         """
-        with raises_apierror(
-            403,
-            "You don't have the permission to access the requested resource. "
-            "It is either read-protected or not readable by the server.",
-        ):
-            host_inventory_non_org_admin.apis.groups.get_groups()
+        if host_inventory.unleash.is_kessel_groups_enabled():
+            response = host_inventory_non_org_admin.apis.groups.get_groups()
+            assert len(response) == 0
+        else:
+            with raises_apierror(
+                403,
+                "You don't have the permission to access the requested resource. "
+                "It is either read-protected or not readable by the server.",
+            ):
+                host_inventory_non_org_admin.apis.groups.get_groups()
 
     def test_rbac_granular_groups_wrong_permission_get_groups_by_id(
         self,
@@ -698,11 +704,7 @@ class TestRBACGranularGroupsWrongPermissionReadEndpoints:
         groups = rbac_setup_resources_for_granular_rbac[1][:2]
 
         for group in groups:
-            with raises_apierror(
-                403,
-                "You don't have the permission to access the requested resource. "
-                "It is either read-protected or not readable by the server.",
-            ):
+            with raises_apierror(FORBIDDEN_OR_NOT_FOUND):
                 host_inventory_non_org_admin.apis.groups.get_groups_by_id(group)
 
 

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_groups_write_permission.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_groups_write_permission.py
@@ -26,7 +26,8 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(
     params=[
-        lf("rbac_inventory_groups_write_user_setup_class"),
+        # TODO: Uncomment this when https://redhat.atlassian.net/browse/RHINENG-25822 is fixed
+        # lf("rbac_inventory_groups_write_user_setup_class"),
         lf("rbac_inventory_groups_all_user_setup_class"),
         lf("rbac_inventory_admin_user_setup_class"),
     ],


### PR DESCRIPTION
## Jira
[RHINENG-25474](https://issues.redhat.com/browse/RHINENG-25474)

## What
Update tests to make them pass when rbac v2 is enabled

## Why
They are failing

## How
- Stop testing `inventory:groups:write` permission without `inventory:groups:read` permission: https://redhat.atlassian.net/browse/RHINENG-25822
- Update a couple of other tests to expect 404 or 403


## Testing
I tested this in Stage

## Summary by Sourcery

Adjust RBAC group tests to align with current behavior when RBAC v2 and Kessel groups are enabled.

Tests:
- Temporarily disable granular write-only RBAC group fixtures pending resolution of RHINENG-25822.
- Update granular RBAC tests to expect either empty group lists or 403/404 responses depending on Kessel groups feature state.

[RHINENG-25474]: https://redhat.atlassian.net/browse/RHINENG-25474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ