### PR TITLE
fix(RHINENG-25949): Fix default groups ordering when `order_by=updated` and kessel-groups is enabled

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/workspaces_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/workspaces_api.py
@@ -24,6 +24,7 @@ from iqe_rbac_v2_api import WorkspacesWorkspace
 from iqe_rbac_v2_api import WorkspacesWorkspaceListResponse
 from iqe_rbac_v2_api import WorkspacesWorkspaceTypes
 from iqe_rbac_v2_api import WorkspacesWorkspaceTypesQueryParam
+from iqe_rbac_v2_api.exceptions import NotFoundException
 
 from iqe_host_inventory import ApplicationHostInventory
 from iqe_host_inventory.utils import is_global_account
@@ -35,7 +36,7 @@ WORKSPACE_NOT_CREATED_ERROR = Exception("Workspace wasn't successfully created")
 WORKSPACE_NOT_UPDATED_ERROR = Exception("Workspace wasn't successfully updated")
 WORKSPACE_NOT_DELETED_ERROR = Exception("Workspace wasn't successfully deleted")
 
-type WORKSPACE_OR_ID = WorkspacesWorkspace | str
+type WORKSPACE_OR_ID = WorkspacesWorkspace | WorkspacesCreateWorkspaceResponse | str
 type WORKSPACE_OR_WORKSPACES = WORKSPACE_OR_ID | Collection[WORKSPACE_OR_ID]
 
 
@@ -245,7 +246,10 @@ class WorkspacesAPIWrapper(BaseEntity):
         workspace_ids = set(_ids_from_workspaces(workspaces))
 
         def get_workspaces() -> list[WorkspacesWorkspace]:
-            return self.get_workspaces_by_id(workspaces)
+            try:
+                return self.get_workspaces_by_id(workspaces)
+            except NotFoundException:
+                return []
 
         def found_all(response_workspaces: list[WorkspacesWorkspace]) -> bool:
             found_ids = {workspace.id for workspace in response_workspaces}

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_get_list.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_get_list.py
@@ -209,7 +209,7 @@ def test_groups_get_list_ordering(
 
 
 @pytest.mark.ephemeral
-@pytest.mark.parametrize("order_by", ["name", "host_count"])
+@pytest.mark.parametrize("order_by", ["name", "host_count", "updated"])
 @pytest.mark.parametrize("order_how", ["ASC", "DESC"])
 def test_groups_get_list_ordering_and_pagination(
     host_inventory,

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -815,7 +815,9 @@ def get_rbac_workspaces(
 
         # RBAC v2 API expects descending order to be prefixed with a hyphen
         # Example: To sort by updated date in descending order, use "-modified"
-        if order_how and order_how.lower() == "desc":
+        # Also, RBAC v2 uses ascending order by default on all `order_by` types.
+        # HBI uses desc order by default when order_by == "updated", so we need to use the hyphen.
+        if (order_how and order_how.lower() == "desc") or (order_by == "updated" and order_how is None):
             rbac_order_by = f"-{rbac_order_by}"
 
         query_params["order_by"] = rbac_order_by

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1232,7 +1232,7 @@ components:
         $ref:  '#/components/schemas/OrderHow'
       description: >-
         Direction of the ordering (case-insensitive); defaults to ASC for name, and to DESC
-        for host_count
+        for host_count and updated
     workspaceTypeParam:
       in: query
       name: group_type

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -2049,7 +2049,7 @@
         "schema": {
           "$ref": "#/components/schemas/OrderHow"
         },
-        "description": "Direction of the ordering (case-insensitive); defaults to ASC for name, and to DESC for host_count"
+        "description": "Direction of the ordering (case-insensitive); defaults to ASC for name, and to DESC for host_count and updated"
       },
       "workspaceTypeParam": {
         "in": "query",

--- a/tests/test_api_groups_get.py
+++ b/tests/test_api_groups_get.py
@@ -673,8 +673,10 @@ def test_get_groups_rbac_v2_flag_toggle(mocker, db_create_group, api_get, flag_e
         # Baseline updated->modified mapping with standard ASC/DESC
         ("updated", "ASC", "modified"),
         ("updated", "DESC", "-modified"),
-        # No order_how: should default to ascending, with the mapped field name and no hyphen
-        ("updated", None, "modified"),
+        # No order_how: should default to ascending on "name", with the mapped field name and no hyphen
+        ("name", None, "name"),
+        # No order_how: should default to descending on "updated", with the mapped field name and hyphen
+        ("updated", None, "-modified"),
         # Different order_how casing: should still be treated as DESC and apply a leading hyphen
         ("updated", "desc", "-modified"),
         ("updated", "Desc", "-modified"),


### PR DESCRIPTION
## Jira
[RHINENG-25949](https://issues.redhat.com/browse/RHINENG-25949)
[RHINENG-25474](https://issues.redhat.com/browse/RHINENG-25474)

## What

1. Fix default groups ordering when `order_by=updated` and kessel-groups is enabled
2. Fix waiting for a workspace to be created in the IQE tests

## Why

1. RBAC v2 uses ascending ordering for all `order_by` values by default, but HBI uses descending ordering for ' updated ' by default
2. The IQE tests didn't account for HTTP 404 when the workspace isn't available

## How

1. Prefix the `order_by` with a hyphen, if `order_by=updated` and `order_how` is not specified.
2. Add try/except block when waiting for a new workspace to be created

## Testing
I tested the IQE tests fix in ephemeral environment.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-25949]: https://redhat.atlassian.net/browse/RHINENG-25949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHINENG-25474]: https://redhat.atlassian.net/browse/RHINENG-25474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Align group and workspace ordering behavior with RBAC v2 while hardening IQE workspace-creation polling.

Bug Fixes:
- Ensure RBAC workspace queries default to descending order when ordering by updated without an explicit order_how.
- Handle transient 404 responses when polling for newly created workspaces in IQE tests.

Documentation:
- Clarify API documentation that the default ordering direction is DESC for both host_count and updated fields.

Tests:
- Extend group listing tests to cover updated ordering behavior and ordering/pagination combinations for updated across RBAC and IQE test suites.