### PR TITLE
test(RHINENG-26067): Add new account for testing RBAC v1 in Prod to config

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/conf/host_inventory.default.yaml
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/conf/host_inventory.default.yaml
@@ -121,6 +121,56 @@ prod:
         org_id:
           vault_path: secrets/qe/prod/users/insights_inventory_qe_2
           vault_key: org_id
+    insights_inventory_test: # Account for testing RBAC v1
+      auth:
+        username:
+          vault_path: secrets/qe/prod/users/insights_inventory_test
+          vault_key: username
+        password:
+          vault_path: secrets/qe/prod/users/insights_inventory_test
+          vault_key: password
+        refresh_token:
+          vault_path: secrets/qe/prod/users/insights_inventory_test
+          vault_key: refresh_token
+      cert_auth:
+        cert:
+          vault_path: secrets/qe/prod/users/insights_inventory_test
+          vault_key: cert
+        key:
+          vault_path: secrets/qe/prod/users/insights_inventory_test
+          vault_key: key
+      identity:
+        account_number:
+          vault_path: secrets/qe/prod/users/insights_inventory_test
+          vault_key: account_number
+        org_id:
+          vault_path: secrets/qe/prod/users/insights_inventory_test
+          vault_key: org_id
+    insights_inventory_test_2: # Account for testing RBAC v1
+      auth:
+        username:
+          vault_path: secrets/qe/prod/users/insights_inventory_test_2
+          vault_key: username
+        password:
+          vault_path: secrets/qe/prod/users/insights_inventory_test_2
+          vault_key: password
+        refresh_token:
+          vault_path: secrets/qe/prod/users/insights_inventory_test_2
+          vault_key: refresh_token
+      cert_auth:
+        cert:
+          vault_path: secrets/qe/prod/users/insights_inventory_test_2
+          vault_key: cert
+        key:
+          vault_path: secrets/qe/prod/users/insights_inventory_test_2
+          vault_key: key
+      identity:
+        account_number:
+          vault_path: secrets/qe/prod/users/insights_inventory_test_2
+          vault_key: account_number
+        org_id:
+          vault_path: secrets/qe/prod/users/insights_inventory_test_2
+          vault_key: org_id
     inventory_service_account:
       auth:
         jwt_grant_type: client_credentials
@@ -375,7 +425,7 @@ stage: &stage
         org_id:
           vault_path: secrets/qe/stage/users/insights_inventory_qe_2
           vault_key: org_id
-    insights_inventory_test:  # Temp account simulating insights_inventory_qe
+    insights_inventory_test:  # Account for testing RBAC v1
       auth:
         username:
           vault_path: secrets/qe/stage/users/insights_inventory_test
@@ -400,7 +450,7 @@ stage: &stage
         org_id:
           vault_path: secrets/qe/stage/users/insights_inventory_test
           vault_key: org_id
-    insights_inventory_test_2:  # Temp account simulating insights_inventory_qe_2
+    insights_inventory_test_2:  # Account for testing RBAC v1
       auth:
         username:
           vault_path: secrets/qe/stage/users/insights_inventory_test_2


### PR DESCRIPTION
## Jira
[RHINENG-26067](https://issues.redhat.com/browse/RHINENG-26067)

## What
Add new account for testing RBAC v1 in Prod to config

This PR is a blocker for https://gitlab.cee.redhat.com/insights-qe/cci-jenkins-insights-config-declaration/-/merge_requests/1102

## Why
When we enable RBAC v2 on our current testing account, it will not be possible to go back to RBAC v1. However, we will still have to keep testing v1, because not all customers will be migrated to v2 at the same time. Also, fedramp will keep using v1.

## How
I created the new accounts, configured them, added their secrets to vault, and now this PR adds the references to those vault entries to the IQE config file.

## Testing
I ran the tests with the new account locally against Prod and it worked.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26067]: https://redhat.atlassian.net/browse/RHINENG-26067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add configuration for new production test accounts dedicated to RBAC v1 validation and align stage account comments with this purpose.

New Features:
- Introduce two dedicated prod test accounts (insights_inventory_test and insights_inventory_test_2) for RBAC v1 in the IQE host inventory configuration.

Enhancements:
- Update stage configuration comments to reflect that the existing test accounts are used for RBAC v1 testing rather than temporary QE account simulation.