### PR TITLE
fix(RHINENG-25872): Immediately delete groups after associated workspaces

### DIFF
--- a/api/group.py
+++ b/api/group.py
@@ -474,15 +474,19 @@ def delete_groups(group_id_list, rbac_filter=None):
             if ungrouped_group_id == group_id:
                 abort(HTTPStatus.BAD_REQUEST, f"Ungrouped workspace {group_id} can not be deleted.")
 
+        groups_to_delete = []
+
         # Attempt to delete the RBAC workspaces
         for group_id in group_id_list:
             try:
                 delete_rbac_workspace(group_id)
-                delete_count += 1
+                groups_to_delete.append(group_id)
             except ResourceNotFoundException:
                 continue
     else:
-        delete_count = delete_group_list(group_id_list, identity, current_app.event_producer)
+        groups_to_delete = group_id_list
+
+    delete_count = delete_group_list(groups_to_delete, identity, current_app.event_producer)
 
     if delete_count == 0:
         log_get_group_list_failed(logger)

--- a/api/group.py
+++ b/api/group.py
@@ -463,8 +463,6 @@ def delete_groups(group_id_list, rbac_filter=None):
     found_groups = get_groups_by_id_list_from_db(group_id_list, identity.org_id)
     check_all_ids_found(group_id_list, found_groups, "group")
 
-    delete_count = 0
-
     if not inventory_config().bypass_kessel:
         # Write is not allowed for the ungrouped through API requests
         ungrouped_group = get_ungrouped_group(identity)

--- a/tests/test_api_groups_delete.py
+++ b/tests/test_api_groups_delete.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.auth.identity import Identity
 from app.auth.identity import to_auth_header
+from app.exceptions import ResourceNotFoundException
 from tests.helpers.api_utils import GROUP_WRITE_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import create_mock_rbac_response
@@ -502,12 +503,11 @@ def test_delete_group_not_deleted_from_hbi_when_rbac_returns_404(
     RBAC v2 returns 404 both when a workspace doesn't exist and when the user lacks
     permission to delete it. Deleting from HBI on 404 would bypass permission checks.
     """
-    from app.exceptions import ResourceNotFoundException
-
     group_id = db_create_group("test group").id
 
     # Enable RBAC v2 for groups so the @rbac decorator skips v1 permission checks
     mocker.patch("lib.middleware.is_rbac_v2_groups_enabled", return_value=True)
+    mocker.patch("api.group.is_rbac_v2_groups_enabled", return_value=True)
 
     # Mock delete_rbac_workspace to raise ResourceNotFoundException (RBAC returns 404)
     mocker.patch(
@@ -524,6 +524,33 @@ def test_delete_group_not_deleted_from_hbi_when_rbac_returns_404(
     assert db_get_group_by_id(group_id) is not None
 
 
+@pytest.mark.usefixtures("event_producer", "enable_kessel")
+def test_delete_groups_kessel_partial_when_rbac_workspace_missing(
+    api_delete_groups_kessel, db_create_group, db_get_group_by_id, mocker
+):
+    """
+    Groups whose workspace delete failed are skipped; others are still removed from HBI.
+    """
+    db_create_group("ungrouped_hosts", ungrouped=True)
+
+    group_kept = db_create_group("kept")
+    group_removed = db_create_group("removed")
+    kept_id = str(group_kept.id)
+    removed_id = str(group_removed.id)
+
+    def delete_workspace(workspace_id):
+        if workspace_id == kept_id:
+            raise ResourceNotFoundException("Workspace not found")
+
+    mocker.patch("api.group.delete_rbac_workspace", side_effect=delete_workspace)
+
+    response_status, _ = api_delete_groups_kessel([kept_id, removed_id])
+    assert_response_status(response_status, expected_status=204)
+
+    assert db_get_group_by_id(kept_id) is not None
+    assert db_get_group_by_id(removed_id) is None
+
+
 @pytest.mark.usefixtures("event_producer")
 @pytest.mark.usefixtures("enable_kessel")
 @pytest.mark.usefixtures("enable_rbac")
@@ -534,6 +561,7 @@ def test_delete_existing_group_kessel_empty_response(api_delete_groups_kessel, d
     Before the fix, an empty response body would cause a JSONDecodeError, resulting in HTTP 503.
     After the fix, the API should handle this gracefully and return HTTP 204.
     """
+    db_create_group("ungrouped_hosts", ungrouped=True)
     group_id = db_create_group("test group").id
 
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")


### PR DESCRIPTION
## Jira
[RHINENG-25872](https://redhat.atlassian.net/browse/RHINENG-25872)

## What
In the `DELETE /groups` flow, after deleting the workspaces via RBAC API, immediately delete the associated groups for the workspaces that were successfully deleted.

## Why
To avoid getting a 403 from Kessel in the period of time between a workspace getting deleted and its group getting deleted (and that group's hosts getting reassigned to the ungrouped-hosts group).

## How
Created a list to track the IDs of successfully-deleted workspaces, and then deleted them all at once.

## Testing
Added `test_delete_groups_kessel_partial_when_rbac_workspace_missing`.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-25872]: https://redhat.atlassian.net/browse/RHINENG-25872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure group deletions only proceed in HBI for workspaces successfully removed via RBAC and validate this behavior with targeted tests.

Bug Fixes:
- Prevent deletion of groups in HBI when their corresponding RBAC workspace deletion fails, skipping only the affected groups while deleting the rest.

Tests:
- Add tests to cover partial Kessel group deletion when some RBAC workspaces are missing and to ensure ungrouped host groups are present in relevant Kessel delete scenarios.