### PR TITLE
test(RHINENG-25474): Stabilize more tests due to rbac v2

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/unleash.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/unleash.py
@@ -110,6 +110,21 @@ class HBIUnleash(BaseEntity):
 
         return feature_flag
 
+    @cached_property
+    def rbac_workspace_access_check_v2_flag(self) -> str:
+        feature_flag = "rbac.workspace-access-check-v2.enabled"
+
+        if isinstance(self._unleash, UnleashBackend) and not self._unleash.has_flag(feature_flag):
+            flag_request = UnleashFlagRequest(
+                name=feature_flag,
+                description="RBAC workspaces v2 access checks toggle",
+                type=_RequestType.RELEASE,
+                impressionData=False,
+            )
+            self._unleash.admin.create_flag(flag_request=flag_request)
+
+        return feature_flag
+
     def is_flag_enabled(self, flag: str) -> bool:
         return self._unleash.is_enabled(flag, context={"orgId": get_org_id(self.application)})
 

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/conftest.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/conftest.py
@@ -196,6 +196,9 @@ def enable_kessel_backend_flags(
         host_inventory.unleash.toggle_feature_flag(
             host_inventory.unleash.rbac_workspaces_flag, enable=True
         )
+        host_inventory.unleash.toggle_feature_flag(
+            host_inventory.unleash.rbac_workspace_access_check_v2_flag, enable=True
+        )
         _ensure_ungrouped_group_exists(host_inventory)
 
 

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/notifications/e2e/test_notifications_e2e_delete.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/notifications/e2e/test_notifications_e2e_delete.py
@@ -47,6 +47,7 @@ def setup_delete_notifications(host_inventory: ApplicationHostInventory) -> Gene
 
 @pytest.fixture()
 def prepare_host_for_delete_notification(
+    host_inventory: ApplicationHostInventory,
     host_inventory_cert_auth: ApplicationHostInventory,
 ) -> tuple[HostOut, list[TagDict], SystemProfile]:
     tags = generate_tags()
@@ -54,6 +55,10 @@ def prepare_host_for_delete_notification(
         tags=tags
     )  # Using cert auth so the host has owner_id
     sp = host_inventory_cert_auth.apis.hosts.get_hosts_system_profile(host)[0].system_profile
+
+    # Cert auth doesn't go through Kessel, so we need to do additional waiting with other auth
+    # to make sure the host got synced and is available
+    host_inventory.apis.hosts.wait_for_created(host)
     return host, tags, sp
 
 


### PR DESCRIPTION
## Jira
[RHINENG-25474](https://issues.redhat.com/browse/RHINENG-25474)

## What
Stabilize more tests that are unstable due to rbac v2

## Why
They are failing sometimes

## How
- Make sure that the host that was created with cert auth is synced to kessel before the test starts
- Add and enable another RBAC v2 feature flag (`rbac.workspace-access-check-v2.enabled`) in ephemeral environments. The absence of this is causing the groups endpoints to not work for non org-admin users in ephemeral: https://redhat-internal.slack.com/archives/C0233N2MBU6/p1776342238850709

## Testing
PR checks

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-25474]: https://redhat.atlassian.net/browse/RHINENG-25474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Stabilize RBAC v2-related tests by ensuring required feature flags are present and hosts created via cert auth are fully synced before assertions.

New Features:
- Introduce an Unleash feature flag helper for `rbac.workspace-access-check-v2.enabled` so it is auto-created when missing.

Enhancements:
- Enable the RBAC workspace access check v2 flag in test environments alongside existing RBAC workspace flags.
- Ensure delete-notification tests wait for cert-auth-created hosts to sync through Kessel before proceeding.