### PR TITLE
perf(RHINENG-25888): disable expire_on_commit during MQ batch processing

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -80,6 +80,7 @@ from app.staleness_serialization import AttrDict
 from lib import group_repository
 from lib import host_app_repository
 from lib import host_repository
+from lib.db import no_expire_on_commit
 from lib.db import raw_db_connection
 from lib.db import session_guard
 from lib.feature_flags import FLAG_INVENTORY_REJECT_RHSM_PAYLOADS
@@ -238,50 +239,56 @@ class HBIMessageConsumerBase:
             InvalidRequestError: When the database session is in an invalid state
             StaleDataError: When trying to update data modified by another transaction
         """
-        with session_guard(db.session, close=False), db.session.no_autoflush, StalenessCache(), UngroupedGroupCache():
-            messages = self.consumer.consume(
-                num_messages=inventory_config().mq_db_batch_max_messages,
-                timeout=inventory_config().mq_db_batch_max_seconds,
-            )
+        with no_expire_on_commit(db.session):
+            with (
+                session_guard(db.session, close=False),
+                db.session.no_autoflush,
+                StalenessCache(),
+                UngroupedGroupCache(),
+            ):
+                messages = self.consumer.consume(
+                    num_messages=inventory_config().mq_db_batch_max_messages,
+                    timeout=inventory_config().mq_db_batch_max_seconds,
+                )
 
-            for msg in messages:
-                if msg is None:
-                    continue
-                elif msg.error():
-                    # This error is raised by the first consumer.consume() on a newly started Kafka.
-                    # msg.error() produces:
-                    # KafkaError{code=UNKNOWN_TOPIC_OR_PART,val=3,str="Subscribed topic not available:
-                    #   platform.inventory.host-ingress: Broker: Unknown topic or partition"}
-                    logger.error(f"Message received but has an error, which is {str(msg.error())}")
-                    self.failure_metric.inc()
-                else:
-                    logger.debug("Message received")
-
-                    try:
-                        self.processed_rows.append(self.handle_message(msg.value(), headers=msg.headers()))
-                        metrics.consumed_message_size.observe(len(str(msg).encode("utf-8")))
-                        self.success_metric.inc()
-                    except OperationalError as oe:
-                        """sqlalchemy.exc.OperationalError: This error occurs when an
-                        authentication failure occurs or the DB is not accessible.
-                        Exit the process to restart the pod
-                        """
-                        logger.error(f"Could not access DB {str(oe)}")
-                        sys.exit(3)
-                    except Exception:
+                for msg in messages:
+                    if msg is None:
+                        continue
+                    elif msg.error():
+                        # This error is raised by the first consumer.consume() on a newly started Kafka.
+                        # msg.error() produces:
+                        # KafkaError{code=UNKNOWN_TOPIC_OR_PART,val=3,str="Subscribed topic not available:
+                        #   platform.inventory.host-ingress: Broker: Unknown topic or partition"}
+                        logger.error(f"Message received but has an error, which is {str(msg.error())}")
                         self.failure_metric.inc()
-                        logger.exception("Unable to process message", extra={"incoming_message": msg.value()})
+                    else:
+                        logger.debug("Message received")
 
-        self.post_process_rows()
-        # Commit Kafka offsets after successful batch processing
-        # This ensures offsets are persisted immediately after DB commit and event production,
-        # preventing duplicate message processing on service restart
-        if len(self.processed_rows) > 0:
-            try:
-                self.consumer.commit(asynchronous=False)
-                logger.debug(f"Successfully committed offsets for {len(self.processed_rows)} messages")
-            except Exception as e:
-                logger.exception(f"Failed to commit Kafka offsets: {e}")
+                        try:
+                            self.processed_rows.append(self.handle_message(msg.value(), headers=msg.headers()))
+                            metrics.consumed_message_size.observe(len(str(msg).encode("utf-8")))
+                            self.success_metric.inc()
+                        except OperationalError as oe:
+                            """sqlalchemy.exc.OperationalError: This error occurs when an
+                            authentication failure occurs or the DB is not accessible.
+                            Exit the process to restart the pod
+                            """
+                            logger.error(f"Could not access DB {str(oe)}")
+                            sys.exit(3)
+                        except Exception:
+                            self.failure_metric.inc()
+                            logger.exception("Unable to process message", extra={"incoming_message": msg.value()})
+
+            self.post_process_rows()
+            # Commit Kafka offsets after successful batch processing
+            # This ensures offsets are persisted immediately after DB commit and event production,
+            # preventing duplicate message processing on service restart
+            if len(self.processed_rows) > 0:
+                try:
+                    self.consumer.commit(asynchronous=False)
+                    logger.debug(f"Successfully committed offsets for {len(self.processed_rows)} messages")
+                except Exception as e:
+                    logger.exception(f"Failed to commit Kafka offsets: {e}")
 
     def event_loop(self, interrupt):
         with self.flask_app.app.app_context():

--- a/lib/db.py
+++ b/lib/db.py
@@ -27,6 +27,11 @@ def no_expire_on_commit(session):
     Used during MQ batch processing where post_process_rows() needs to
     serialize Host objects into event payloads after the session commits.
     Without this, each attribute access triggers a SELECT per host.
+
+    On exit, expire_all() is called to purge stale objects from the identity
+    map. Without this, objects committed while expire_on_commit was False
+    would persist across subsequent batches and could return stale data on
+    queries that hit the identity map instead of the DB.
     """
     actual_session = session() if callable(session) else session
     original = actual_session.expire_on_commit
@@ -35,6 +40,7 @@ def no_expire_on_commit(session):
         yield
     finally:
         actual_session.expire_on_commit = original
+        actual_session.expire_all()
 
 
 @contextmanager

--- a/lib/db.py
+++ b/lib/db.py
@@ -20,6 +20,24 @@ def session_guard(session, close=True):
 
 
 @contextmanager
+def no_expire_on_commit(session):
+    """Temporarily disable expire_on_commit so ORM objects retain their
+    loaded state after commit, avoiding lazy-reload queries.
+
+    Used during MQ batch processing where post_process_rows() needs to
+    serialize Host objects into event payloads after the session commits.
+    Without this, each attribute access triggers a SELECT per host.
+    """
+    actual_session = session() if callable(session) else session
+    original = actual_session.expire_on_commit
+    actual_session.expire_on_commit = False
+    try:
+        yield
+    finally:
+        actual_session.expire_on_commit = original
+
+
+@contextmanager
 def multi_session_guard(session_list):
     yield session_list
     for session in session_list:


### PR DESCRIPTION
## Jira
[RHINENG-25888](https://issues.redhat.com/browse/RHINENG-25888)

## What
Disable SQLAlchemy's `expire_on_commit` during MQ batch processing to eliminate redundant per-host SELECT queries that occur when serializing hosts into event payloads after the transaction commits.

## Why
After `session_guard` commits the batch transaction, SQLAlchemy expires all ORM objects in the session. When `post_process_rows()` then accesses Host attributes to serialize them into outbox events, each access triggers a lazy-load `SELECT hbi.hosts.* WHERE id = X` round-trip to Postgres. With a batch size of 50 messages, this adds 50 unnecessary SELECT queries per batch cycle.

## How
- Added a `no_expire_on_commit()` context manager in `lib/db.py` that temporarily sets `expire_on_commit=False` on the session and restores the original value on exit.
- Wrapped `_process_batch()` in `app/queue/host_mq.py` with `no_expire_on_commit(db.session)` so that both the session guard (flush/commit) and `post_process_rows()` (event serialization) run while expire is disabled.
- This is safe because `post_process_rows()` only reads attributes from already-committed Host objects to build event payloads — it does not depend on seeing concurrent writes from other transactions.

## Testing
- All 225 MQ service tests pass (`tests/test_host_mq_service.py`).

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-25888]: https://redhat.atlassian.net/browse/RHINENG-25888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Disable SQLAlchemy expire_on_commit during MQ batch processing to avoid redundant database reloads while preserving existing message handling and offset commit behavior.

Enhancements:
- Introduce a no_expire_on_commit context manager to temporarily disable SQLAlchemy session expire_on_commit and restore it afterward.
- Wrap host MQ batch processing, including post_process_rows and Kafka offset committing, in the no_expire_on_commit context to keep ORM instances warm during event serialization.