### PR TITLE
fix(ci): strip ANSI codes before parsing test logs

### DIFF
--- a/.github/workflows/konflux-test-report.yaml
+++ b/.github/workflows/konflux-test-report.yaml
@@ -97,6 +97,9 @@ jobs:
         run: |
           LOGS="/tmp/iqe-logs.txt"
 
+          # Strip ANSI color codes from logs for reliable parsing
+          sed -i 's/\x1b\[[0-9;]*m//g' "$LOGS"
+
           # Check for pytest summary line (e.g. "= 43 failed, 4605 passed, 65 skipped ...")
           SUMMARY_LINE=$(grep -E '^=+ .*(failed|passed|error).*=+$' "$LOGS" | tail -1)
 
@@ -115,8 +118,8 @@ jobs:
             echo "errors=${ERRORS:-0}" >> "$GITHUB_OUTPUT"
             echo "summary_line=$SUMMARY_LINE" >> "$GITHUB_OUTPUT"
 
-            # Extract failed and errored test names
-            FAILED_TESTS=$(grep -E '^(FAILED|ERROR) ' "$LOGS" | sed -E 's|^(FAILED|ERROR) iqe-local-plugin/||' | head -50)
+            # Extract failed and errored test names from the short test summary section
+            FAILED_TESTS=$(grep -E '^FAILED |^ERROR ' "$LOGS" | sed -E 's/^(FAILED|ERROR) (iqe-local-plugin\/)?//' | grep -v '^\s*$' | head -50)
             echo "$FAILED_TESTS" > /tmp/failed-tests.txt
 
           else
@@ -171,7 +174,8 @@ jobs:
           TOTAL=$((FAILED + PASSED + SKIPPED + ERRORS))
 
           # Group failures by test module
-          GROUPED=$(echo "$FAILED_TESTS" | sed 's|/[^/]*$||' | sort | uniq -c | sort -rn | head -10)
+          # Strip ::test_method, then strip filename (last /segment), filter empty lines
+          GROUPED=$(echo "$FAILED_TESTS" | grep -v '^\s*$' | sed -E 's|::.*||' | sed -E 's|/[^/]*$||' | grep -v '^\s*$' | sort | uniq -c | sort -rn | head -10)
 
           MARKER="<!-- konflux-test-report:$SCENARIO -->"
 
@@ -191,7 +195,8 @@ jobs:
           # Add failed/errored tests section
           PROBLEM_COUNT=$((FAILED + ERRORS))
           if [ "$PROBLEM_COUNT" -gt 0 ]; then
-            BODY="$BODY
+            if [ -n "$FAILED_TESTS" ] && [ -n "$(echo "$FAILED_TESTS" | grep -v '^\s*$')" ]; then
+              BODY="$BODY
 
           ### Failed/Errored Tests ($PROBLEM_COUNT)
 
@@ -209,6 +214,14 @@ jobs:
 
           </details>
           "
+            else
+              BODY="$BODY
+
+          ### Failed/Errored Tests ($PROBLEM_COUNT)
+
+          _Could not extract individual test names from logs._
+          "
+            fi
           fi
 
           BODY="$BODY

--- a/.github/workflows/konflux-test-report.yaml
+++ b/.github/workflows/konflux-test-report.yaml
@@ -119,7 +119,8 @@ jobs:
             echo "summary_line=$SUMMARY_LINE" >> "$GITHUB_OUTPUT"
 
             # Extract failed and errored test names from the short test summary section
-            FAILED_TESTS=$(grep -E '^FAILED |^ERROR ' "$LOGS" | sed -E 's/^(FAILED|ERROR) (iqe-local-plugin\/)?//' | grep -v '^\s*$' | head -50)
+            FAILED_TESTS=$(grep -E '^(FAILED|ERROR) ' "$LOGS" | sed -E 's/^(FAILED|ERROR) (iqe-local-plugin\/)?//' | head -50)
+            FAILED_TESTS=$(echo "$FAILED_TESTS" | grep -v '^\s*$' || true)
             echo "$FAILED_TESTS" > /tmp/failed-tests.txt
 
           else
@@ -173,9 +174,8 @@ jobs:
           FAILED_TESTS=$(cat /tmp/failed-tests.txt)
           TOTAL=$((FAILED + PASSED + SKIPPED + ERRORS))
 
-          # Group failures by test module
-          # Strip ::test_method, then strip filename (last /segment), filter empty lines
-          GROUPED=$(echo "$FAILED_TESTS" | grep -v '^\s*$' | sed -E 's|::.*||' | sed -E 's|/[^/]*$||' | grep -v '^\s*$' | sort | uniq -c | sort -rn | head -10)
+          # Group failures by test module (strip ::test_method, then filename)
+          GROUPED=$(echo "$FAILED_TESTS" | sed -E 's|::.*||' | sed -E 's|/[^/]*$||' | sort | uniq -c | sort -rn | head -10)
 
           MARKER="<!-- konflux-test-report:$SCENARIO -->"
 
@@ -195,7 +195,7 @@ jobs:
           # Add failed/errored tests section
           PROBLEM_COUNT=$((FAILED + ERRORS))
           if [ "$PROBLEM_COUNT" -gt 0 ]; then
-            if [ -n "$FAILED_TESTS" ] && [ -n "$(echo "$FAILED_TESTS" | grep -v '^\s*$')" ]; then
+            if [ -n "$FAILED_TESTS" ]; then
               BODY="$BODY
 
           ### Failed/Errored Tests ($PROBLEM_COUNT)


### PR DESCRIPTION
## What

Strip ANSI color escape sequences from Konflux test logs before parsing, fixing broken "Most affected modules" sections in PR comments.

## Why

Pytest outputs colored text (ANSI escape sequences) when running in Konflux pods. The `grep '^FAILED '` pattern failed to match because lines actually started with `\033[31mFAILED\033[0m` instead of plain `FAILED`. This caused the failed test extraction to return empty results, producing blank module groupings like `      1 ` in the PR comment (visible in [PR #4147](https://github.com/RedHatInsights/insights-host-inventory/pull/4147)).

## How

- Strip all ANSI escape codes (`\x1b\[[0-9;]*m`) from the log file upfront before any parsing
- Make `iqe-local-plugin/` prefix optional in the sed extraction (handles varied log formats)
- Improve module grouping: strip `::test_method` before path extraction so directory grouping works correctly
- Add graceful fallback: if test names can't be extracted despite failures being counted, show "_Could not extract individual test names from logs._" instead of broken empty sections

## Testing

Simulated the fix against the actual log output from `insights-hbi-all-7kxnl` (PR #4147). Verified:
- ANSI-wrapped `FAILED` lines are correctly matched after stripping
- Module grouping produces `iqe_host_inventory/tests/rest/notifications/kafka` as expected
- Plain text logs (no ANSI) continue to work unchanged

## Summary by Sourcery

Improve Konflux test log parsing in the CI workflow to correctly detect and report failed tests and their most affected modules.

Bug Fixes:
- Strip ANSI color escape codes from Konflux test logs before parsing so FAILED/ERROR lines are reliably detected.
- Handle optional iqe-local-plugin path prefixes and empty lines when extracting failed test names from logs to avoid broken summaries.
- Ensure module grouping ignores test method suffixes and omits empty entries so the 'Most affected modules' section is accurate.
- Add a fallback message when individual test names cannot be extracted despite failures being present to avoid malformed PR comments.

CI:
- Update konflux-test-report GitHub Actions workflow to normalize logs and robustly build the failed/errored tests section in PR comments.