### PR TITLE
test(RHINENG-25474): Update more tests to pass with RBAC v2

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/rbac_fixtures.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/rbac_fixtures.py
@@ -5,9 +5,7 @@ from collections.abc import Generator
 from typing import NamedTuple
 
 import pytest
-from iqe.base.application import Application
-from iqe.base.application.implementations.rest import ViaREST
-from iqe_rbac.entities.group import Group
+from _pytest.fixtures import FixtureRequest
 
 from iqe_host_inventory import ApplicationHostInventory
 from iqe_host_inventory.modeling.groups_api import GROUP_OR_ID
@@ -18,7 +16,6 @@ from iqe_host_inventory.utils.datagen_utils import generate_display_name
 from iqe_host_inventory.utils.rbac_utils import RBACInventoryPermission
 from iqe_host_inventory.utils.rbac_utils import RBACRoles
 from iqe_host_inventory.utils.rbac_utils import get_role_id
-from iqe_host_inventory.utils.rbac_utils import update_group_with_roles
 from iqe_host_inventory.utils.rbac_utils import wait_for_kessel_sync
 from iqe_host_inventory_api import GroupOutWithHostCount
 from iqe_host_inventory_api import HostOut
@@ -599,55 +596,28 @@ def rbac_setup_granular_hosts_permissions_for_sa(
     host_inventory.apis.rbac.delete_role(get_role_id(role))
 
 
-@pytest.fixture
-def rbac_setup_group_with_member(
-    application: Application, hbi_non_org_admin_user_username: str
-) -> Generator[tuple[Group, Application]]:
-    with application.context.use(ViaREST):
-        group = application.rbac.collections.groups.create(
-            name=generate_display_name(),
-            members=[
-                application.rbac.collections.users.instantiate(hbi_non_org_admin_user_username)
-            ],
+@pytest.fixture(params=[RBACRoles.RHEL_ADMIN, RBACRoles.RHEL_OPERATOR, RBACRoles.RHEL_VIEWER])
+def rbac_setup_user_with_rhel_role(
+    hbi_non_org_admin_user_username: str,
+    host_inventory: ApplicationHostInventory,
+    request: FixtureRequest,
+) -> Generator[str]:
+    host_inventory.apis.rbac.reset_user_groups(hbi_non_org_admin_user_username)
+
+    group = host_inventory.apis.rbac.create_group(request.param)
+    host_inventory.apis.rbac.add_user_to_a_group(hbi_non_org_admin_user_username, group.uuid)
+
+    role = host_inventory.apis.rbac.get_role_by_name(request.param.value)
+    if host_inventory.unleash.is_rbac_workspaces_enabled:
+        workspace_id = host_inventory.apis.workspaces.root_workspace.id
+        host_inventory.apis.rbac.create_role_bindings(
+            [get_role_id(role)], group.uuid, [workspace_id]
         )
-
-    yield group, application
-
-    with application.context.use(ViaREST):
-        group.delete_if_exists()
-
-
-@pytest.fixture
-def rbac_setup_user_with_rhel_admin_role(
-    rbac_setup_group_with_member, host_inventory: ApplicationHostInventory
-) -> str:
-    group, app = rbac_setup_group_with_member
-    update_group_with_roles(app, group, [RBACRoles.RHEL_ADMIN])
+    else:
+        host_inventory.apis.rbac.add_roles_to_a_group([role], group.uuid)
 
     wait_for_kessel_sync(host_inventory)
 
-    return RBACRoles.RHEL_ADMIN
+    yield request.param.value
 
-
-@pytest.fixture
-def rbac_setup_user_with_rhel_operator_role(
-    rbac_setup_group_with_member, host_inventory: ApplicationHostInventory
-) -> str:
-    group, app = rbac_setup_group_with_member
-    update_group_with_roles(app, group, [RBACRoles.RHEL_OPERATOR])
-
-    wait_for_kessel_sync(host_inventory)
-
-    return RBACRoles.RHEL_OPERATOR
-
-
-@pytest.fixture
-def rbac_setup_user_with_rhel_viewer_role(
-    rbac_setup_group_with_member, host_inventory: ApplicationHostInventory
-) -> str:
-    group, app = rbac_setup_group_with_member
-    update_group_with_roles(app, group, [RBACRoles.RHEL_VIEWER])
-
-    wait_for_kessel_sync(host_inventory)
-
-    return RBACRoles.RHEL_VIEWER
+    host_inventory.apis.rbac.delete_group(group.uuid)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/hosts_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/hosts_api.py
@@ -891,7 +891,7 @@ class HostsAPIWrapper(BaseEntity):
         hosts: HOST_OR_HOSTS,
         *,
         delay: float = 0.5,
-        retries: int = 40,
+        retries: int = 60,
         error: Exception | None = HOST_NOT_CREATED_ERROR,
     ) -> list[HostOut]:
         """Wait until the hosts are successfully created and retrievable by API
@@ -1076,7 +1076,7 @@ class HostsAPIWrapper(BaseEntity):
         insights_ids: list[str],
         *,
         delay: float = 0.5,
-        retries: int = 40,
+        retries: int = 60,
     ) -> list[HostIdOut]:
         host_ids = []
 

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
@@ -35,6 +35,7 @@ from iqe_host_inventory.schemas import RBACRestClient
 from iqe_host_inventory.schemas import RBACRestClientV2
 from iqe_host_inventory.utils.datagen_utils import generate_uuid
 from iqe_host_inventory.utils.rbac_utils import RBACInventoryPermission
+from iqe_host_inventory.utils.rbac_utils import RBACRoles
 from iqe_host_inventory.utils.rbac_utils import permission_to_v2
 from iqe_host_inventory.utils.rbac_utils import wait_for_kessel_sync
 
@@ -74,11 +75,11 @@ class RBACAPIWrapper(BaseEntity):
     def raw_api_v2(self) -> RBACRestClientV2:
         if not self._host_inventory.unleash.is_rbac_workspaces_enabled:
             raise RuntimeError("RBAC v2 can be used only on v2 enabled accounts")
-        return self._rbac.rest_client_v2
+        return self._rbac.rbac_v2_api
 
     def create_group(
         self,
-        permission: RBACInventoryPermission,
+        permission: RBACInventoryPermission | RBACRoles,
         *,
         hbi_groups: Sequence[GROUP_OR_ID | None] | None = None,
         name: str | None = None,
@@ -318,8 +319,11 @@ class RBACAPIWrapper(BaseEntity):
 
         return group, roles
 
+    def get_role_by_name(self, name: str) -> RoleWithAccess:
+        return self.raw_api.role_api.list_roles(name=name).data[0]
+
     def get_rbac_admin_role(self) -> RoleWithAccess:
-        return self.raw_api.role_api.list_roles(name="User Access Administrator").data[0]
+        return self.get_role_by_name("User Access Administrator")
 
     def get_group_by_name(self, name: str) -> RBACGroupOut:
         response = self.raw_api.group_api.list_groups(name=name)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/workspaces_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/workspaces_api.py
@@ -114,7 +114,7 @@ class WorkspacesAPIWrapper(BaseEntity):
         Use high level API wrapper methods instead of this raw API client.
         Outside this class, this should be used only for negative validation testing.
         """
-        return self._rbac.rest_client_v2.workspaces_api
+        return self._rbac.rbac_v2_api.workspaces_api
 
     def create_workspace(
         self,

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/kessel/test_kessel_rbac_granular.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/kessel/test_kessel_rbac_granular.py
@@ -281,11 +281,7 @@ def test_rbac_granular_groups_read_permission_ungrouped_group(
     )
 
     # Test
-    with raises_apierror(
-        403,
-        "You don't have the permission to access the requested resource. "
-        "It is either read-protected or not readable by the server.",
-    ):
+    with raises_apierror(FORBIDDEN_OR_NOT_FOUND):
         host_inventory_non_org_admin.apis.groups.get_groups_by_id_response(groups)
 
 
@@ -353,11 +349,7 @@ def test_rbac_granular_groups_read_permission_ungrouped_and_normal_group(
     assert response.results[0].id == groups[0].id
 
     for group in groups[1:]:
-        with raises_apierror(
-            403,
-            "You don't have the permission to access the requested resource. "
-            "It is either read-protected or not readable by the server.",
-        ):
+        with raises_apierror(FORBIDDEN_OR_NOT_FOUND):
             host_inventory_non_org_admin.apis.groups.get_groups_by_id_response(group)
 
 
@@ -379,7 +371,8 @@ def test_rbac_granular_groups_write_permission_ungrouped_and_normal_group(
     groups = rbac_setup_resources_for_granular_rbac[1]
     ungrouped_group = host_inventory.apis.groups.get_groups(group_type="ungrouped-hosts")[0]
     hbi_non_org_admin_user_rbac_setup(
-        permissions=[RBACInventoryPermission.GROUPS_WRITE], hbi_groups=[groups[0], ungrouped_group]
+        permissions=[RBACInventoryPermission.GROUPS_READ, RBACInventoryPermission.GROUPS_WRITE],
+        hbi_groups=[groups[0], ungrouped_group],
     )
 
     # Test

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
@@ -146,11 +146,7 @@ class TestRBACGranularGroupsReadPermission:
         """
         all_groups = rbac_setup_resources_for_granular_rbac[1]
 
-        with raises_apierror(
-            403,
-            "You don't have the permission to access the requested resource. "
-            "It is either read-protected or not readable by the server.",
-        ):
+        with raises_apierror(FORBIDDEN_OR_NOT_FOUND):
             host_inventory_non_org_admin.apis.groups.get_groups_by_id_response(all_groups)
 
 
@@ -791,7 +787,8 @@ def test_rbac_granular_groups_write_permission_single_group(
     # Setup
     groups = rbac_setup_resources_for_granular_rbac[1]
     hbi_non_org_admin_user_rbac_setup(
-        permissions=[RBACInventoryPermission.GROUPS_WRITE], hbi_groups=[groups[0]]
+        permissions=[RBACInventoryPermission.GROUPS_READ, RBACInventoryPermission.GROUPS_WRITE],
+        hbi_groups=[groups[0]],
     )
 
     # Test
@@ -831,11 +828,7 @@ def test_rbac_granular_groups_read_permission_null_group(
     )
 
     # Test
-    with raises_apierror(
-        403,
-        "You don't have the permission to access the requested resource. "
-        "It is either read-protected or not readable by the server.",
-    ):
+    with raises_apierror(FORBIDDEN_OR_NOT_FOUND):
         host_inventory_non_org_admin.apis.groups.get_groups_by_id_response(groups)
 
 
@@ -911,11 +904,7 @@ def test_rbac_granular_groups_read_permission_null_and_normal_group(
     assert response.results[0].id == groups[0].id
 
     for group in groups[1:]:
-        with raises_apierror(
-            403,
-            "You don't have the permission to access the requested resource. "
-            "It is either read-protected or not readable by the server.",
-        ):
+        with raises_apierror(FORBIDDEN_OR_NOT_FOUND):
             host_inventory_non_org_admin.apis.groups.get_groups_by_id_response(group)
 
 
@@ -941,7 +930,8 @@ def test_rbac_granular_groups_write_permission_null_and_normal_group(
     hbi_groups = [groups[0], ungrouped_groups[0]["id"] if len(ungrouped_groups) > 0 else None]  # type: ignore[index]
 
     hbi_non_org_admin_user_rbac_setup(
-        permissions=[RBACInventoryPermission.GROUPS_WRITE], hbi_groups=hbi_groups
+        permissions=[RBACInventoryPermission.GROUPS_READ, RBACInventoryPermission.GROUPS_WRITE],
+        hbi_groups=hbi_groups,
     )
 
     # Test
@@ -1333,11 +1323,7 @@ class TestRBACGranularResourceDefinitionsInMultipleRoles:
         """
         all_groups = rbac_setup_resources_for_granular_rbac[1]
 
-        with raises_apierror(
-            403,
-            "You don't have the permission to access the requested resource. "
-            "It is either read-protected or not readable by the server.",
-        ):
+        with raises_apierror(FORBIDDEN_OR_NOT_FOUND):
             host_inventory_non_org_admin.apis.groups.get_groups_by_id_response(all_groups)
 
     def test_rbac_granular_groups_multiple_roles_patch_group(

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/service_accounts/test_rbac_sa_groups_write_permission.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/service_accounts/test_rbac_sa_groups_write_permission.py
@@ -191,11 +191,7 @@ class TestRBACSAGroupsNoWritePermission:
           title: Test that service accounts without "groups:write" permission can't create a group
         """
         group_name = generate_display_name()
-        with raises_apierror(
-            403,
-            "You don't have the permission to access the requested resource. "
-            "It is either read-protected or not readable by the server.",
-        ):
+        with raises_apierror(403):
             host_inventory_sa_2.apis.groups.create_group(group_name, wait_for_created=False)
 
         host_inventory.apis.groups.verify_not_created(group_name=group_name)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/test_rbac_rhel_roles.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/test_rbac_rhel_roles.py
@@ -16,6 +16,14 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True, scope="module")
+def _skip_if_rbac_workspaces(host_inventory: ApplicationHostInventory):
+    """The RHEL roles are not supported with RBAC v2.
+    https://redhat-internal.slack.com/archives/C0233N2MBU6/p1776248880616269"""
+    if host_inventory.unleash.is_rbac_workspaces_enabled:
+        pytest.skip("The RHEL roles are not supported with RBAC v2")
+
+
 def test_rbac_inventory_with_rhel_roles(
     host_inventory: ApplicationHostInventory,
     host_inventory_non_org_admin: ApplicationHostInventory,
@@ -25,7 +33,7 @@ def test_rbac_inventory_with_rhel_roles(
 ):
     """
     Test that user with RHEL roles has required inventory permissions.
-    RHEL admin and RHEL operator roles have inventory read and wrrite permissions.
+    RHEL admin and RHEL operator roles have inventory read and write permissions.
     RHEL viewer has only inventory read permissions.
 
     https://issues.redhat.com/browse/RHINENG-16109

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/test_rbac_rhel_roles.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/test_rbac_rhel_roles.py
@@ -1,7 +1,6 @@
 import logging
 
 import pytest
-from pytest_lazy_fixtures import lf
 
 from iqe_host_inventory import ApplicationHostInventory
 from iqe_host_inventory.utils.datagen_utils import generate_display_name
@@ -17,22 +16,12 @@ pytestmark = [
 ]
 
 
-@pytest.mark.parametrize(
-    "role",
-    [
-        lf("rbac_setup_user_with_rhel_admin_role"),
-        lf("rbac_setup_user_with_rhel_viewer_role"),
-        lf("rbac_setup_user_with_rhel_operator_role"),
-    ],
-    scope="function",
-)
 def test_rbac_inventory_with_rhel_roles(
     host_inventory: ApplicationHostInventory,
-    hbi_non_org_admin_user_org_id: str,
     host_inventory_non_org_admin: ApplicationHostInventory,
     rbac_setup_resources,
     hbi_staleness_defaults: dict[str, int],
-    role: str,
+    rbac_setup_user_with_rhel_role: str,
 ):
     """
     Test that user with RHEL roles has required inventory permissions.
@@ -48,10 +37,11 @@ def test_rbac_inventory_with_rhel_roles(
         assignee: zabikeno
         title: Test that user with RHEL roles has required inventory permissions
     """
+    role = rbac_setup_user_with_rhel_role
     role_with_write_permissions = role in ["RHEL operator", "RHEL admin"]
 
     # Hosts
-    # check RHEL viewer's inventory read permission
+    # check RHEL viewer's inventory read access
     hosts = rbac_setup_resources[0]
     expected_hosts_ids = {host.id for host in hosts}
 
@@ -61,7 +51,7 @@ def test_rbac_inventory_with_rhel_roles(
     assert len(response.results) >= 2
     assert expected_hosts_ids.issubset(response_hosts_ids)
 
-    # check at least one hosts CRUD function to make sure user got RHEL admin/operator role
+    # check at least one hosts edit operation to make sure user has write access
     if role_with_write_permissions:
         new_display_name = generate_display_name()
         host_inventory_non_org_admin.apis.hosts.patch_hosts(
@@ -69,27 +59,27 @@ def test_rbac_inventory_with_rhel_roles(
         )
 
     # Groups
-    # check RHEL viewer's inventory read permission
+    # check RHEL viewer's inventory read access
     groups = rbac_setup_resources[1]
     expected_groups_ids = {group.id for group in groups}
 
     response = host_inventory_non_org_admin.apis.groups.get_groups()
-    expected_groups_ids = {group.id for group in response}
+    response_groups_ids = {group.id for group in response}
 
     assert len(response) >= 2
-    assert expected_groups_ids.issubset(expected_groups_ids)
+    assert expected_groups_ids.issubset(response_groups_ids)
 
-    # check at least one groups CRUD function to make sure user got RHEL admin/operator role
+    # check at least one groups edit operation to make sure user has write access
     if role_with_write_permissions:
         new_group_name = generate_display_name()
         host_inventory_non_org_admin.apis.groups.patch_group(groups[0], name=new_group_name)
 
     # Staleness
-    # check RHEL viewer's inventory read permission
+    # check RHEL viewer's inventory read access
     response = host_inventory_non_org_admin.apis.account_staleness.get_staleness_response()
     validate_staleness_response(response.to_dict(), hbi_staleness_defaults)
 
-    # check at least one staleness CRUD function to make sure user got RHEL admin/operator role
+    # check at least one staleness edit operation to make sure user has write access
     if role_with_write_permissions:
         settings = dict(zip(get_staleness_fields(), [1, 2, 3], strict=False))
         original = host_inventory.apis.account_staleness.create_staleness(**settings).to_dict()

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_legacy_paths.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_legacy_paths.py
@@ -333,8 +333,10 @@ def test_legacy_paths(
     if "cert" not in legacy_hostname:  # These endpoints are forbidden with cert auth (HTTP 403)
         host_inventory.apis.groups.create_n_empty_groups(1)
         check_legacy_get_groups(session, base_url)
-        check_legacy_get_resource_types(session, base_url)
         check_legacy_get_staleness_defaults(session, base_url)
+        if not host_inventory.unleash.is_rbac_workspaces_enabled:
+            # Resource-types endpoints are not supported with rbac v2
+            check_legacy_get_resource_types(session, base_url)
 
 
 @pytest.mark.ephemeral
@@ -384,8 +386,10 @@ def test_legacy_paths_ephemeral(
     if not sys_conf:  # These endpoints are forbidden with cert auth (HTTP 403)
         test_host_inventory.apis.groups.create_n_empty_groups(1)
         check_legacy_get_groups(session, base_url)
-        check_legacy_get_resource_types(session, base_url)
         check_legacy_get_staleness_defaults(session, base_url)
+        if not test_host_inventory.unleash.is_rbac_workspaces_enabled:
+            # Resource-types endpoints are not supported with rbac v2
+            check_legacy_get_resource_types(session, base_url)
 
     check_legacy_patch_facts(test_host_inventory, session, base_url, host)
     check_legacy_put_facts(test_host_inventory, session, base_url, host)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
@@ -4,9 +4,6 @@ import logging
 from enum import Enum
 from time import sleep
 
-from iqe.base.application import Application
-from iqe.base.application.implementations.rest import ViaREST
-from iqe_rbac.entities.group import Group
 from iqe_rbac_api import RoleWithAccess
 from iqe_rbac_v2_api import Permission as RBACV2Permission
 from iqe_rbac_v2_api import Role as RBACV2Role
@@ -32,7 +29,7 @@ class RBACInventoryPermission(Enum):
     STALENESS_ALL = "staleness:staleness:*"
 
 
-class RBACRoles:
+class RBACRoles(Enum):
     HOSTS_VIEWER = "Inventory Hosts viewer"
     HOSTS_ADMIN = "Inventory Hosts administrator"
     GROUPS_VIEWER = "Inventory Groups viewer"
@@ -54,14 +51,6 @@ def permission_to_v2(permission: RBACInventoryPermission) -> RBACV2Permission:
     """Convert an RBACInventoryPermission enum to a V2 Permission model."""
     app, resource_type, operation = permission.value.split(":")
     return RBACV2Permission(application=app, resource_type=resource_type, operation=operation)
-
-
-def update_group_with_roles(app: Application, group: Group, roles: list[str]) -> None:
-    """Help function to update RBAC group with roles (which assign permissions)"""
-    with app.context.use(ViaREST):
-        group.update(
-            roles=[app.rbac.collections.roles.instantiate(role) for role in roles],
-        )
 
 
 def wait_for_kessel_sync(host_inventory: ApplicationHostInventory) -> None:


### PR DESCRIPTION
## Jira
[RHINENG-25474](https://issues.redhat.com/browse/RHINENG-25474)

## What
Update tests to make them work with RBAC v2

## Why
They don't work now

## How
- Make them less strict on checking API response statuses: 403 vs 404
- Refactor test for predefined RHEL roles
- Change the name of the RBAC's API module from `rest_client_v2` to `rbac_v2_api` (they changed the name without our knowledge recently)
- Increase the number of maximum retries while waitin for new hosts to be available

## Testing
I tested this with RBAC v2 enabled account on Stage

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-25474]: https://redhat.atlassian.net/browse/RHINENG-25474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Adjust RBAC- and legacy-related host inventory tests and utilities to be compatible with RBAC v2 behavior and APIs.

Enhancements:
- Introduce RBAC role lookup and RBAC v2 API access helpers and switch RBAC utilities to use the renamed v2 client and workspace APIs.
- Convert RBACRoles to an Enum and extend RBAC group creation to accept either inventory permissions or predefined RBAC roles.

Tests:
- Refactor RHEL role setup fixtures into a single parametrized fixture that works with both legacy RBAC and RBAC v2, including workspace-aware role bindings.
- Relax RBAC granular group tests to accept both 403 and 404 responses and ensure required read permissions are included where needed.
- Skip legacy resource-types endpoint checks when RBAC v2/workspaces are enabled and simplify certain negative-permission assertions to only validate status codes.
- Increase host creation/existence wait retries in tests to reduce flakiness under RBAC v2-related delays.