### PR TITLE
test(RHINENG-25474): Update tests to make them more stable when Kessel is enabled

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/upload_fixtures.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/upload_fixtures.py
@@ -86,9 +86,14 @@ def hbi_secondary_upload_prepare_host_module(
 
 @pytest.fixture()
 def hbi_cert_auth_upload_prepare_host(
+    host_inventory: ApplicationHostInventory,
     host_inventory_cert_auth: ApplicationHostInventory,
 ) -> Generator[HostOut]:
     host = host_inventory_cert_auth.upload.create_host(register_for_cleanup=False)
+    # Cert auth doesn't go through Kessel, so we need to do additional waiting with other auth
+    # to make sure the host got synced and is available
+    host_inventory.apis.hosts.wait_for_created(host)
+
     yield host
 
     # Explicit cleanup needed if this fixture is used by other plugins
@@ -97,9 +102,14 @@ def hbi_cert_auth_upload_prepare_host(
 
 @pytest.fixture(scope="class")
 def hbi_cert_auth_upload_prepare_host_class(
+    host_inventory: ApplicationHostInventory,
     host_inventory_cert_auth: ApplicationHostInventory,
 ) -> Generator[HostOut]:
     host = host_inventory_cert_auth.upload.create_host(register_for_cleanup=False)
+    # Cert auth doesn't go through Kessel, so we need to do additional waiting with other auth
+    # to make sure the host got synced and is available
+    host_inventory.apis.hosts.wait_for_created(host)
+
     yield host
 
     # Explicit cleanup needed if this fixture is used by other plugins
@@ -108,9 +118,14 @@ def hbi_cert_auth_upload_prepare_host_class(
 
 @pytest.fixture(scope="module")
 def hbi_cert_auth_upload_prepare_host_module(
+    host_inventory: ApplicationHostInventory,
     host_inventory_cert_auth: ApplicationHostInventory,
 ) -> Generator[HostOut]:
     host = host_inventory_cert_auth.upload.create_host(register_for_cleanup=False)
+    # Cert auth doesn't go through Kessel, so we need to do additional waiting with other auth
+    # to make sure the host got synced and is available
+    host_inventory.apis.hosts.wait_for_created(host)
+
     yield host
 
     # Explicit cleanup needed if this fixture is used by other plugins

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/cache/test_cache_insights_client.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/cache/test_cache_insights_client.py
@@ -123,6 +123,10 @@ def test_cache_invalidation_insights_client_get_hosts_list_delete_host_by_id(
     # Prepare the second host
     host_to_delete = host_inventory_cert_auth.upload.create_host(insights_id=generate_uuid())
 
+    # Cert auth doesn't go through Kessel, so we need to do additional waiting with other auth
+    # to make sure the host got synced and is available
+    host_inventory.apis.hosts.wait_for_created(host_to_delete)
+
     # Init the cache
     response = host_inventory_cert_auth.apis.hosts.get_hosts(
         insights_id=host_to_delete.insights_id
@@ -157,6 +161,10 @@ def test_cache_invalidation_insights_client_get_hosts_list_delete_filtered(
     # Prepare the second host
     host_to_delete = host_inventory_cert_auth.upload.create_host(insights_id=generate_uuid())
 
+    # Cert auth doesn't go through Kessel, so we need to do additional waiting with other auth
+    # to make sure the host got synced and is available
+    host_inventory.apis.hosts.wait_for_created(host_to_delete)
+
     # Init the cache
     response = host_inventory_cert_auth.apis.hosts.get_hosts(
         insights_id=host_to_delete.insights_id
@@ -166,7 +174,6 @@ def test_cache_invalidation_insights_client_get_hosts_list_delete_filtered(
 
     # Delete the second host to invalidate the cache
     host_inventory.apis.hosts.delete_filtered(insights_id=host_to_delete.insights_id)
-    host_inventory.apis.hosts.wait_for_deleted(host_to_delete)
 
     # Check that the cache has been invalidated
     response = host_inventory_cert_auth.apis.hosts.get_hosts(
@@ -538,6 +545,10 @@ def test_cache_invalidation_insights_client_get_host_exists(
 
     # Create a new host to invalidate the cache
     new_host = host_inventory_cert_auth.upload.create_host(insights_id=insights_id)
+
+    # Cert auth doesn't go through Kessel, so we need to do additional waiting with other auth
+    # to make sure the host got synced and is available
+    host_inventory.apis.hosts.wait_for_created(new_host)
 
     # Check that the cache has been invalidated
     response = host_inventory_cert_auth.apis.hosts.get_host_exists(insights_id)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/notifications/e2e/test_notifications_e2e_registered.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/notifications/e2e/test_notifications_e2e_registered.py
@@ -102,7 +102,7 @@ def test_notifications_e2e_registered(
     """
     tags = generate_tags()
     host = host_inventory_test_app.upload.create_host(tags=tags)
-    sp = host_inventory.apis.hosts.get_hosts_system_profile(host)[0].system_profile
+    sp = host_inventory_test_app.apis.hosts.get_hosts_system_profile(host)[0].system_profile
 
     check_instant_email(
         host_inventory.application,


### PR DESCRIPTION
## Jira
[RHINENG-25474](https://issues.redhat.com/browse/RHINENG-25474)

## What
Update tests to make them more stable when Kessel is enabled

## Why
A few tests are flaky in Stage, sometimes failing, sometimes passing

## How
When we make a request with cert-auth, it doesn't go through Kessel (it uses `owner_id` check instead). So, when we create a new host via cert-auth and then wait for it being available, it is available immediatelly with cert auth. So, when we then make some API request with a different auth, we can sometimes get HTTP 403, because the host is not synced to Kessel yet. This PR makes the tests wait for the host to be available with basic auth as well, after it is created with cert auth,.

## Testing
I tested this against Stage

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-25474]: https://redhat.atlassian.net/browse/RHINENG-25474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Stabilize host inventory tests that rely on certificate-authenticated host creation by ensuring hosts are available via standard auth paths before assertions and cache/notification flows run.

Tests:
- Add synchronization waits after certificate-auth host creation so tests query hosts only after they are available through non-certificate auth, reducing flakiness with Kessel enabled.
- Adjust a notifications end-to-end test to fetch system profiles via the same test application client used to create the host.