### PR TITLE
refactor: consolidate duplicate and redundant tests

### DIFF
--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -605,6 +605,32 @@ def create_mock_rbac_response(permissions_response_file):
         return resp_data["data"]
 
 
+def run_rbac_test(subtests, mocker, api_operation, rbac_response_files, expected_status, operation_args=None, operation_kwargs=None):
+    """
+    Generic RBAC test helper that tests an API operation with multiple RBAC permission files.
+
+    Args:
+        subtests: pytest subtests fixture
+        mocker: pytest-mock mocker fixture
+        api_operation: API fixture function to call (e.g., api_create_staleness, api_delete_staleness)
+        rbac_response_files: tuple of RBAC mock response file paths to test
+        expected_status: expected HTTP status code (e.g., 201, 403, 200)
+        operation_args: optional list of positional arguments to pass to api_operation
+        operation_kwargs: optional dict of keyword arguments to pass to api_operation
+    """
+    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
+    operation_args = operation_args or []
+    operation_kwargs = operation_kwargs or {}
+
+    for response_file in rbac_response_files:
+        mock_rbac_response = create_mock_rbac_response(response_file)
+
+        with subtests.test():
+            get_rbac_permissions_mock.return_value = mock_rbac_response
+            response_status, _ = api_operation(*operation_args, **operation_kwargs)
+            assert_response_status(response_status, expected_status)
+
+
 class RBACFilterOperation(StrEnum):
     EQUAL = "equal"
     IN = "in"

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -605,7 +605,9 @@ def create_mock_rbac_response(permissions_response_file):
         return resp_data["data"]
 
 
-def run_rbac_test(subtests, mocker, api_operation, rbac_response_files, expected_status, operation_args=None, operation_kwargs=None):
+def run_rbac_test(
+    subtests, mocker, api_operation, rbac_response_files, expected_status, operation_args=None, operation_kwargs=None
+):
     """
     Generic RBAC test helper that tests an API operation with multiple RBAC permission files.
 

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -541,57 +541,31 @@ def test_query_using_fqdn_as_hostname(mq_create_three_specific_hosts, api_get, s
     assert len(response_data["results"]) == 1
 
 
-def test_query_using_id(mq_create_three_specific_hosts, api_get, subtests):
+@pytest.mark.parametrize(
+    "param_name,value_getter",
+    [
+        ("hostname_or_id", lambda h: h[0].id),
+        ("insights_id", lambda h: h[0].insights_id.upper()),
+        ("subscription_manager_id", lambda h: h[0].subscription_manager_id),
+    ],
+)
+def test_query_using_single_field(mq_create_three_specific_hosts, api_get, subtests, param_name, value_getter):
     created_hosts = mq_create_three_specific_hosts
-    url = build_hosts_url(query=f"?hostname_or_id={created_hosts[0].id}")
-
+    url = build_hosts_url(query=f"?{param_name}={value_getter(created_hosts)}")
     response_status, response_data = api_get(url)
     api_pagination_test(api_get, subtests, url, expected_total=1)
-
     assert response_status == 200
     assert len(response_data["results"]) == 1
 
 
-def test_query_using_non_existent_hostname(api_get, subtests):
-    url = build_hosts_url(query="?hostname_or_id=NotGonnaFindMe")
-
+@pytest.mark.parametrize("value", ["NotGonnaFindMe", lambda: generate_uuid()])
+def test_query_using_non_existent_host(api_get, subtests, value):
+    query_value = value() if callable(value) else value
+    url = build_hosts_url(query=f"?hostname_or_id={query_value}")
     response_status, response_data = api_get(url)
     api_pagination_test(api_get, subtests, url, expected_total=0)
-
     assert response_status == 200
     assert len(response_data["results"]) == 0
-
-
-def test_query_using_non_existent_id(api_get, subtests):
-    url = build_hosts_url(query=f"?hostname_or_id={generate_uuid()}")
-
-    response_status, response_data = api_get(url)
-    api_pagination_test(api_get, subtests, url, expected_total=0)
-
-    assert response_status == 200
-    assert len(response_data["results"]) == 0
-
-
-def test_query_using_insights_id(mq_create_three_specific_hosts, api_get, subtests):
-    created_hosts = mq_create_three_specific_hosts
-    url = build_hosts_url(query=f"?insights_id={created_hosts[0].insights_id.upper()}")
-
-    response_status, response_data = api_get(url)
-    api_pagination_test(api_get, subtests, url, expected_total=1)
-
-    assert response_status == 200
-    assert len(response_data["results"]) == 1
-
-
-def test_query_using_subscription_manager_id(mq_create_three_specific_hosts, api_get, subtests):
-    created_hosts = mq_create_three_specific_hosts
-    url = build_hosts_url(query=f"?subscription_manager_id={created_hosts[0].subscription_manager_id}")
-
-    response_status, response_data = api_get(url)
-    api_pagination_test(api_get, subtests, url, expected_total=1)
-
-    assert response_status == 200
-    assert len(response_data["results"]) == 1
 
 
 def test_get_host_by_tag(mq_create_three_specific_hosts, api_get, subtests):

--- a/tests/test_api_staleness_create.py
+++ b/tests/test_api_staleness_create.py
@@ -7,7 +7,7 @@ from tests.helpers.api_utils import _INPUT_DATA
 from tests.helpers.api_utils import STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import assert_response_status
-from tests.helpers.api_utils import create_mock_rbac_response
+from tests.helpers.api_utils import run_rbac_test
 
 
 def test_create_staleness(api_create_staleness, db_get_staleness_culling):
@@ -55,32 +55,12 @@ def test_create_staleness_with_wrong_input(api_create_staleness):
 
 @pytest.mark.usefixtures("enable_rbac")
 def test_create_staleness_rbac_allowed(subtests, mocker, api_create_staleness):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-
-    for response_file in STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-
-        with subtests.test():
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-
-            response_status, _ = api_create_staleness(_INPUT_DATA)
-
-            assert_response_status(response_status, 201)
+    run_rbac_test(subtests, mocker, api_create_staleness, STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES, 201, [_INPUT_DATA])
 
 
 @pytest.mark.usefixtures("enable_rbac")
 def test_create_staleness_rbac_denied(subtests, mocker, api_create_staleness):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-
-    for response_file in STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-
-        with subtests.test():
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-
-            response_status, _ = api_create_staleness(_INPUT_DATA)
-
-            assert_response_status(response_status, 403)
+    run_rbac_test(subtests, mocker, api_create_staleness, STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES, 403, [_INPUT_DATA])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api_staleness_create.py
+++ b/tests/test_api_staleness_create.py
@@ -55,12 +55,16 @@ def test_create_staleness_with_wrong_input(api_create_staleness):
 
 @pytest.mark.usefixtures("enable_rbac")
 def test_create_staleness_rbac_allowed(subtests, mocker, api_create_staleness):
-    run_rbac_test(subtests, mocker, api_create_staleness, STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES, 201, [_INPUT_DATA])
+    run_rbac_test(
+        subtests, mocker, api_create_staleness, STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES, 201, [_INPUT_DATA]
+    )
 
 
 @pytest.mark.usefixtures("enable_rbac")
 def test_create_staleness_rbac_denied(subtests, mocker, api_create_staleness):
-    run_rbac_test(subtests, mocker, api_create_staleness, STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES, 403, [_INPUT_DATA])
+    run_rbac_test(
+        subtests, mocker, api_create_staleness, STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES, 403, [_INPUT_DATA]
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api_staleness_delete.py
+++ b/tests/test_api_staleness_delete.py
@@ -4,6 +4,7 @@ from tests.helpers.api_utils import STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import create_mock_rbac_response
+from tests.helpers.api_utils import run_rbac_test
 
 
 def test_delete_existing_staleness(db_create_staleness_culling, api_delete_staleness, db_get_staleness_culling):
@@ -29,34 +30,18 @@ def test_delete_non_existing_staleness(api_delete_staleness):
 @pytest.mark.usefixtures("enable_rbac")
 def test_delete_staleness_rbac_allowed(subtests, mocker, api_delete_staleness, db_create_staleness_culling):
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-
     for response_file in STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-
         with subtests.test():
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-
+            get_rbac_permissions_mock.return_value = create_mock_rbac_response(response_file)
             db_create_staleness_culling(
                 conventional_time_to_stale=1,
                 conventional_time_to_stale_warning=7,
                 conventional_time_to_delete=30,
             )
-
             response_status, _ = api_delete_staleness()
-
             assert_response_status(response_status, 204)
 
 
 @pytest.mark.usefixtures("enable_rbac")
 def test_delete_staleness_rbac_denied(subtests, mocker, api_delete_staleness):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-
-    for response_file in STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-
-        with subtests.test():
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-
-            response_status, _ = api_delete_staleness()
-
-            assert_response_status(response_status, 403)
+    run_rbac_test(subtests, mocker, api_delete_staleness, STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES, 403)

--- a/tests/test_api_staleness_get.py
+++ b/tests/test_api_staleness_get.py
@@ -7,28 +7,12 @@ from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_staleness_url
 from tests.helpers.api_utils import build_sys_default_staleness_url
 from tests.helpers.api_utils import create_mock_rbac_response
+from tests.helpers.api_utils import run_rbac_test
 
 
-def test_get_default_staleness(api_get):
-    url = build_staleness_url()
-    response_status, response_data = api_get(url)
-    assert_response_status(response_status, 200)
-    assert response_data["conventional_time_to_stale"] == _INPUT_DATA["conventional_time_to_stale"]
-    assert response_data["conventional_time_to_stale_warning"] == _INPUT_DATA["conventional_time_to_stale_warning"]
-    assert response_data["conventional_time_to_delete"] == _INPUT_DATA["conventional_time_to_delete"]
-
-
-def test_get_custom_staleness(api_get):
-    url = build_sys_default_staleness_url()
-    response_status, response_data = api_get(url)
-    assert response_data["conventional_time_to_stale"] == _INPUT_DATA["conventional_time_to_stale"]
-    assert response_data["conventional_time_to_stale_warning"] == _INPUT_DATA["conventional_time_to_stale_warning"]
-    assert response_data["conventional_time_to_delete"] == _INPUT_DATA["conventional_time_to_delete"]
-    assert_response_status(response_status, 200)
-
-
-def test_get_sys_default_staleness(api_get):
-    url = build_sys_default_staleness_url()
+@pytest.mark.parametrize("url_builder", [build_staleness_url, build_sys_default_staleness_url])
+def test_get_staleness(api_get, url_builder):
+    url = url_builder()
     response_status, response_data = api_get(url)
     assert_response_status(response_status, 200)
     assert response_data["conventional_time_to_stale"] == _INPUT_DATA["conventional_time_to_stale"]
@@ -40,31 +24,17 @@ def test_get_sys_default_staleness(api_get):
 def test_get_staleness_rbac_denied(subtests, mocker, api_get):
     get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
     url = build_sys_default_staleness_url()
-
     for response_file in STALENESS_READ_PROHIBITED_RBAC_RESPONSE_FILES:
         mock_rbac_response = create_mock_rbac_response(response_file)
         if mock_rbac_response and len(mock_rbac_response[0]["resourceDefinitions"]) > 0:
             mock_rbac_response[0]["resourceDefinitions"][0]["attributeFilter"]["value"] = [None]
-
         with subtests.test():
             get_rbac_permissions_mock.return_value = mock_rbac_response
-
             response_status, _ = api_get(url)
-
             assert_response_status(response_status, 403)
 
 
 @pytest.mark.usefixtures("enable_rbac")
 def test_get_staleness_rbac_allowed(subtests, mocker, api_get):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
     url = build_sys_default_staleness_url()
-
-    for response_file in STALENESS_READ_ALLOWED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-
-        with subtests.test():
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-
-            response_status, _ = api_get(url)
-
-            assert_response_status(response_status, 200)
+    run_rbac_test(subtests, mocker, api_get, STALENESS_READ_ALLOWED_RBAC_RESPONSE_FILES, 200, [url])

--- a/tests/test_api_staleness_update.py
+++ b/tests/test_api_staleness_update.py
@@ -5,6 +5,7 @@ from tests.helpers.api_utils import STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FIL
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_staleness_url
 from tests.helpers.api_utils import create_mock_rbac_response
+from tests.helpers.api_utils import run_rbac_test
 
 _INPUT_DATA = {"conventional_time_to_stale": 99}
 
@@ -32,33 +33,13 @@ def test_update_with_wrong_data(api_patch):
 
 @pytest.mark.usefixtures("enable_rbac")
 def test_update_staleness_rbac_allowed(subtests, mocker, api_patch, db_create_staleness_culling):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
     db_create_staleness_culling(conventional_time_to_stale=1)
-
-    for response_file in STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-
-        with subtests.test():
-            url = build_staleness_url()
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-
-            response_status, _ = api_patch(url, _INPUT_DATA)
-
-            assert_response_status(response_status, 200)
+    url = build_staleness_url()
+    run_rbac_test(subtests, mocker, api_patch, STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES, 200, [url, _INPUT_DATA])
 
 
 @pytest.mark.usefixtures("enable_rbac")
 def test_update_staleness_rbac_denied(subtests, mocker, api_patch, db_create_staleness_culling):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
     db_create_staleness_culling(conventional_time_to_stale=1)
-
-    for response_file in STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-
-        with subtests.test():
-            url = build_staleness_url()
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-
-            response_status, _ = api_patch(url, _INPUT_DATA)
-
-            assert_response_status(response_status, 403)
+    url = build_staleness_url()
+    run_rbac_test(subtests, mocker, api_patch, STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES, 403, [url, _INPUT_DATA])

--- a/tests/test_api_staleness_update.py
+++ b/tests/test_api_staleness_update.py
@@ -4,7 +4,6 @@ from tests.helpers.api_utils import STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_staleness_url
-from tests.helpers.api_utils import create_mock_rbac_response
 from tests.helpers.api_utils import run_rbac_test
 
 _INPUT_DATA = {"conventional_time_to_stale": 99}

--- a/tests/test_system_profile.py
+++ b/tests/test_system_profile.py
@@ -23,6 +23,7 @@ from tests.helpers.api_utils import build_system_profile_operating_system_url
 from tests.helpers.api_utils import build_system_profile_sap_sids_url
 from tests.helpers.api_utils import build_system_profile_sap_system_url
 from tests.helpers.api_utils import create_mock_rbac_response
+from tests.helpers.api_utils import run_rbac_test
 from tests.helpers.mq_utils import create_kafka_consumer_mock
 from tests.helpers.system_profile_utils import system_profile_specification
 from tests.helpers.test_utils import SYSTEM_IDENTITY
@@ -77,35 +78,10 @@ def test_system_profile_valid_date_format(mq_create_or_update_host, boot_time):
 
 
 @pytest.mark.usefixtures("enable_rbac")
-def test_get_system_profile_sap_system_with_RBAC_allowed(subtests, mocker, api_get):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-
-    url = build_system_profile_sap_system_url()
-
-    for response_file in HOST_READ_ALLOWED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-        with subtests.test():
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-
-            response_status, _ = api_get(url)
-
-            assert_response_status(response_status, 200)
-
-
-@pytest.mark.usefixtures("enable_rbac")
-def test_get_system_profile_sap_sids_with_RBAC_allowed(subtests, mocker, api_get):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-
-    url = build_system_profile_sap_sids_url()
-
-    for response_file in HOST_READ_ALLOWED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-        with subtests.test():
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-
-            response_status, _ = api_get(url)
-
-            assert_response_status(response_status, 200)
+@pytest.mark.parametrize("url_builder", [build_system_profile_sap_system_url, build_system_profile_sap_sids_url])
+def test_get_system_profile_endpoints_with_RBAC_allowed(subtests, mocker, api_get, url_builder):
+    url = url_builder()
+    run_rbac_test(subtests, mocker, api_get, HOST_READ_ALLOWED_RBAC_RESPONSE_FILES, 200, [url])
 
 
 @pytest.mark.usefixtures("enable_rbac")
@@ -145,18 +121,8 @@ def test_get_system_profile_sap_sids_with_RBAC_bypassed_as_system(api_get):
 
 @pytest.mark.usefixtures("enable_rbac")
 def test_get_system_profile_RBAC_allowed(mocker, subtests, db_create_host, api_get):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-
     host_id = str(db_create_host().id)
-
-    for response_file in HOST_READ_ALLOWED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-
-        with subtests.test():
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-            response_status, _ = api_get(f"{HOST_URL}/{host_id}/system_profile")
-
-            assert_response_status(response_status, 200)
+    run_rbac_test(subtests, mocker, api_get, HOST_READ_ALLOWED_RBAC_RESPONSE_FILES, 200, [f"{HOST_URL}/{host_id}/system_profile"])
 
 
 @pytest.mark.usefixtures("enable_rbac")

--- a/tests/test_system_profile.py
+++ b/tests/test_system_profile.py
@@ -122,7 +122,9 @@ def test_get_system_profile_sap_sids_with_RBAC_bypassed_as_system(api_get):
 @pytest.mark.usefixtures("enable_rbac")
 def test_get_system_profile_RBAC_allowed(mocker, subtests, db_create_host, api_get):
     host_id = str(db_create_host().id)
-    run_rbac_test(subtests, mocker, api_get, HOST_READ_ALLOWED_RBAC_RESPONSE_FILES, 200, [f"{HOST_URL}/{host_id}/system_profile"])
+    run_rbac_test(
+        subtests, mocker, api_get, HOST_READ_ALLOWED_RBAC_RESPONSE_FILES, 200, [f"{HOST_URL}/{host_id}/system_profile"]
+    )
 
 
 @pytest.mark.usefixtures("enable_rbac")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -13,6 +13,7 @@ from tests.helpers.api_utils import build_host_tags_url
 from tests.helpers.api_utils import build_tags_count_url
 from tests.helpers.api_utils import build_tags_url
 from tests.helpers.api_utils import create_mock_rbac_response
+from tests.helpers.api_utils import run_rbac_test
 from tests.helpers.test_utils import SYSTEM_IDENTITY
 from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import now
@@ -203,37 +204,18 @@ def test_get_tags_count_from_host_with_no_tags(api_get, db_create_host):
 
 @pytest.mark.usefixtures("enable_rbac")
 def test_get_host_tags_with_RBAC_allowed(subtests, mocker, api_get, db_create_host):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
-
-    for response_file in HOST_READ_ALLOWED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-        with subtests.test():
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-
-            host_id = str(db_create_host().id)
-            url = build_host_tags_url(host_list_or_id=host_id)
-            response_status, _ = api_get(url)
-
-            assert_response_status(response_status, 200)
+    host_id = str(db_create_host().id)
+    url = build_host_tags_url(host_list_or_id=host_id)
+    run_rbac_test(subtests, mocker, api_get, HOST_READ_ALLOWED_RBAC_RESPONSE_FILES, 200, [url])
 
 
 @pytest.mark.usefixtures("enable_rbac")
 def test_get_host_tags_with_RBAC_denied(subtests, db_create_host, mocker, api_get):
-    get_rbac_permissions_mock = mocker.patch("lib.middleware.get_rbac_permissions")
     get_host_tags_list_mock = mocker.patch("api.host.get_host_tags_list_by_id_list")
-
-    for response_file in HOST_READ_PROHIBITED_RBAC_RESPONSE_FILES:
-        mock_rbac_response = create_mock_rbac_response(response_file)
-        with subtests.test():
-            get_rbac_permissions_mock.return_value = mock_rbac_response
-
-            host_id = str(db_create_host().id)
-            url = build_host_tags_url(host_list_or_id=host_id)
-            response_status, _ = api_get(url)
-
-            assert_response_status(response_status, 403)
-
-            get_host_tags_list_mock.assert_not_called()
+    host_id = str(db_create_host().id)
+    url = build_host_tags_url(host_list_or_id=host_id)
+    run_rbac_test(subtests, mocker, api_get, HOST_READ_PROHIBITED_RBAC_RESPONSE_FILES, 403, [url])
+    get_host_tags_list_mock.assert_not_called()
 
 
 @pytest.mark.usefixtures("enable_rbac")


### PR DESCRIPTION
## What
Reduced test suite duplication by consolidating repetitive RBAC test patterns and merging similar query parameter tests.

Generated with Claude code.

Note: Feel free to close this PR if it doesn't meet with the direction or methodology you want for this repo. I ran this out of curiously of what type of reduction claude could achieve, and figured it was worth posting for consideration.

Changes:
- Added run_rbac_test() helper to tests/helpers/api_utils.py
- Consolidated 17 tests into 10 parametrized tests
- Removed 166 lines of duplicate code across 8 files

Impact:
- test_api_staleness_create.py: 154 → 133 lines (-21)
- test_api_staleness_delete.py: 63 → 47 lines (-16)
- test_api_staleness_update.py: 65 → 45 lines (-20)
- test_api_staleness_get.py: 71 → 40 lines (-31)
- test_api_hosts_get.py: 2,947 → 2,921 lines (-26)
- test_tags.py: 497 → 479 lines (-18)
- test_system_profile.py: 796 → 762 lines (-34)

## Why
Benefits:
- Centralized RBAC test logic for easier maintenance
- Improved test readability by removing boilerplate
- Consistent test patterns across the codebase
- Maintained 100% test coverage

## How
Prompted claude to review and remove duplicate tests while maintaining the same test coverage.

## Summary by Sourcery

Refactor tests to consolidate duplicate RBAC and query parameter coverage while preserving behavior and coverage.

Enhancements:
- Introduce a reusable run_rbac_test helper to centralize common RBAC test setup and assertions across API tests.

Tests:
- Parametrize host query tests to cover multiple identifier fields and non-existent host values in fewer, more general cases.
- Replace repeated RBAC permission loop patterns in staleness, system profile, and tags tests with the shared run_rbac_test helper for allowed and denied scenarios.
- Merge multiple staleness retrieval tests into a single parametrized test that covers both default and system-default staleness endpoints.
- Simplify staleness create, update, and delete RBAC tests by delegating repeated logic to the shared helper and reducing boilerplate.