### PR TITLE
fix: Always pull the latest nginx image

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -192,6 +192,7 @@ objects:
             fieldRef:
               fieldPath: metadata.name
         image: registry.access.redhat.com/ubi9/nginx-124:latest
+        imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
           httpGet:


### PR DESCRIPTION
Given that the `latest` tag is used, we need to ensure that anytime nginx is updated we get the latest image. Without `imagePullPolicy: Always` configured, openshift defaults to `ifNeeded`. This means that an old nginx image could stay on the cluster over multiple deployment cycles.

This is particularly key for govcloud since CVEs need to be continuously resolved. The latest nginx version containing fixes should be deployed each time.

## Jira


## What
<!-- Short description of the change -->

Ensure the latest nginx image is pulled with each deployment

## Why
<!-- Reason for change / linked ticket -->

Using the latest tag means that often an image will not be refreshed even though there may be a newer image with resolved CVEs in it. This fixes that.

## How
<!-- Brief explanation of approach -->

Add `imagePullPolicy: Alwasy` to the Clowdapp

## Testing
<!-- How was this tested? -->

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Deployment:
- Configure the nginx container to use imagePullPolicy: Always so updated images are fetched consistently.