### PR TITLE
fix(RHINENG-26185): remove org_id label from host app data metrics

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -776,15 +776,13 @@ class HostAppMessageConsumer(HBIMessageConsumerBase):
                 org_id=org_id,
                 hosts_data=hosts_data,
             )
-            metrics.host_app_data_processing_success.labels(application=application, org_id=org_id).inc(success_count)
+            metrics.host_app_data_processing_success.labels(application=application).inc(success_count)
 
             # Update data freshness metric with current timestamp
             # In test/dev environments, Gauge metrics may fail if PROMETHEUS_MULTIPROC_DIR
             # isn't properly configured for multiprocess mode. This is non-fatal.
             with suppress(TypeError, OSError):
-                metrics.host_app_data_last_processed_timestamp.labels(application=application, org_id=org_id).set(
-                    time.time()
-                )
+                metrics.host_app_data_last_processed_timestamp.labels(application=application).set(time.time())
 
         except OperationalError as e:
             logger.exception(

--- a/app/queue/metrics.py
+++ b/app/queue/metrics.py
@@ -111,7 +111,7 @@ host_app_data_message_parsing_time = Summary(
 host_app_data_processing_success = Counter(
     "inventory_host_app_data_processing_successes",
     "Total number of host app data records successfully processed",
-    ["application", "org_id"],
+    ["application"],
 )
 host_app_data_failure = Counter(
     "inventory_host_app_data_failures",
@@ -121,5 +121,5 @@ host_app_data_failure = Counter(
 host_app_data_last_processed_timestamp = Gauge(
     "inventory_host_app_data_last_processed_timestamp",
     "Unix timestamp of the last successfully processed message for each application",
-    ["application", "org_id"],
+    ["application"],
 )

--- a/tests/test_host_app_mq_service.py
+++ b/tests/test_host_app_mq_service.py
@@ -234,7 +234,7 @@ class TestHostAppMessageConsumerMetrics:
         headers = [("application", b"advisor"), ("request_id", generate_uuid().encode("utf-8"))]
         host_app_consumer.handle_message(json.dumps(message), headers=headers)
 
-        mock_metrics.host_app_data_processing_success.labels.assert_called_with(application="advisor", org_id=org_id)
+        mock_metrics.host_app_data_processing_success.labels.assert_called_with(application="advisor")
 
     @patch("app.queue.host_mq.metrics")
     def test_unicode_error_increments_failure_metric(self, mock_metrics, host_app_consumer):


### PR DESCRIPTION
## Jira
[RHINENG-26185](https://issues.redhat.com/browse/RRHINENG-26185)

## What
Remove `org_id` from the label set of host app data Prometheus metrics to eliminate a high cardinality issue.

## Why
The `org_id` label on `inventory_host_app_data_processing_successes_total`, `inventory_host_app_data_last_processed_timestamp`, and `inventory_host_app_data_processing_successes_created` was generating ~81,890 unique time series each, making them the top 3 highest cardinality metrics in the CRCP Prometheus instance and putting significant stress on the infrastructure. Per-org granularity provides no operational value for these metrics.

## How
- Removed `org_id` from the label definitions of `host_app_data_processing_success` (Counter) and `host_app_data_last_processed_timestamp` (Gauge) in `app/queue/metrics.py`.
- Updated `.labels()` calls in `app/queue/host_mq.py` to stop passing `org_id`.
- Updated the metric assertion in `tests/test_host_app_mq_service.py`.

This reduces cardinality from ~81,890 to 6 (one per supported application).

## Testing
All 37 existing tests in `tests/test_host_app_mq_service.py` pass, including the metric-specific assertions in `TestHostAppMessageConsumerMetrics`.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26185]: https://redhat.atlassian.net/browse/RHINENG-26185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Remove per-org labeling from host app data Prometheus metrics to reduce metric cardinality and associated infrastructure load.

Bug Fixes:
- Eliminate high-cardinality org_id label from host app data processing success and last-processed timestamp metrics.

Enhancements:
- Simplify host app data metric label sets to be keyed only by application while keeping existing test coverage aligned.