### PR TITLE
fix(RHINENG-25609): Change the order of columns in exports (CSV)

### DIFF
--- a/app/serialization.py
+++ b/app/serialization.py
@@ -42,11 +42,11 @@ __all__ = (
 
 
 _EXPORT_SERVICE_FIELDS = [
-    "host_id",
+    "display_name",
     "fqdn",
+    "host_id",
     "subscription_manager_id",
     "satellite_id",
-    "display_name",
     "group_id",
     "group_name",
     "os_release",

--- a/tests/helpers/export_service_utils.py
+++ b/tests/helpers/export_service_utils.py
@@ -156,11 +156,11 @@ def create_export_csv_mock(mocker):
 def create_export_json_mock(mocker):
     return [
         {
+            "display_name": mocker.ANY,
+            "fqdn": mocker.ANY,
             "host_id": mocker.ANY,
             "subscription_manager_id": mocker.ANY,
             "satellite_id": mocker.ANY,
-            "display_name": mocker.ANY,
-            "fqdn": mocker.ANY,
             "group_id": mocker.ANY,
             "group_name": mocker.ANY,
             "os_release": mocker.ANY,


### PR DESCRIPTION
## Summary
Export payloads (CSV and JSON from the export service path) now list `display_name` and `fqdn` before `host_id`, so the first columns match identifiers customers actually use instead of leading with the internal HBI UUID.

## Jira
[RHINENG-25609](https://issues.redhat.com/browse/RHINENG-25609)

## Changes
- Reordered `_EXPORT_SERVICE_FIELDS` in `app/serialization.py` so `serialize_host_for_export_svc` emits keys in the new order (CSV headers and row order follow dict iteration used by `json_arr_to_csv`).

## Testing
- `make style`
- `pipenv run pytest tests/test_export_service.py`

Made with [Cursor](https://cursor.com)

[RHINENG-25609]: https://redhat.atlassian.net/browse/RHINENG-25609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Correct the ordering of host identifier columns in export payloads so customer-facing identifiers precede internal IDs.