### PR TITLE
fix(RHINENG-15763): case-insensitive OS name for version range filters

### DIFF
--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -206,6 +206,11 @@ def separate_operating_system_filters(filter_url_params) -> list[OsFilter]:
     return os_filter_list
 
 
+def _operating_system_name_lower(os_field) -> ColumnElement:
+    """Lowercase `operating_system.name` text for case-insensitive comparisons."""
+    return func.lower(os_field["name"].astext)
+
+
 # Takes an OS filter param and converts it into a tuple containing the DB filter
 def build_operating_system_filter(filter_param: dict) -> tuple:
     os_filter_list = []  # Top-level filter
@@ -224,7 +229,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
 
         elif os_filter.comparator in ["eq", "neq"]:
             os_filters = [
-                func.lower(os_field["name"].astext).operate(comparator, os_filter.name.lower()),
+                _operating_system_name_lower(os_field).operate(comparator, os_filter.name.lower()),
             ]
 
             if os_filter.major is not None:
@@ -241,7 +246,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
                 # output: (major < 9) OR (major = 9 AND minor <= 5)
                 comparator_no_eq = POSTGRES_COMPARATOR_NO_EQ_LOOKUP.get(os_filter.comparator)
                 os_filter = and_(
-                    func.lower(os_field["name"].astext) == os_filter.name.lower(),
+                    _operating_system_name_lower(os_field) == os_filter.name.lower(),
                     or_(
                         os_field["major"].astext.cast(Integer).operate(comparator_no_eq, os_filter.major),
                         and_(
@@ -253,7 +258,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
 
             else:
                 os_filter = and_(
-                    func.lower(os_field["name"].astext) == os_filter.name.lower(),
+                    _operating_system_name_lower(os_field) == os_filter.name.lower(),
                     os_field["major"].astext.cast(Integer).operate(comparator, os_filter.major),
                 )
 

--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -62,7 +62,7 @@ class OsFilter:
         except ValidationException:
             raise
 
-        self.name = name
+        self.name = name.lower()
         self.comparator = comparator
         self.major = major
         self.minor = minor
@@ -229,7 +229,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
 
         elif os_filter.comparator in ["eq", "neq"]:
             os_filters = [
-                _operating_system_name_lower(os_field).operate(comparator, os_filter.name.lower()),
+                _operating_system_name_lower(os_field).operate(comparator, os_filter.name),
             ]
 
             if os_filter.major is not None:
@@ -246,7 +246,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
                 # output: (major < 9) OR (major = 9 AND minor <= 5)
                 comparator_no_eq = POSTGRES_COMPARATOR_NO_EQ_LOOKUP.get(os_filter.comparator)
                 os_filter = and_(
-                    _operating_system_name_lower(os_field) == os_filter.name.lower(),
+                    _operating_system_name_lower(os_field) == os_filter.name,
                     or_(
                         os_field["major"].astext.cast(Integer).operate(comparator_no_eq, os_filter.major),
                         and_(
@@ -258,7 +258,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
 
             else:
                 os_filter = and_(
-                    _operating_system_name_lower(os_field) == os_filter.name.lower(),
+                    _operating_system_name_lower(os_field) == os_filter.name,
                     os_field["major"].astext.cast(Integer).operate(comparator, os_filter.major),
                 )
 

--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -206,7 +206,7 @@ def separate_operating_system_filters(filter_url_params) -> list[OsFilter]:
     return os_filter_list
 
 
-def _operating_system_name_lower(os_field) -> ColumnElement:
+def _operating_system_name_lower(os_field: ColumnElement) -> ColumnElement:
     """Lowercase `operating_system.name` text for case-insensitive comparisons."""
     return func.lower(os_field["name"].astext)
 

--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -241,7 +241,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
                 # output: (major < 9) OR (major = 9 AND minor <= 5)
                 comparator_no_eq = POSTGRES_COMPARATOR_NO_EQ_LOOKUP.get(os_filter.comparator)
                 os_filter = and_(
-                    os_field["name"].astext == os_filter.name,
+                    func.lower(os_field["name"].astext) == os_filter.name.lower(),
                     or_(
                         os_field["major"].astext.cast(Integer).operate(comparator_no_eq, os_filter.major),
                         and_(
@@ -253,7 +253,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
 
             else:
                 os_filter = and_(
-                    os_field["name"].astext == os_filter.name,
+                    func.lower(os_field["name"].astext) == os_filter.name.lower(),
                     os_field["major"].astext.cast(Integer).operate(comparator, os_filter.major),
                 )
 

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1719,6 +1719,12 @@ def test_query_all_sp_filters_not_found(db_create_host, api_get, sp_filter_param
         "[RHEL][version][eq][]=8",
         "[RHEL][version]=8",  # Minor version should be ignored
         "[RHEL][version][gte]=8&filter[system_profile][operating_system][RHEL][version][lte]=8",
+        # RHINENG-15763: range comparators must match stored OS name case-insensitively
+        "[rhel][version][gt][]=7",
+        "[rhel][version][gte]=8",
+        "[rhel][version][gt][]=7&filter[system_profile][operating_system][rhel][version][lt][]=9",
+        "[rhel][version][gt][]=7&filter[system_profile][operating_system][rhel][version][lte][]=8",
+        "[rhel][version][gte]=8&filter[system_profile][operating_system][rhel][version][lte]=8",
     ),
 )
 def test_query_all_sp_filters_operating_system(db_create_host, api_get, sp_filter_param):

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1720,8 +1720,8 @@ def test_query_all_sp_filters_not_found(db_create_host, api_get, sp_filter_param
         "[RHEL][version]=8",  # Minor version should be ignored
         "[RHEL][version][gte]=8&filter[system_profile][operating_system][RHEL][version][lte]=8",
         # RHINENG-15763: range comparators must match stored OS name case-insensitively
-        "[rhel][version][gt][]=7",
-        "[rhel][version][gte]=8",
+        "[Rhel][version][gt][]=7",
+        "[rHeL][version][gte]=8",
         "[rhel][version][gt][]=7&filter[system_profile][operating_system][rhel][version][lt][]=9",
         "[rhel][version][gt][]=7&filter[system_profile][operating_system][rhel][version][lte][]=8",
         "[rhel][version][gte]=8&filter[system_profile][operating_system][rhel][version][lte]=8",


### PR DESCRIPTION
## Summary
Operating system filters using `gt`, `lt`, `gte`, and `lte` compared the stored JSON `name` to the filter key with a case-sensitive equality check, while `eq`/`neq` already used `lower()` on both sides. Range filters now use the same case-insensitive name match.

## Jira
[RHINENG-15763](https://issues.redhat.com/browse/RHINENG-15763)

## Changes
- Use `func.lower(os_field["name"].astext) == os_filter.name.lower()` in `build_operating_system_filter` for range branches (with and without minor version).
- Extend `test_query_all_sp_filters_operating_system` with lowercase `rhel` filter paths, including combined range filters that isolate the expected host.

## Testing
- `pipenv run pytest tests/test_api_hosts_get.py::test_query_all_sp_filters_operating_system -q`
- `pipenv run pytest tests/test_api_hosts_get.py -q`
- `make style`

Made with [Cursor](https://cursor.com)

[RHINENG-15763]: https://redhat.atlassian.net/browse/RHINENG-15763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Make operating system version range filters treat OS names case-insensitively, consistent with equality comparators.

Bug Fixes:
- Ensure operating system version range filters (`gt`, `lt`, `gte`, `lte`) use case-insensitive comparisons for OS names.

Tests:
- Extend operating system filter tests to cover lowercase OS name inputs and combined range filters.