### PR TITLE
fix(RHINENG-15779): sqldumps decorator doesn't work

### DIFF
--- a/tests/helpers/sql_dump.py
+++ b/tests/helpers/sql_dump.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from functools import wraps
 
@@ -28,7 +29,7 @@ Usage:
     from tests.helpers.sql_dump import dumps_sql
     :
     :
-    # Or decorator for whole method
+    # Or decorator for whole method (including generators and async functions)
     @dumps_sql
     def test_find_host_using_superset_canonical_fact_match(db_create_host):
 """
@@ -36,8 +37,7 @@ Usage:
 
 class SQLDump:
     def __init__(self, dump_method=None, write_method=print):
-        if dump_method is None:
-            self.dump_method = self.dump_sql
+        self.dump_method = self.dump_sql if dump_method is None else dump_method
         self.write_method = write_method
 
     def __enter__(self):
@@ -56,15 +56,54 @@ class SQLDump:
 
 def dumps_sql(_func=None, *, dump_method=None, write_method=print):
     def decorator_dumps_sql(old_func):
+        if inspect.isgeneratorfunction(old_func):
+
+            @wraps(old_func)
+            def gen_wrapper(*args, **kwargs):
+                sqld = SQLDump(dump_method=dump_method, write_method=write_method)
+                sqld.__enter__()
+                try:
+                    yield from old_func(*args, **kwargs)
+                finally:
+                    sqld.__exit__(None, None, None)
+
+            return gen_wrapper
+
+        if inspect.isasyncgenfunction(old_func):
+
+            @wraps(old_func)
+            async def asyncgen_wrapper(*args, **kwargs):
+                sqld = SQLDump(dump_method=dump_method, write_method=write_method)
+                sqld.__enter__()
+                try:
+                    async for item in old_func(*args, **kwargs):
+                        yield item
+                finally:
+                    sqld.__exit__(None, None, None)
+
+            return asyncgen_wrapper
+
+        if inspect.iscoroutinefunction(old_func):
+
+            @wraps(old_func)
+            async def async_wrapper(*args, **kwargs):
+                sqld = SQLDump(dump_method=dump_method, write_method=write_method)
+                sqld.__enter__()
+                try:
+                    return await old_func(*args, **kwargs)
+                finally:
+                    sqld.__exit__(None, None, None)
+
+            return async_wrapper
+
         @wraps(old_func)
         def new_func(*args, **kwargs):
             sqld = SQLDump(dump_method=dump_method, write_method=write_method)
             sqld.__enter__()
-
-            results = old_func(*args, **kwargs)
-
-            sqld.__exit__(None, None, None)
-            return results
+            try:
+                return old_func(*args, **kwargs)
+            finally:
+                sqld.__exit__(None, None, None)
 
         return new_func
 
@@ -72,3 +111,7 @@ def dumps_sql(_func=None, *, dump_method=None, write_method=print):
         return decorator_dumps_sql
     else:
         return decorator_dumps_sql(_func)
+
+
+# Alias for the name used in RHINENG-15779 and similar reports
+sqldumps = dumps_sql

--- a/tests/helpers/sql_dump.py
+++ b/tests/helpers/sql_dump.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import sys
 from functools import wraps
 
 from sqlalchemy import event as sqlevent
@@ -54,18 +55,27 @@ class SQLDump:
         self.write_method("\n****************\n")
 
 
+def _sqldump_enter(dump_method, write_method):
+    sqld = SQLDump(dump_method=dump_method, write_method=write_method)
+    sqld.__enter__()
+    return sqld
+
+
+def _sqldump_exit(sqld):
+    sqld.__exit__(*sys.exc_info())
+
+
 def dumps_sql(_func=None, *, dump_method=None, write_method=print):
     def decorator_dumps_sql(old_func):
         if inspect.isgeneratorfunction(old_func):
 
             @wraps(old_func)
             def gen_wrapper(*args, **kwargs):
-                sqld = SQLDump(dump_method=dump_method, write_method=write_method)
-                sqld.__enter__()
+                sqld = _sqldump_enter(dump_method, write_method)
                 try:
                     yield from old_func(*args, **kwargs)
                 finally:
-                    sqld.__exit__(None, None, None)
+                    _sqldump_exit(sqld)
 
             return gen_wrapper
 
@@ -73,13 +83,12 @@ def dumps_sql(_func=None, *, dump_method=None, write_method=print):
 
             @wraps(old_func)
             async def asyncgen_wrapper(*args, **kwargs):
-                sqld = SQLDump(dump_method=dump_method, write_method=write_method)
-                sqld.__enter__()
+                sqld = _sqldump_enter(dump_method, write_method)
                 try:
                     async for item in old_func(*args, **kwargs):
                         yield item
                 finally:
-                    sqld.__exit__(None, None, None)
+                    _sqldump_exit(sqld)
 
             return asyncgen_wrapper
 
@@ -87,23 +96,21 @@ def dumps_sql(_func=None, *, dump_method=None, write_method=print):
 
             @wraps(old_func)
             async def async_wrapper(*args, **kwargs):
-                sqld = SQLDump(dump_method=dump_method, write_method=write_method)
-                sqld.__enter__()
+                sqld = _sqldump_enter(dump_method, write_method)
                 try:
                     return await old_func(*args, **kwargs)
                 finally:
-                    sqld.__exit__(None, None, None)
+                    _sqldump_exit(sqld)
 
             return async_wrapper
 
         @wraps(old_func)
         def new_func(*args, **kwargs):
-            sqld = SQLDump(dump_method=dump_method, write_method=write_method)
-            sqld.__enter__()
+            sqld = _sqldump_enter(dump_method, write_method)
             try:
                 return old_func(*args, **kwargs)
             finally:
-                sqld.__exit__(None, None, None)
+                _sqldump_exit(sqld)
 
         return new_func
 

--- a/tests/helpers/test_sql_dump.py
+++ b/tests/helpers/test_sql_dump.py
@@ -57,3 +57,56 @@ def test_dumps_sql_async_function_logs_sql(flask_app: FlaskApp) -> None:
 
         asyncio.run(run_query())
         assert "**** QUERY:" in _joined_output(chunks)
+
+
+def test_dumps_sql_async_generator_logs_sql_during_iteration(flask_app: FlaskApp) -> None:
+    with flask_app.app.app_context():
+        chunks: list[str] = []
+
+        @dumps_sql(write_method=chunks.append)
+        async def gen_queries():
+            db.session.execute(text("SELECT 1 AS a"))
+            yield 1
+            db.session.execute(text("SELECT 2 AS b"))
+
+        async def consume() -> None:
+            async for _ in gen_queries():
+                pass
+
+        asyncio.run(consume())
+        assert _joined_output(chunks).count("**** QUERY:") >= 2
+
+
+def test_dumps_sql_honors_custom_dump_method(flask_app: FlaskApp) -> None:
+    with flask_app.app.app_context():
+        markers: list[str] = []
+
+        def custom_dump(*_args):
+            markers.append("dump")
+
+        @dumps_sql(dump_method=custom_dump, write_method=lambda *_: None)
+        def run_query():
+            db.session.execute(text("SELECT 1"))
+            db.session.commit()
+
+        run_query()
+        assert markers == ["dump"]
+
+
+def test_dumps_sql_sync_removes_listener_after_exception(flask_app: FlaskApp) -> None:
+    with flask_app.app.app_context():
+        chunks: list[str] = []
+
+        @dumps_sql(write_method=chunks.append)
+        def boom():
+            db.session.execute(text("SELECT 1"))
+            raise RuntimeError("fail")
+
+        with pytest.raises(RuntimeError, match="fail"):
+            boom()
+
+        logged = len(chunks)
+        assert logged > 0
+
+        db.session.execute(text("SELECT 2"))
+        assert len(chunks) == logged

--- a/tests/helpers/test_sql_dump.py
+++ b/tests/helpers/test_sql_dump.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from connexion import FlaskApp
+from sqlalchemy import text
+
+from app.models import db
+from tests.helpers.sql_dump import dumps_sql
+
+
+def _joined_output(write_calls: list[str]) -> str:
+    return "".join(write_calls)
+
+
+def test_dumps_sql_sync_function_logs_sql(flask_app: FlaskApp) -> None:
+    with flask_app.app.app_context():
+        chunks: list[str] = []
+
+        @dumps_sql(write_method=chunks.append)
+        def run_query():
+            db.session.execute(text("SELECT 1 AS x"))
+            db.session.commit()
+
+        run_query()
+        assert "**** QUERY:" in _joined_output(chunks)
+
+
+def test_dumps_sql_generator_logs_sql_during_iteration(flask_app: FlaskApp) -> None:
+    with flask_app.app.app_context():
+        chunks: list[str] = []
+
+        @dumps_sql(write_method=chunks.append)
+        def gen_queries():
+            db.session.execute(text("SELECT 1 AS a"))
+            yield 1
+            db.session.execute(text("SELECT 2 AS b"))
+
+        g = gen_queries()
+        assert next(g) == 1
+        with pytest.raises(StopIteration):
+            next(g)
+
+        out = _joined_output(chunks)
+        assert out.count("**** QUERY:") >= 2
+
+
+def test_dumps_sql_async_function_logs_sql(flask_app: FlaskApp) -> None:
+    with flask_app.app.app_context():
+        chunks: list[str] = []
+
+        @dumps_sql(write_method=chunks.append)
+        async def run_query():
+            db.session.execute(text("SELECT 3 AS c"))
+            db.session.commit()
+
+        asyncio.run(run_query())
+        assert "**** QUERY:" in _joined_output(chunks)


### PR DESCRIPTION
## Summary
The `dumps_sql` decorator attached the SQLAlchemy `before_execute` listener and then returned immediately when the wrapped callable was a **generator** (e.g. `get_hosts_to_export`). The generator body runs only while the consumer iterates, so all queries ran after the listener was removed. The context manager worked because it stays entered for the whole `with` block across yields.

## Jira
[RHINENG-15779](https://issues.redhat.com/browse/RHINENG-15779)

## Changes
- Wrap generator functions with `yield from` so the listener stays active for the full iteration
- Support async and async-generator callables the same way
- Use `try`/`finally` so the listener is always removed (including on exceptions)
- Fix `SQLDump.__init__` to honor a non-default `dump_method`
- Add `sqldumps` as an alias for `dumps_sql` (ticket wording)
- Add regression tests in `tests/helpers/test_sql_dump.py`

## Testing
- `pipenv run pytest tests/helpers/test_sql_dump.py -v`
- `make style`

Made with [Cursor](https://cursor.com)

[RHINENG-15779]: https://redhat.atlassian.net/browse/RHINENG-15779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure the SQL query dumping helper works consistently for sync, async, and generator callables and add regression coverage.

Bug Fixes:
- Keep the SQLAlchemy before_execute listener active for the full lifetime of generator, async-generator, and coroutine functions decorated with dumps_sql.
- Honor a non-default dump_method passed to SQLDump when constructing the helper.

Enhancements:
- Add sqldumps as an alias of dumps_sql for compatibility with existing references.

Tests:
- Add regression tests verifying dumps_sql logs SQL for synchronous functions and generators, including during iteration, and for async functions.