### PR TITLE
test(RHINENG-26103): Update tests to bind RBAC roles to the default workspace

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/rbac_fixtures.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/rbac_fixtures.py
@@ -98,7 +98,7 @@ def rbac_non_org_admin_rbac_admin_setup_class(
 
     role = host_inventory.apis.rbac.get_rbac_admin_role()
     if host_inventory.unleash.is_rbac_workspaces_enabled:
-        workspace_id = host_inventory.apis.workspaces.root_workspace.id
+        workspace_id = host_inventory.apis.workspaces.default_workspace.id
         host_inventory.apis.rbac.create_role_bindings(
             [get_role_id(role)], group.uuid, [workspace_id]
         )
@@ -609,7 +609,7 @@ def rbac_setup_user_with_rhel_role(
 
     role = host_inventory.apis.rbac.get_role_by_name(request.param.value)
     if host_inventory.unleash.is_rbac_workspaces_enabled:
-        workspace_id = host_inventory.apis.workspaces.root_workspace.id
+        workspace_id = host_inventory.apis.workspaces.default_workspace.id
         host_inventory.apis.rbac.create_role_bindings(
             [get_role_id(role)], group.uuid, [workspace_id]
         )

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
@@ -322,7 +322,7 @@ class RBACAPIWrapper(BaseEntity):
                     for ws_id in _hbi_groups_to_ids(hbi_groups)
                 ]
             else:
-                workspace_ids = [self._host_inventory.apis.workspaces.root_workspace.id]
+                workspace_ids = [self._host_inventory.apis.workspaces.default_workspace.id]
             role_ids = [role.id for role in roles]
             self.create_role_bindings(role_ids, group.uuid, workspace_ids)
         else:

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
@@ -23,17 +23,18 @@ from iqe_bindings.v7.rbac_v1 import ResourceDefinitionFilter
 from iqe_bindings.v7.rbac_v1 import ResourceDefinitionFilterOperationEqual
 from iqe_bindings.v7.rbac_v1 import ResourceDefinitionFilterOperationIn
 from iqe_bindings.v7.rbac_v1 import RoleIn
+from iqe_bindings.v7.rbac_v1 import RoleOutDynamic
 from iqe_bindings.v7.rbac_v1 import RoleWithAccess
 from iqe_bindings.v7.rbac_v2 import ApiException as RBACV2ApiException
 from iqe_bindings.v7.rbac_v2 import ResourceType
 from iqe_bindings.v7.rbac_v2 import Role as RBACV2Role
 from iqe_bindings.v7.rbac_v2 import RoleBindingsBatchCreateRoleBindingsRequest
 from iqe_bindings.v7.rbac_v2 import RoleBindingsBatchCreateRoleBindingsResponse
+from iqe_bindings.v7.rbac_v2 import RoleBindingsBindingSubjectType
 from iqe_bindings.v7.rbac_v2 import RoleBindingsCreateRoleBindingsRequest
 from iqe_bindings.v7.rbac_v2 import RoleBindingsCreateRoleBindingsRequestResource
 from iqe_bindings.v7.rbac_v2 import RoleBindingsCreateRoleBindingsRequestRole
 from iqe_bindings.v7.rbac_v2 import RoleBindingsCreateRoleBindingsRequestSubject
-from iqe_bindings.v7.rbac_v2 import RoleBindingsRoleBindingSubject
 from iqe_bindings.v7.rbac_v2 import RoleBindingsUpdateRoleBindingsRequest
 from iqe_bindings.v7.rbac_v2 import RolesBatchDeleteRolesRequest
 from iqe_bindings.v7.rbac_v2 import RolesCreateOrUpdateRoleRequest
@@ -46,6 +47,7 @@ from iqe_host_inventory.schemas import RBACRestClientV2
 from iqe_host_inventory.utils.datagen_utils import generate_uuid
 from iqe_host_inventory.utils.rbac_utils import RBACInventoryPermission
 from iqe_host_inventory.utils.rbac_utils import RBACRoles
+from iqe_host_inventory.utils.rbac_utils import get_role_id
 from iqe_host_inventory.utils.rbac_utils import permission_to_v2
 from iqe_host_inventory.utils.rbac_utils import wait_for_kessel_sync
 
@@ -190,9 +192,11 @@ class RBACAPIWrapper(BaseEntity):
             )
         )
 
-    def add_roles_to_a_group(self, roles: list[RoleWithAccess], group_uuid: str) -> None:
-        role_uuids = [role.uuid for role in roles]
-        self.raw_api.group_api.add_role_to_group(group_uuid, GroupRoleIn(roles=role_uuids))
+    def add_roles_to_a_group(
+        self, roles: list[RoleWithAccess | RoleOutDynamic], group_uuid: str
+    ) -> None:
+        role_ids = [get_role_id(role) for role in roles]
+        self.raw_api.group_api.add_role_to_group(group_uuid, GroupRoleIn(roles=role_ids))
 
     def create_role_bindings(
         self,
@@ -209,7 +213,7 @@ class RBACAPIWrapper(BaseEntity):
                             id=workspace_id, type="workspace"
                         ),
                         subject=RoleBindingsCreateRoleBindingsRequestSubject(
-                            id=group_uuid, type=RoleBindingsRoleBindingSubject.GROUP
+                            id=group_uuid, type=RoleBindingsBindingSubjectType.GROUP
                         ),
                         role=RoleBindingsCreateRoleBindingsRequestRole(id=role_id),
                     )
@@ -248,7 +252,7 @@ class RBACAPIWrapper(BaseEntity):
         bindings for each (resource, subject) combination.
         """
         get_response = self.raw_api_v2.role_bindings_api.role_bindings_list(
-            subject_type=RoleBindingsRoleBindingSubject.GROUP,
+            subject_type=RoleBindingsBindingSubjectType.GROUP,
             subject_id=group_uuid,
             limit=10000,
         )
@@ -265,7 +269,7 @@ class RBACAPIWrapper(BaseEntity):
                         ResourceType(resource.type) if resource.type else ResourceType.WORKSPACE
                     ),
                     subject_id=group_uuid,
-                    subject_type=RoleBindingsRoleBindingSubject.GROUP,
+                    subject_type=RoleBindingsBindingSubjectType.GROUP,
                     role_bindings_update_role_bindings_request=empty_request,
                 )
             )
@@ -323,7 +327,7 @@ class RBACAPIWrapper(BaseEntity):
                 ]
             else:
                 workspace_ids = [self._host_inventory.apis.workspaces.default_workspace.id]
-            role_ids = [role.id for role in roles]
+            role_ids = [get_role_id(role) for role in roles]
             self.create_role_bindings(role_ids, group.uuid, workspace_ids)
         else:
             roles = [self.create_role_v1(perm, hbi_groups=hbi_groups) for perm in permissions]
@@ -333,10 +337,10 @@ class RBACAPIWrapper(BaseEntity):
 
         return group, roles
 
-    def get_role_by_name(self, name: str) -> RoleWithAccess:
+    def get_role_by_name(self, name: str) -> RoleOutDynamic:
         return self.raw_api.role_api.list_roles(name=name).data[0]
 
-    def get_rbac_admin_role(self) -> RoleWithAccess:
+    def get_rbac_admin_role(self) -> RoleOutDynamic:
         return self.get_role_by_name("User Access Administrator")
 
     def get_group_by_name(self, name: str) -> RBACGroupOut:

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/workspaces_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/workspaces_api.py
@@ -329,6 +329,13 @@ class WorkspacesAPIWrapper(BaseEntity):
             type=WorkspacesWorkspaceTypesQueryParam.DEFAULT,
         )[0]
 
+    @cached_property
+    def default_workspace(self) -> WorkspacesWorkspace:
+        """
+        A cached property for getting the default workspace.
+        """
+        return self.get_default_workspace()
+
     def get_workspaces_response(
         self,
         *,

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
@@ -1123,7 +1123,7 @@ def setup_permissions_with_and_without_resource_definitions(
     """Creates 2 roles, one with and one without resource definitions.
     User should have access to all resources.
 
-    V2 equivalent: one role bound to a specific workspace, one bound to root workspace.
+    V2 equivalent: one role bound to a specific workspace, one bound to default workspace.
     """
     hbi_groups = [rbac_setup_resources_for_granular_rbac[1][0]]
     host_inventory.apis.rbac.reset_user_groups(hbi_non_org_admin_user_username)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/rbac/groups/test_rbac_granular_groups.py
@@ -1138,7 +1138,7 @@ def setup_permissions_with_and_without_resource_definitions(
         role_without = host_inventory.apis.rbac.create_role_v2(RBACInventoryPermission.ALL_READ)
 
         workspace_ids = [g.id for g in hbi_groups]
-        root_workspace_id = host_inventory.apis.workspaces.root_workspace.id
+        default_workspace_id = host_inventory.apis.workspaces.default_workspace.id
 
         if request.param == "first_with":
             roles = [role_with, role_without]
@@ -1147,7 +1147,7 @@ def setup_permissions_with_and_without_resource_definitions(
 
         host_inventory.apis.rbac.create_role_bindings([role_with.id], group.uuid, workspace_ids)
         host_inventory.apis.rbac.create_role_bindings(
-            [role_without.id], group.uuid, [root_workspace_id]
+            [role_without.id], group.uuid, [default_workspace_id]
         )
     else:
         if request.param == "first_with":

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
@@ -4,6 +4,7 @@ import logging
 from enum import Enum
 from time import sleep
 
+from iqe_bindings.v7.rbac_v1 import RoleOutDynamic
 from iqe_bindings.v7.rbac_v1 import RoleWithAccess
 from iqe_bindings.v7.rbac_v2 import Permission as RBACV2Permission
 from iqe_bindings.v7.rbac_v2 import Role as RBACV2Role
@@ -42,7 +43,7 @@ class RBACRoles(Enum):
     USER_ACCESS = "User Access administrator"
 
 
-def get_role_id(role: RoleWithAccess | RBACV2Role) -> str:
+def get_role_id(role: RoleWithAccess | RoleOutDynamic | RBACV2Role) -> str:
     """Get role ID from either V1 (RoleWithAccess.uuid) or V2 (Role.id) role object."""
     return getattr(role, "uuid", None) or role.id
 


### PR DESCRIPTION
## Jira
[RHINENG-26103](https://issues.redhat.com/browse/RHINENG-26103)

## What
Update tests to bind RBAC roles to the default workspace. Also, fix new RBAC API object types imported from iqe-bindings.

## Why
Our tests are failing in Stage on Kessel-enabled account. The reason is that RBAC restricted role bindings, now we can’t bind roles to the root workspace. The default workspace is forbidden to have siblings now, so we can do the binding to the default workspace to achieve global access.

## How
Bind the "global access" roles to the default workspace, instead of the root workspace

## Testing
I tested this with a few tests against Stage + RBAC PR check

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26103]: https://redhat.atlassian.net/browse/RHINENG-26103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update RBAC-related test and helper code to bind roles to the default workspace instead of the root workspace when workspaces-based RBAC is enabled.

Enhancements:
- Introduce a cached default_workspace property on the workspaces API model to simplify reuse of the default workspace lookup.

Tests:
- Adjust RBAC fixtures and granular group tests to create role bindings against the default workspace for global access scenarios.

## Summary by Sourcery

Bind RBAC roles and tests to the default workspace instead of the root workspace to align with updated workspace and RBAC behavior.

Enhancements:
- Add a cached default_workspace accessor on the workspaces API for reuse in RBAC-related logic.
- Broaden RBAC helper and API method type hints to support both static and dynamic role representations and updated subject type enums.

Tests:
- Update RBAC-related fixtures and granular group tests to create role bindings against the default workspace rather than the root workspace.