### PR TITLE
ci(RHINENG-26070): Update db-migration-downgrade deployment config

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1741,13 +1741,17 @@ objects:
             cpu: ${CPU_REQUEST_DB_MIGRATIONS_JOB}
             memory: ${MEMORY_REQUEST_DB_MIGRATIONS_JOB}
     - name: db-migration-downgrade
-      restartPolicy: OnFailure
+      restartPolicy: Never
       suspend: ${{DB_MIGRATION_DOWNGRADE_SUSPEND}}
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         command: ["/bin/sh", "-c"]
         args:
           - |
+            if [ "${DB_MIGRATION_DOWNGRADE_SUSPEND}" = "true" ]; then
+              echo "INFO: db-migration-downgrade job is suspended. Exiting."
+              exit 0
+            fi
             if [ -z "${DB_MIGRATION_DOWNGRADE_REVISION}" ] || [ "${DB_MIGRATION_DOWNGRADE_REVISION}" = "change-me" ]; then
               echo "ERROR: DB_MIGRATION_DOWNGRADE_REVISION is not set. Aborting downgrade." >&2
               exit 1
@@ -1776,6 +1780,8 @@ objects:
             value: ${MIGRATION_MODE}
           - name: HOSTS_TABLE_NUM_PARTITIONS
             value: ${HOSTS_TABLE_NUM_PARTITIONS}
+          - name: DB_MIGRATION_DOWNGRADE_SUSPEND
+            value: ${DB_MIGRATION_DOWNGRADE_SUSPEND}
         resources:
           limits:
             cpu: ${CPU_LIMIT_DB_MIGRATIONS_JOB}
@@ -2672,7 +2678,7 @@ parameters:
   value: '1'
 - name: DB_MIGRATION_DOWNGRADE_SUSPEND
   description: Whether to suspend the db-migration-downgrade job
-  value: 'false'
+  value: 'true'
 
 
 # =================================================================================


### PR DESCRIPTION
## Jira
[RHINENG-26070](https://issues.redhat.com/browse/RHINENG-26070)

## What
Update db-migration-downgrade deployment config

## Why
Every time we use bonfire to deploy Inventory to ephemeral, it waits for db-migration-downgrade-change-me-1 to finish, which slows down the deployment. This is unnecessary and this job shouldn’t run when deploying to ephemeral.

This happens because the job exits with exit code `1` if the downgrade revision is not set, and the restart policy is set to `OnFailure`. So the job tries to run 6 times after the deployment to ephemeral, and bonfire is waiting for the deployment to finish, which slows it down.

## How
- Change the `restartPolicy` from `OnFailure` to `Never`. Restarting the job is unnecessary. If the DB downgrade fails once, it won't work the second time.
- Add suspend check inside the script itself and exit with `0` if the suspend is true. The `suspend` field on the job only suspends the (scheduled) cron job, but it doesn't do anything if the job is explicitly triggered by CJI.
- Change the default value for `DB_MIGRATION_DOWNGRADE_SUSPEND` to `true`. This will not only suspend the job automatically in ephemeral, but it's also safer if the default is `true` in other environments, because it makes the job run only if we explicitly un-suspend it.

Note: Just changing the restartPolicy, or just implementing the suspend check and changing the suspend value in ephemeral would be enough to fix our problem, but I think that all of these changes make sense, so I pushed them all together.

## Testing
PR checks

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26070]: https://redhat.atlassian.net/browse/RHINENG-26070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Adjust db-migration-downgrade job configuration to avoid unnecessary reruns and make it opt-in by default.

Enhancements:
- Set the db-migration-downgrade job restart policy to never retry on failure.
- Add an in-script suspend check that cleanly exits when the downgrade job is marked as suspended.
- Change the default configuration to suspend the db-migration-downgrade job by default and pass the suspend flag into the job environment.