### PR TITLE
ci: base PR review Slack reminder on 24h human activity

### DIFF
--- a/.github/workflows/pr-review-reminder.yaml
+++ b/.github/workflows/pr-review-reminder.yaml
@@ -1,4 +1,5 @@
-# Posts a daily Slack reminder listing open PRs that have received no reviews.
+# Posts a daily Slack reminder listing open PRs (older than 1 day) with no human
+# review or comment activity in the last 24 hours.
 
 name: PR Review Reminder
 
@@ -30,15 +31,15 @@ jobs:
             --json number,title,author,createdAt,url,isDraft,reviewDecision,reviews,comments \
             --limit 100)
 
-          # Filter: not draft, older than 1 day, no human reviews or comments
+          # Filter: not draft, older than 1 day, no human reviews or comments in the last 24 hours
           # Bot interactions (logins matching "bot", "sourcery", or "github-actions") are ignored
           # Sort: oldest first (highest priority)
           FILTERED=$(echo "$PRS" | jq --argjson now "$NOW" --argjson day "$ONE_DAY" '
             [ .[]
               | select(.isDraft == false)
               | .author.login as $pr_author
-              | select(([.reviews[] | select(.author.login != $pr_author and (.author.login | test("bot|sourcery|github-actions") | not))] | length) == 0)
-              | select(([.comments[] | select(.author.login != $pr_author and (.author.login | test("bot|sourcery|github-actions") | not))] | length) == 0)
+              | select(([.reviews[] | select(.author.login != $pr_author and (.author.login | test("bot|sourcery|github-actions") | not)) | select(.submittedAt != null and ($now - (.submittedAt | fromdateiso8601)) <= $day)] | length) == 0)
+              | select(([.comments[] | select(.author.login != $pr_author and (.author.login | test("bot|sourcery|github-actions") | not)) | select(($now - (.createdAt | fromdateiso8601)) <= $day)] | length) == 0)
               | select(.reviewDecision != "APPROVED")
               | (.createdAt | fromdateiso8601) as $created
               | select(($now - $created) > $day)
@@ -50,7 +51,7 @@ jobs:
           COUNT=$(echo "$FILTERED" | jq 'length')
 
           if [ "$COUNT" -eq 0 ]; then
-            echo "No unreviewed PRs older than 1 day. Skipping Slack notification."
+            echo "No open PRs older than 1 day with no human review/comment activity in the last 24 hours. Skipping Slack notification."
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

Updates the daily **PR Review Reminder** workflow so Slack lists open PRs (older than one day) that have had **no human review or issue comment in the last 24 hours**, instead of requiring no such activity **ever** on the PR.

- Human reviews are detected by `submittedAt` (same author/bot exclusions as before).
- Issue comments use `createdAt`.
- The 24h window reuses the existing 86400s `ONE_DAY` value for consistency with the “PR must be older than 1 day” rule.

## Testing

- Validated the jq filter locally with synthetic JSON (recent vs. older human activity).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

CI:
- Adjust the GitHub Actions jq filter to consider human reviews and comments within the last 24 hours when selecting PRs for Slack reminders.