### PR TITLE
chore(IQE-4098): move to iqe-bindings for export-service

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.15.13
   hooks:
-  - id: ruff
+  - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix]
   - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy

--- a/iqe-host-inventory-plugin/iqe_host_inventory/__init__.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/__init__.py
@@ -38,6 +38,7 @@ class ApplicationHostInventory(ApplicationPlugin):
 
     v7_notifications_v1 = RESTPluginService.declare("v7_notifications_v1")
     v7_integrations_v1 = RESTPluginService.declare("v7_integrations_v1")
+    v7_export_v1 = RESTPluginService.declare("v7_export_v1")
 
     @cached_property
     def datagen(self) -> kafka_interaction.HBIKafkaDatagen:

--- a/iqe-host-inventory-plugin/iqe_host_inventory/conf/host_inventory.default.yaml
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/conf/host_inventory.default.yaml
@@ -51,6 +51,11 @@ default:
       config:
         module_name: iqe_bindings.v7.rbac_v2
         path: api/rbac/v2
+    v7_export_v1:
+      type: rest
+      config:
+        module_name: iqe_bindings.v7.export_v1
+        path: api/export/v1
   email_account:
     insights-qe:
       username: {vault_path: secrets/qe/global/insights-qe-sa, vault_key: username}
@@ -744,6 +749,11 @@ clowder_smoke:
         hostname: "@jinja {{ env_parser.get_hostname('rbac', 'service') }}"
         scheme: http
         port: "@jinja {{ env_parser.get_port('rbac', 'service') }}"
+    v7_export_v1:
+      config:
+        hostname: "@jinja {{ env_parser.get_hostname('export-service', 'service') }}"
+        scheme: http
+        port: "@jinja {{ env_parser.get_port('export-service', 'service') }}"
   db:
     hostname: "@jinja {{ env_parser.get_db_config('host-inventory').hostname }}"
     database: "@jinja {{ env_parser.get_db_config('host-inventory').name }}"
@@ -790,6 +800,11 @@ stage_post_deploy:
         hostname: "@jinja {{ env_parser.get_hostname('rbac', 'service') }}"
         scheme: http
         port: "@jinja {{ env_parser.get_port('rbac', 'service') }}"
+    v7_export_v1:
+      config:
+        hostname: "@jinja {{ env_parser.get_hostname('export-service', 'service') }}"
+        scheme: http
+        port: "@jinja {{ env_parser.get_port('export-service', 'service') }}"
   db:
     hostname: "@jinja {{ env_parser.get_db_config('host-inventory').hostname }}"
     database: "@jinja {{ env_parser.get_db_config('host-inventory').name }}"

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/exports_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/exports_api.py
@@ -8,19 +8,19 @@ import logging
 import os
 import re
 import shutil
+import tempfile
 import zipfile
 from functools import cached_property
 from typing import Any
 
 import attr
 from iqe.base.modeling import BaseEntity
-from iqe_export_service import ApplicationExportService
-from iqe_export_service_api import ApiException
-from iqe_export_service_api.api.default_api import DefaultApi
-from iqe_export_service_api.models.export_list import ExportList
-from iqe_export_service_api.models.export_request import ExportRequest
-from iqe_export_service_api.models.export_request_resource import ExportRequestResource
-from iqe_export_service_api.models.export_status import ExportStatus
+from iqe_bindings.v7.export_v1 import ApiException
+from iqe_bindings.v7.export_v1 import DefaultApi
+from iqe_bindings.v7.export_v1 import ExportList
+from iqe_bindings.v7.export_v1 import ExportRequest
+from iqe_bindings.v7.export_v1 import ExportRequestResource
+from iqe_bindings.v7.export_v1 import ExportStatus
 
 import iqe_host_inventory
 from iqe_host_inventory.utils.api_utils import accept_when
@@ -28,6 +28,8 @@ from iqe_host_inventory.utils.datagen_utils import generate_uuid
 from iqe_host_inventory_api.models.host_out import HostOut
 
 logger = logging.getLogger(__name__)
+
+SPEC_SOURCE_STATUSES = {"partial", "pending", "running", "complete", "failed"}
 
 HBI_EXPORT_APPLICATION = "urn:redhat:application:inventory"
 HBI_EXPORT_RESOURCE = "urn:redhat:application:inventory:export:systems"
@@ -131,24 +133,67 @@ class ExportsAPIWrapper(BaseEntity):
         return self.application.host_inventory
 
     @cached_property
-    def _exports(self) -> ApplicationExportService:
-        return self.application.export_service
-
-    @cached_property
     def raw_api(self) -> DefaultApi:
         """
         Raw auto-generated OpenAPI client.
         Use high level API wrapper methods instead of this raw API client.
         Outside this class this should be used only for negative validation testing.
         """
-        return self._exports.rest_client.default_api
+        return self._host_inventory.v7_export_v1.default_api
+
+    def _create_export_via_workaround(self, request: ExportRequest) -> str:
+        """Workaround for RHCLOUD-47769: the export service returns 202 instead
+        of the spec-defined 200, so the v7 bindings client leaves
+        create_response.data as None. Deserialize the body directly."""
+        create_response = self.raw_api.create_export_with_http_info(export_request=request)
+        if create_response.status_code != 202:
+            raise RuntimeError(
+                f"RHCLOUD-47769 workaround: expected 202, got {create_response.status_code}. "
+                "If the status is now 200 the upstream bug may be fixed — remove this workaround."
+            )
+        return ExportStatus.model_validate_json(create_response.raw_data).id
+
+    def _get_export_status_via_workaround(self, export_id: str) -> ExportStatus:
+        """Workaround for RHCLOUD-47776: the export service returns source-level
+        status values not declared in the OpenAPI spec's Status enum. Normalize
+        unknown statuses so model_validate can properly coerce datetime fields."""
+        response = self.raw_api.get_export_status_without_preload_content(id=export_id)
+        body = json.loads(response.read())
+
+        for idx, src in enumerate(body.get("sources") or []):
+            src_status = src.get("status")
+            if src_status and src_status not in SPEC_SOURCE_STATUSES:
+                logger.warning(
+                    "RHCLOUD-47776: GET /exports/%s/status — source[%d] has "
+                    "status=%r which is NOT in the OpenAPI spec enum %s; "
+                    "normalizing to 'complete' for validation.",
+                    export_id,
+                    idx,
+                    src_status,
+                    sorted(SPEC_SOURCE_STATUSES),
+                )
+                src["status"] = "complete"
+
+        return ExportStatus.model_validate(body)
+
+    def _write_zip_bytes_to_tempfile(self, zip_bytes: bytes) -> str:
+        """Workaround for RHCLOUD-47769 migration gap: v7 bindings return raw
+        bytes instead of a file path. Write to a named temp file so callers
+        continue to receive a path.
+
+        Callers are responsible for cleanup; fetch_export_data handles this
+        by default via delete_zip=True.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            tmp.write(zip_bytes)
+            return tmp.name
 
     def wait_for_completion(
         self,
         export_id: str,
         *,
-        retries: int = 20,
-        delay: float = 0.5,
+        retries: int = 30,
+        delay: float = 1,
     ) -> str:
         """Wait for an export to complete, return its status
 
@@ -209,16 +254,13 @@ class ExportsAPIWrapper(BaseEntity):
             application=HBI_EXPORT_APPLICATION, resource=HBI_EXPORT_RESOURCE, filters=filters
         )
         request = ExportRequest(name=name, format=format, sources=[source])
-
-        export_id = self.raw_api.create_export(export_request=request).id
+        export_id = self._create_export_via_workaround(request)
 
         if register_for_cleanup:
             self._host_inventory.cleanup.add_exports({export_id}, scope=cleanup_scope)
 
         if wait_for_completion:
             status = self.wait_for_completion(export_id, **kwargs)
-
-            # Terminal states are "failed" and "complete".
             assert status == "complete", (
                 f"Export request didn't complete successfully, status={status}"
             )
@@ -242,7 +284,7 @@ class ExportsAPIWrapper(BaseEntity):
         :param str export_id: export id
         :return: ExportStatus
         """
-        return self.raw_api.get_export_status(id=export_id)
+        return self._get_export_status_via_workaround(export_id)
 
     def delete_export(self, export_id: str, *, fail_when_not_found: bool = False) -> None:
         """Delete an export
@@ -282,12 +324,16 @@ class ExportsAPIWrapper(BaseEntity):
         data can then be fetched from this archive.  Assumes the export is
         complete.
 
+        The returned temp file is NOT automatically cleaned up; pass the path
+        to fetch_export_data (which deletes it by default) or remove it manually.
+
         :param str export_id: export id
         :return: str
         """
-        path = self.raw_api.download_export(id=export_id)
-        assert os.path.isfile(path)
-
+        zip_bytes = self.raw_api.download_export(id=export_id)
+        path = self._write_zip_bytes_to_tempfile(zip_bytes)
+        if not os.path.isfile(path):
+            raise RuntimeError(f"Failed to write export zip to temp file: {path}")
         return path
 
     def fetch_export_data(self, path: str, delete_zip: bool = True) -> list[dict] | list[tuple]:

--- a/iqe-host-inventory-plugin/mypy.ini
+++ b/iqe-host-inventory-plugin/mypy.ini
@@ -46,6 +46,3 @@ ignore_errors=true
 
 [mypy-confluent_kafka.*]
 ignore_missing_imports = True
-
-[mypy-iqe_export_service_api.*]
-ignore_missing_imports = True

--- a/iqe-host-inventory-plugin/pyproject.toml
+++ b/iqe-host-inventory-plugin/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
   "google-auth",
   "iqe-bindings",
   "iqe-core>=24.11.29.1",
-  "iqe-export-service-plugin",
   "iqe-kessel-sync-plugin",
   "iqe-mq-plugin>=24.11.29",
   "lxml",


### PR DESCRIPTION
includes workarounds for 2 export-service bugs

## Jira
[IQE-4098](https://redhat.atlassian.net/browse/IQE-4098)

## What
Use iqe-bindings v7 clients for export-service

## Why
validated client, remove plugin dependency

## How
cursor, do it.

## Testing
locally testing against stage/prod

### prod
```
(.iqe-env) ➜  iqe-host-inventory-plugin git:(bindings-export) ENV_FOR_DYNACONF=prod iqe tests plugin host_inventory -vv -m "not ephemeral" iqe_host_inventory/tests/rest/exports/test_exports.py
<redacted>
  ============= 4 passed, 8 deselected, 2 warnings in 62.17s (0:01:02) ======
```

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[IQE-4098]: https://redhat.atlassian.net/browse/IQE-4098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Switch host-inventory IQE plugin to use the iqe-bindings v7 export-service client and add temporary workarounds for current export-service API contract issues.

Bug Fixes:
- Add a workaround for create_export responses returning HTTP 202 instead of the spec-defined 200 by manually deserializing the response body.
- Add a workaround for export status responses containing non-spec source status values by bypassing strict enum validation and logging unexpected statuses.

Enhancements:
- Configure a new v7_export_v1 REST client in the host-inventory application and wire ExportsAPIWrapper to use it instead of the legacy export-service plugin.
- Remove the iqe-export-service-plugin dependency and related mypy ignore configuration as it is no longer needed.

Build:
- Update dependency list in pyproject.toml to drop iqe-export-service-plugin now that iqe-bindings v7 is used.

## Summary by Sourcery

Switch host-inventory export tests to use the iqe-bindings v7 export-service client and add compatibility workarounds for current export-service behavior.

Bug Fixes:
- Work around non-spec HTTP 202 responses from create_export by manually deserializing the response body to obtain the export ID.
- Work around non-spec source-level status values in export status responses by bypassing strict enum validation while logging unexpected values.
- Prevent tests from hanging on exports stuck in non-terminal states by marking such cases as expected failures.
- Preserve the existing file-path-based download contract by writing the v7 client's raw zip bytes to a temporary file.

Enhancements:
- Configure and wire a new v7_export_v1 REST client into the host-inventory application for export-service interactions.
- Increase wait_for_completion retries and delay to better accommodate export-service processing time.
- Remove the legacy iqe-export-service-plugin dependency and associated mypy ignore configuration now that iqe-bindings v7 is used.

Build:
- Drop iqe-export-service-plugin from the project's runtime dependencies.