### PR TITLE
fix(ci): detect pytest errors in test failure report

### DIFF
--- a/.github/workflows/konflux-test-report.yaml
+++ b/.github/workflows/konflux-test-report.yaml
@@ -115,9 +115,8 @@ jobs:
             echo "errors=${ERRORS:-0}" >> "$GITHUB_OUTPUT"
             echo "summary_line=$SUMMARY_LINE" >> "$GITHUB_OUTPUT"
 
-            # Extract failed test names
-            FAILED_TESTS=$(grep '^FAILED ' "$LOGS" | sed 's|^FAILED iqe-local-plugin/||' | head -50)
-            # Save to file for the comment step (multiline)
+            # Extract failed and errored test names
+            FAILED_TESTS=$(grep -E '^(FAILED|ERROR) ' "$LOGS" | sed -E 's|^(FAILED|ERROR) iqe-local-plugin/||' | head -50)
             echo "$FAILED_TESTS" > /tmp/failed-tests.txt
 
           else
@@ -165,10 +164,11 @@ jobs:
           FAILED: ${{ steps.parse.outputs.failed }}
           PASSED: ${{ steps.parse.outputs.passed }}
           SKIPPED: ${{ steps.parse.outputs.skipped }}
+          ERRORS: ${{ steps.parse.outputs.errors }}
           PIPELINERUN: ${{ steps.extract.outputs.pipelinerun }}
         run: |
           FAILED_TESTS=$(cat /tmp/failed-tests.txt)
-          TOTAL=$((FAILED + PASSED + SKIPPED))
+          TOTAL=$((FAILED + PASSED + SKIPPED + ERRORS))
 
           # Group failures by test module
           GROUPED=$(echo "$FAILED_TESTS" | sed 's|/[^/]*$||' | sort | uniq -c | sort -rn | head -10)
@@ -184,14 +184,16 @@ jobs:
           | Total  | $TOTAL |
           | Passed | $PASSED |
           | Failed | $FAILED |
+          | Errors | $ERRORS |
           | Skipped | $SKIPPED |
           "
 
-          # Add failed tests section
-          if [ "$FAILED" -gt 0 ]; then
+          # Add failed/errored tests section
+          PROBLEM_COUNT=$((FAILED + ERRORS))
+          if [ "$PROBLEM_COUNT" -gt 0 ]; then
             BODY="$BODY
 
-          ### Failed Tests ($FAILED)
+          ### Failed/Errored Tests ($PROBLEM_COUNT)
 
           Most affected modules:
           \`\`\`


### PR DESCRIPTION
## Jira
N/A

## What
Fix the Konflux test failure report workflow to correctly detect and report pytest errors (not just failures).

## Why
The initial version only captured tests marked as `FAILED` but ignored pytest `ERROR` lines (which indicate setup/fixture failures). This caused the report to show "0 failed, 183 skipped" when in reality there were 290 errors — making the PR comment misleading.

## How
- Extract both `FAILED` and `ERROR` lines from pytest output using `grep -E '^(FAILED|ERROR) '`
- Fix the errors count regex to match both `"error"` and `"errors"` (`errors?`)
- Add `Errors` row to the summary table
- Include errors in the total count and in the condition that triggers the detailed test list
- Add `ERRORS` env var to the comment posting step

## Testing
- Validated regex patterns against real pytest output from `insights-hbi-rbac-rqz2g` pipeline run
- Confirmed correct extraction: 290 errors, 183 skipped from summary line `== 183 skipped, 4844 deselected, 68 warnings, 290 errors in 67.68s ==`
- YAML validated with `yaml.safe_load()`

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Ensure Konflux test failure report workflow includes pytest errors alongside failures in its summary and detailed section.

Bug Fixes:
- Capture both FAILED and ERROR test lines from pytest logs when extracting problematic tests.
- Include pytest errors in the total test count and in the condition that triggers the detailed test list in the report comment.
- Expose the parsed errors count to the comment posting step and display it in the summary table.