### PR TITLE
fix(RHINENG-25757): Return 400 for RBAC v2 orgs on resource-types end…

### DIFF
--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -50,6 +50,7 @@ RBAC_PRIVATE_UNGROUPED_ROUTE = "/_private/_s2s/workspaces/ungrouped/"
 CHECKED_TYPES = [IdentityType.USER, IdentityType.SERVICE_ACCOUNT]
 RETRY_STATUSES = [500, 502, 503, 504]
 HIDE_WORKSPACE_TYPES = ["root", "default"]
+RESOURCE_TYPES_V2_ERROR_MESSAGE = "The resource_types endpoint is for RBAC v1 only and is not needed for RBAC v2."
 
 
 def get_rbac_url(app: str) -> str:
@@ -493,16 +494,15 @@ def rbac(resource_type: RbacResourceType, required_permission: RbacPermission, p
             # RBAC v2 for Groups: Skip RBAC v1 authorization when feature flag is enabled
             # In RBAC v2, authorization is handled by workspace API calls within the endpoint
             # (but identity type check above still applies - cert auth is always denied for groups)
-            if resource_type == RbacResourceType.GROUPS and is_rbac_v2_enabled(current_identity.org_id):
+            is_v2 = is_rbac_v2_enabled(current_identity.org_id)
+
+            if resource_type == RbacResourceType.GROUPS and is_v2:
                 return func(*args, **kwargs)
 
             # Resource-types endpoints are not supported for v2 orgs.
             # In v2, resource-types are managed via RBAC v2 Role Bindings.
-            if resource_type == RbacResourceType.ALL and is_rbac_v2_enabled(current_identity.org_id):
-                abort(
-                    HTTPStatus.BAD_REQUEST,
-                    "The resource_types endpoint is for RBAC v1 only and is not needed for RBAC v2.",
-                )
+            if resource_type == RbacResourceType.ALL and is_v2:
+                abort(HTTPStatus.BAD_REQUEST, RESOURCE_TYPES_V2_ERROR_MESSAGE)
 
             # RBAC v1 path: Check permissions via RBAC v1 API
             request_headers = _build_rbac_request_headers()

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -50,7 +50,9 @@ RBAC_PRIVATE_UNGROUPED_ROUTE = "/_private/_s2s/workspaces/ungrouped/"
 CHECKED_TYPES = [IdentityType.USER, IdentityType.SERVICE_ACCOUNT]
 RETRY_STATUSES = [500, 502, 503, 504]
 HIDE_WORKSPACE_TYPES = ["root", "default"]
-RESOURCE_TYPES_V2_ERROR_MESSAGE = "The resource_types endpoint is for RBAC v1 only and is not needed for RBAC v2."
+RESOURCE_TYPES_V2_ERROR_MESSAGE = (
+    "The resource_types endpoints are only used for RBAC v1, and are not allowed for RBAC v2."
+)
 
 
 def get_rbac_url(app: str) -> str:

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -496,6 +496,14 @@ def rbac(resource_type: RbacResourceType, required_permission: RbacPermission, p
             if resource_type == RbacResourceType.GROUPS and is_rbac_v2_enabled(current_identity.org_id):
                 return func(*args, **kwargs)
 
+            # Resource-types endpoints are not supported for v2 orgs.
+            # In v2, resource-types are managed via RBAC v2 Role Bindings.
+            if resource_type == RbacResourceType.ALL and is_rbac_v2_enabled(current_identity.org_id):
+                abort(
+                    HTTPStatus.BAD_REQUEST,
+                    "The resource_types endpoint is for RBAC v1 only and is not needed for RBAC v2.",
+                )
+
             # RBAC v1 path: Check permissions via RBAC v1 API
             request_headers = _build_rbac_request_headers()
 

--- a/tests/test_api_resource_types_get.py
+++ b/tests/test_api_resource_types_get.py
@@ -1,5 +1,6 @@
 import pytest
 
+from lib.middleware import RESOURCE_TYPES_V2_ERROR_MESSAGE
 from tests.helpers.api_utils import RBAC_ADMIN_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import assert_resource_types_pagination
 from tests.helpers.api_utils import assert_response_status
@@ -128,7 +129,7 @@ def test_get_resource_types_v2_org_returns_error(mocker, api_get, url_builder):
     response_status, response_data = api_get(url_builder())
 
     assert_response_status(response_status, 400)
-    assert "The resource_types endpoint is for RBAC v1 only and is not needed for RBAC v2." in response_data["detail"]
+    assert RESOURCE_TYPES_V2_ERROR_MESSAGE in response_data["detail"]
 
 
 @pytest.mark.usefixtures("enable_rbac")

--- a/tests/test_api_resource_types_get.py
+++ b/tests/test_api_resource_types_get.py
@@ -118,6 +118,20 @@ def test_get_resource_types_RBAC_denied(mocker, api_get, url_builder, subtests):
 
 
 @pytest.mark.usefixtures("enable_rbac")
+@pytest.mark.parametrize(
+    "url_builder",
+    [build_resource_types_url, build_resource_types_groups_url],
+)
+def test_get_resource_types_v2_org_returns_error(mocker, api_get, url_builder):
+    mocker.patch("lib.middleware.is_rbac_v2_enabled", return_value=True)
+
+    response_status, response_data = api_get(url_builder())
+
+    assert_response_status(response_status, 400)
+    assert "The resource_types endpoint is for RBAC v1 only and is not needed for RBAC v2." in response_data["detail"]
+
+
+@pytest.mark.usefixtures("enable_rbac")
 def test_get_resource_types_ungrouped_is_not_returned(
     mocker,
     api_get,


### PR DESCRIPTION
…points

## Jira
[RHINENG-25757](https://issues.redhat.com/browse/RHINENG-25757)

## What
Return error when the `resource_types` endpoint is used by RBAC v1 UI and not for RBAC v2.

## Why
resource_types endpoint is used only by RBAC v1 UI.

## How
<!-- Brief explanation of approach -->

## Testing
<!-- How was this tested? -->

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-25757]: https://redhat.atlassian.net/browse/RHINENG-25757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Return a 400 error from RBAC middleware when RBAC v2 orgs access the legacy resource_types endpoints and add coverage for this behavior.

Bug Fixes:
- Prevent RBAC v2 organizations from using the legacy resource_types endpoints by returning an HTTP 400 error with a clear message.

Enhancements:
- Introduce a shared error message constant for unsupported use of resource_types in RBAC v2 and reuse it in middleware and tests.

Tests:
- Add tests ensuring RBAC v2 organizations receive a 400 response and descriptive error when calling resource_types and resource_types_groups endpoints.