### PR TITLE
test(RHINENG-26156): Stabilize timezone dependent unit tests

### DIFF
--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -5,6 +5,7 @@ import math
 import types
 from base64 import b64encode
 from collections.abc import Callable
+from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 from enum import StrEnum
@@ -675,8 +676,8 @@ def assert_group_response(response, expected_group, expected_host_count):
     assert response["org_id"] == expected_group.org_id
     assert response["account"] == expected_group.account
     assert response["name"] == expected_group.name
-    assert response["created"] == expected_group.created_on.isoformat()
-    assert response["updated"] == expected_group.modified_on.isoformat()
+    assert response["created"] == expected_group.created_on.astimezone(UTC).isoformat()
+    assert response["updated"] == expected_group.modified_on.astimezone(UTC).isoformat()
     assert response["host_count"] == expected_host_count
 
 

--- a/tests/helpers/mq_utils.py
+++ b/tests/helpers/mq_utils.py
@@ -449,7 +449,7 @@ def assert_patch_event_is_valid(
             "stale_warning_timestamp": stale_warning_timestamp,
             "culled_timestamp": culled_timestamp,
             "created": host.created_on.astimezone(UTC).isoformat(),
-            "last_check_in": host.last_check_in.isoformat(),
+            "last_check_in": host.last_check_in.astimezone(UTC).isoformat(),
             "provider_id": host.provider_id,
             "provider_type": host.provider_type,
             "openshift_cluster_id": host.openshift_cluster_id,

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -1,5 +1,6 @@
 import json
 import time
+from datetime import UTC
 from datetime import datetime
 from threading import Thread
 from unittest.mock import MagicMock
@@ -621,5 +622,5 @@ def test_patch_updated_timestamp(event_producer, db_create_host, db_get_host, ap
     b64_identity = json.loads(event_producer.write_event.call_args_list[0][0][0])["platform_metadata"]["b64_identity"]
     identity = from_auth_header(b64_identity)
 
-    assert updated_timestamp_from_event == record.modified_on.isoformat()
+    assert updated_timestamp_from_event == record.modified_on.astimezone(UTC).isoformat()
     assert identity._asdict() == USER_IDENTITY

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 import uuid
 from copy import deepcopy
+from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 
@@ -1573,7 +1574,7 @@ def test_add_dynamic_profile(db_create_host):
         # We return datetime objects from the database,
         # so we need to convert them to strings for comparison
         if isinstance(getattr(retrieved, key), datetime):
-            assert getattr(retrieved, key).isoformat() == value
+            assert getattr(retrieved, key).astimezone(UTC).isoformat() == value
         else:
             assert getattr(retrieved, key) == value
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 
@@ -369,7 +370,7 @@ def test_query_tags_filter_last_check_in_both_same(db_create_host, api_get):
             "tags": _deserialize_tags_dict({"ns2": {"nomatch_key": ["nomatch_value"]}}),
         },
     )
-    last_check_in = str(match_host.last_check_in).replace("+00:00", "Z")
+    last_check_in = match_host.last_check_in.astimezone(UTC).isoformat().replace("+00:00", "Z")
     response_status, response_data = api_get(
         build_tags_url(query=f"?last_check_in_start={last_check_in}&last_check_in_end={last_check_in}")
     )


### PR DESCRIPTION
## Jira
[RHINENG-26156](https://issues.redhat.com/browse/RHINENG-26156)

## What

Stabilize unit tests dependent on timezone to run on my local environment.

## Why

Predictable tests.

## How

Use UTC always

## Testing

Locally before I had 10 failures on master, now 0.

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26156]: https://redhat.atlassian.net/browse/RHINENG-26156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Tests:
- Update datetime assertions in host, tag, and model tests to compare values in UTC rather than local time.