### PR TITLE
ci: add Konflux test failure report workflow

### DIFF
--- a/.github/workflows/konflux-test-report.yaml
+++ b/.github/workflows/konflux-test-report.yaml
@@ -85,8 +85,8 @@ jobs:
             exit 0
           fi
 
-          # Sanitize logs: remove lines that may contain secrets/tokens/passwords (case-insensitive)
-          grep -ivE '(password|token|secret|credential|bearer|authorization|private.token)' /tmp/iqe-logs-raw.txt > /tmp/iqe-logs.txt
+          # Sanitize logs: redact sensitive values in-place (case-insensitive)
+          sed -E 's/(password|token|secret|credential|bearer|authorization)[=: ]+[^ "]+/\1=***REDACTED***/gI' /tmp/iqe-logs-raw.txt > /tmp/iqe-logs.txt
           rm -f /tmp/iqe-logs-raw.txt
 
           echo "status=ok" >> "$GITHUB_OUTPUT"
@@ -107,7 +107,7 @@ jobs:
             FAILED=$(echo "$SUMMARY_LINE" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' || echo "0")
             PASSED=$(echo "$SUMMARY_LINE" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' || echo "0")
             SKIPPED=$(echo "$SUMMARY_LINE" | grep -oE '[0-9]+ skipped' | grep -oE '[0-9]+' || echo "0")
-            ERRORS=$(echo "$SUMMARY_LINE" | grep -oE '[0-9]+ error' | grep -oE '[0-9]+' || echo "0")
+            ERRORS=$(echo "$SUMMARY_LINE" | grep -oE '[0-9]+ errors?' | grep -oE '[0-9]+' || echo "0")
 
             echo "failed=${FAILED:-0}" >> "$GITHUB_OUTPUT"
             echo "passed=${PASSED:-0}" >> "$GITHUB_OUTPUT"
@@ -135,8 +135,8 @@ jobs:
               ERROR_MSG=$(tail -50 "$LOGS")
             fi
 
-            # Sanitize error message: strip any lines containing tokens/secrets (case-insensitive)
-            echo "$ERROR_MSG" | grep -ivE '(password|token|secret|credential|bearer|authorization|private.token)' | head -c 4000 > /tmp/error-msg.txt
+            # Sanitize error message: redact sensitive values in-place (case-insensitive)
+            echo "$ERROR_MSG" | sed -E 's/(password|token|secret|credential|bearer|authorization)[=: ]+[^ "]+/\1=***REDACTED***/gI' | head -c 4000 > /tmp/error-msg.txt
           fi
 
       - name: Logout from Konflux cluster

--- a/.github/workflows/konflux-test-report.yaml
+++ b/.github/workflows/konflux-test-report.yaml
@@ -125,7 +125,9 @@ jobs:
             echo "type=infra_error" >> "$GITHUB_OUTPUT"
 
             # Look for common infrastructure error patterns
-            if grep -q "ApiException" "$LOGS"; then
+            if grep -q "deploy failed" "$LOGS"; then
+              ERROR_MSG=$(grep -E '(deploy failed|ErrImagePull|timed out waiting)' "$LOGS" | sort -u | head -20)
+            elif grep -q "ApiException" "$LOGS"; then
               ERROR_MSG=$(grep -B2 "ApiException" "$LOGS" | tail -3)
             elif grep -q "Traceback" "$LOGS"; then
               ERROR_MSG=$(grep -A20 "Traceback (most recent call last)" "$LOGS" | tail -25)

--- a/.github/workflows/konflux-test-report.yaml
+++ b/.github/workflows/konflux-test-report.yaml
@@ -1,0 +1,287 @@
+name: Konflux Test Failure Report
+
+on:
+  check_run:
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  checks: read
+
+jobs:
+  report-failures:
+    if: >
+      github.event.check_run.app.slug == 'red-hat-konflux' &&
+      github.event.check_run.conclusion == 'failure' &&
+      contains(github.event.check_run.name, 'insights-hbi-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Extract pipeline run info
+        id: extract
+        env:
+          CHECK_RUN_OUTPUT: ${{ toJSON(github.event.check_run.output) }}
+          CHECK_RUN_NAME: ${{ github.event.check_run.name }}
+          HEAD_SHA: ${{ github.event.check_run.head_sha }}
+        run: |
+          echo "check_run_name=$CHECK_RUN_NAME" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+          # Extract scenario name (e.g. insights-hbi-all, insights-hbi-rbac, insights-hbi-smoke)
+          SCENARIO=$(echo "$CHECK_RUN_NAME" | grep -oE 'insights-hbi-[a-z]+')
+          echo "scenario=$SCENARIO" >> "$GITHUB_OUTPUT"
+
+          # Extract pipeline run name from the check run output HTML
+          PIPELINERUN=$(echo "$CHECK_RUN_OUTPUT" | jq -r '.text' | grep -oE 'pipelinerun/[a-z0-9-]+' | head -1 | sed 's|pipelinerun/||')
+          echo "pipelinerun=$PIPELINERUN" >> "$GITHUB_OUTPUT"
+
+      - name: Install oc CLI
+        uses: actions/cache@v4
+        id: oc-cache
+        with:
+          path: /usr/local/bin/oc
+          key: oc-cli-4.15.10-linux
+      - name: Download oc CLI
+        if: steps.oc-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.15.10/openshift-client-linux.tar.gz | tar xz -C /usr/local/bin oc kubectl
+
+      - name: Fetch test logs from Konflux
+        id: logs
+        env:
+          KONFLUX_TOKEN: ${{ secrets.KONFLUX_BOT_TOKEN }}
+          KONFLUX_SERVER: https://api.stone-prd-rh01.pg1f.p1.openshiftapps.com:6443
+          KONFLUX_NAMESPACE: insights-management-tenant
+          PIPELINERUN: ${{ steps.extract.outputs.pipelinerun }}
+        run: |
+          set +e
+
+          # Mask the token from workflow logs
+          echo "::add-mask::$KONFLUX_TOKEN"
+
+          # Login to the cluster (suppress all output to avoid leaking server details)
+          oc login --token="$KONFLUX_TOKEN" --server="$KONFLUX_SERVER" > /dev/null 2>&1
+          if [ $? -ne 0 ]; then
+            echo "status=log_error" >> "$GITHUB_OUTPUT"
+            echo "Failed to authenticate to Konflux cluster"
+            exit 0
+          fi
+
+          # Find the run-iqe-cji task run pod
+          TASKRUN="${PIPELINERUN}-run-iqe-cji"
+          POD_NAME=$(oc get taskrun "$TASKRUN" -n "$KONFLUX_NAMESPACE" -o jsonpath='{.status.podName}' 2>/dev/null)
+
+          if [ -z "$POD_NAME" ]; then
+            echo "status=no_pod" >> "$GITHUB_OUTPUT"
+            echo "Could not find pod for taskrun: $TASKRUN"
+            exit 0
+          fi
+
+          echo "Fetching logs from pod: $POD_NAME"
+          oc logs "$POD_NAME" -n "$KONFLUX_NAMESPACE" -c step-deploy-iqe-cji > /tmp/iqe-logs-raw.txt 2>&1
+
+          if [ $? -ne 0 ]; then
+            echo "status=log_error" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Sanitize logs: remove lines that may contain secrets/tokens/passwords (case-insensitive)
+          grep -ivE '(password|token|secret|credential|bearer|authorization|private.token)' /tmp/iqe-logs-raw.txt > /tmp/iqe-logs.txt
+          rm -f /tmp/iqe-logs-raw.txt
+
+          echo "status=ok" >> "$GITHUB_OUTPUT"
+
+      - name: Parse test results
+        id: parse
+        if: steps.logs.outputs.status == 'ok'
+        run: |
+          LOGS="/tmp/iqe-logs.txt"
+
+          # Check for pytest summary line (e.g. "= 43 failed, 4605 passed, 65 skipped ...")
+          SUMMARY_LINE=$(grep -E '^=+ .*(failed|passed|error).*=+$' "$LOGS" | tail -1)
+
+          if [ -n "$SUMMARY_LINE" ]; then
+            echo "type=test_results" >> "$GITHUB_OUTPUT"
+
+            # Extract counts
+            FAILED=$(echo "$SUMMARY_LINE" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' || echo "0")
+            PASSED=$(echo "$SUMMARY_LINE" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' || echo "0")
+            SKIPPED=$(echo "$SUMMARY_LINE" | grep -oE '[0-9]+ skipped' | grep -oE '[0-9]+' || echo "0")
+            ERRORS=$(echo "$SUMMARY_LINE" | grep -oE '[0-9]+ error' | grep -oE '[0-9]+' || echo "0")
+
+            echo "failed=${FAILED:-0}" >> "$GITHUB_OUTPUT"
+            echo "passed=${PASSED:-0}" >> "$GITHUB_OUTPUT"
+            echo "skipped=${SKIPPED:-0}" >> "$GITHUB_OUTPUT"
+            echo "errors=${ERRORS:-0}" >> "$GITHUB_OUTPUT"
+            echo "summary_line=$SUMMARY_LINE" >> "$GITHUB_OUTPUT"
+
+            # Extract failed test names
+            FAILED_TESTS=$(grep '^FAILED ' "$LOGS" | sed 's|^FAILED iqe-local-plugin/||' | head -50)
+            # Save to file for the comment step (multiline)
+            echo "$FAILED_TESTS" > /tmp/failed-tests.txt
+
+          else
+            # No pytest summary — check for setup/infrastructure errors
+            echo "type=infra_error" >> "$GITHUB_OUTPUT"
+
+            # Look for common infrastructure error patterns
+            if grep -q "ApiException" "$LOGS"; then
+              ERROR_MSG=$(grep -B2 "ApiException" "$LOGS" | tail -3)
+            elif grep -q "Traceback" "$LOGS"; then
+              ERROR_MSG=$(grep -A20 "Traceback (most recent call last)" "$LOGS" | tail -25)
+            elif grep -q "Tests FAILED" "$LOGS"; then
+              ERROR_MSG=$(tail -30 "$LOGS")
+            else
+              ERROR_MSG=$(tail -50 "$LOGS")
+            fi
+
+            # Sanitize error message: strip any lines containing tokens/secrets (case-insensitive)
+            echo "$ERROR_MSG" | grep -ivE '(password|token|secret|credential|bearer|authorization|private.token)' | head -c 4000 > /tmp/error-msg.txt
+          fi
+
+      - name: Logout from Konflux cluster
+        if: always()
+        run: |
+          oc logout > /dev/null 2>&1 || true
+          rm -f ~/.kube/config
+
+      - name: Find associated PR
+        id: find_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.extract.outputs.head_sha }}
+        run: |
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA/pulls" --jq '.[0].number' 2>/dev/null || echo "")
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Post test results comment
+        if: steps.logs.outputs.status == 'ok' && steps.parse.outputs.type == 'test_results' && steps.find_pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+          SCENARIO: ${{ steps.extract.outputs.scenario }}
+          FAILED: ${{ steps.parse.outputs.failed }}
+          PASSED: ${{ steps.parse.outputs.passed }}
+          SKIPPED: ${{ steps.parse.outputs.skipped }}
+          PIPELINERUN: ${{ steps.extract.outputs.pipelinerun }}
+        run: |
+          FAILED_TESTS=$(cat /tmp/failed-tests.txt)
+          TOTAL=$((FAILED + PASSED + SKIPPED))
+
+          # Group failures by test module
+          GROUPED=$(echo "$FAILED_TESTS" | sed 's|/[^/]*$||' | sort | uniq -c | sort -rn | head -10)
+
+          MARKER="<!-- konflux-test-report:$SCENARIO -->"
+
+          # Build the comment body
+          BODY="$MARKER
+          ## Konflux Test Report: \`$SCENARIO\`
+
+          | Metric | Count |
+          |--------|-------|
+          | Total  | $TOTAL |
+          | Passed | $PASSED |
+          | Failed | $FAILED |
+          | Skipped | $SKIPPED |
+          "
+
+          # Add failed tests section
+          if [ "$FAILED" -gt 0 ]; then
+            BODY="$BODY
+
+          ### Failed Tests ($FAILED)
+
+          Most affected modules:
+          \`\`\`
+          $GROUPED
+          \`\`\`
+
+          <details>
+          <summary>Full list of failed tests</summary>
+
+          \`\`\`
+          $FAILED_TESTS
+          \`\`\`
+
+          </details>
+          "
+          fi
+
+          BODY="$BODY
+          ---
+          [View pipeline run](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/insights-management-tenant/pipelinerun/$PIPELINERUN/logs/run-iqe-cji)
+          "
+
+          # Check for existing comment to update
+          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" 2>/dev/null | head -1)
+
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/$EXISTING_COMMENT_ID" -X PATCH -f body="$BODY"
+          else
+            gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" -f body="$BODY"
+          fi
+
+      - name: Post infrastructure error comment
+        if: steps.logs.outputs.status == 'ok' && steps.parse.outputs.type == 'infra_error' && steps.find_pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+          SCENARIO: ${{ steps.extract.outputs.scenario }}
+          PIPELINERUN: ${{ steps.extract.outputs.pipelinerun }}
+        run: |
+          ERROR_MSG=$(cat /tmp/error-msg.txt)
+
+          MARKER="<!-- konflux-test-report:$SCENARIO -->"
+          BODY="$MARKER
+          ## Konflux Test Report: \`$SCENARIO\`
+
+          **Tests did not run** — infrastructure/setup error detected.
+
+          <details>
+          <summary>Error details</summary>
+
+          \`\`\`
+          $ERROR_MSG
+          \`\`\`
+
+          </details>
+
+          ---
+          [View pipeline run](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/insights-management-tenant/pipelinerun/$PIPELINERUN/logs/run-iqe-cji)
+          "
+
+          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" 2>/dev/null | head -1)
+
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/$EXISTING_COMMENT_ID" -X PATCH -f body="$BODY"
+          else
+            gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" -f body="$BODY"
+          fi
+
+      - name: Post unavailable logs comment
+        if: steps.logs.outputs.status == 'no_pod' && steps.find_pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+          SCENARIO: ${{ steps.extract.outputs.scenario }}
+          PIPELINERUN: ${{ steps.extract.outputs.pipelinerun }}
+        run: |
+          MARKER="<!-- konflux-test-report:$SCENARIO -->"
+          BODY="$MARKER
+          ## Konflux Test Report: \`$SCENARIO\`
+
+          **Could not fetch test logs** — the pipeline run has been garbage-collected before logs could be retrieved.
+
+          Pipeline run: \`$PIPELINERUN\`
+
+          ---
+          [View pipeline run](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/insights-management-tenant/pipelinerun/$PIPELINERUN/logs/run-iqe-cji)
+          "
+
+          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" 2>/dev/null | head -1)
+
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/$EXISTING_COMMENT_ID" -X PATCH -f body="$BODY"
+          else
+            gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" -f body="$BODY"
+          fi


### PR DESCRIPTION
## Jira
N/A

## What
Add a GitHub Actions workflow that automatically reports Konflux integration test failures as PR comments.

## Why
Currently, when Konflux integration tests (`insights-hbi-all`, `insights-hbi-rbac`, `insights-hbi-smoke`) fail, developers have to manually navigate to the Konflux UI to investigate failures. This workflow provides immediate visibility by posting a structured summary directly on the PR with pass/fail counts and the list of failed tests.

## How
- New workflow `.github/workflows/konflux-test-report.yaml` triggers on `check_run` completion events from the `red-hat-konflux` app
- Uses a dedicated read-only OpenShift service account (`konflux-bot-0`) to fetch IQE test logs via `oc logs`
- Parses pytest summary output to extract pass/fail/skip counts and individual failed test names
- Posts one of three comment types: test failure summary, infrastructure/setup error, or logs unavailable (garbage-collected)
- Updates existing comments (idempotent via HTML markers) instead of posting duplicates
- Security hardening: token masking, TLS enforcement, case-insensitive log sanitization, cluster logout on completion, pinned `oc` CLI version with caching, least-privilege GitHub token permissions, 10-minute job timeout

## Testing
- YAML validated with `yaml.safe_load()`
- Security review: confirmed bot SA has only `get/list/watch` on pods, pods/log, pipelineruns, taskruns — no write access, no ClusterRoleBindings
- Token masking verified via `::add-mask::` directive
- Will be validated end-to-end on next Konflux test failure after merge

## Note
This is the initial version focused on basic log parsing and summary reporting. The next iteration will introduce a Failure Analysis Agent that uses LLM to provide deeper insights — root cause analysis, correlation with recent changes, suggested fixes, and historical failure patterns — delivering a much richer and more actionable report.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

CI:
- Introduce a Konflux test failure reporting workflow that triggers on failed Konflux check runs and posts or updates PR comments with summarized test results or error details, handling missing logs gracefully.