### PR TITLE
feat(RHINENG-26024): add OpenTelemetry distributed tracing instrumentation

### DIFF
--- a/.otel/grafana-datasources.yaml
+++ b/.otel/grafana-datasources.yaml
@@ -1,0 +1,14 @@
+apiVersion: 1
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    isDefault: true
+    jsonData:
+      nodeGraph:
+        enabled: true
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus-gateway:9091

--- a/.otel/tempo.yaml
+++ b/.otel/tempo.yaml
@@ -1,0 +1,24 @@
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: "0.0.0.0:4318"
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+  storage:
+    path: /tmp/tempo/generator/wal

--- a/Pipfile
+++ b/Pipfile
@@ -40,6 +40,13 @@ ratelimit = "*"
 confluent-kafka = "==2.14.0"
 kessel-sdk = {version = "~=2.6.0", extras = ["auth", "console"]}
 googleapis-common-protos = "*"
+# OpenTelemetry - distributed tracing
+opentelemetry-api = "~=1.32"
+opentelemetry-sdk = "~=1.32"
+opentelemetry-exporter-otlp-proto-http = "~=1.32"
+opentelemetry-instrumentation-flask = "~=0.53b"
+opentelemetry-instrumentation-sqlalchemy = "~=0.53b"
+opentelemetry-instrumentation-requests = "~=0.53b"
 # pinning versions of transitive dependencies to avoid hermetic build issues
 unleashclient = "==6.7.0"
 rpds-py = "==0.30.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6787f9dd42e722b3aa9ed1e6e83e7414540dfc4061ce9bbc12cb94865b0c5683"
+            "sha256": "f21f03d838c62f39c5cf6af5427825ad865cc3cd6041a47899d8d7078b24fab9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -392,11 +392,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5",
-                "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d"
+                "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2",
+                "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.3.2"
+            "version": "==8.3.3"
         },
         "confluent-kafka": {
             "hashes": [
@@ -456,58 +456,58 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65",
-                "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832",
-                "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067",
-                "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de",
-                "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4",
-                "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0",
-                "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b",
-                "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968",
-                "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef",
-                "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b",
-                "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4",
-                "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3",
-                "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308",
-                "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e",
-                "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163",
-                "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f",
-                "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee",
-                "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77",
-                "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85",
-                "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99",
-                "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7",
-                "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83",
-                "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85",
-                "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006",
-                "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb",
-                "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e",
-                "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba",
-                "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325",
-                "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d",
-                "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1",
-                "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1",
-                "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2",
-                "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0",
-                "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455",
-                "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842",
-                "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457",
-                "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15",
-                "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2",
-                "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c",
-                "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb",
-                "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5",
-                "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4",
-                "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902",
-                "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246",
-                "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022",
-                "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f",
-                "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e",
-                "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298",
-                "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce"
+                "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7",
+                "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27",
+                "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd",
+                "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7",
+                "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001",
+                "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4",
+                "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca",
+                "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0",
+                "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe",
+                "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93",
+                "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475",
+                "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe",
+                "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515",
+                "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10",
+                "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7",
+                "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92",
+                "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829",
+                "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8",
+                "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52",
+                "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b",
+                "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc",
+                "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c",
+                "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63",
+                "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac",
+                "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31",
+                "sha256:7f1207974a904e005f762869996cf620e9bf79ecb4622f148550bb48e0eb35a7",
+                "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1",
+                "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203",
+                "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7",
+                "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769",
+                "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923",
+                "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74",
+                "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b",
+                "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb",
+                "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab",
+                "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76",
+                "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f",
+                "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7",
+                "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973",
+                "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0",
+                "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8",
+                "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310",
+                "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b",
+                "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318",
+                "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab",
+                "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8",
+                "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa",
+                "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50",
+                "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736"
             ],
             "markers": "python_version >= '3.8' and python_full_version not in '3.9.0, 3.9.1'",
-            "version": "==46.0.7"
+            "version": "==47.0.0"
         },
         "fcache": {
             "hashes": [
@@ -583,68 +583,68 @@
         },
         "greenlet": {
             "hashes": [
-                "sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267",
-                "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2",
-                "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19",
-                "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd",
-                "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d",
-                "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077",
-                "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82",
-                "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e",
-                "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97",
-                "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705",
-                "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a",
-                "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72",
-                "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d",
-                "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729",
-                "sha256:234582c20af9742583c3b2ddfbdbb58a756cfff803763ffaae1ac7990a9fac31",
-                "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a",
-                "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1",
-                "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6",
-                "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf",
-                "sha256:523677e69cd4711b5a014e37bc1fb3a29947c3e3a5bb6a527e1cc50312e5a398",
-                "sha256:5434271357be07f3ad0936c312645853b7e689e679e29310e2de09a9ea6c3adf",
-                "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1",
-                "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c",
-                "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711",
-                "sha256:636d2f95c309e35f650e421c23297d5011716be15d966e6328b367c9fc513a82",
-                "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d",
-                "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f",
-                "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58",
-                "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08",
-                "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940",
-                "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81",
-                "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda",
-                "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf",
-                "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76",
-                "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996",
-                "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a",
-                "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71",
-                "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f",
-                "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de",
-                "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2",
-                "sha256:a19093fbad824ed7c0f355b5ff4214bffda5f1a7f35f29b31fcaa240cc0135ab",
-                "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc",
-                "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8",
-                "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875",
-                "sha256:ac6a5f618be581e1e0713aecec8e54093c235e5fa17d6d8eb7ffc487e2300508",
-                "sha256:b45e45fe47a19051a396abb22e19e7836a59ee6c5a90f3be427343c37908d65b",
-                "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55",
-                "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa",
-                "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83",
-                "sha256:d18eae9a7fb0f499efcd146b8c9750a2e1f6e0e93b5a382b3481875354a430e6",
-                "sha256:d336d46878e486de7d9458653c722875547ac8d36a1cff9ffaf4a74a3c1f62eb",
-                "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece",
-                "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed",
-                "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615",
-                "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2",
-                "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e",
-                "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff",
-                "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802",
-                "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf"
+                "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846",
+                "sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4",
+                "sha256:0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662",
+                "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce",
+                "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2",
+                "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588",
+                "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13",
+                "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e",
+                "sha256:29ea813b2e1f45fa9649a17853b2b5465c4072fbcb072e5af6cd3a288216574a",
+                "sha256:362624e6a8e5bca3b8233e45eef33903a100e9539a2b995c364d595dbc4018b3",
+                "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b",
+                "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033",
+                "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628",
+                "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136",
+                "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b",
+                "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d",
+                "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2",
+                "sha256:4b28037cb07768933c54d81bfe47a85f9f402f57d7d69743b991a713b63954eb",
+                "sha256:4d0eadc7e4d9ffb2af4247b606cae307be8e448911e5a0d0b16d72fc3d224cfd",
+                "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b",
+                "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1",
+                "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16",
+                "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d",
+                "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106",
+                "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba",
+                "sha256:5ecd83806b0f4c2f53b1018e0005cd82269ea01d42befc0368730028d850ed1c",
+                "sha256:64d6ac45f7271f48e45f67c95b54ef73534c52ec041fcda8edf520c6d811f4bc",
+                "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7",
+                "sha256:6c18dfb59c70f5a94acd271c72e90128c3c776e41e5f07767908c8c1b74ad339",
+                "sha256:6d874e79afd41a96e11ff4c5d0bc90a80973e476fda1c2c64985667397df432b",
+                "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae",
+                "sha256:703cb211b820dbffbbc55a16bfc6e4583a6e6e990f33a119d2cc8b83211119c8",
+                "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2",
+                "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5",
+                "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf",
+                "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f",
+                "sha256:804a70b328e706b785c6ef16187051c394a63dd1a906d89be24b6ad77759f13f",
+                "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2",
+                "sha256:884f649de075b84739713d41dd4dfd41e2b910bfb769c4a3ea02ec1da52cd9bb",
+                "sha256:8f1cc966c126639cd152fdaa52624d2655f492faa79e013fea161de3e6dda082",
+                "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7",
+                "sha256:9c615f869163e14bb1ced20322d8038fb680b08236521ac3f30cd4c1288785a0",
+                "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c",
+                "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853",
+                "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988",
+                "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3",
+                "sha256:ba8f0bdc2fae6ce915dfd0c16d2d00bca7e4247c1eae4416e06430e522137858",
+                "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37",
+                "sha256:cda05425526240807408156b6960a17a79a0c760b813573b67027823be760977",
+                "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4",
+                "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8",
+                "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86",
+                "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f",
+                "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112",
+                "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e",
+                "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2",
+                "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8",
+                "sha256:f8c30c2225f40dd76c50790f0eb3b5c7c18431efb299e2782083e1981feed243",
+                "sha256:fa94cb2288681e3a11645958f1871d48ee9211bd2f66628fdace505927d6e564"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==3.4.0"
+            "version": "==3.5.0"
         },
         "grpcio": {
             "hashes": [
@@ -797,19 +797,19 @@
         },
         "idna": {
             "hashes": [
-                "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67",
-                "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254"
+                "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242",
+                "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.12"
+            "version": "==3.13"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7",
-                "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc"
+                "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb",
+                "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==9.0.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==8.7.1"
         },
         "inflection": {
             "hashes": [
@@ -1203,13 +1203,115 @@
             "markers": "python_full_version >= '3.8.0' and python_full_version < '4.0.0'",
             "version": "==0.7.2"
         },
+        "opentelemetry-api": {
+            "hashes": [
+                "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621",
+                "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==1.41.1"
+        },
+        "opentelemetry-exporter-otlp-proto-common": {
+            "hashes": [
+                "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb",
+                "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.41.1"
+        },
+        "opentelemetry-exporter-otlp-proto-http": {
+            "hashes": [
+                "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4",
+                "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==1.41.1"
+        },
+        "opentelemetry-instrumentation": {
+            "hashes": [
+                "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45",
+                "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.62b1"
+        },
+        "opentelemetry-instrumentation-flask": {
+            "hashes": [
+                "sha256:37662ad159570dab1e3017a2a415193c014a5798fc32d33f3bdd254469e8c69a",
+                "sha256:6df32684a7dd5dab5feb499c0748a4628b3fd139bffd8171326fb479aa525367"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==0.62b1"
+        },
+        "opentelemetry-instrumentation-requests": {
+            "hashes": [
+                "sha256:67a79c4b67e2192445c1cf03d62126fa623065688d8bd1a9f87f858b0e5f0286",
+                "sha256:ca348f2f51b715c21e86d82106d784f7069ae849c3e636ab37e34dc0ba510b8c"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==0.62b1"
+        },
+        "opentelemetry-instrumentation-sqlalchemy": {
+            "hashes": [
+                "sha256:613542ecd52aabeec83d8813b5c287a3fb6c9ac3cd660694c94c0571f066e972",
+                "sha256:bdeac015351a1de057e8ea39f1fe26c9e60ea6bedbf1d5ad6a8262a516b3dc7d"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==0.62b1"
+        },
+        "opentelemetry-instrumentation-wsgi": {
+            "hashes": [
+                "sha256:02a364fd9c940a46b19c825c5bfe386b007d5292ef91573894164836953fe831",
+                "sha256:a2df11de0113f504043e2b0fa0288238a93ee49ff607bd5100cb2d3a75bc771f"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.62b1"
+        },
+        "opentelemetry-proto": {
+            "hashes": [
+                "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720",
+                "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.41.1"
+        },
+        "opentelemetry-sdk": {
+            "hashes": [
+                "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6",
+                "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==1.41.1"
+        },
+        "opentelemetry-semantic-conventions": {
+            "hashes": [
+                "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802",
+                "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.62b1"
+        },
+        "opentelemetry-util-http": {
+            "hashes": [
+                "sha256:adf6facbb89aef8f8bc566e2f04624942ba08a7b678b3479a91051a8f4dc70a3",
+                "sha256:c57e8a6c19fc422c288e6074e882f506f85030b69b7376182f74f9257b9261f0"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.62b1"
+        },
         "packaging": {
             "hashes": [
-                "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f",
-                "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
+                "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
+                "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.1"
+            "version": "==26.2"
         },
         "pathable": {
             "hashes": [
@@ -1334,11 +1436,11 @@
         },
         "python-multipart": {
             "hashes": [
-                "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17",
-                "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185"
+                "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645",
+                "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==0.0.26"
+            "version": "==0.0.27"
         },
         "pyyaml": {
             "hashes": [
@@ -1859,11 +1961,11 @@
                 "standard"
             ],
             "hashes": [
-                "sha256:2db26f588131aeec7439de00f2dd52d5f210710c1f01e407a52c90b880d1fd4f",
-                "sha256:3fe650df136c5bd2b9b06efc5980636344a2fbb840e9ddd86437d53144fa335d"
+                "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048",
+                "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==0.45.0"
+            "version": "==0.46.0"
         },
         "uvloop": {
             "hashes": [
@@ -2127,6 +2229,102 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==3.1.8"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5",
+                "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b",
+                "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9",
+                "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267",
+                "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca",
+                "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63",
+                "sha256:1c6cc827c00dc839350155f316f1f8b4b0c370f52b6a19e782e2bda89600c7dc",
+                "sha256:2b8b28e97a44d21836259739ae76284e180b18abbb4dcfdff07a415cf1016c3e",
+                "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d",
+                "sha256:305d8a1755116bfdad5dda9e771dcb2138990a1d66e9edd81658816edf51aed1",
+                "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3",
+                "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015",
+                "sha256:3756219045f73fb28c5d7662778e4156fbd06cf823c4d2d4b19f97305e52819c",
+                "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596",
+                "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a",
+                "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e",
+                "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7",
+                "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf",
+                "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9",
+                "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf",
+                "sha256:45914e8efbe4b9d5102fcf0e8e2e3258b83a5d5fba9f8f7b6d15681e9d29ffe0",
+                "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04",
+                "sha256:478282ebd3795a089154fb16d3db360e103aa13d3b2ad30f8f6aac0d2207de0e",
+                "sha256:4b7a86d99a14f76facb269dc148590c01aaf47584071809a70da30555228158c",
+                "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e",
+                "sha256:5681123e60aed0e64c7d44f72bbf8b4ce45f79d81467e2c4c728629f5baf06eb",
+                "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6",
+                "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90",
+                "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b",
+                "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6",
+                "sha256:5e0fa9cc32300daf9eb09a1f5bdc6deb9a79defd70d5356ba453bcd50aef3742",
+                "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb",
+                "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748",
+                "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1",
+                "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9",
+                "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1",
+                "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413",
+                "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b",
+                "sha256:710f6e5dfaf6a5d5c397d2d6758a78fecd9649deb21f1b645f5b57a328d63050",
+                "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00",
+                "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67",
+                "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894",
+                "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586",
+                "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b",
+                "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8",
+                "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2",
+                "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f",
+                "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15",
+                "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb",
+                "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c",
+                "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d",
+                "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842",
+                "sha256:a5d516e22aedb7c9c1d47cba1c63160b1a6f61ec2f3948d127cd38d5cfbb556f",
+                "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044",
+                "sha256:a819e39017f95bf7aede768f75915635aa8f671f2993c036991b8d3bfe8dbb6f",
+                "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92",
+                "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2",
+                "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679",
+                "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18",
+                "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8",
+                "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a",
+                "sha256:b8aefb4dbb18d904b96827435a763fa42fc1f08ea096a391710407a60983ced8",
+                "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8",
+                "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb",
+                "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a",
+                "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e",
+                "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22",
+                "sha256:c87cf3f0c85e27b3ac7d9ad95da166bf8739ca215a8b171e8404a2d739897a45",
+                "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf",
+                "sha256:cef91c95a50596fcdc31397eb6955476f82ae8a3f5a8eabdc13611b60ee380ba",
+                "sha256:d1c5fea4f9fe3762e2b905fdd67df51e4be7a73b7674957af2d2ade71a5c075d",
+                "sha256:d307aa6888d5efab2c1cde09843d48c843990be13069003184b67d426d145394",
+                "sha256:d8f7740e1af13dff2684e4d56fe604a7e04d6c94e737a60568d8d4238b9a0c71",
+                "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575",
+                "sha256:dad63212b168de8569b1c512f4eac4b57f2c6934b30df32d6ee9534a79f1493f",
+                "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e",
+                "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c",
+                "sha256:e5aeab8fe15c3dff75cfee94260dcd9cded012d4ff06add036c28fae7718593b",
+                "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508",
+                "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0",
+                "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd",
+                "sha256:f069e113743a21a3defac6677f000068ebb931639f789b5b226598e247a4c89e",
+                "sha256:f0d8fc30a43b5fe191cf2b1a0c82bab2571dadd38e7c0062ee87d6df858dd06e",
+                "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f",
+                "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8",
+                "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1",
+                "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c",
+                "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19",
+                "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9",
+                "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.1.2"
         },
         "yggdrasil-engine": {
             "hashes": [
@@ -2416,58 +2614,58 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65",
-                "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832",
-                "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067",
-                "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de",
-                "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4",
-                "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0",
-                "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b",
-                "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968",
-                "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef",
-                "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b",
-                "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4",
-                "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3",
-                "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308",
-                "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e",
-                "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163",
-                "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f",
-                "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee",
-                "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77",
-                "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85",
-                "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99",
-                "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7",
-                "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83",
-                "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85",
-                "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006",
-                "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb",
-                "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e",
-                "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba",
-                "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325",
-                "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d",
-                "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1",
-                "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1",
-                "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2",
-                "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0",
-                "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455",
-                "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842",
-                "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457",
-                "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15",
-                "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2",
-                "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c",
-                "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb",
-                "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5",
-                "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4",
-                "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902",
-                "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246",
-                "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022",
-                "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f",
-                "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e",
-                "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298",
-                "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce"
+                "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7",
+                "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27",
+                "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd",
+                "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7",
+                "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001",
+                "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4",
+                "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca",
+                "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0",
+                "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe",
+                "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93",
+                "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475",
+                "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe",
+                "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515",
+                "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10",
+                "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7",
+                "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92",
+                "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829",
+                "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8",
+                "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52",
+                "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b",
+                "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc",
+                "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c",
+                "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63",
+                "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac",
+                "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31",
+                "sha256:7f1207974a904e005f762869996cf620e9bf79ecb4622f148550bb48e0eb35a7",
+                "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1",
+                "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203",
+                "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7",
+                "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769",
+                "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923",
+                "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74",
+                "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b",
+                "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb",
+                "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab",
+                "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76",
+                "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f",
+                "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7",
+                "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973",
+                "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0",
+                "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8",
+                "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310",
+                "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b",
+                "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318",
+                "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab",
+                "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8",
+                "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa",
+                "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50",
+                "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736"
             ],
             "markers": "python_version >= '3.8' and python_full_version not in '3.9.0, 3.9.1'",
-            "version": "==46.0.7"
+            "version": "==47.0.0"
         },
         "distlib": {
             "hashes": [
@@ -2495,68 +2693,68 @@
         },
         "greenlet": {
             "hashes": [
-                "sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267",
-                "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2",
-                "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19",
-                "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd",
-                "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d",
-                "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077",
-                "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82",
-                "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e",
-                "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97",
-                "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705",
-                "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a",
-                "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72",
-                "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d",
-                "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729",
-                "sha256:234582c20af9742583c3b2ddfbdbb58a756cfff803763ffaae1ac7990a9fac31",
-                "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a",
-                "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1",
-                "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6",
-                "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf",
-                "sha256:523677e69cd4711b5a014e37bc1fb3a29947c3e3a5bb6a527e1cc50312e5a398",
-                "sha256:5434271357be07f3ad0936c312645853b7e689e679e29310e2de09a9ea6c3adf",
-                "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1",
-                "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c",
-                "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711",
-                "sha256:636d2f95c309e35f650e421c23297d5011716be15d966e6328b367c9fc513a82",
-                "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d",
-                "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f",
-                "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58",
-                "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08",
-                "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940",
-                "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81",
-                "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda",
-                "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf",
-                "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76",
-                "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996",
-                "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a",
-                "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71",
-                "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f",
-                "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de",
-                "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2",
-                "sha256:a19093fbad824ed7c0f355b5ff4214bffda5f1a7f35f29b31fcaa240cc0135ab",
-                "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc",
-                "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8",
-                "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875",
-                "sha256:ac6a5f618be581e1e0713aecec8e54093c235e5fa17d6d8eb7ffc487e2300508",
-                "sha256:b45e45fe47a19051a396abb22e19e7836a59ee6c5a90f3be427343c37908d65b",
-                "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55",
-                "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa",
-                "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83",
-                "sha256:d18eae9a7fb0f499efcd146b8c9750a2e1f6e0e93b5a382b3481875354a430e6",
-                "sha256:d336d46878e486de7d9458653c722875547ac8d36a1cff9ffaf4a74a3c1f62eb",
-                "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece",
-                "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed",
-                "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615",
-                "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2",
-                "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e",
-                "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff",
-                "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802",
-                "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf"
+                "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846",
+                "sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4",
+                "sha256:0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662",
+                "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce",
+                "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2",
+                "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588",
+                "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13",
+                "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e",
+                "sha256:29ea813b2e1f45fa9649a17853b2b5465c4072fbcb072e5af6cd3a288216574a",
+                "sha256:362624e6a8e5bca3b8233e45eef33903a100e9539a2b995c364d595dbc4018b3",
+                "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b",
+                "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033",
+                "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628",
+                "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136",
+                "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b",
+                "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d",
+                "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2",
+                "sha256:4b28037cb07768933c54d81bfe47a85f9f402f57d7d69743b991a713b63954eb",
+                "sha256:4d0eadc7e4d9ffb2af4247b606cae307be8e448911e5a0d0b16d72fc3d224cfd",
+                "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b",
+                "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1",
+                "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16",
+                "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d",
+                "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106",
+                "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba",
+                "sha256:5ecd83806b0f4c2f53b1018e0005cd82269ea01d42befc0368730028d850ed1c",
+                "sha256:64d6ac45f7271f48e45f67c95b54ef73534c52ec041fcda8edf520c6d811f4bc",
+                "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7",
+                "sha256:6c18dfb59c70f5a94acd271c72e90128c3c776e41e5f07767908c8c1b74ad339",
+                "sha256:6d874e79afd41a96e11ff4c5d0bc90a80973e476fda1c2c64985667397df432b",
+                "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae",
+                "sha256:703cb211b820dbffbbc55a16bfc6e4583a6e6e990f33a119d2cc8b83211119c8",
+                "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2",
+                "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5",
+                "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf",
+                "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f",
+                "sha256:804a70b328e706b785c6ef16187051c394a63dd1a906d89be24b6ad77759f13f",
+                "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2",
+                "sha256:884f649de075b84739713d41dd4dfd41e2b910bfb769c4a3ea02ec1da52cd9bb",
+                "sha256:8f1cc966c126639cd152fdaa52624d2655f492faa79e013fea161de3e6dda082",
+                "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7",
+                "sha256:9c615f869163e14bb1ced20322d8038fb680b08236521ac3f30cd4c1288785a0",
+                "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c",
+                "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853",
+                "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988",
+                "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3",
+                "sha256:ba8f0bdc2fae6ce915dfd0c16d2d00bca7e4247c1eae4416e06430e522137858",
+                "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37",
+                "sha256:cda05425526240807408156b6960a17a79a0c760b813573b67027823be760977",
+                "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4",
+                "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8",
+                "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86",
+                "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f",
+                "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112",
+                "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e",
+                "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2",
+                "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8",
+                "sha256:f8c30c2225f40dd76c50790f0eb3b5c7c18431efb299e2782083e1981feed243",
+                "sha256:fa94cb2288681e3a11645958f1871d48ee9211bd2f66628fdace505927d6e564"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==3.4.0"
+            "version": "==3.5.0"
         },
         "honcho": {
             "hashes": [
@@ -2747,19 +2945,19 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f",
-                "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
+                "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
+                "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.1"
+            "version": "==26.2"
         },
         "pathspec": {
             "hashes": [
-                "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645",
-                "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"
+                "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a",
+                "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.0.4"
+            "version": "==1.1.1"
         },
         "pgxnclient": {
             "hashes": [
@@ -2771,11 +2969,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a",
-                "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"
+                "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3",
+                "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"
             ],
-            "markers": "python_version >= '3.10'",
-            "version": "==4.9.6"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.11.0"
         },
         "pluggy": {
             "hashes": [
@@ -2930,33 +3128,34 @@
                 "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926",
                 "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==6.0.3"
         },
         "ruff": {
             "hashes": [
-                "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19",
-                "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4",
-                "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c",
-                "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890",
-                "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7",
-                "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431",
-                "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0",
-                "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4",
-                "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3",
-                "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb",
-                "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e",
-                "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3",
-                "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e",
-                "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5",
-                "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb",
-                "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7",
-                "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33",
-                "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d"
+                "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b",
+                "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33",
+                "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0",
+                "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002",
+                "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339",
+                "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e",
+                "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847",
+                "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f",
+                "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6",
+                "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d",
+                "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20",
+                "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd",
+                "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c",
+                "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5",
+                "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6",
+                "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c",
+                "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5",
+                "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.15.11"
+            "version": "==0.15.12"
         },
         "six": {
             "hashes": [
@@ -3151,11 +3350,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac",
-                "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada"
+                "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7",
+                "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==21.2.4"
+            "version": "==21.3.0"
         }
     }
 }

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,6 +38,9 @@ from app.queue.metrics import notification_event_producer_success
 from app.queue.metrics import rbac_access_denied
 from app.queue.notifications import NotificationType
 from app.tags_blueprint import tags_bp
+from app.telemetry import instrument_flask_app
+from app.telemetry import instrument_outbound_http
+from app.telemetry import instrument_sqlalchemy
 from lib.check_org import check_org_id
 from lib.feature_flags import SchemaStrategy
 from lib.feature_flags import init_unleash_app
@@ -361,5 +364,14 @@ def create_app(runtime_environment) -> connexion.FlaskApp:
     # Register automatic outbox event listeners for Host model
     # This must be imported after db.init_app() is called
     from lib import host_outbox_events  # noqa: F401
+
+    # OpenTelemetry instrumentation
+    instrument_flask_app(flask_app)
+    try:
+        with flask_app.app_context():
+            instrument_sqlalchemy(db.engine)
+    except RuntimeError:
+        logger.debug("Skipping SQLAlchemy OTel instrumentation (no app context or db not initialized)")
+    instrument_outbound_http()
 
     return app

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -19,6 +19,7 @@ from flask_sqlalchemy.model import Model
 from marshmallow import Schema
 from marshmallow import ValidationError
 from marshmallow import fields
+from opentelemetry.trace import StatusCode
 from psycopg2.errors import UniqueViolation
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from sqlalchemy.exc import IntegrityError
@@ -77,6 +78,7 @@ from app.serialization import remove_null_canonical_facts
 from app.serialization import serialize_host
 from app.serialization import serialize_uuid
 from app.staleness_serialization import AttrDict
+from app.telemetry import get_tracer
 from lib import group_repository
 from lib import host_app_repository
 from lib import host_repository
@@ -90,6 +92,7 @@ from lib.host_repository import host_exists
 from utils.system_profile_log import extract_host_dict_sp_to_log
 
 logger = get_logger(__name__)
+tracer = get_tracer(__name__)
 
 CONSUMER_POLL_TIMEOUT_SECONDS = 0.5
 MAX_RETRIES = 5
@@ -232,6 +235,33 @@ class HBIMessageConsumerBase:
     def post_process_rows(self) -> None:
         pass  # No action is taken by default
 
+    def _process_single_message(self, msg) -> None:
+        """Process a single Kafka message within a tracing span."""
+        logger.debug("Message received")
+
+        with tracer.start_as_current_span(
+            f"mq.process {msg.topic()}",
+            attributes={
+                "messaging.operation": "process",
+                "messaging.destination.name": msg.topic() or "",
+                "messaging.kafka.partition": msg.partition() or 0,
+            },
+        ) as span:
+            try:
+                self.processed_rows.append(self.handle_message(msg.value(), headers=msg.headers()))
+                metrics.consumed_message_size.observe(len(str(msg).encode("utf-8")))
+                self.success_metric.inc()
+            except OperationalError as oe:
+                span.set_status(StatusCode.ERROR, str(oe))
+                span.record_exception(oe)
+                logger.error(f"Could not access DB {str(oe)}")
+                sys.exit(3)
+            except Exception as exc:
+                span.set_status(StatusCode.ERROR, str(exc))
+                span.record_exception(exc)
+                self.failure_metric.inc()
+                logger.exception("Unable to process message", extra={"incoming_message": msg.value()})
+
     def _process_batch(self) -> None:
         """Process a single batch of messages from Kafka.
 
@@ -239,45 +269,42 @@ class HBIMessageConsumerBase:
             InvalidRequestError: When the database session is in an invalid state
             StaleDataError: When trying to update data modified by another transaction
         """
-        with no_expire_on_commit(db.session):
+        messages = self.consumer.consume(
+            num_messages=inventory_config().mq_db_batch_max_messages,
+            timeout=inventory_config().mq_db_batch_max_seconds,
+        )
+
+        valid_messages = []
+        for msg in messages:
+            if msg is None:
+                continue
+            if msg.error():
+                logger.error(f"Message received but has an error, which is {str(msg.error())}")
+                self.failure_metric.inc()
+            else:
+                valid_messages.append(msg)
+
+        if not valid_messages:
+            return
+
+        with (
+            tracer.start_as_current_span(
+                "mq.batch",
+                attributes={
+                    "messaging.system": "kafka",
+                    "messaging.batch.message_count": len(valid_messages),
+                },
+            ),
+            no_expire_on_commit(db.session),
+        ):
             with (
                 session_guard(db.session, close=False),
                 db.session.no_autoflush,
                 StalenessCache(),
                 UngroupedGroupCache(),
             ):
-                messages = self.consumer.consume(
-                    num_messages=inventory_config().mq_db_batch_max_messages,
-                    timeout=inventory_config().mq_db_batch_max_seconds,
-                )
-
-                for msg in messages:
-                    if msg is None:
-                        continue
-                    elif msg.error():
-                        # This error is raised by the first consumer.consume() on a newly started Kafka.
-                        # msg.error() produces:
-                        # KafkaError{code=UNKNOWN_TOPIC_OR_PART,val=3,str="Subscribed topic not available:
-                        #   platform.inventory.host-ingress: Broker: Unknown topic or partition"}
-                        logger.error(f"Message received but has an error, which is {str(msg.error())}")
-                        self.failure_metric.inc()
-                    else:
-                        logger.debug("Message received")
-
-                        try:
-                            self.processed_rows.append(self.handle_message(msg.value(), headers=msg.headers()))
-                            metrics.consumed_message_size.observe(len(str(msg).encode("utf-8")))
-                            self.success_metric.inc()
-                        except OperationalError as oe:
-                            """sqlalchemy.exc.OperationalError: This error occurs when an
-                            authentication failure occurs or the DB is not accessible.
-                            Exit the process to restart the pod
-                            """
-                            logger.error(f"Could not access DB {str(oe)}")
-                            sys.exit(3)
-                        except Exception:
-                            self.failure_metric.inc()
-                            logger.exception("Unable to process message", extra={"incoming_message": msg.value()})
+                for msg in valid_messages:
+                    self._process_single_message(msg)
 
             self.post_process_rows()
             # Commit Kafka offsets after successful batch processing

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -1,0 +1,176 @@
+"""OpenTelemetry initialization for HBI services.
+
+Provides centralized tracing setup for all HBI entry points (web API, MQ service,
+export service). Controlled by the OTEL_ENABLED environment variable.
+
+Usage:
+    from app.telemetry import init_otel, instrument_flask_app, instrument_sqlalchemy, instrument_outbound_http
+
+    # In gunicorn.conf.py post_fork or service main():
+    init_otel(service_name="host-inventory")
+
+    # After Flask app creation:
+    instrument_flask_app(flask_app)
+
+    # After db.init_app():
+    instrument_sqlalchemy(db.engine)
+
+    # For outbound HTTP (e.g., RBAC calls):
+    instrument_outbound_http()
+"""
+
+import contextlib
+import os
+
+from app.logging import get_logger
+
+logger = get_logger(__name__)
+
+OTEL_ENABLED = os.getenv("OTEL_ENABLED", "false").lower() == "true"
+
+
+def get_tracer(name: str):
+    """Get an OpenTelemetry tracer for creating custom spans.
+
+    When init_otel() has not been called (i.e. OTEL is disabled), the SDK's
+    default TracerProvider is a no-op that creates zero-overhead no-op spans.
+    """
+    from opentelemetry import trace
+
+    return trace.get_tracer(name)
+
+
+def init_otel(service_name: str, service_version: str = "unknown"):
+    """Initialize OpenTelemetry tracing. Call once per process.
+
+    For Gunicorn workers, call this from the post_fork hook (BatchSpanProcessor is not fork-safe).
+    For MQ/export services, call this from main().
+    """
+    if not OTEL_ENABLED:
+        logger.info("OpenTelemetry is disabled (OTEL_ENABLED != 'true')")
+        return
+
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import SERVICE_NAME
+    from opentelemetry.sdk.resources import SERVICE_VERSION
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    resource = Resource.create(
+        attributes={
+            SERVICE_NAME: service_name,
+            SERVICE_VERSION: service_version,
+            "deployment.environment": os.getenv("NAMESPACE", "development"),
+        }
+    )
+
+    provider = TracerProvider(resource=resource)
+
+    # OTLP exporter — picks up endpoint from OTEL_EXPORTER_OTLP_ENDPOINT
+    # (falls back to OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, then default localhost:4318)
+    exporter = OTLPSpanExporter()
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+
+    trace.set_tracer_provider(provider)
+    logger.info("OpenTelemetry initialized for service=%s version=%s", service_name, service_version)
+
+
+def instrument_flask_app(flask_app):
+    """Instrument a Flask app with OpenTelemetry request tracing.
+
+    Each HTTP request becomes a span with method, path, status code,
+    plus HBI-specific attributes (org_id, request_id).
+    """
+    if not OTEL_ENABLED:
+        return
+
+    from opentelemetry.instrumentation.flask import FlaskInstrumentor
+
+    FlaskInstrumentor().instrument_app(
+        flask_app,
+        excluded_urls="^/health$,^/metrics$,^/version$",
+        request_hook=_request_hook,
+        response_hook=_response_hook,
+    )
+    logger.info("Flask instrumented with OpenTelemetry")
+
+
+def instrument_sqlalchemy(engine):
+    """Instrument a SQLAlchemy engine with OpenTelemetry query tracing.
+
+    Every SQL query becomes a child span of the request that triggered it,
+    with the query text and duration. SQLCommenter adds traceparent to SQL
+    comments so queries are visible in pg_stat_activity.
+    """
+    if not OTEL_ENABLED:
+        return
+
+    from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+
+    SQLAlchemyInstrumentor().instrument(
+        engine=engine,
+        enable_commenter=True,
+        commenter_options={
+            "db_framework": True,
+            "db_driver": True,
+        },
+    )
+    logger.info("SQLAlchemy engine instrumented with OpenTelemetry")
+
+
+def instrument_outbound_http():
+    """Instrument outbound HTTP calls (e.g., RBAC) with OpenTelemetry.
+
+    Automatically creates spans for all requests made via the `requests` library,
+    including trace context propagation to downstream services.
+    """
+    if not OTEL_ENABLED:
+        return
+
+    from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+    RequestsInstrumentor().instrument()
+    logger.info("Outbound HTTP (requests library) instrumented with OpenTelemetry")
+
+
+def _request_hook(span, environ):  # noqa: ARG001
+    """Add HBI-specific attributes to every request span.
+
+    Adds org_id and request_id so traces can be filtered in Grafana/Tempo:
+        - hbi.org_id = "12345"         → all traces for an org
+        - hbi.request_id = "abc-..."   → find a specific request
+    """
+    if not span or not span.is_recording():
+        return
+
+    from flask import request
+
+    # Add request_id from the x-rh-insights-request-id header
+    request_id = request.headers.get("x-rh-insights-request-id", "")
+    if request_id:
+        span.set_attribute("hbi.request_id", request_id)
+
+    # Add org_id from the decoded identity header
+    try:
+        from app.auth.identity import from_auth_header
+
+        encoded_id = request.headers.get("x-rh-identity", "")
+        if encoded_id:
+            identity = from_auth_header(encoded_id)
+            if identity and hasattr(identity, "org_id"):
+                span.set_attribute("hbi.org_id", identity.org_id or "")
+    except Exception:
+        pass  # Don't break requests if identity extraction fails
+
+
+def _response_hook(span, status, response_headers):  # noqa: ARG001
+    """Add response-level attributes to request spans."""
+    if span and span.is_recording():
+        if isinstance(status, str):
+            # status can be "200 OK" — extract the code
+            with contextlib.suppress(ValueError, IndexError):
+                span.set_attribute("http.status_code", int(status.split()[0]))
+        elif isinstance(status, int):
+            span.set_attribute("http.status_code", status)

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -27,6 +27,7 @@ from app.logging import get_logger
 logger = get_logger(__name__)
 
 OTEL_ENABLED = os.getenv("OTEL_ENABLED", "false").lower() == "true"
+_otel_initialized_pid = None
 
 
 def get_tracer(name: str):
@@ -41,13 +42,23 @@ def get_tracer(name: str):
 
 
 def init_otel(service_name: str, service_version: str = "unknown"):
-    """Initialize OpenTelemetry tracing. Call once per process.
+    """Initialize OpenTelemetry tracing. Safe to call multiple times.
 
-    For Gunicorn workers, call this from the post_fork hook (BatchSpanProcessor is not fork-safe).
-    For MQ/export services, call this from main().
+    Uses the current PID to detect fork boundaries: if run.py initializes
+    in the Gunicorn master process and then post_fork calls again in a
+    worker, the PID will differ and the worker will re-initialize with a
+    fresh (fork-safe) TracerProvider and BatchSpanProcessor.
+
+    For single-process services (MQ, export), the second call is a no-op.
     """
+    global _otel_initialized_pid
+
+    if _otel_initialized_pid == os.getpid():
+        return
+
     if not OTEL_ENABLED:
         logger.info("OpenTelemetry is disabled (OTEL_ENABLED != 'true')")
+        _otel_initialized_pid = os.getpid()
         return
 
     from opentelemetry import trace
@@ -74,6 +85,7 @@ def init_otel(service_name: str, service_version: str = "unknown"):
     provider.add_span_processor(BatchSpanProcessor(exporter))
 
     trace.set_tracer_provider(provider)
+    _otel_initialized_pid = os.getpid()
     logger.info("OpenTelemetry initialized for service=%s version=%s", service_name, service_version)
 
 

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -267,6 +267,10 @@ objects:
             value: ${BYPASS_RBAC}
           - name: BYPASS_KESSEL
             value: ${BYPASS_KESSEL}
+          - name: OTEL_ENABLED
+            value: ${OTEL_ENABLED}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
           - name: KAFKA_PRODUCER_ACKS
             value: ${KAFKA_PRODUCER_ACKS}
           - name: KAFKA_PRODUCER_RETRIES
@@ -378,6 +382,10 @@ objects:
             value: ${BYPASS_RBAC}
           - name: BYPASS_KESSEL
             value: ${BYPASS_KESSEL}
+          - name: OTEL_ENABLED
+            value: ${OTEL_ENABLED}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
           - name: KAFKA_PRODUCER_ACKS
             value: ${KAFKA_PRODUCER_ACKS}
           - name: KAFKA_PRODUCER_RETRIES
@@ -508,6 +516,10 @@ objects:
             value: "${KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS}"
           - name: BYPASS_KESSEL
             value: ${BYPASS_KESSEL}
+          - name: OTEL_ENABLED
+            value: ${OTEL_ENABLED}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
           - name: UNLEASH_URL
             value: ${UNLEASH_URL}
           - <<: *unleashToken
@@ -579,6 +591,10 @@ objects:
             value: ${KAFKA_SASL_MECHANISM}
           - name: BYPASS_KESSEL
             value: ${BYPASS_KESSEL}
+          - name: OTEL_ENABLED
+            value: ${OTEL_ENABLED}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
           - name: CLOWDER_ENABLED
             value: "true"
           - name: INVENTORY_DB_SCHEMA
@@ -688,6 +704,10 @@ objects:
             value: "${KAFKA_CONSUMER_HEARTBEAT_INTERVAL_MS}"
           - name: BYPASS_KESSEL
             value: ${BYPASS_KESSEL}
+          - name: OTEL_ENABLED
+            value: ${OTEL_ENABLED}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
           - name: UNLEASH_URL
             value: ${UNLEASH_URL}
           - <<: *unleashToken
@@ -755,6 +775,10 @@ objects:
             value: ${KAFKA_SECURITY_PROTOCOL}
           - name: KAFKA_SASL_MECHANISM
             value: ${KAFKA_SASL_MECHANISM}
+          - name: OTEL_ENABLED
+            value: ${OTEL_ENABLED}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
           - name: CLOWDER_ENABLED
             value: "true"
           - name: INVENTORY_DB_SCHEMA
@@ -896,6 +920,10 @@ objects:
             value: ${KAFKA_SECURITY_PROTOCOL}
           - name: KAFKA_SASL_MECHANISM
             value: ${KAFKA_SASL_MECHANISM}
+          - name: OTEL_ENABLED
+            value: ${OTEL_ENABLED}
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
           - name: CLOWDER_ENABLED
             value: "true"
           - name: INVENTORY_DB_SCHEMA
@@ -2670,3 +2698,15 @@ parameters:
 - name: FLOORIST_DB_SECRET_NAME
   description: database secret name
   value: host-inventory-db
+
+# =================================================================================
+# VII. OpenTelemetry Configuration
+# =================================================================================
+# Settings for distributed tracing via OpenTelemetry.
+
+- name: OTEL_ENABLED
+  description: Enable OpenTelemetry distributed tracing
+  value: 'false'
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  description: OTLP HTTP endpoint for trace export
+  value: 'http://otel-collector.otel-stage.svc:4318'

--- a/dev.yml
+++ b/dev.yml
@@ -163,6 +163,29 @@ services:
         timeout: 5s
         retries: 5
 
+    tempo:
+      container_name: tempo
+      image: grafana/tempo:2.7.1
+      command: ["-config.file=/etc/tempo.yaml"]
+      volumes:
+        - ./.otel/tempo.yaml:/etc/tempo.yaml
+      ports:
+        - "4318:4318"
+        - "3200:3200"
+
+    grafana:
+      container_name: grafana
+      image: grafana/grafana:11.5.2
+      ports:
+        - "3000:3000"
+      environment:
+        - GF_AUTH_ANONYMOUS_ENABLED=true
+        - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      volumes:
+        - ./.otel/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      depends_on:
+        - tempo
+
     hbi-web:
       container_name: hbi-web
       build: .
@@ -197,6 +220,8 @@ services:
         - INVENTORY_API_STALENESS_CACHE_ENABLED=${INVENTORY_API_STALENESS_CACHE_ENABLED:-true}
         - CACHE_HOST=redis
         - CACHE_PORT=6379
+        - OTEL_ENABLED=${OTEL_ENABLED:-true}
+        - OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318
       depends_on:
         db:
           condition: service_healthy
@@ -229,6 +254,9 @@ services:
         - OUTBOX_USE_BATCHED_QUERIES=${OUTBOX_USE_BATCHED_QUERIES:-false}
         - CACHE_HOST=redis
         - CACHE_PORT=6379
+        - OTEL_ENABLED=${OTEL_ENABLED:-true}
+        - OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318
+        - MQ_DB_BATCH_MAX_MESSAGES=${MQ_DB_BATCH_MAX_MESSAGES:-10}
       depends_on:
         db:
           condition: service_healthy

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,12 +1,22 @@
 from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
 
+from app.common import get_build_version
 from app.config import Config
 from app.environment import RuntimeEnvironment
+from app.telemetry import init_otel
 
 
 def when_ready(server):  # noqa: ARG001, needed by gunicorn
     config = Config(RuntimeEnvironment.SERVER)
     GunicornPrometheusMetrics.start_http_server_when_ready(config.metrics_port)
+
+
+def post_fork(server, worker):  # noqa: ARG001, needed by gunicorn
+    """Initialize OpenTelemetry per worker process.
+
+    https://opentelemetry-python.readthedocs.io/en/stable/examples/fork-process-model/README.html
+    """
+    init_otel(service_name="host-inventory", service_version=get_build_version())
 
 
 def child_exit(server, worker):  # noqa: ARG001, needed by gunicorn

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -4,6 +4,7 @@ from prometheus_client import start_http_server
 
 from api.cache import init_cache
 from app import create_app
+from app.common import get_build_version
 from app.environment import RuntimeEnvironment
 from app.logging import get_logger
 from app.queue.event_producer import create_event_producer
@@ -13,6 +14,7 @@ from app.queue.host_mq import IngressMessageConsumer
 from app.queue.host_mq import SystemProfileMessageConsumer
 from app.queue.host_mq import WorkspaceMessageConsumer
 from app.queue.host_mq import create_consumer
+from app.telemetry import init_otel
 from lib.handlers import ShutdownHandler
 from lib.handlers import register_shutdown
 
@@ -20,6 +22,8 @@ logger = get_logger("host_mq_service")
 
 
 def main():
+    init_otel(service_name="host-inventory-mq", service_version=get_build_version())
+
     application = create_app(RuntimeEnvironment.SERVICE)
     config = application.app.config["INVENTORY_CONFIG"]
     init_cache(config, application)

--- a/run.py
+++ b/run.py
@@ -2,7 +2,11 @@
 import os
 
 from app import create_app
+from app.common import get_build_version
 from app.environment import RuntimeEnvironment
+from app.telemetry import init_otel
+
+init_otel(service_name="host-inventory", service_version=get_build_version())
 
 app = create_app(RuntimeEnvironment.SERVER)
 

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -67,6 +67,9 @@ class FakeMessage:
     def error(self):
         return self._error
 
+    def topic(self):
+        return "platform.inventory.host-ingress"
+
     def partition(self):
         return 0
 


### PR DESCRIPTION
## Jira
[RHINENG-26024](https://issues.redhat.com/browse/RHINENG-26024)

## What
Add OpenTelemetry distributed tracing instrumentation to HBI web API and MQ service, controlled by the `OTEL_ENABLED` environment variable (defaults to `false`).

## Why
We need visibility into request flows, SQL query performance, and MQ message processing across HBI services. This is the application-side instrumentation required to export trace data to the shared OTEL collector being deployed in our OSD clusters (see epic RHINENG-25812).

## How
- **`app/telemetry.py`** (new): Centralized OTEL init module — `init_otel()`, `instrument_flask_app()`, `instrument_sqlalchemy()`, `instrument_outbound_http()`. All are no-ops when `OTEL_ENABLED != "true"`.
- **`gunicorn.conf.py`**: `post_fork` hook calls `init_otel()` per worker (BatchSpanProcessor is not fork-safe).
- **`inv_mq_service.py`**: `init_otel()` called at startup for the MQ service.
- **`app/__init__.py`**: Flask, SQLAlchemy, and outbound HTTP instrumentation applied after app creation.
- **`app/queue/host_mq.py`**: `mq.batch` parent span per consume cycle with message count; `mq.process` child spans per message with Kafka topic, partition, and error recording.
- **`dev.yml` + `.otel/`**: Tempo and Grafana containers added for local trace visualization.
- **`Pipfile`**: Added `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-http`, and Flask/SQLAlchemy/requests instrumentors.

## Testing
- All existing tests pass
- Local dev validated with `docker compose -f dev.yml up` — traces visible in Grafana at `localhost:3000`
- Verified zero overhead when `OTEL_ENABLED=false` (no-op tracer, no exporter initialized)

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26024]: https://redhat.atlassian.net/browse/RHINENG-26024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce OpenTelemetry-based distributed tracing across the web API and MQ service, with centralized initialization and local observability support.

New Features:
- Add centralized OpenTelemetry initialization and instrumentation module for Flask, SQLAlchemy, and outbound HTTP.
- Add tracing spans around Kafka message batch consumption and per-message processing in the host MQ consumer.
- Provide local Tempo and Grafana services for viewing traces in the development docker-compose environment.

Enhancements:
- Initialize OpenTelemetry in Gunicorn workers, the standalone server entrypoint, and the MQ service with service metadata.
- Propagate HBI-specific context such as org ID and request ID into HTTP request spans for better trace filtering.

Build:
- Add OpenTelemetry runtime and instrumentation dependencies to the Python environment configuration.

Tests:
- Extend MQ test helper message stub with topic information to support tracing-related behavior in tests.

## Summary by Sourcery

Introduce OpenTelemetry-based distributed tracing across the web API and MQ service with centralized initialization and environment-driven configuration.

New Features:
- Add centralized OpenTelemetry initialization and instrumentation module for Flask, SQLAlchemy, outbound HTTP, and custom tracers.
- Add tracing spans for Kafka message batch consumption and per-message processing in the host MQ consumer.
- Provide local Tempo and Grafana services for viewing traces in the development Docker Compose environment.

Enhancements:
- Initialize OpenTelemetry in Gunicorn workers, the standalone server entrypoint, and the MQ service with service metadata.
- Propagate request metadata such as org ID and request ID into HTTP request spans for improved trace observability.

Build:
- Add OpenTelemetry runtime and instrumentation dependencies and configure OTEL-related environment variables in deployment manifests.

Tests:
- Extend MQ test helper message stub with topic information to support tracing-related behavior in tests.