### PR TITLE
feat(RHINENG-26335): Add environment-configurable OTEL tracing tunables

### DIFF
--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -1,7 +1,8 @@
 """OpenTelemetry initialization for HBI services.
 
 Provides centralized tracing setup for all HBI entry points (web API, MQ service,
-export service). Controlled by the OTEL_ENABLED environment variable.
+export service). Every knob is configurable via environment variables so stage and
+prod can run independent configurations without code changes.
 
 Usage:
     from app.telemetry import init_otel, instrument_flask_app, instrument_sqlalchemy, instrument_outbound_http
@@ -27,7 +28,24 @@ from app.logging import get_logger
 
 logger = get_logger(__name__)
 
+# ---------------------------------------------------------------------------
+# Configuration — all tunables are environment-driven
+# ---------------------------------------------------------------------------
 OTEL_ENABLED = os.getenv("OTEL_ENABLED", "false").lower() == "true"
+OTEL_SQL_ENABLED = os.getenv("OTEL_SQL_ENABLED", "true").lower() == "true"
+OTEL_SQL_COMMENTER_ENABLED = os.getenv("OTEL_SQL_COMMENTER_ENABLED", "false").lower() == "true"
+OTEL_HTTP_ENABLED = os.getenv("OTEL_HTTP_ENABLED", "true").lower() == "true"
+OTEL_SAMPLING_RATE = min(max(float(os.getenv("OTEL_SAMPLING_RATE", "1.0")), 0.0), 1.0)
+
+OTEL_BSP_MAX_QUEUE_SIZE = int(os.getenv("OTEL_BSP_MAX_QUEUE_SIZE", "8192"))
+OTEL_BSP_MAX_EXPORT_BATCH_SIZE = int(os.getenv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "256"))
+OTEL_BSP_SCHEDULE_DELAY = int(os.getenv("OTEL_BSP_SCHEDULE_DELAY", "2000"))
+OTEL_BSP_EXPORT_TIMEOUT = int(os.getenv("OTEL_BSP_EXPORT_TIMEOUT", "10000"))
+
+OTEL_EXPORTER_OTLP_COMPRESSION = os.getenv("OTEL_EXPORTER_OTLP_COMPRESSION", "gzip").lower()
+OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT = int(os.getenv("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", "64"))
+OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT = int(os.getenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "1024"))
+
 _otel_initialized_pid = None
 
 
@@ -67,8 +85,10 @@ def init_otel(service_name: str, service_version: str = "unknown"):
     from opentelemetry.sdk.resources import SERVICE_NAME
     from opentelemetry.sdk.resources import SERVICE_VERSION
     from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import SpanLimits
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
 
     resource = Resource.create(
         attributes={
@@ -78,16 +98,47 @@ def init_otel(service_name: str, service_version: str = "unknown"):
         }
     )
 
-    provider = TracerProvider(resource=resource)
+    sampler = TraceIdRatioBased(OTEL_SAMPLING_RATE)
+    span_limits = SpanLimits(
+        max_attributes=OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
+        max_attribute_length=OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+    )
+    provider = TracerProvider(resource=resource, sampler=sampler, span_limits=span_limits)
 
-    # OTLP exporter — picks up endpoint from OTEL_EXPORTER_OTLP_ENDPOINT
-    # (falls back to OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, then default localhost:4318)
-    exporter = OTLPSpanExporter()
-    provider.add_span_processor(BatchSpanProcessor(exporter))
+    from opentelemetry.exporter.otlp.proto.http import Compression
+
+    _compression_map = {"gzip": Compression.Gzip, "deflate": Compression.Deflate}
+    compression = _compression_map.get(OTEL_EXPORTER_OTLP_COMPRESSION, Compression.NoCompression)
+    exporter = OTLPSpanExporter(compression=compression)
+    provider.add_span_processor(
+        BatchSpanProcessor(
+            exporter,
+            max_queue_size=OTEL_BSP_MAX_QUEUE_SIZE,
+            max_export_batch_size=OTEL_BSP_MAX_EXPORT_BATCH_SIZE,
+            schedule_delay_millis=OTEL_BSP_SCHEDULE_DELAY,
+            export_timeout_millis=OTEL_BSP_EXPORT_TIMEOUT,
+        )
+    )
 
     trace.set_tracer_provider(provider)
     _otel_initialized_pid = os.getpid()
     logger.info("OpenTelemetry initialized for service=%s version=%s", service_name, service_version)
+    logger.info(
+        "OpenTelemetry config: sampling=%.2f sql=%s commenter=%s http=%s "
+        "bsp_queue=%d bsp_batch=%d bsp_delay=%dms bsp_timeout=%dms "
+        "compression=%s attr_limit=%d attr_len_limit=%d",
+        OTEL_SAMPLING_RATE,
+        OTEL_SQL_ENABLED,
+        OTEL_SQL_COMMENTER_ENABLED,
+        OTEL_HTTP_ENABLED,
+        OTEL_BSP_MAX_QUEUE_SIZE,
+        OTEL_BSP_MAX_EXPORT_BATCH_SIZE,
+        OTEL_BSP_SCHEDULE_DELAY,
+        OTEL_BSP_EXPORT_TIMEOUT,
+        OTEL_EXPORTER_OTLP_COMPRESSION,
+        OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
+        OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+    )
 
 
 def instrument_flask_app(flask_app):
@@ -115,33 +166,33 @@ def instrument_flask_app(flask_app):
 def instrument_sqlalchemy(engine):
     """Instrument a SQLAlchemy engine with OpenTelemetry query tracing.
 
-    Every SQL query becomes a child span of the request that triggered it,
-    with the query text and duration. SQLCommenter adds traceparent to SQL
-    comments so queries are visible in pg_stat_activity.
+    Controlled by OTEL_SQL_ENABLED (master toggle) and OTEL_SQL_COMMENTER_ENABLED
+    (adds traceparent to SQL comments for pg_stat_activity visibility).
     """
-    if not OTEL_ENABLED:
+    if not OTEL_ENABLED or not OTEL_SQL_ENABLED:
         return
 
     from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
 
     SQLAlchemyInstrumentor().instrument(
         engine=engine,
-        enable_commenter=True,
+        enable_commenter=OTEL_SQL_COMMENTER_ENABLED,
         commenter_options={
             "db_framework": True,
             "db_driver": True,
         },
     )
-    logger.info("SQLAlchemy engine instrumented with OpenTelemetry")
+    logger.info("SQLAlchemy engine instrumented with OpenTelemetry (commenter=%s)", OTEL_SQL_COMMENTER_ENABLED)
 
 
 def instrument_outbound_http():
     """Instrument outbound HTTP calls (e.g., RBAC) with OpenTelemetry.
 
-    Automatically creates spans for all requests made via the `requests` library,
-    including trace context propagation to downstream services.
+    Controlled by OTEL_HTTP_ENABLED. Automatically creates spans for all
+    requests made via the `requests` library, including trace context
+    propagation to downstream services.
     """
-    if not OTEL_ENABLED:
+    if not OTEL_ENABLED or not OTEL_HTTP_ENABLED:
         return
 
     from opentelemetry.instrumentation.requests import RequestsInstrumentor

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -272,6 +272,28 @@ objects:
             value: ${OTEL_ENABLED}
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+          - name: OTEL_SQL_ENABLED
+            value: ${OTEL_SQL_ENABLED}
+          - name: OTEL_SQL_COMMENTER_ENABLED
+            value: ${OTEL_SQL_COMMENTER_ENABLED}
+          - name: OTEL_HTTP_ENABLED
+            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_SAMPLING_RATE
+            value: ${OTEL_SAMPLING_RATE}
+          - name: OTEL_BSP_MAX_QUEUE_SIZE
+            value: ${OTEL_BSP_MAX_QUEUE_SIZE}
+          - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+            value: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE}
+          - name: OTEL_BSP_SCHEDULE_DELAY
+            value: ${OTEL_BSP_SCHEDULE_DELAY}
+          - name: OTEL_BSP_EXPORT_TIMEOUT
+            value: ${OTEL_BSP_EXPORT_TIMEOUT}
+          - name: OTEL_EXPORTER_OTLP_COMPRESSION
+            value: ${OTEL_EXPORTER_OTLP_COMPRESSION}
+          - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
+          - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
           - name: KAFKA_PRODUCER_ACKS
             value: ${KAFKA_PRODUCER_ACKS}
           - name: KAFKA_PRODUCER_RETRIES
@@ -387,6 +409,28 @@ objects:
             value: ${OTEL_ENABLED}
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+          - name: OTEL_SQL_ENABLED
+            value: ${OTEL_SQL_ENABLED}
+          - name: OTEL_SQL_COMMENTER_ENABLED
+            value: ${OTEL_SQL_COMMENTER_ENABLED}
+          - name: OTEL_HTTP_ENABLED
+            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_SAMPLING_RATE
+            value: ${OTEL_SAMPLING_RATE}
+          - name: OTEL_BSP_MAX_QUEUE_SIZE
+            value: ${OTEL_BSP_MAX_QUEUE_SIZE}
+          - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+            value: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE}
+          - name: OTEL_BSP_SCHEDULE_DELAY
+            value: ${OTEL_BSP_SCHEDULE_DELAY}
+          - name: OTEL_BSP_EXPORT_TIMEOUT
+            value: ${OTEL_BSP_EXPORT_TIMEOUT}
+          - name: OTEL_EXPORTER_OTLP_COMPRESSION
+            value: ${OTEL_EXPORTER_OTLP_COMPRESSION}
+          - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
+          - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
           - name: KAFKA_PRODUCER_ACKS
             value: ${KAFKA_PRODUCER_ACKS}
           - name: KAFKA_PRODUCER_RETRIES
@@ -521,6 +565,28 @@ objects:
             value: ${OTEL_ENABLED}
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+          - name: OTEL_SQL_ENABLED
+            value: ${OTEL_SQL_ENABLED}
+          - name: OTEL_SQL_COMMENTER_ENABLED
+            value: ${OTEL_SQL_COMMENTER_ENABLED}
+          - name: OTEL_HTTP_ENABLED
+            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_SAMPLING_RATE
+            value: ${OTEL_SAMPLING_RATE}
+          - name: OTEL_BSP_MAX_QUEUE_SIZE
+            value: ${OTEL_BSP_MAX_QUEUE_SIZE}
+          - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+            value: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE}
+          - name: OTEL_BSP_SCHEDULE_DELAY
+            value: ${OTEL_BSP_SCHEDULE_DELAY}
+          - name: OTEL_BSP_EXPORT_TIMEOUT
+            value: ${OTEL_BSP_EXPORT_TIMEOUT}
+          - name: OTEL_EXPORTER_OTLP_COMPRESSION
+            value: ${OTEL_EXPORTER_OTLP_COMPRESSION}
+          - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
+          - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
           - name: UNLEASH_URL
             value: ${UNLEASH_URL}
           - <<: *unleashToken
@@ -596,6 +662,28 @@ objects:
             value: ${OTEL_ENABLED}
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+          - name: OTEL_SQL_ENABLED
+            value: ${OTEL_SQL_ENABLED}
+          - name: OTEL_SQL_COMMENTER_ENABLED
+            value: ${OTEL_SQL_COMMENTER_ENABLED}
+          - name: OTEL_HTTP_ENABLED
+            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_SAMPLING_RATE
+            value: ${OTEL_SAMPLING_RATE}
+          - name: OTEL_BSP_MAX_QUEUE_SIZE
+            value: ${OTEL_BSP_MAX_QUEUE_SIZE}
+          - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+            value: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE}
+          - name: OTEL_BSP_SCHEDULE_DELAY
+            value: ${OTEL_BSP_SCHEDULE_DELAY}
+          - name: OTEL_BSP_EXPORT_TIMEOUT
+            value: ${OTEL_BSP_EXPORT_TIMEOUT}
+          - name: OTEL_EXPORTER_OTLP_COMPRESSION
+            value: ${OTEL_EXPORTER_OTLP_COMPRESSION}
+          - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
+          - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
           - name: CLOWDER_ENABLED
             value: "true"
           - name: INVENTORY_DB_SCHEMA
@@ -709,6 +797,28 @@ objects:
             value: ${OTEL_ENABLED}
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+          - name: OTEL_SQL_ENABLED
+            value: ${OTEL_SQL_ENABLED}
+          - name: OTEL_SQL_COMMENTER_ENABLED
+            value: ${OTEL_SQL_COMMENTER_ENABLED}
+          - name: OTEL_HTTP_ENABLED
+            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_SAMPLING_RATE
+            value: ${OTEL_SAMPLING_RATE}
+          - name: OTEL_BSP_MAX_QUEUE_SIZE
+            value: ${OTEL_BSP_MAX_QUEUE_SIZE}
+          - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+            value: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE}
+          - name: OTEL_BSP_SCHEDULE_DELAY
+            value: ${OTEL_BSP_SCHEDULE_DELAY}
+          - name: OTEL_BSP_EXPORT_TIMEOUT
+            value: ${OTEL_BSP_EXPORT_TIMEOUT}
+          - name: OTEL_EXPORTER_OTLP_COMPRESSION
+            value: ${OTEL_EXPORTER_OTLP_COMPRESSION}
+          - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
+          - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
           - name: UNLEASH_URL
             value: ${UNLEASH_URL}
           - <<: *unleashToken
@@ -780,6 +890,28 @@ objects:
             value: ${OTEL_ENABLED}
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+          - name: OTEL_SQL_ENABLED
+            value: ${OTEL_SQL_ENABLED}
+          - name: OTEL_SQL_COMMENTER_ENABLED
+            value: ${OTEL_SQL_COMMENTER_ENABLED}
+          - name: OTEL_HTTP_ENABLED
+            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_SAMPLING_RATE
+            value: ${OTEL_SAMPLING_RATE}
+          - name: OTEL_BSP_MAX_QUEUE_SIZE
+            value: ${OTEL_BSP_MAX_QUEUE_SIZE}
+          - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+            value: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE}
+          - name: OTEL_BSP_SCHEDULE_DELAY
+            value: ${OTEL_BSP_SCHEDULE_DELAY}
+          - name: OTEL_BSP_EXPORT_TIMEOUT
+            value: ${OTEL_BSP_EXPORT_TIMEOUT}
+          - name: OTEL_EXPORTER_OTLP_COMPRESSION
+            value: ${OTEL_EXPORTER_OTLP_COMPRESSION}
+          - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
+          - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
           - name: CLOWDER_ENABLED
             value: "true"
           - name: INVENTORY_DB_SCHEMA
@@ -925,6 +1057,28 @@ objects:
             value: ${OTEL_ENABLED}
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
             value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+          - name: OTEL_SQL_ENABLED
+            value: ${OTEL_SQL_ENABLED}
+          - name: OTEL_SQL_COMMENTER_ENABLED
+            value: ${OTEL_SQL_COMMENTER_ENABLED}
+          - name: OTEL_HTTP_ENABLED
+            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_SAMPLING_RATE
+            value: ${OTEL_SAMPLING_RATE}
+          - name: OTEL_BSP_MAX_QUEUE_SIZE
+            value: ${OTEL_BSP_MAX_QUEUE_SIZE}
+          - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+            value: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE}
+          - name: OTEL_BSP_SCHEDULE_DELAY
+            value: ${OTEL_BSP_SCHEDULE_DELAY}
+          - name: OTEL_BSP_EXPORT_TIMEOUT
+            value: ${OTEL_BSP_EXPORT_TIMEOUT}
+          - name: OTEL_EXPORTER_OTLP_COMPRESSION
+            value: ${OTEL_EXPORTER_OTLP_COMPRESSION}
+          - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
+          - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+            value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
           - name: CLOWDER_ENABLED
             value: "true"
           - name: INVENTORY_DB_SCHEMA
@@ -2717,3 +2871,36 @@ parameters:
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
   description: OTLP HTTP endpoint for trace export
   value: 'http://otel-collector.otel-stage.svc:4318'
+- name: OTEL_SQL_ENABLED
+  description: Enable SQLAlchemy query tracing
+  value: 'true'
+- name: OTEL_SQL_COMMENTER_ENABLED
+  description: Enable SQLCommenter (adds trace context to SQL comments)
+  value: 'false'
+- name: OTEL_HTTP_ENABLED
+  description: Enable outbound HTTP request tracing
+  value: 'true'
+- name: OTEL_SAMPLING_RATE
+  description: Trace sampling ratio (0.0-1.0). 1.0 = all traces
+  value: '1.0'
+- name: OTEL_BSP_MAX_QUEUE_SIZE
+  description: BatchSpanProcessor max queue size
+  value: '8192'
+- name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+  description: BatchSpanProcessor max export batch size
+  value: '256'
+- name: OTEL_BSP_SCHEDULE_DELAY
+  description: BatchSpanProcessor schedule delay in milliseconds
+  value: '2000'
+- name: OTEL_BSP_EXPORT_TIMEOUT
+  description: BatchSpanProcessor export timeout in milliseconds
+  value: '10000'
+- name: OTEL_EXPORTER_OTLP_COMPRESSION
+  description: OTLP exporter compression (gzip, deflate, or none)
+  value: 'gzip'
+- name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+  description: Max number of attributes per span
+  value: '64'
+- name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+  description: Max length of span attribute values (truncates long SQL text, etc.)
+  value: '1024'

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -2,7 +2,9 @@
 
 import importlib
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
+import pytest
 from flask import Flask
 from opentelemetry import trace
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
@@ -114,3 +116,231 @@ def test_instrument_flask_app_excludes_ops_urls_but_traces_other_routes(monkeypa
         provider.shutdown()
         monkeypatch.setenv("OTEL_ENABLED", "false")
         importlib.reload(telemetry_mod)
+
+
+def _reload_telemetry(monkeypatch, env_overrides):
+    """Reload the telemetry module with the given env var overrides applied."""
+    for key, value in env_overrides.items():
+        monkeypatch.setenv(key, value)
+    import app.telemetry as telemetry_mod
+
+    importlib.reload(telemetry_mod)
+    return telemetry_mod
+
+
+def _cleanup_telemetry(monkeypatch):
+    """Reset the telemetry module back to disabled state."""
+    monkeypatch.setenv("OTEL_ENABLED", "false")
+    import app.telemetry as telemetry_mod
+
+    importlib.reload(telemetry_mod)
+
+
+def test_sampling_rate_applied_in_init_otel(monkeypatch):
+    """TraceIdRatioBased sampler is created with OTEL_SAMPLING_RATE."""
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_SAMPLING_RATE": "0.25"})
+
+    with patch.object(telemetry_mod, "_otel_initialized_pid", None):
+        from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+
+        with (
+            patch("opentelemetry.sdk.trace.TracerProvider") as mock_provider_cls,
+            patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"),
+        ):
+            mock_provider_cls.return_value = MagicMock()
+            telemetry_mod.init_otel(service_name="test-service")
+
+            call_kwargs = mock_provider_cls.call_args
+            sampler = call_kwargs[1]["sampler"] if "sampler" in call_kwargs[1] else call_kwargs[0][1]
+            assert isinstance(sampler, TraceIdRatioBased)
+            assert sampler.rate == 0.25
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_bsp_params_passed_to_batch_span_processor(monkeypatch):
+    """BatchSpanProcessor receives the env-configured queue/batch/delay/timeout values."""
+    telemetry_mod = _reload_telemetry(
+        monkeypatch,
+        {
+            "OTEL_ENABLED": "true",
+            "OTEL_BSP_MAX_QUEUE_SIZE": "4096",
+            "OTEL_BSP_MAX_EXPORT_BATCH_SIZE": "128",
+            "OTEL_BSP_SCHEDULE_DELAY": "3000",
+            "OTEL_BSP_EXPORT_TIMEOUT": "5000",
+        },
+    )
+
+    with patch.object(telemetry_mod, "_otel_initialized_pid", None):
+        with (
+            patch("opentelemetry.sdk.trace.export.BatchSpanProcessor") as mock_bsp,
+            patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"),
+        ):
+            mock_bsp.return_value = MagicMock()
+            telemetry_mod.init_otel(service_name="test-service")
+
+            _, kwargs = mock_bsp.call_args
+            assert kwargs["max_queue_size"] == 4096
+            assert kwargs["max_export_batch_size"] == 128
+            assert kwargs["schedule_delay_millis"] == 3000
+            assert kwargs["export_timeout_millis"] == 5000
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_sql_instrumentation_skipped_when_disabled(monkeypatch):
+    """instrument_sqlalchemy is a no-op when OTEL_SQL_ENABLED=false."""
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_SQL_ENABLED": "false"})
+
+    with patch("opentelemetry.instrumentation.sqlalchemy.SQLAlchemyInstrumentor") as mock_instrumentor:
+        engine = MagicMock()
+        telemetry_mod.instrument_sqlalchemy(engine)
+        mock_instrumentor.assert_not_called()
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_sql_commenter_toggled_by_env(monkeypatch):
+    """enable_commenter reflects the OTEL_SQL_COMMENTER_ENABLED setting."""
+    telemetry_mod = _reload_telemetry(
+        monkeypatch, {"OTEL_ENABLED": "true", "OTEL_SQL_ENABLED": "true", "OTEL_SQL_COMMENTER_ENABLED": "true"}
+    )
+
+    with patch("opentelemetry.instrumentation.sqlalchemy.SQLAlchemyInstrumentor") as mock_cls:
+        instance = MagicMock()
+        mock_cls.return_value = instance
+        engine = MagicMock()
+        telemetry_mod.instrument_sqlalchemy(engine)
+        _, kwargs = instance.instrument.call_args
+        assert kwargs["enable_commenter"] is True
+
+    _cleanup_telemetry(monkeypatch)
+
+    telemetry_mod = _reload_telemetry(
+        monkeypatch, {"OTEL_ENABLED": "true", "OTEL_SQL_ENABLED": "true", "OTEL_SQL_COMMENTER_ENABLED": "false"}
+    )
+
+    with patch("opentelemetry.instrumentation.sqlalchemy.SQLAlchemyInstrumentor") as mock_cls:
+        instance = MagicMock()
+        mock_cls.return_value = instance
+        engine = MagicMock()
+        telemetry_mod.instrument_sqlalchemy(engine)
+        _, kwargs = instance.instrument.call_args
+        assert kwargs["enable_commenter"] is False
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_http_instrumentation_skipped_when_disabled(monkeypatch):
+    """instrument_outbound_http is a no-op when OTEL_HTTP_ENABLED=false."""
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_HTTP_ENABLED": "false"})
+
+    with patch("opentelemetry.instrumentation.requests.RequestsInstrumentor") as mock_instrumentor:
+        telemetry_mod.instrument_outbound_http()
+        mock_instrumentor.assert_not_called()
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_http_instrumentation_runs_when_enabled(monkeypatch):
+    """instrument_outbound_http instruments when OTEL_HTTP_ENABLED=true."""
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_HTTP_ENABLED": "true"})
+
+    with patch("opentelemetry.instrumentation.requests.RequestsInstrumentor") as mock_cls:
+        instance = MagicMock()
+        mock_cls.return_value = instance
+        telemetry_mod.instrument_outbound_http()
+        instance.instrument.assert_called_once()
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_config_defaults_without_env_vars(monkeypatch):
+    """Module-level config constants use sensible defaults when env vars are absent."""
+    for var in [
+        "OTEL_SQL_ENABLED",
+        "OTEL_SQL_COMMENTER_ENABLED",
+        "OTEL_HTTP_ENABLED",
+        "OTEL_SAMPLING_RATE",
+        "OTEL_BSP_MAX_QUEUE_SIZE",
+        "OTEL_BSP_MAX_EXPORT_BATCH_SIZE",
+        "OTEL_BSP_SCHEDULE_DELAY",
+        "OTEL_BSP_EXPORT_TIMEOUT",
+        "OTEL_EXPORTER_OTLP_COMPRESSION",
+        "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT",
+        "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("OTEL_ENABLED", "false")
+
+    import app.telemetry as telemetry_mod
+
+    importlib.reload(telemetry_mod)
+
+    assert telemetry_mod.OTEL_ENABLED is False
+    assert telemetry_mod.OTEL_SQL_ENABLED is True
+    assert telemetry_mod.OTEL_SQL_COMMENTER_ENABLED is False
+    assert telemetry_mod.OTEL_HTTP_ENABLED is True
+    assert telemetry_mod.OTEL_SAMPLING_RATE == 1.0
+    assert telemetry_mod.OTEL_BSP_MAX_QUEUE_SIZE == 8192
+    assert telemetry_mod.OTEL_BSP_MAX_EXPORT_BATCH_SIZE == 256
+    assert telemetry_mod.OTEL_BSP_SCHEDULE_DELAY == 2000
+    assert telemetry_mod.OTEL_BSP_EXPORT_TIMEOUT == 10000
+    assert telemetry_mod.OTEL_EXPORTER_OTLP_COMPRESSION == "gzip"
+    assert telemetry_mod.OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT == 64
+    assert telemetry_mod.OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT == 1024
+
+
+@pytest.mark.parametrize(
+    "env_value,expected_compression",
+    [
+        ("gzip", "Gzip"),
+        ("GZIP", "Gzip"),
+        ("deflate", "Deflate"),
+        ("none", "NoCompression"),
+        ("foobar", "NoCompression"),
+    ],
+)
+def test_exporter_compression_mapping(monkeypatch, env_value, expected_compression):
+    """OTLPSpanExporter receives the correct Compression enum for each config value."""
+    from opentelemetry.exporter.otlp.proto.http import Compression
+
+    telemetry_mod = _reload_telemetry(
+        monkeypatch, {"OTEL_ENABLED": "true", "OTEL_EXPORTER_OTLP_COMPRESSION": env_value}
+    )
+
+    with patch.object(telemetry_mod, "_otel_initialized_pid", None):
+        with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter") as mock_exporter:
+            mock_exporter.return_value = MagicMock()
+            telemetry_mod.init_otel(service_name="test-service")
+            expected_enum = getattr(Compression, expected_compression)
+            mock_exporter.assert_called_once_with(compression=expected_enum)
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_span_limits_applied_to_tracer_provider(monkeypatch):
+    """SpanLimits are created with env-configured attribute limits."""
+    telemetry_mod = _reload_telemetry(
+        monkeypatch,
+        {
+            "OTEL_ENABLED": "true",
+            "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT": "32",
+            "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT": "512",
+        },
+    )
+
+    with patch.object(telemetry_mod, "_otel_initialized_pid", None):
+        with (
+            patch("opentelemetry.sdk.trace.TracerProvider") as mock_provider_cls,
+            patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"),
+        ):
+            mock_provider_cls.return_value = MagicMock()
+            telemetry_mod.init_otel(service_name="test-service")
+
+            call_kwargs = mock_provider_cls.call_args[1]
+            span_limits = call_kwargs["span_limits"]
+            assert span_limits.max_attributes == 32
+            assert span_limits.max_attribute_length == 512
+
+    _cleanup_telemetry(monkeypatch)


### PR DESCRIPTION
## Jira
[RHINENG-26335](https://issues.redhat.com/browse/RHINENG-26335)

## What
Make every OTEL tracing setting configurable via environment variables so stage and prod can run independent configurations without code changes.

## Why
Enabling tracing in production with default settings caused Kafka consumer lag (205K), API latency regression, and outbound HTTP degradation due to untuned BatchSpanProcessor, SQLCommenter overhead.

## How
- Added env-var-driven config block in `app/telemetry.py` for per-instrument toggles (`OTEL_SQL_ENABLED`, `OTEL_SQL_COMMENTER_ENABLED`, `OTEL_HTTP_ENABLED`), sampling rate, BSP tuning, OTLP gzip compression, and span attribute limits.
- Applied `TraceIdRatioBased` sampler and `SpanLimits` to the `TracerProvider`.
- Passed explicit BSP parameters instead of relying on SDK defaults.
- Wired all new env vars into all 7 deployments in `deploy/clowdapp.yml` with sensible defaults.

## Testing
- 15 unit tests in `tests/test_telemetry.py` covering all new config knobs: sampling rate, BSP params, SQL toggle, commenter toggle, HTTP toggle, compression enum mapping, span limits, and default values.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26335]: https://redhat.atlassian.net/browse/RHINENG-26335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Make OpenTelemetry tracing behavior fully configurable via environment variables to safely tune observability across environments.

New Features:
- Introduce environment-driven configuration for OTEL sampling rate, span limits, exporter compression, and BatchSpanProcessor tunables.
- Add per-instrument toggles for SQLAlchemy, SQLCommenter, and outbound HTTP tracing, controlled via environment variables.

Enhancements:
- Log the effective OTEL runtime configuration at initialization to aid debugging and tuning.

Build:
- Wire new OTEL-related environment variables into all ClowdApp deployments and define their default parameter values for each environment.

Tests:
- Add comprehensive telemetry tests covering sampling configuration, BSP parameters, instrumentation toggles, exporter compression behavior, span limits, and default values.