### PR TITLE
test: Don't use dot in workspace name

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/datagen_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/datagen_utils.py
@@ -814,7 +814,7 @@ def generate_fqdn(panic_prevention: str = "rhiqe") -> str:
 
 
 def generate_display_name(panic_prevention: str = "rhiqe") -> str:
-    return f"{panic_prevention}.{generate_uuid()}"
+    return f"{panic_prevention}_{generate_uuid()}"
 
 
 def generate_ips(num_ips: int = 2) -> list[str]:


### PR DESCRIPTION
## What
Don't use dot in workspace name in IQE tests

## Why
RBAC doesn't accept dots in names:
```
RBAC client error: Workspace name may only contain letters, numbers, spaces, hyphens, and underscores.
```

## How
Switch from `.` to `_` in `generate_display_name` function

## Testing
PR checks + I ran a couple of tests against Stage and it worked.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Bug Fixes:
- Ensure generated workspace display names use an underscore instead of a dot to comply with RBAC name validation rules.