### PR TITLE
test: Fix failing staleness test

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_staleness_patch.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_staleness_patch.py
@@ -186,7 +186,7 @@ def test_staleness_update_invalid_field(host_inventory: ApplicationHostInventory
       negative: true
       title: Attempt to update a new staleness record with an invalid field
     """
-    host_inventory.apis.account_staleness.create_staleness()
+    host_inventory.apis.account_staleness.create_staleness(**gen_staleness_settings(False))
 
     test_data = {TIME_TO_STALE: DAY_SECS, "bad_field": DAY_SECS}
     logger.info(f"Updating account record with:\n{test_data}")

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/staleness_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/staleness_utils.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 DAY_SECS = 24 * 60 * 60
 
 MIN_DELTA = 1
+DEFAULT_BUFFER = 3601
 
 type DELTAS = tuple[int, int, int]
 type HOSTS_INPUT = list[dict[str, Any]]
@@ -102,7 +103,15 @@ def gen_staleness_settings(want_sample: bool = True) -> dict[str, int]:
             STALENESS_DEFAULTS[fields[1]],
             STALENESS_LIMITS[fields[2]],
         ]
-        return dict(zip(fields, starmap(randint, pairwise(boundaries)), strict=False))
+        result = dict(zip(fields, starmap(randint, pairwise(boundaries)), strict=False))
+
+        # If the values are too close to the defaults, HBI keeps the default config
+        # https://redhat.atlassian.net/browse/RHINENG-20674
+        for field in fields:
+            default = STALENESS_DEFAULTS[field]
+            if abs(result[field] - default) < DEFAULT_BUFFER:
+                result[field] = default - DEFAULT_BUFFER
+        return result
 
     settings = {}
 


### PR DESCRIPTION
## What
Fix failing `test_staleness_update_invalid_field`

## Why
It probably started failing when we started ignoring staleness config that is similar to the default config, because the `update` call is failing with "Staleness record for org_id 3340851 does not exist."

## How
Create random settings (non-empty) in the initial staleness create call

## Testing
I ran the test in ephemeral environment and it passed.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Tests:
- Update the staleness invalid-field PATCH test to create randomized non-empty staleness settings before performing the update.

## Summary by Sourcery

Tests:
- Adjust the staleness invalid-field PATCH test to create a staleness record using generated non-empty settings prior to the update operation.