### PR TITLE
RHINENG-25885: enforce global permissions on staleness endpoint

### DIFF
--- a/api/staleness.py
+++ b/api/staleness.py
@@ -218,8 +218,8 @@ def _async_update_host_staleness(identity: Identity, staleness_orm_or_defaults: 
 
 
 @api_operation
-@access(KesselResourceTypes.STALENESS.view)
-@access(KesselResourceTypes.HOST.view)
+@access(KesselResourceTypes.STALENESS.view, require_global=True)
+@access(KesselResourceTypes.HOST.view, require_global=True)
 @metrics.api_request_time.time()
 def get_staleness(rbac_filter=None):  # noqa: ARG001, 'rbac_filter' is required for all API endpoints
     try:
@@ -232,8 +232,8 @@ def get_staleness(rbac_filter=None):  # noqa: ARG001, 'rbac_filter' is required 
 
 
 @api_operation
-@access(KesselResourceTypes.STALENESS.view)
-@access(KesselResourceTypes.HOST.view)
+@access(KesselResourceTypes.STALENESS.view, require_global=True)
+@access(KesselResourceTypes.HOST.view, require_global=True)
 @metrics.api_request_time.time()
 def get_default_staleness(rbac_filter=None):  # noqa: ARG001, 'rbac_filter' is required for all API endpoints
     try:
@@ -247,8 +247,8 @@ def get_default_staleness(rbac_filter=None):  # noqa: ARG001, 'rbac_filter' is r
 
 
 @api_operation
-@access(KesselResourceTypes.STALENESS.update)
-@access(KesselResourceTypes.HOST.update)
+@access(KesselResourceTypes.STALENESS.update, require_global=True)
+@access(KesselResourceTypes.HOST.update, require_global=True)
 @metrics.api_request_time.time()
 def create_staleness(body):
     # Validate account staleness input data
@@ -280,8 +280,8 @@ def create_staleness(body):
 
 
 @api_operation
-@access(KesselResourceTypes.STALENESS.update)
-@access(KesselResourceTypes.HOST.update)
+@access(KesselResourceTypes.STALENESS.update, require_global=True)
+@access(KesselResourceTypes.HOST.update, require_global=True)
 @metrics.api_request_time.time()
 def delete_staleness():
     identity = get_current_identity()
@@ -301,8 +301,8 @@ def delete_staleness():
 
 
 @api_operation
-@access(KesselResourceTypes.STALENESS.update)
-@access(KesselResourceTypes.HOST.update)
+@access(KesselResourceTypes.STALENESS.update, require_global=True)
+@access(KesselResourceTypes.HOST.update, require_global=True)
 @metrics.api_request_time.time()
 def update_staleness(body):
     # Validate account staleness input data

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -528,7 +528,7 @@ def rbac(resource_type: RbacResourceType, required_permission: RbacPermission, p
     return other_func
 
 
-def access(permission: KesselPermission, id_param: str = ""):
+def access(permission: KesselPermission, id_param: str = "", require_global: bool = False):
     def other_func(func):
         sig = inspect.signature(func)
 
@@ -543,13 +543,13 @@ def access(permission: KesselPermission, id_param: str = ""):
             if inventory_config().bypass_rbac:
                 return func(*args, **kwargs)
 
-            ids = []
-            if id_param:
-                ids = permission.resource_type.get_resource_id(kwargs, id_param)
+            ids = permission.resource_type.get_resource_id(kwargs, id_param)
 
             allowed, rbac_filter = resolve_permission(current_identity, permission, ids)
 
             if allowed:
+                if require_global and rbac_filter is not None:
+                    abort(HTTPStatus.FORBIDDEN)
                 if rbac_filter and "rbac_filter" in sig.parameters:
                     kwargs["rbac_filter"] = rbac_filter
                 return func(*args, **kwargs)

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -156,12 +156,14 @@ STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES = (
     "tests/helpers/rbac-mock-data/inv-read-only.json",
     "tests/helpers/rbac-mock-data/inv-star-read.json",
     "tests/helpers/rbac-mock-data/inv-staleness-write-only.json",
+    "tests/helpers/rbac-mock-data/inv-staleness-hosts-write-granular.json",
 )
 STALENESS_READ_PROHIBITED_RBAC_RESPONSE_FILES = (
     "tests/helpers/rbac-mock-data/inv-none.json",
     "tests/helpers/rbac-mock-data/inv-hosts-read-only.json",
     "tests/helpers/rbac-mock-data/inv-staleness-read-only.json",
     "tests/helpers/rbac-mock-data/inv-staleness-write-only.json",
+    "tests/helpers/rbac-mock-data/inv-staleness-hosts-read-granular.json",
 )
 STALENESS_READ_ALLOWED_RBAC_RESPONSE_FILES = ("tests/helpers/rbac-mock-data/inv-staleness-hosts-read-only.json",)
 STALENESS_WRITE_ALLOWED_RBAC_RESPONSE_FILES = ("tests/helpers/rbac-mock-data/inv-staleness-hosts-write-only.json",)

--- a/tests/helpers/rbac-mock-data/inv-staleness-hosts-read-granular.json
+++ b/tests/helpers/rbac-mock-data/inv-staleness-hosts-read-granular.json
@@ -1,0 +1,39 @@
+{
+  "meta": {
+      "count": 1,
+      "limit": 1000,
+      "offset": 0
+  },
+  "links": {
+      "first": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0",
+      "next": null,
+      "previous": null,
+      "last": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0"
+  },
+  "data": [
+      {
+          "resourceDefinitions": [
+              {
+                  "attributeFilter": {
+                      "key": "group.id",
+                      "value": ["df7db8f2-a866-4efd-a4e1-1cea3abb5d38"],
+                      "operation": "in"
+                  }
+              }
+          ],
+          "permission": "staleness:staleness:read"
+      },
+      {
+          "resourceDefinitions": [
+              {
+                  "attributeFilter": {
+                      "key": "group.id",
+                      "value": ["df7db8f2-a866-4efd-a4e1-1cea3abb5d38"],
+                      "operation": "in"
+                  }
+              }
+          ],
+          "permission": "inventory:hosts:read"
+      }
+  ]
+}

--- a/tests/helpers/rbac-mock-data/inv-staleness-hosts-write-granular.json
+++ b/tests/helpers/rbac-mock-data/inv-staleness-hosts-write-granular.json
@@ -1,0 +1,39 @@
+{
+  "meta": {
+      "count": 1,
+      "limit": 1000,
+      "offset": 0
+  },
+  "links": {
+      "first": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0",
+      "next": null,
+      "previous": null,
+      "last": "/api/rbac/v1/access/?application=inventory&limit=1000&offset=0"
+  },
+  "data": [
+      {
+          "resourceDefinitions": [
+              {
+                  "attributeFilter": {
+                      "key": "group.id",
+                      "value": ["df7db8f2-a866-4efd-a4e1-1cea3abb5d38"],
+                      "operation": "in"
+                  }
+              }
+          ],
+          "permission": "staleness:staleness:write"
+      },
+      {
+          "resourceDefinitions": [
+              {
+                  "attributeFilter": {
+                      "key": "group.id",
+                      "value": ["df7db8f2-a866-4efd-a4e1-1cea3abb5d38"],
+                      "operation": "in"
+                  }
+              }
+          ],
+          "permission": "inventory:hosts:write"
+      }
+  ]
+}

--- a/tests/test_api_staleness_create.py
+++ b/tests/test_api_staleness_create.py
@@ -119,6 +119,18 @@ def test_create_staleness_rbac_denied(subtests, mocker, api_create_staleness):
     )
 
 
+@pytest.mark.usefixtures("enable_rbac")
+def test_create_staleness_rbac_denied_granular(subtests, mocker, api_create_staleness):
+    run_rbac_test(
+        subtests,
+        mocker,
+        api_create_staleness,
+        ("tests/helpers/rbac-mock-data/inv-staleness-hosts-write-granular.json",),
+        403,
+        [_INPUT_DATA],
+    )
+
+
 @pytest.mark.parametrize(
     "input_data",
     (

--- a/tests/test_api_staleness_delete.py
+++ b/tests/test_api_staleness_delete.py
@@ -46,3 +46,14 @@ def test_delete_staleness_rbac_allowed(subtests, mocker, api_delete_staleness, d
 @pytest.mark.usefixtures("enable_rbac")
 def test_delete_staleness_rbac_denied(subtests, mocker, api_delete_staleness):
     run_rbac_test(subtests, mocker, api_delete_staleness, STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES, 403)
+
+
+@pytest.mark.usefixtures("enable_rbac")
+def test_delete_staleness_rbac_denied_granular(subtests, mocker, api_delete_staleness):
+    run_rbac_test(
+        subtests,
+        mocker,
+        api_delete_staleness,
+        ("tests/helpers/rbac-mock-data/inv-staleness-hosts-write-granular.json",),
+        403,
+    )

--- a/tests/test_api_staleness_get.py
+++ b/tests/test_api_staleness_get.py
@@ -38,3 +38,16 @@ def test_get_staleness_rbac_denied(subtests, mocker, api_get):
 def test_get_staleness_rbac_allowed(subtests, mocker, api_get):
     url = build_sys_default_staleness_url()
     run_rbac_test(subtests, mocker, api_get, STALENESS_READ_ALLOWED_RBAC_RESPONSE_FILES, 200, [url])
+
+
+@pytest.mark.usefixtures("enable_rbac")
+def test_get_staleness_rbac_denied_granular(subtests, mocker, api_get):
+    url = build_sys_default_staleness_url()
+    run_rbac_test(
+        subtests,
+        mocker,
+        api_get,
+        ("tests/helpers/rbac-mock-data/inv-staleness-hosts-read-granular.json",),
+        403,
+        [url],
+    )

--- a/tests/test_api_staleness_update.py
+++ b/tests/test_api_staleness_update.py
@@ -50,6 +50,20 @@ def test_update_staleness_rbac_denied(subtests, mocker, api_patch, db_create_sta
     run_rbac_test(subtests, mocker, api_patch, STALENESS_WRITE_PROHIBITED_RBAC_RESPONSE_FILES, 403, [url, _INPUT_DATA])
 
 
+@pytest.mark.usefixtures("enable_rbac")
+def test_update_staleness_rbac_denied_granular(subtests, mocker, api_patch, db_create_staleness_culling):
+    db_create_staleness_culling(conventional_time_to_stale=1)
+    url = build_staleness_url()
+    run_rbac_test(
+        subtests,
+        mocker,
+        api_patch,
+        ("tests/helpers/rbac-mock-data/inv-staleness-hosts-write-granular.json",),
+        403,
+        [url, _INPUT_DATA],
+    )
+
+
 def test_patch_staleness_at_defaults_without_custom_returns_404(api_patch):
     """No custom row: PATCH does not update anything and returns 404 (even for default-equivalent payload)."""
     response_status, _ = api_patch(build_staleness_url(), host_data=_DEFAULT_STALENESS_TRIPLE)


### PR DESCRIPTION
## Jira
[RHINENG-25885](https://issues.redhat.com/browse/RHINENG-25885)

## What
**DRAFT** PR created to save the code changes

## Why
<!-- Reason for change / linked ticket -->

## How
<!-- Brief explanation of approach -->

## Testing
<!-- How was this tested? -->

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-25885]: https://redhat.atlassian.net/browse/RHINENG-25885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enforce global-only RBAC permissions for staleness API endpoints and cover the new behavior with RBAC tests.

Enhancements:
- Add a require_global flag to the access middleware decorator to optionally reject non-global (filtered) RBAC access for a given permission.
- Apply global-only access requirements to all staleness read and write API endpoints.

Tests:
- Add RBAC test cases to verify that granular (non-global) staleness and hosts permissions are forbidden on staleness endpoints.
- Extend RBAC test fixtures and mock data to cover granular staleness/hosts read and write permission combinations.