### PR TITLE
Fix race condition in ungrouped hosts group creation and segmentio test

### DIFF
--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -1,6 +1,7 @@
 import time
 from uuid import UUID
 
+from psycopg2.errors import UniqueViolation
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -577,13 +578,33 @@ def get_or_create_ungrouped_hosts_group_for_identity(identity: Identity) -> Grou
     # Otherwise, create the workspace
     workspace_id = rbac_create_ungrouped_hosts_workspace(identity)
 
-    group = add_group(
-        group_name="Ungrouped Hosts",
-        org_id=identity.org_id,
-        account=getattr(identity, "account_number", None),
-        group_id=workspace_id,
-        ungrouped=True,
-    )
+    try:
+        group = add_group(
+            group_name="Ungrouped Hosts",
+            org_id=identity.org_id,
+            account=getattr(identity, "account_number", None),
+            group_id=workspace_id,
+            ungrouped=True,
+        )
+    except IntegrityError as e:
+        # Handle race condition: another thread may have created the group
+        if isinstance(e.orig, UniqueViolation):
+            logger.debug(
+                "Ungrouped group creation failed with UniqueViolation, retrying fetch",
+                extra={"org_id": identity.org_id, "workspace_id": str(workspace_id)},
+            )
+            db.session.rollback()
+            group = get_ungrouped_group(identity)
+            if group is None:
+                # Still not found after retry, something else is wrong
+                logger.error(
+                    "Ungrouped group not found after UniqueViolation retry",
+                    extra={"org_id": identity.org_id, "workspace_id": str(workspace_id)},
+                )
+                raise
+        else:
+            raise
+
     UngroupedGroupCache.put(identity.org_id, group)
     return group
 

--- a/lib/group_repository.py
+++ b/lib/group_repository.py
@@ -600,6 +600,7 @@ def get_or_create_ungrouped_hosts_group_for_identity(identity: Identity) -> Grou
                 logger.error(
                     "Ungrouped group not found after UniqueViolation retry",
                     extra={"org_id": identity.org_id, "workspace_id": str(workspace_id)},
+                    exc_info=True,
                 )
                 raise
         else:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2859,3 +2859,39 @@ def test_ungrouped_group_cache_deduplicates_group_creation(flask_app, mocker):  
         group_id="ws-id",
         ungrouped=True,
     )
+
+
+def test_ungrouped_group_handles_race_condition(flask_app, mocker):  # noqa: ARG001
+    """When two threads try to create ungrouped group simultaneously, handle UniqueViolation gracefully."""
+    from psycopg2.errors import UniqueViolation
+    from sqlalchemy.exc import IntegrityError
+
+    from lib.group_repository import get_or_create_ungrouped_hosts_group_for_identity
+
+    mock_identity = mocker.Mock()
+    mock_identity.org_id = "test_org"
+    mock_identity.account_number = "test_account"
+
+    mock_existing_group = mocker.Mock(name="existing_ungrouped_group")
+    mock_existing_group.id = "existing-group-id"
+
+    # Simulate race condition: first get_ungrouped_group returns None, then add_group fails with UniqueViolation
+    get_ungrouped_calls = [None, mock_existing_group]
+    get_ungrouped = mocker.patch("lib.group_repository.get_ungrouped_group", side_effect=get_ungrouped_calls)
+
+    mock_rbac = mocker.patch("lib.group_repository.rbac_create_ungrouped_hosts_workspace", return_value="ws-id")
+
+    # Simulate UniqueViolation on add_group
+    unique_violation = UniqueViolation()
+    integrity_error = IntegrityError("statement", "params", unique_violation)
+    mock_add = mocker.patch("lib.group_repository.add_group", side_effect=integrity_error)
+
+    mock_rollback = mocker.patch("lib.group_repository.db.session.rollback")
+
+    result = get_or_create_ungrouped_hosts_group_for_identity(mock_identity)
+
+    assert result is mock_existing_group
+    assert get_ungrouped.call_count == 2
+    mock_rbac.assert_called_once_with(mock_identity)
+    mock_add.assert_called_once()
+    mock_rollback.assert_called_once()

--- a/tests/test_segmentio.py
+++ b/tests/test_segmentio.py
@@ -148,7 +148,7 @@ def test_segmentio_rate_limit(mocker, api_get):
     #
     # Test calls that do exceed the limit.
     #
-    mock_track.call_count = 0
+    mock_track.reset_mock()
     for _ in range(max_calls * 2):
         response_status, response_data = api_get(
             build_resource_types_url(), extra_headers={"User-Agent": "test-user-agent"}


### PR DESCRIPTION
## Summary
- Fix race condition when multiple workers create ungrouped hosts group simultaneously
- Fix segmentio rate limit test mock counter reset

## Details

### Race Condition Fix (Primary Issue)
When multiple workers simultaneously add hosts for an org_id that doesn't have an "Ungrouped Hosts" group yet, they can race to create it. Both workers call `rbac_create_ungrouped_hosts_workspace()` which returns the same workspace UUID for the same org_id, then both try to insert a group with that UUID, causing:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "groups_pkey"
DETAIL:  Key (id)=(019db8db-4c39-7d40-b029-63e2a7584ebc) already exists.
```

**Solution:** Catch the `UniqueViolation` during group creation, roll back the transaction, and retry fetching the group that was created by the other thread. This is a standard optimistic locking pattern.

### Test Fix (Unrelated)
The `test_segmentio_rate_limit` test was using `mock_track.call_count = 0` to reset the mock counter, but this doesn't properly reset the mock's internal state. After module reload, subsequent calls were being added to the existing count (8 + 4 = 12 instead of 4), causing assertion failures.

**Solution:** Use `reset_mock()` instead, which properly clears all mock state.

## Test Plan
- [x] Added test case `test_ungrouped_group_handles_race_condition` that simulates the race condition
- [x] Existing ungrouped group tests pass
- [x] Segmentio rate limit test now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle race conditions when creating the ungrouped hosts group and correct Segment.io rate limit test mocking.

Bug Fixes:
- Prevent duplicate ungrouped hosts group creation by handling unique constraint violations and retrying the lookup.
- Fix Segment.io rate limit test by properly resetting the tracking mock between assertions.

Tests:
- Add a test that simulates concurrent ungrouped group creation and verifies graceful handling of unique constraint violations.