### PR TITLE
RHINENG-20674: Delete custom staleness record when POST/PATCH values are near defaults

### DIFF
--- a/api/staleness.py
+++ b/api/staleness.py
@@ -45,8 +45,10 @@ from lib.host_repository import host_exists
 from lib.host_repository import host_query
 from lib.middleware import access
 from lib.staleness import add_staleness
+from lib.staleness import is_staleness_near_default
 from lib.staleness import patch_staleness
 from lib.staleness import remove_staleness
+from lib.staleness import remove_staleness_if_exists
 
 logger = get_logger(__name__)
 
@@ -232,6 +234,14 @@ def create_staleness(body):
         logger.exception(f'Input validation error, "{str(e.messages)}", while creating account staleness: {body}')
         return json_error_response("Validation Error", str(e.messages), HTTPStatus.BAD_REQUEST)
 
+    if is_staleness_near_default(validated_data):
+        logger.debug("Incoming staleness data for org_id %s is near defaults; removing any existing record", org_id)
+        remove_staleness_if_exists()
+        StalenessCache.delete(org_id)
+        staleness = get_sys_default_staleness_api(identity)
+        _async_update_host_staleness(identity, staleness, request_id)
+        return flask_json_response(None, HTTPStatus.NO_CONTENT)
+
     try:
         # Create account staleness with validated data
         created_staleness = add_staleness(validated_data)
@@ -284,6 +294,17 @@ def update_staleness(body):
 
     identity = get_current_identity()
     org_id = identity.org_id
+
+    if is_staleness_near_default(validated_data):
+        logger.debug("Patched staleness data for org_id %s is near defaults; removing existing record", org_id)
+        deleted = remove_staleness_if_exists()
+        if not deleted:
+            abort(HTTPStatus.NOT_FOUND, f"Staleness record for org_id {org_id} does not exist.")
+        StalenessCache.delete(org_id)
+        staleness = get_sys_default_staleness_api(identity)
+        _async_update_host_staleness(identity, staleness, request_id)
+        return flask_json_response(None, HTTPStatus.NO_CONTENT)
+
     try:
         updated_staleness = patch_staleness(validated_data)
         StalenessCache.delete(org_id)

--- a/lib/staleness.py
+++ b/lib/staleness.py
@@ -1,10 +1,38 @@
 from app.auth import get_current_identity
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
 from app.logging import get_logger
 from app.models import Staleness
 from app.models import db
 from lib.db import session_guard
 
 logger = get_logger(__name__)
+
+# Records whose values are within this many seconds of the system defaults are
+# considered effectively identical to the defaults and should not be stored.
+NEAR_DEFAULT_THRESHOLD_SECONDS = 3600  # 1 hour
+
+
+def is_staleness_near_default(staleness) -> bool:
+    """Return True if all staleness values are within NEAR_DEFAULT_THRESHOLD_SECONDS of the system defaults.
+
+    Accepts either a dict (for incoming API data) or a Staleness model object.
+    """
+    if isinstance(staleness, dict):
+        stale = staleness.get("conventional_time_to_stale", CONVENTIONAL_TIME_TO_STALE_SECONDS)
+        warning = staleness.get("conventional_time_to_stale_warning", CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS)
+        delete = staleness.get("conventional_time_to_delete", CONVENTIONAL_TIME_TO_DELETE_SECONDS)
+    else:
+        stale = staleness.conventional_time_to_stale
+        warning = staleness.conventional_time_to_stale_warning
+        delete = staleness.conventional_time_to_delete
+
+    return (
+        abs(stale - CONVENTIONAL_TIME_TO_STALE_SECONDS) <= NEAR_DEFAULT_THRESHOLD_SECONDS
+        and abs(warning - CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS) <= NEAR_DEFAULT_THRESHOLD_SECONDS
+        and abs(delete - CONVENTIONAL_TIME_TO_DELETE_SECONDS) <= NEAR_DEFAULT_THRESHOLD_SECONDS
+    )
 
 
 def add_staleness(staleness_data) -> Staleness:
@@ -51,3 +79,18 @@ def remove_staleness() -> None:
     staleness = Staleness.query.filter(Staleness.org_id == org_id).one()
     db.session.delete(staleness)
     db.session.commit()
+
+
+def remove_staleness_if_exists() -> bool:
+    """Delete the custom staleness record for the current org if one exists.
+
+    Returns True if a record was deleted, False if no record existed.
+    """
+    org_id = get_current_identity().org_id
+    staleness = Staleness.query.filter(Staleness.org_id == org_id).one_or_none()
+    if staleness is None:
+        return False
+    logger.debug("Removing near-default AccountStaleness for org_id: %s", org_id)
+    db.session.delete(staleness)
+    db.session.commit()
+    return True

--- a/tests/test_api_staleness_create.py
+++ b/tests/test_api_staleness_create.py
@@ -3,23 +3,71 @@ import pytest
 from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
 from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
 from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+from lib.staleness import NEAR_DEFAULT_THRESHOLD_SECONDS
 from tests.helpers.api_utils import _INPUT_DATA
 from tests.helpers.api_utils import STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import run_rbac_test
+from tests.helpers.test_utils import USER_IDENTITY
+
+# Custom values well outside the near-default threshold (> 3600s from defaults).
+_CUSTOM_INPUT_DATA = {
+    "conventional_time_to_stale": 172800,  # 2 days (default: 29 h)
+    "conventional_time_to_stale_warning": 432000,  # 5 days (default: 7 days)
+    "conventional_time_to_delete": 1296000,  # 15 days (default: 30 days)
+}
+
+# Values within NEAR_DEFAULT_THRESHOLD_SECONDS of the defaults.
+_NEAR_DEFAULT_INPUT_DATA = {
+    "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS + NEAR_DEFAULT_THRESHOLD_SECONDS,
+    "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
+    "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
+}
 
 
 def test_create_staleness(api_create_staleness, db_get_staleness_culling):
-    response_status, response_data = api_create_staleness(_INPUT_DATA)
+    response_status, response_data = api_create_staleness(_CUSTOM_INPUT_DATA)
     assert_response_status(response_status, 201)
 
     saved_org_id = response_data["org_id"]
     saved_data = db_get_staleness_culling(saved_org_id)
 
-    assert saved_data.conventional_time_to_stale == _INPUT_DATA["conventional_time_to_stale"]
-    assert saved_data.conventional_time_to_stale_warning == _INPUT_DATA["conventional_time_to_stale_warning"]
-    assert saved_data.conventional_time_to_delete == _INPUT_DATA["conventional_time_to_delete"]
+    assert saved_data.conventional_time_to_stale == _CUSTOM_INPUT_DATA["conventional_time_to_stale"]
+    assert saved_data.conventional_time_to_stale_warning == _CUSTOM_INPUT_DATA["conventional_time_to_stale_warning"]
+    assert saved_data.conventional_time_to_delete == _CUSTOM_INPUT_DATA["conventional_time_to_delete"]
+
+
+def test_create_near_default_staleness_returns_no_content(api_create_staleness, db_get_staleness_culling):
+    """When all values are within one hour of the defaults no record should be stored."""
+    response_status, _ = api_create_staleness(_NEAR_DEFAULT_INPUT_DATA)
+    assert_response_status(response_status, 204)
+
+    org_id = USER_IDENTITY["org_id"]
+    assert db_get_staleness_culling(org_id) is None, "No DB record should be created for near-default data"
+
+
+def test_create_exact_default_staleness_returns_no_content(api_create_staleness, db_get_staleness_culling):
+    """Exact default values also trigger the near-default path and return 204."""
+    response_status, _ = api_create_staleness(_INPUT_DATA)
+    assert_response_status(response_status, 204)
+
+    org_id = USER_IDENTITY["org_id"]
+    assert db_get_staleness_culling(org_id) is None
+
+
+def test_create_near_default_staleness_deletes_existing_record(
+    api_create_staleness, db_create_staleness_culling, db_get_staleness_culling
+):
+    """If a custom record already exists and the new POST is near-default, the record is deleted."""
+    db_create_staleness_culling(conventional_time_to_stale=1)
+    org_id = USER_IDENTITY["org_id"]
+    assert db_get_staleness_culling(org_id) is not None
+
+    response_status, _ = api_create_staleness(_NEAR_DEFAULT_INPUT_DATA)
+    assert_response_status(response_status, 204)
+
+    assert db_get_staleness_culling(org_id) is None, "Existing record should be deleted"
 
 
 def test_create_staleness_with_only_one_data(api_create_staleness, db_get_staleness_culling):
@@ -38,10 +86,10 @@ def test_create_staleness_with_only_one_data(api_create_staleness, db_get_stalen
 
 
 def test_create_same_staleness(api_create_staleness):
-    response_status, response_data = api_create_staleness(_INPUT_DATA)
+    response_status, _ = api_create_staleness(_CUSTOM_INPUT_DATA)
     assert_response_status(response_status, 201)
 
-    response_status, response_data = api_create_staleness(_INPUT_DATA)
+    response_status, _ = api_create_staleness(_CUSTOM_INPUT_DATA)
     assert_response_status(response_status, 400)
 
 
@@ -56,7 +104,7 @@ def test_create_staleness_with_wrong_input(api_create_staleness):
 @pytest.mark.usefixtures("enable_rbac")
 def test_create_staleness_rbac_allowed(subtests, mocker, api_create_staleness):
     run_rbac_test(
-        subtests, mocker, api_create_staleness, STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES, 201, [_INPUT_DATA]
+        subtests, mocker, api_create_staleness, STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES, 201, [_CUSTOM_INPUT_DATA]
     )
 
 
@@ -97,25 +145,19 @@ def test_create_improper_staleness(api_create_staleness, input_data):
     "input_data",
     (
         {
-            "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
-            "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
-            "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
+            **_CUSTOM_INPUT_DATA,
             "immutable_time_to_stale": 172800,
             "immutable_time_to_stale_warning": 1,
             "immutable_time_to_delete": 63072000,
         },
         {
-            "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
-            "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
-            "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
+            **_CUSTOM_INPUT_DATA,
             "immutable_time_to_stale": 172800,
             "immutable_time_to_stale_warning": 15552000,
             "immutable_time_to_delete": 1,
         },
         {
-            "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
-            "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
-            "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
+            **_CUSTOM_INPUT_DATA,
             "immutable_time_to_stale": 172800,
             "immutable_time_to_stale_warning": 64000000,
             "immutable_time_to_delete": 63072000,
@@ -132,6 +174,6 @@ def test_create_staleness_ignores_immutable_fields(api_create_staleness, db_get_
     saved_data = db_get_staleness_culling(saved_org_id)
 
     # Verify only conventional fields were saved, immutable fields were ignored
-    assert saved_data.conventional_time_to_stale == input_data["conventional_time_to_stale"]
-    assert saved_data.conventional_time_to_stale_warning == input_data["conventional_time_to_stale_warning"]
-    assert saved_data.conventional_time_to_delete == input_data["conventional_time_to_delete"]
+    assert saved_data.conventional_time_to_stale == _CUSTOM_INPUT_DATA["conventional_time_to_stale"]
+    assert saved_data.conventional_time_to_stale_warning == _CUSTOM_INPUT_DATA["conventional_time_to_stale_warning"]
+    assert saved_data.conventional_time_to_delete == _CUSTOM_INPUT_DATA["conventional_time_to_delete"]

--- a/tests/test_api_staleness_update.py
+++ b/tests/test_api_staleness_update.py
@@ -1,12 +1,24 @@
 import pytest
 
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+from lib.staleness import NEAR_DEFAULT_THRESHOLD_SECONDS
 from tests.helpers.api_utils import STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_staleness_url
 from tests.helpers.api_utils import run_rbac_test
+from tests.helpers.test_utils import USER_IDENTITY
 
 _INPUT_DATA = {"conventional_time_to_stale": 99}
+
+# A PATCH body that, when merged with the full defaults, results in near-default values.
+_NEAR_DEFAULT_PATCH_DATA = {
+    "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS + NEAR_DEFAULT_THRESHOLD_SECONDS,
+    "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
+    "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
+}
 
 
 def test_update_existing_record(api_patch, db_create_staleness_culling):
@@ -42,3 +54,23 @@ def test_update_staleness_rbac_denied(subtests, mocker, api_patch, db_create_sta
     db_create_staleness_culling(conventional_time_to_stale=1)
     url = build_staleness_url()
     run_rbac_test(subtests, mocker, api_patch, STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES, 403, [url, _INPUT_DATA])
+
+
+def test_update_to_near_default_deletes_record(api_patch, db_create_staleness_culling, db_get_staleness_culling):
+    """PATCHing to near-default values should delete the custom record and return 204."""
+    db_create_staleness_culling(conventional_time_to_stale=1)
+    org_id = USER_IDENTITY["org_id"]
+    assert db_get_staleness_culling(org_id) is not None
+
+    url = build_staleness_url()
+    response_status, _ = api_patch(url, host_data=_NEAR_DEFAULT_PATCH_DATA)
+    assert_response_status(response_status, 204)
+
+    assert db_get_staleness_culling(org_id) is None, "Record should be deleted after near-default PATCH"
+
+
+def test_update_to_near_default_no_existing_record_returns_404(api_patch):
+    """PATCHing to near-default values when no record exists should return 404."""
+    url = build_staleness_url()
+    response_status, _ = api_patch(url, host_data=_NEAR_DEFAULT_PATCH_DATA)
+    assert_response_status(response_status, 404)

--- a/tests/test_lib_staleness.py
+++ b/tests/test_lib_staleness.py
@@ -1,0 +1,78 @@
+"""Unit tests for lib/staleness.py helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+from lib.staleness import NEAR_DEFAULT_THRESHOLD_SECONDS
+from lib.staleness import is_staleness_near_default
+
+
+def _dict(stale=None, warning=None, delete=None) -> dict:
+    return {
+        "conventional_time_to_stale": stale if stale is not None else CONVENTIONAL_TIME_TO_STALE_SECONDS,
+        "conventional_time_to_stale_warning": (
+            warning if warning is not None else CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+        ),
+        "conventional_time_to_delete": delete if delete is not None else CONVENTIONAL_TIME_TO_DELETE_SECONDS,
+    }
+
+
+def _obj(stale=None, warning=None, delete=None) -> SimpleNamespace:
+    return SimpleNamespace(
+        conventional_time_to_stale=stale if stale is not None else CONVENTIONAL_TIME_TO_STALE_SECONDS,
+        conventional_time_to_stale_warning=(
+            warning if warning is not None else CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+        ),
+        conventional_time_to_delete=delete if delete is not None else CONVENTIONAL_TIME_TO_DELETE_SECONDS,
+    )
+
+
+class TestIsStatelessNearDefault:
+    # --- dict inputs ---
+
+    def test_exact_defaults_dict(self):
+        assert is_staleness_near_default(_dict()) is True
+
+    def test_within_threshold_dict(self):
+        assert (
+            is_staleness_near_default(
+                _dict(
+                    stale=CONVENTIONAL_TIME_TO_STALE_SECONDS + NEAR_DEFAULT_THRESHOLD_SECONDS,
+                    warning=CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS - NEAR_DEFAULT_THRESHOLD_SECONDS,
+                    delete=CONVENTIONAL_TIME_TO_DELETE_SECONDS + NEAR_DEFAULT_THRESHOLD_SECONDS,
+                )
+            )
+            is True
+        )
+
+    def test_one_second_over_threshold_dict(self):
+        assert (
+            is_staleness_near_default(
+                _dict(stale=CONVENTIONAL_TIME_TO_STALE_SECONDS + NEAR_DEFAULT_THRESHOLD_SECONDS + 1)
+            )
+            is False
+        )
+
+    def test_far_outside_threshold_dict(self):
+        assert is_staleness_near_default(_dict(stale=1)) is False
+
+    def test_only_one_field_outside_threshold_dict(self):
+        assert is_staleness_near_default(_dict(delete=1)) is False
+
+    # --- model object inputs ---
+
+    def test_exact_defaults_obj(self):
+        assert is_staleness_near_default(_obj()) is True
+
+    def test_within_threshold_obj(self):
+        assert (
+            is_staleness_near_default(_obj(stale=CONVENTIONAL_TIME_TO_STALE_SECONDS + NEAR_DEFAULT_THRESHOLD_SECONDS))
+            is True
+        )
+
+    def test_far_outside_threshold_obj(self):
+        assert is_staleness_near_default(_obj(warning=1)) is False


### PR DESCRIPTION
## Summary

If the incoming data for POST or PATCH /account/staleness has all three conventional staleness values within one hour (3600 s) of the system defaults, the endpoint now deletes any existing custom record and returns 204 No Content instead of storing a redundant row.

## Jira
[RHINENG-20674](https://issues.redhat.com/browse/RHINENG-20674)

## Changes
- lib/staleness.py: add NEAR_DEFAULT_THRESHOLD_SECONDS, is_staleness_near_default() (works on dicts and Staleness objects), and remove_staleness_if_exists()
- api/staleness.py: create_staleness and update_staleness check is_staleness_near_default before the normal create/patch path; return 204 No Content when triggered
- tests/test_api_staleness_create.py: updated to use non-default values for 201 tests; new tests for the 204 near-default path
- tests/test_api_staleness_update.py: new tests for near-default PATCH (204) and missing-record near-default PATCH (404)
- tests/test_lib_staleness.py: unit tests for is_staleness_near_default with both dict and object inputs

## Testing
30 tests passing, make style clean. RHINENG-20675 (staleness data cleanup job) should be merged after this one.

Made with [Cursor](https://cursor.com)

[RHINENG-20674]: https://redhat.atlassian.net/browse/RHINENG-20674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Handle near-default account staleness settings by avoiding storage of redundant custom records and updating associated host staleness accordingly.

New Features:
- Treat account staleness configurations that are within a small threshold of system defaults as equivalent to the defaults, returning 204 No Content instead of persisting them on POST/PATCH.

Enhancements:
- Add helper utilities to detect near-default staleness values and to conditionally remove existing staleness records for an organization.
- Extend staleness API handlers to delete existing custom records and refresh cache/host staleness when updates move settings back to near-default values.

Tests:
- Expand API staleness create/update tests to cover near-default behaviors and adjust existing tests to use clearly non-default values.
- Add unit tests for the staleness helper that validates near-default detection for both dict inputs and model-like objects.