### PR TITLE
fix: pass hbi_groups to RBAC user setup fixtures for workspace access

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/rbac_fixtures.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/rbac_fixtures.py
@@ -243,43 +243,83 @@ def rbac_staleness_all_hosts_write_user_setup(hbi_non_org_admin_user_rbac_setup)
 
 
 @pytest.fixture(scope="class")
-def rbac_inventory_hosts_read_user_setup_class(hbi_non_org_admin_user_rbac_setup_class):
-    hbi_non_org_admin_user_rbac_setup_class(permissions=[RBACInventoryPermission.HOSTS_READ])
+def rbac_inventory_hosts_read_user_setup_class(
+    hbi_non_org_admin_user_rbac_setup_class, rbac_setup_resources
+):
+    groups = rbac_setup_resources[1]
+    hbi_non_org_admin_user_rbac_setup_class(
+        permissions=[RBACInventoryPermission.HOSTS_READ], hbi_groups=groups
+    )
 
 
 @pytest.fixture(scope="class")
-def rbac_inventory_groups_read_user_setup_class(hbi_non_org_admin_user_rbac_setup_class):
-    hbi_non_org_admin_user_rbac_setup_class(permissions=[RBACInventoryPermission.GROUPS_READ])
+def rbac_inventory_groups_read_user_setup_class(
+    hbi_non_org_admin_user_rbac_setup_class, rbac_setup_resources
+):
+    groups = rbac_setup_resources[1]
+    hbi_non_org_admin_user_rbac_setup_class(
+        permissions=[RBACInventoryPermission.GROUPS_READ], hbi_groups=groups
+    )
 
 
 @pytest.fixture(scope="class")
-def rbac_inventory_all_read_user_setup_class(hbi_non_org_admin_user_rbac_setup_class):
-    hbi_non_org_admin_user_rbac_setup_class(permissions=[RBACInventoryPermission.ALL_READ])
+def rbac_inventory_all_read_user_setup_class(
+    hbi_non_org_admin_user_rbac_setup_class, rbac_setup_resources
+):
+    groups = rbac_setup_resources[1]
+    hbi_non_org_admin_user_rbac_setup_class(
+        permissions=[RBACInventoryPermission.ALL_READ], hbi_groups=groups
+    )
 
 
 @pytest.fixture(scope="class")
-def rbac_inventory_hosts_write_user_setup_class(hbi_non_org_admin_user_rbac_setup_class):
-    hbi_non_org_admin_user_rbac_setup_class(permissions=[RBACInventoryPermission.HOSTS_WRITE])
+def rbac_inventory_hosts_write_user_setup_class(
+    hbi_non_org_admin_user_rbac_setup_class, rbac_setup_resources
+):
+    groups = rbac_setup_resources[1]
+    hbi_non_org_admin_user_rbac_setup_class(
+        permissions=[RBACInventoryPermission.HOSTS_WRITE], hbi_groups=groups
+    )
 
 
 @pytest.fixture(scope="class")
-def rbac_inventory_groups_write_user_setup_class(hbi_non_org_admin_user_rbac_setup_class):
-    hbi_non_org_admin_user_rbac_setup_class(permissions=[RBACInventoryPermission.GROUPS_WRITE])
+def rbac_inventory_groups_write_user_setup_class(
+    hbi_non_org_admin_user_rbac_setup_class, rbac_setup_resources
+):
+    groups = rbac_setup_resources[1]
+    hbi_non_org_admin_user_rbac_setup_class(
+        permissions=[RBACInventoryPermission.GROUPS_WRITE], hbi_groups=groups
+    )
 
 
 @pytest.fixture(scope="class")
-def rbac_inventory_hosts_all_user_setup_class(hbi_non_org_admin_user_rbac_setup_class):
-    hbi_non_org_admin_user_rbac_setup_class(permissions=[RBACInventoryPermission.HOSTS_ALL])
+def rbac_inventory_hosts_all_user_setup_class(
+    hbi_non_org_admin_user_rbac_setup_class, rbac_setup_resources
+):
+    groups = rbac_setup_resources[1]
+    hbi_non_org_admin_user_rbac_setup_class(
+        permissions=[RBACInventoryPermission.HOSTS_ALL], hbi_groups=groups
+    )
 
 
 @pytest.fixture(scope="class")
-def rbac_inventory_groups_all_user_setup_class(hbi_non_org_admin_user_rbac_setup_class):
-    hbi_non_org_admin_user_rbac_setup_class(permissions=[RBACInventoryPermission.GROUPS_ALL])
+def rbac_inventory_groups_all_user_setup_class(
+    hbi_non_org_admin_user_rbac_setup_class, rbac_setup_resources
+):
+    groups = rbac_setup_resources[1]
+    hbi_non_org_admin_user_rbac_setup_class(
+        permissions=[RBACInventoryPermission.GROUPS_ALL], hbi_groups=groups
+    )
 
 
 @pytest.fixture(scope="class")
-def rbac_inventory_admin_user_setup_class(hbi_non_org_admin_user_rbac_setup_class):
-    hbi_non_org_admin_user_rbac_setup_class(permissions=[RBACInventoryPermission.ADMIN])
+def rbac_inventory_admin_user_setup_class(
+    hbi_non_org_admin_user_rbac_setup_class, rbac_setup_resources
+):
+    groups = rbac_setup_resources[1]
+    hbi_non_org_admin_user_rbac_setup_class(
+        permissions=[RBACInventoryPermission.ADMIN], hbi_groups=groups
+    )
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
## Jira
[RHINENG-25288](https://issues.redhat.com/browse/RHINENG-25288)

## What
Fix rbac_fixture to pass hbi_groups to the fixture

## Why
Attempting to fix failing tests

## How
I tried to run IQE test to use the code in this branch and by running against the IQE core in this [IQE Core MR](https://gitlab.cee.redhat.com/insights-qe/iqe-core/-/merge_requests/2395)


It turns out that in order to run tests against my ephemeral namespace, feature flags have to be set.

@fstavela if you like you can deploy the IQE Core in the [MR](https://gitlab.cee.redhat.com/insights-qe/iqe-core/-/merge_requests/2395) provided to test the HBI's IQE Tests.

## Testing
Here is what needs to be done:

⏺ Aha! That's the issue! Feature flags config is empty {}, which means:
  1. _create_feature_flag_checker returns None
  2. check_feature_flag is None in StandaloneUserProvider                                                                                                                                                                                            
  3. _is_rbac_v2_enabled() defaults to False (safe fallback)
  4. Code tries to use v1 API                                                                                                                                                                                                                        
  5. v1 API fails because the org is using v2!                                                                                                                                                                                                       
                                                                                                                                                                                                                                                     
  Let's see the full feature flag checker implementation and understand what's needed:                                                                                                                                                               
                                                                                                                                                                                                                                                     
  # See the complete _create_feature_flag_checker method
  grep -A 60 "def _create_feature_flag_checker" /iqe_venv/lib/python3.12/site-packages/iqe/base/_dependency_inject.py                                                                                                                                
                                                                                                                                                                                                                                                     
  The issue is that the pod doesn't have Unleash feature flag backend configured. Your RBAC v2 code is working correctly - it's just that without the feature flag configuration, it safely defaults to v1, which then fails because the org is      
  actually using v2.                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                     
  This is a configuration issue, not a code deployment issue. Your deployment was successful! 🎉                                                                                                                                                     
   


## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-25288]: https://redhat.atlassian.net/browse/RHINENG-25288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Ensure inventory RBAC class fixtures supply hbi_groups to the shared non-org-admin user setup fixture so workspace-based access tests receive the correct group context.