### PR TITLE
chore(deps): bump pyjwt to 2.12.1 on foreman-3.18

### DIFF
--- a/.hermetic_builds/requirements.txt
+++ b/.hermetic_builds/requirements.txt
@@ -56,7 +56,7 @@ prance==23.6.21.0; python_version >= '3.8'
 prometheus-client==0.22.1; python_version >= '3.9'
 prometheus-flask-exporter==0.23.2
 psycopg2==2.9.10; python_version >= '3.8'
-pyjwt==2.10.1; python_version >= '3.9'
+pyjwt==2.12.1; python_version >= '3.9'
 python-dateutil==2.9.0.post0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 python-dotenv==1.1.1; python_version >= '3.9'
 python-multipart==0.0.20; python_version >= '3.8'

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -837,11 +837,11 @@
         },
         "pyjwt": {
             "hashes": [
-                "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953",
-                "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb"
+                "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c",
+                "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.10.1"
+            "version": "==2.12.1"
         },
         "python-dateutil": {
             "hashes": [


### PR DESCRIPTION
## Jira
[SAT-43404](https://redhat.atlassian.net/browse/SAT-43404)

## What
<!-- Short description of the change -->

## Why
<!-- Reason for change / linked ticket -->

## How
<!-- Brief explanation of approach -->

## Testing
<!-- How was this tested? -->

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Build:
- Update hermetic build requirements to use pyjwt 2.12.1 instead of 2.10.1.

[SAT-43404]: https://redhat.atlassian.net/browse/SAT-43404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ