### PR TITLE
ci: Automatically approve, enable automerge for base-image-update PRs

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -23,6 +23,21 @@ jobs:
           git add .baseimagedigest
           git commit -m "chore(image): update base image" || echo "No new changes"
       - name: Create pull request
+        id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
           title: 'chore(image): update base image'
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.AUTOMERGE_APP_ID }}
+          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+      - name: Approve and enable auto-merge for the base image PR
+        if: ${{ steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated' }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Jira
(None)

## What
Modifies the GH action that opens our base-image-update PRs. Adds steps to automatically approve and enable automerge for the PR it just created.

## Why
As long as the PR checks pass, these PRs should be merged, so we don't need a manual step.

## How
Added a couple of extra steps to the `checkimage.yaml` GH workflow.

## Testing
N/A

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

CI:
- Extend the base image check workflow to generate a GitHub App token and automatically approve and enable auto-merge for newly created or updated base image PRs.