### PR TITLE
refactor(RHINENG-25844): Make staleness_timestamp nullable

### DIFF
--- a/app/models/host.py
+++ b/app/models/host.py
@@ -267,7 +267,7 @@ class LimitedHost(db.Model, HostTypeDeriver):
 
 
 class Host(LimitedHost):
-    stale_timestamp = db.Column(db.DateTime(timezone=True), nullable=False)
+    stale_timestamp = db.Column(db.DateTime(timezone=True), nullable=True)
     deletion_timestamp = db.Column(db.DateTime(timezone=True))
     stale_warning_timestamp = db.Column(db.DateTime(timezone=True))
     reporter = db.Column(db.String(255), nullable=False)

--- a/migrations/versions/41e07d4c1092_make_hosts_stale_timestamp_nullable.py
+++ b/migrations/versions/41e07d4c1092_make_hosts_stale_timestamp_nullable.py
@@ -1,0 +1,44 @@
+"""Make hosts.stale_timestamp nullable
+
+Revision ID: 41e07d4c1092
+Revises: c4e8f2a91b03
+Create Date: 2026-04-28
+
+Reversibility: ``downgrade()`` re-applies ``NOT NULL`` and will fail if any row has
+``stale_timestamp IS NULL``. After the application begins omitting or clearing this
+column, those NULLs are expected, so the migration is not reliably reversible in
+production without backfilling NULLs to concrete timestamps first.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.models.constants import INVENTORY_SCHEMA
+
+# revision identifiers, used by Alembic.
+revision = "41e07d4c1092"
+down_revision = "c4e8f2a91b03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "hosts",
+        "stale_timestamp",
+        existing_type=sa.DateTime(timezone=True),
+        nullable=True,
+        schema=INVENTORY_SCHEMA,
+    )
+
+
+def downgrade():
+    # Fails if any host has NULL stale_timestamp; see module docstring.
+    op.alter_column(
+        "hosts",
+        "stale_timestamp",
+        existing_type=sa.DateTime(timezone=True),
+        nullable=False,
+        schema=INVENTORY_SCHEMA,
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -431,6 +431,37 @@ def test_host_model_default_timestamps(db_create_host):
     assert host.modified_on < after_commit
 
 
+def test_host_stale_timestamp_nullable_on_insert(db_create_host):
+    """The hosts table allows inserting a row with stale_timestamp NULL."""
+    host = Host(
+        account=USER_IDENTITY["account_number"],
+        subscription_manager_id=generate_uuid(),
+        reporter="yupana",
+        org_id=USER_IDENTITY["org_id"],
+    )
+    host.stale_timestamp = None
+    db_create_host(host=host)
+    db.session.refresh(host)
+    assert host.stale_timestamp is None
+
+
+def test_host_stale_timestamp_nullable_update_to_null(db_create_host):
+    """An existing row may update stale_timestamp from a value to NULL."""
+    host = Host(
+        account=USER_IDENTITY["account_number"],
+        subscription_manager_id=generate_uuid(),
+        reporter="yupana",
+        org_id=USER_IDENTITY["org_id"],
+    )
+    db_create_host(host=host)
+    assert host.stale_timestamp is not None
+
+    host.stale_timestamp = None
+    db.session.commit()
+    db.session.refresh(host)
+    assert host.stale_timestamp is None
+
+
 def test_host_model_updated_timestamp(db_create_host):
     host = Host(
         account=USER_IDENTITY["account_number"],


### PR DESCRIPTION
## Jira
[RHINENG-25844](https://issues.redhat.com/browse/RHINENG-25844)

## What

- Alembic migration to drop the NOT NULL constraint on hbi.hosts.stale_timestamp.
- SQLAlchemy Host model updated so stale_timestamp is nullable=True, matching the database.

## Why

- Phase 2: allow new/updated host rows to exist without a persisted stale_timestamp once read paths no longer depend on the column being always written at check-in.
- Depends on Phase 1 (staleness reads decoupled) before production can safely stop persisting these values.

## How

- New revision 41e07d4c1092

## Testing

- -----

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Enhancements:
- Relax the Host model stale_timestamp field to be nullable to align with updated staleness handling requirements.

[RHINENG-25844]: https://redhat.atlassian.net/browse/RHINENG-25844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ