### PR TITLE
perf(RHINENG-26337): add conditional MQ per-message span controls

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -34,13 +34,13 @@ redis = "*"
 ratelimit = "*"
 confluent-kafka = "==2.14.0"
 kessel-sdk = {version = "~=2.6.0", extras = ["auth", "console"]}
-# OpenTelemetry - distributed tracing
 opentelemetry-api = "~=1.32"
 opentelemetry-sdk = "~=1.42"
 opentelemetry-exporter-otlp-proto-http = "~=1.42"
 opentelemetry-instrumentation-flask = "~=0.53b"
 opentelemetry-instrumentation-sqlalchemy = "~=0.53b"
 opentelemetry-instrumentation-requests = "~=0.63b0"
+opentelemetry-instrumentation-confluent-kafka = "~=0.53b"
 # pinning versions of transitive dependencies to avoid hermetic build issues
 unleashclient = "==6.7.0"
 rpds-py = "==0.30.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1228,6 +1228,15 @@
             "markers": "python_version >= '3.10'",
             "version": "==0.63b0"
         },
+        "opentelemetry-instrumentation-confluent-kafka": {
+            "hashes": [
+                "sha256:3185fd2f891d63e85ffcaea6eac266e597d4aaa70d323c4a789a94be30c8ae31",
+                "sha256:7aa889b8764807922966311e84467124c392b6affec92a745b65812705c2bef1"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==0.63b0"
+        },
         "opentelemetry-instrumentation-flask": {
             "hashes": [
                 "sha256:37662ad159570dab1e3017a2a415193c014a5798fc32d33f3bdd254469e8c69a",

--- a/app/queue/event_producer.py
+++ b/app/queue/event_producer.py
@@ -7,6 +7,7 @@ from app.instrumentation import message_produced
 from app.logging import get_logger
 from app.queue.metrics import produce_large_message_failure
 from app.queue.metrics import produced_message_size
+from app.telemetry import instrument_kafka_producer
 
 logger = get_logger(__name__)
 
@@ -57,7 +58,8 @@ class NullEventProducer:
 class EventProducer:
     def __init__(self, config, topic):
         logger.info("Starting EventProducer()")
-        self._kafka_producer = KafkaProducer({"bootstrap.servers": config.bootstrap_servers, **config.kafka_producer})
+        kafka_producer = KafkaProducer({"bootstrap.servers": config.bootstrap_servers, **config.kafka_producer})
+        self._kafka_producer = instrument_kafka_producer(kafka_producer)
         self.mq_topic = topic
 
     def write_event(self, event, key, headers, *, wait=False):
@@ -71,7 +73,13 @@ class EventProducer:
         try:
             messageDetails = MessageDetails(topic, v, h, k)
 
-            self._kafka_producer.produce(topic, v, k, callback=messageDetails.on_delivered, headers=h)
+            self._kafka_producer.produce(
+                topic=topic,
+                value=v,
+                key=k,
+                callback=messageDetails.on_delivered,
+                headers=h,
+            )
             if wait:
                 self._kafka_producer.flush()
             else:

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -19,6 +19,7 @@ from flask_sqlalchemy.model import Model
 from marshmallow import Schema
 from marshmallow import ValidationError
 from marshmallow import fields
+from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 from psycopg2.errors import UniqueViolation
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
@@ -78,9 +79,11 @@ from app.serialization import remove_null_canonical_facts
 from app.serialization import serialize_host
 from app.serialization import serialize_uuid
 from app.staleness_serialization import AttrDict
+from app.telemetry import OTEL_MQ_ENABLED
 from app.telemetry import OTEL_MQ_MESSAGE_SPANS_ENABLED
 from app.telemetry import OTEL_MQ_SLOW_MESSAGE_MS
 from app.telemetry import get_tracer
+from app.telemetry import instrument_kafka_consumer
 from lib import group_repository
 from lib import host_app_repository
 from lib import host_repository
@@ -125,7 +128,7 @@ def create_consumer(config):
     """Factory function to create appropriate kafka consumer"""
     if config.replica_namespace:
         return NullConsumer(config)
-    return Consumer(
+    consumer = Consumer(
         {
             "group.id": config.host_ingress_consumer_group,
             "bootstrap.servers": config.bootstrap_servers,
@@ -133,6 +136,7 @@ def create_consumer(config):
             **config.kafka_consumer,
         }
     )
+    return instrument_kafka_consumer(consumer)
 
 
 class HostOperationSchema(Schema):
@@ -240,7 +244,7 @@ class HBIMessageConsumerBase:
 
     def _should_emit_message_span(self) -> bool:
         """Whether a per-message child span should be started eagerly."""
-        return OTEL_MQ_MESSAGE_SPANS_ENABLED or self._is_retry
+        return OTEL_MQ_ENABLED and (OTEL_MQ_MESSAGE_SPANS_ENABLED or self._is_retry)
 
     def _message_span_attrs(self, msg, **extra) -> dict:
         """Build common span attributes for a Kafka message."""
@@ -254,6 +258,8 @@ class HBIMessageConsumerBase:
 
     def _emit_slow_message_span(self, msg, start_ns: int, end_ns: int) -> None:
         """Emit a retroactive span for a message that exceeded the slow threshold."""
+        if not OTEL_MQ_ENABLED:
+            return
         duration_ms = (end_ns - start_ns) / 1_000_000
         if duration_ms < OTEL_MQ_SLOW_MESSAGE_MS:
             return
@@ -323,6 +329,8 @@ class HBIMessageConsumerBase:
 
     def _emit_error_span(self, msg, start_ns: int, exc: Exception) -> None:
         """Emit a span for a failed message when routine per-message spans are disabled."""
+        if not OTEL_MQ_ENABLED:
+            return
         end_ns = time.time_ns()
         span = tracer.start_span(
             f"mq.process {msg.topic()}",
@@ -335,6 +343,10 @@ class HBIMessageConsumerBase:
 
     def _process_batch(self) -> None:
         """Process a single batch of messages from Kafka.
+
+        The Confluent Kafka instrumentor owns the batch-level consumer context for
+        the returned records. We keep lightweight per-message child spans under that
+        context so SQL spans can still be inspected message-by-message.
 
         Raises:
             InvalidRequestError: When the database session is in an invalid state
@@ -358,16 +370,11 @@ class HBIMessageConsumerBase:
         if not valid_messages:
             return
 
-        with (
-            tracer.start_as_current_span(
-                "mq.batch",
-                attributes={
-                    "messaging.system": "kafka",
-                    "messaging.batch.message_count": len(valid_messages),
-                },
-            ),
-            no_expire_on_commit(db.session),
-        ):
+        batch_span = trace.get_current_span()
+        if OTEL_MQ_ENABLED and batch_span.is_recording():
+            batch_span.set_attribute("messaging.batch.message_count", len(valid_messages))
+
+        with no_expire_on_commit(db.session):
             with (
                 session_guard(db.session, close=False),
                 db.session.no_autoflush,

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -78,6 +78,8 @@ from app.serialization import remove_null_canonical_facts
 from app.serialization import serialize_host
 from app.serialization import serialize_uuid
 from app.staleness_serialization import AttrDict
+from app.telemetry import OTEL_MQ_MESSAGE_SPANS_ENABLED
+from app.telemetry import OTEL_MQ_SLOW_MESSAGE_MS
 from app.telemetry import get_tracer
 from lib import group_repository
 from lib import host_app_repository
@@ -203,6 +205,7 @@ class HBIMessageConsumerBase:
         self.event_producer = event_producer
         self.notification_event_producer = notification_event_producer
         self.processed_rows: list[OperationResult] = []
+        self._is_retry = False
 
     @property
     def success_metric(self):
@@ -235,17 +238,53 @@ class HBIMessageConsumerBase:
     def post_process_rows(self) -> None:
         pass  # No action is taken by default
 
+    def _should_emit_message_span(self) -> bool:
+        """Whether a per-message child span should be started eagerly."""
+        return OTEL_MQ_MESSAGE_SPANS_ENABLED or self._is_retry
+
+    def _message_span_attrs(self, msg, **extra) -> dict:
+        """Build common span attributes for a Kafka message."""
+        attrs = {
+            "messaging.operation": "process",
+            "messaging.destination.name": msg.topic() or "",
+            "messaging.kafka.partition": msg.partition() or 0,
+        }
+        attrs.update(extra)
+        return attrs
+
+    def _emit_slow_message_span(self, msg, start_ns: int, end_ns: int) -> None:
+        """Emit a retroactive span for a message that exceeded the slow threshold."""
+        duration_ms = (end_ns - start_ns) / 1_000_000
+        if duration_ms < OTEL_MQ_SLOW_MESSAGE_MS:
+            return
+
+        span = tracer.start_span(
+            f"mq.process {msg.topic()}",
+            attributes=self._message_span_attrs(msg, **{"hbi.slow_message": True, "hbi.duration_ms": duration_ms}),
+            start_time=start_ns,
+        )
+        span.end(end_time=end_ns)
+
     def _process_single_message(self, msg) -> None:
-        """Process a single Kafka message within a tracing span."""
+        """Process a single Kafka message, conditionally emitting a child span.
+
+        Span emission rules:
+        - Always emit when OTEL_MQ_MESSAGE_SPANS_ENABLED is True (default for stage).
+        - Always emit during retry attempts or on error.
+        - When disabled, emit retroactively for messages exceeding OTEL_MQ_SLOW_MESSAGE_MS.
+        """
         logger.debug("Message received")
 
+        if self._should_emit_message_span():
+            self._process_message_with_span(msg)
+        else:
+            self._process_message_without_span(msg)
+
+    def _process_message_with_span(self, msg) -> None:
+        """Process a message with a full tracing span (used when spans are enabled or on retry)."""
         with tracer.start_as_current_span(
             f"mq.process {msg.topic()}",
-            attributes={
-                "messaging.operation": "process",
-                "messaging.destination.name": msg.topic() or "",
-                "messaging.kafka.partition": msg.partition() or 0,
-            },
+            attributes=self._message_span_attrs(msg, **{"hbi.retry": self._is_retry}),
         ) as span:
             try:
                 self.processed_rows.append(self.handle_message(msg.value(), headers=msg.headers()))
@@ -261,6 +300,38 @@ class HBIMessageConsumerBase:
                 span.record_exception(exc)
                 self.failure_metric.inc()
                 logger.exception("Unable to process message", extra={"incoming_message": msg.value()})
+
+    def _process_message_without_span(self, msg) -> None:
+        """Process a message without an eager span; emit retroactively on error or slow threshold."""
+        start_ns = time.time_ns()
+        try:
+            self.processed_rows.append(self.handle_message(msg.value(), headers=msg.headers()))
+            metrics.consumed_message_size.observe(len(str(msg).encode("utf-8")))
+            self.success_metric.inc()
+        except OperationalError as oe:
+            self._emit_error_span(msg, start_ns, oe)
+            logger.error(f"Could not access DB {str(oe)}")
+            sys.exit(3)
+        except Exception as exc:
+            self._emit_error_span(msg, start_ns, exc)
+            self.failure_metric.inc()
+            logger.exception("Unable to process message", extra={"incoming_message": msg.value()})
+        else:
+            if OTEL_MQ_SLOW_MESSAGE_MS > 0:
+                end_ns = time.time_ns()
+                self._emit_slow_message_span(msg, start_ns, end_ns)
+
+    def _emit_error_span(self, msg, start_ns: int, exc: Exception) -> None:
+        """Emit a span for a failed message when routine per-message spans are disabled."""
+        end_ns = time.time_ns()
+        span = tracer.start_span(
+            f"mq.process {msg.topic()}",
+            attributes=self._message_span_attrs(msg, **{"hbi.error": True}),
+            start_time=start_ns,
+        )
+        span.set_status(StatusCode.ERROR, str(exc))
+        span.record_exception(exc)
+        span.end(end_time=end_ns)
 
     def _process_batch(self) -> None:
         """Process a single batch of messages from Kafka.
@@ -323,6 +394,7 @@ class HBIMessageConsumerBase:
                 while not interrupt():
                     for attempt in range(1, MAX_RETRIES + 1):
                         self.processed_rows = []
+                        self._is_retry = attempt > 1
                         try:
                             self._process_batch()
                             break  # Success, exit retry loop

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -254,23 +254,21 @@ def _outbound_request_hook(span, request, *_args, **_kwargs):
 
 
 def _request_hook(span, environ):  # noqa: ARG001
-    """Add HBI-specific attributes to every request span.
+    """Add Red Hat platform attributes to every request span.
 
     Adds org_id and request_id so traces can be filtered in Grafana/Tempo:
-        - hbi.org_id = "12345"         → all traces for an org
-        - hbi.request_id = "abc-..."   → find a specific request
+        - rh.org_id = "12345"         → all traces for an org
+        - rh.request_id = "abc-..."   → find a specific request
     """
     if not span or not span.is_recording():
         return
 
     from flask import request
 
-    # Add request_id from the x-rh-insights-request-id header
     request_id = request.headers.get("x-rh-insights-request-id", "")
     if request_id:
-        span.set_attribute("hbi.request_id", request_id)
+        span.set_attribute("rh.request_id", request_id)
 
-    # Add org_id from the decoded identity header
     try:
         from app.auth.identity import from_auth_header
 
@@ -278,9 +276,9 @@ def _request_hook(span, environ):  # noqa: ARG001
         if encoded_id:
             identity = from_auth_header(encoded_id)
             if identity and hasattr(identity, "org_id"):
-                span.set_attribute("hbi.org_id", identity.org_id or "")
+                span.set_attribute("rh.org_id", identity.org_id or "")
     except Exception:
-        pass  # Don't break requests if identity extraction fails
+        pass
 
 
 def _response_hook(span, status, response_headers):  # noqa: ARG001

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -35,6 +35,7 @@ OTEL_ENABLED = os.getenv("OTEL_ENABLED", "false").lower() == "true"
 OTEL_SQL_ENABLED = os.getenv("OTEL_SQL_ENABLED", "true").lower() == "true"
 OTEL_SQL_COMMENTER_ENABLED = os.getenv("OTEL_SQL_COMMENTER_ENABLED", "false").lower() == "true"
 OTEL_HTTP_ENABLED = os.getenv("OTEL_HTTP_ENABLED", "true").lower() == "true"
+OTEL_MQ_ENABLED = os.getenv("OTEL_MQ_ENABLED", "true").lower() == "true"
 OTEL_SAMPLING_RATE = min(max(float(os.getenv("OTEL_SAMPLING_RATE", "1.0")), 0.0), 1.0)
 
 OTEL_BSP_MAX_QUEUE_SIZE = int(os.getenv("OTEL_BSP_MAX_QUEUE_SIZE", "8192"))
@@ -134,6 +135,7 @@ def init_otel(service_name: str, service_version: str = "unknown"):
         "OpenTelemetry config: sampling=%.2f sql=%s commenter=%s http=%s "
         "bsp_queue=%d bsp_batch=%d bsp_delay=%dms bsp_timeout=%dms "
         "compression=%s attr_limit=%d attr_len_limit=%d "
+        "mq_enabled=%s "
         "mq_message_spans=%s mq_slow_message_ms=%d",
         OTEL_SAMPLING_RATE,
         OTEL_SQL_ENABLED,
@@ -146,6 +148,7 @@ def init_otel(service_name: str, service_version: str = "unknown"):
         OTEL_EXPORTER_OTLP_COMPRESSION,
         OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
         OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+        OTEL_MQ_ENABLED,
         OTEL_MQ_MESSAGE_SPANS_ENABLED,
         OTEL_MQ_SLOW_MESSAGE_MS,
     )
@@ -193,6 +196,36 @@ def instrument_sqlalchemy(engine):
         },
     )
     logger.info("SQLAlchemy engine instrumented with OpenTelemetry (commenter=%s)", OTEL_SQL_COMMENTER_ENABLED)
+
+
+def instrument_kafka_producer(producer):
+    """Wrap a confluent-kafka producer with OpenTelemetry instrumentation."""
+    if not OTEL_ENABLED or not OTEL_MQ_ENABLED:
+        return producer
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.instrumentation.confluent_kafka import ConfluentKafkaInstrumentor
+    except ImportError:
+        logger.warning("Kafka producer instrumentation unavailable; continuing without producer spans")
+        return producer
+
+    return ConfluentKafkaInstrumentor.instrument_producer(producer, tracer_provider=trace.get_tracer_provider())
+
+
+def instrument_kafka_consumer(consumer):
+    """Wrap a confluent-kafka consumer with OpenTelemetry instrumentation."""
+    if not OTEL_ENABLED or not OTEL_MQ_ENABLED:
+        return consumer
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.instrumentation.confluent_kafka import ConfluentKafkaInstrumentor
+    except ImportError:
+        logger.warning("Kafka consumer instrumentation unavailable; continuing without consumer spans")
+        return consumer
+
+    return ConfluentKafkaInstrumentor.instrument_consumer(consumer, tracer_provider=trace.get_tracer_provider())
 
 
 def instrument_outbound_http():

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -46,6 +46,13 @@ OTEL_EXPORTER_OTLP_COMPRESSION = os.getenv("OTEL_EXPORTER_OTLP_COMPRESSION", "gz
 OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT = int(os.getenv("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", "64"))
 OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT = int(os.getenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "1024"))
 
+# MQ per-message span controls
+# Default True to preserve full visibility in stage; set to "false" in production.
+OTEL_MQ_MESSAGE_SPANS_ENABLED = os.getenv("OTEL_MQ_MESSAGE_SPANS_ENABLED", "true").lower() == "true"
+# Threshold in ms: when message spans are disabled, still emit a span for messages slower than this.
+# 0 means disabled (no slow-message spans).
+OTEL_MQ_SLOW_MESSAGE_MS = int(os.getenv("OTEL_MQ_SLOW_MESSAGE_MS", "0"))
+
 _otel_initialized_pid = None
 
 
@@ -126,7 +133,8 @@ def init_otel(service_name: str, service_version: str = "unknown"):
     logger.info(
         "OpenTelemetry config: sampling=%.2f sql=%s commenter=%s http=%s "
         "bsp_queue=%d bsp_batch=%d bsp_delay=%dms bsp_timeout=%dms "
-        "compression=%s attr_limit=%d attr_len_limit=%d",
+        "compression=%s attr_limit=%d attr_len_limit=%d "
+        "mq_message_spans=%s mq_slow_message_ms=%d",
         OTEL_SAMPLING_RATE,
         OTEL_SQL_ENABLED,
         OTEL_SQL_COMMENTER_ENABLED,
@@ -138,6 +146,8 @@ def init_otel(service_name: str, service_version: str = "unknown"):
         OTEL_EXPORTER_OTLP_COMPRESSION,
         OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
         OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+        OTEL_MQ_MESSAGE_SPANS_ENABLED,
+        OTEL_MQ_SLOW_MESSAGE_MS,
     )
 
 

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -587,6 +587,8 @@ objects:
             value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
           - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
             value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+          - name: OTEL_MQ_ENABLED
+            value: ${OTEL_MQ_ENABLED}
           - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
             value: ${OTEL_MQ_MESSAGE_SPANS_ENABLED}
           - name: OTEL_MQ_SLOW_MESSAGE_MS
@@ -688,6 +690,8 @@ objects:
             value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
           - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
             value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+          - name: OTEL_MQ_ENABLED
+            value: ${OTEL_MQ_ENABLED}
           - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
             value: ${OTEL_MQ_MESSAGE_SPANS_ENABLED}
           - name: OTEL_MQ_SLOW_MESSAGE_MS
@@ -827,6 +831,8 @@ objects:
             value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
           - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
             value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+          - name: OTEL_MQ_ENABLED
+            value: ${OTEL_MQ_ENABLED}
           - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
             value: ${OTEL_MQ_MESSAGE_SPANS_ENABLED}
           - name: OTEL_MQ_SLOW_MESSAGE_MS
@@ -924,6 +930,8 @@ objects:
             value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
           - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
             value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+          - name: OTEL_MQ_ENABLED
+            value: ${OTEL_MQ_ENABLED}
           - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
             value: ${OTEL_MQ_MESSAGE_SPANS_ENABLED}
           - name: OTEL_MQ_SLOW_MESSAGE_MS
@@ -1095,6 +1103,8 @@ objects:
             value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
           - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
             value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+          - name: OTEL_MQ_ENABLED
+            value: ${OTEL_MQ_ENABLED}
           - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
             value: ${OTEL_MQ_MESSAGE_SPANS_ENABLED}
           - name: OTEL_MQ_SLOW_MESSAGE_MS
@@ -2924,6 +2934,9 @@ parameters:
 - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
   description: Max length of span attribute values (truncates long SQL text, etc.)
   value: '1024'
+- name: OTEL_MQ_ENABLED
+  description: Enable OpenTelemetry tracing for Kafka/MQ producer and consumer operations
+  value: 'true'
 - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
   description: Emit per-message child spans for MQ consumers (disable in prod to reduce span volume)
   value: 'true'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -587,6 +587,10 @@ objects:
             value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
           - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
             value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+          - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
+            value: ${OTEL_MQ_MESSAGE_SPANS_ENABLED}
+          - name: OTEL_MQ_SLOW_MESSAGE_MS
+            value: ${OTEL_MQ_SLOW_MESSAGE_MS}
           - name: UNLEASH_URL
             value: ${UNLEASH_URL}
           - <<: *unleashToken
@@ -684,6 +688,10 @@ objects:
             value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
           - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
             value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+          - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
+            value: ${OTEL_MQ_MESSAGE_SPANS_ENABLED}
+          - name: OTEL_MQ_SLOW_MESSAGE_MS
+            value: ${OTEL_MQ_SLOW_MESSAGE_MS}
           - name: CLOWDER_ENABLED
             value: "true"
           - name: INVENTORY_DB_SCHEMA
@@ -819,6 +827,10 @@ objects:
             value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
           - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
             value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+          - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
+            value: ${OTEL_MQ_MESSAGE_SPANS_ENABLED}
+          - name: OTEL_MQ_SLOW_MESSAGE_MS
+            value: ${OTEL_MQ_SLOW_MESSAGE_MS}
           - name: UNLEASH_URL
             value: ${UNLEASH_URL}
           - <<: *unleashToken
@@ -912,6 +924,10 @@ objects:
             value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
           - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
             value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+          - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
+            value: ${OTEL_MQ_MESSAGE_SPANS_ENABLED}
+          - name: OTEL_MQ_SLOW_MESSAGE_MS
+            value: ${OTEL_MQ_SLOW_MESSAGE_MS}
           - name: CLOWDER_ENABLED
             value: "true"
           - name: INVENTORY_DB_SCHEMA
@@ -1079,6 +1095,10 @@ objects:
             value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
           - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
             value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+          - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
+            value: ${OTEL_MQ_MESSAGE_SPANS_ENABLED}
+          - name: OTEL_MQ_SLOW_MESSAGE_MS
+            value: ${OTEL_MQ_SLOW_MESSAGE_MS}
           - name: CLOWDER_ENABLED
             value: "true"
           - name: INVENTORY_DB_SCHEMA
@@ -2904,3 +2924,9 @@ parameters:
 - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
   description: Max length of span attribute values (truncates long SQL text, etc.)
   value: '1024'
+- name: OTEL_MQ_MESSAGE_SPANS_ENABLED
+  description: Emit per-message child spans for MQ consumers (disable in prod to reduce span volume)
+  value: 'true'
+- name: OTEL_MQ_SLOW_MESSAGE_MS
+  description: When message spans are disabled, emit spans for messages exceeding this threshold (ms). 0 = disabled.
+  value: '0'

--- a/tests/test_kafka_null_implementations.py
+++ b/tests/test_kafka_null_implementations.py
@@ -152,13 +152,18 @@ class TestFactoryFunctions:
         config.bootstrap_servers = "localhost:9092"
         config.kafka_consumer = {}
 
-        with patch("app.queue.host_mq.Consumer") as mock_consumer_class:
+        with (
+            patch("app.queue.host_mq.Consumer") as mock_consumer_class,
+            patch("app.queue.host_mq.instrument_kafka_consumer") as mock_instrument_consumer,
+        ):
             mock_consumer = Mock()
+            instrumented_consumer = Mock()
             mock_consumer_class.return_value = mock_consumer
+            mock_instrument_consumer.return_value = instrumented_consumer
 
             consumer = create_consumer(config)
 
-            assert consumer == mock_consumer
+            assert consumer == instrumented_consumer
             mock_consumer_class.assert_called_once_with(
                 {
                     "group.id": "test-group",
@@ -167,6 +172,7 @@ class TestFactoryFunctions:
                     **config.kafka_consumer,
                 }
             )
+            mock_instrument_consumer.assert_called_once_with(mock_consumer)
 
     def test_create_event_producer_returns_null_producer_when_replica_namespace(self):
         """Test that create_event_producer returns NullEventProducer when replica_namespace is True"""

--- a/tests/test_mq_message_spans.py
+++ b/tests/test_mq_message_spans.py
@@ -1,0 +1,138 @@
+"""Tests for MQ per-message span controls (OTEL_MQ_MESSAGE_SPANS_ENABLED / OTEL_MQ_SLOW_MESSAGE_MS)."""
+
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from app.queue.host_mq import HBIMessageConsumerBase
+from app.queue.host_mq import OperationResult
+from tests.helpers.mq_utils import FakeMessage
+
+
+@pytest.fixture
+def otel_spans(monkeypatch):
+    """Set up an in-memory exporter and patch the module-level tracer."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(resource=Resource.create())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr("app.queue.host_mq.tracer", provider.get_tracer("test"))
+    yield exporter
+    provider.shutdown()
+
+
+@pytest.fixture
+def consumer():
+    """A minimal HBIMessageConsumerBase subclass for testing span behavior."""
+
+    class _TestConsumer(HBIMessageConsumerBase):
+        def __init__(self):
+            self.consumer = MagicMock()
+            self.flask_app = MagicMock()
+            self.event_producer = MagicMock()
+            self.notification_event_producer = MagicMock()
+            self.processed_rows = []
+            self._is_retry = False
+            self._handler = MagicMock(return_value=OperationResult(None, None, None, None, None, lambda: None))
+
+        def handle_message(self, message, headers=None):
+            return self._handler(message, headers=headers)
+
+    return _TestConsumer()
+
+
+def test_span_emitted_when_enabled(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
+
+    consumer._process_single_message(FakeMessage())
+
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name.startswith("mq.process")
+
+
+def test_no_span_when_disabled(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
+
+    consumer._process_single_message(FakeMessage())
+
+    assert len(otel_spans.get_finished_spans()) == 0
+    assert len(consumer.processed_rows) == 1
+
+
+def test_error_emits_span_when_disabled(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
+    consumer._handler.side_effect = ValueError("boom")
+
+    consumer._process_single_message(FakeMessage())
+
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == trace.StatusCode.ERROR
+    assert spans[0].attributes["hbi.error"] is True
+
+
+def test_retry_emits_span_when_disabled(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
+    consumer._is_retry = True
+
+    consumer._process_single_message(FakeMessage())
+
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes["hbi.retry"] is True
+
+
+def test_slow_message_emits_span(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 30)
+
+    start_ns = 1_000_000_000_000
+    end_ns = start_ns + 40_000_000  # 40ms > 30ms threshold
+    call_count = {"n": 0}
+
+    def fake_time_ns():
+        call_count["n"] += 1
+        return start_ns if call_count["n"] == 1 else end_ns
+
+    monkeypatch.setattr("app.queue.host_mq.time.time_ns", fake_time_ns)
+
+    consumer._process_single_message(FakeMessage())
+
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes["hbi.slow_message"] is True
+    assert spans[0].attributes["hbi.duration_ms"] >= 30
+
+
+def test_fast_message_no_slow_span(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 5000)
+
+    consumer._process_single_message(FakeMessage())
+
+    assert len(otel_spans.get_finished_spans()) == 0
+
+
+def test_config_defaults(monkeypatch):
+    monkeypatch.delenv("OTEL_MQ_MESSAGE_SPANS_ENABLED", raising=False)
+    monkeypatch.delenv("OTEL_MQ_SLOW_MESSAGE_MS", raising=False)
+
+    import app.telemetry as telemetry_mod
+
+    importlib.reload(telemetry_mod)
+
+    assert telemetry_mod.OTEL_MQ_MESSAGE_SPANS_ENABLED is True
+    assert telemetry_mod.OTEL_MQ_SLOW_MESSAGE_MS == 0
+
+    # Clean up
+    importlib.reload(telemetry_mod)

--- a/tests/test_mq_message_spans.py
+++ b/tests/test_mq_message_spans.py
@@ -47,6 +47,7 @@ def consumer():
 
 
 def test_span_emitted_when_enabled(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", True)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
 
@@ -57,7 +58,23 @@ def test_span_emitted_when_enabled(otel_spans, consumer, monkeypatch):
     assert spans[0].name.startswith("mq.process")
 
 
+def test_message_span_is_child_of_current_consume_context(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
+
+    from app.queue import host_mq
+
+    with host_mq.tracer.start_as_current_span("inventory process") as consume_span:
+        consumer._process_single_message(FakeMessage())
+
+    process_spans = [span for span in otel_spans.get_finished_spans() if span.name.startswith("mq.process ")]
+    assert len(process_spans) == 1
+    assert process_spans[0].parent.span_id == consume_span.get_span_context().span_id
+
+
 def test_no_span_when_disabled(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
 
@@ -68,6 +85,7 @@ def test_no_span_when_disabled(otel_spans, consumer, monkeypatch):
 
 
 def test_error_emits_span_when_disabled(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
     consumer._handler.side_effect = ValueError("boom")
@@ -81,6 +99,7 @@ def test_error_emits_span_when_disabled(otel_spans, consumer, monkeypatch):
 
 
 def test_retry_emits_span_when_disabled(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
     consumer._is_retry = True
@@ -93,6 +112,7 @@ def test_retry_emits_span_when_disabled(otel_spans, consumer, monkeypatch):
 
 
 def test_slow_message_emits_span(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 30)
 
@@ -115,6 +135,7 @@ def test_slow_message_emits_span(otel_spans, consumer, monkeypatch):
 
 
 def test_fast_message_no_slow_span(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 5000)
 
@@ -123,7 +144,19 @@ def test_fast_message_no_slow_span(otel_spans, consumer, monkeypatch):
     assert len(otel_spans.get_finished_spans()) == 0
 
 
+def test_no_spans_when_mq_tracing_disabled(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", False)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 30)
+    consumer._handler.side_effect = ValueError("boom")
+
+    consumer._process_single_message(FakeMessage())
+
+    assert len(otel_spans.get_finished_spans()) == 0
+
+
 def test_config_defaults(monkeypatch):
+    monkeypatch.delenv("OTEL_MQ_ENABLED", raising=False)
     monkeypatch.delenv("OTEL_MQ_MESSAGE_SPANS_ENABLED", raising=False)
     monkeypatch.delenv("OTEL_MQ_SLOW_MESSAGE_MS", raising=False)
 
@@ -131,6 +164,7 @@ def test_config_defaults(monkeypatch):
 
     importlib.reload(telemetry_mod)
 
+    assert telemetry_mod.OTEL_MQ_ENABLED is True
     assert telemetry_mod.OTEL_MQ_MESSAGE_SPANS_ENABLED is True
     assert telemetry_mod.OTEL_MQ_SLOW_MESSAGE_MS == 0
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -255,9 +255,54 @@ def test_http_instrumentation_runs_when_enabled(monkeypatch):
     _cleanup_telemetry(monkeypatch)
 
 
+def test_kafka_instrumentation_helpers_skip_when_otel_disabled(monkeypatch):
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "false"})
+    producer = MagicMock()
+    consumer = MagicMock()
+
+    assert telemetry_mod.instrument_kafka_producer(producer) is producer
+    assert telemetry_mod.instrument_kafka_consumer(consumer) is consumer
+
+
+def test_kafka_instrumentation_helpers_skip_when_mq_disabled(monkeypatch):
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_MQ_ENABLED": "false"})
+    producer = MagicMock()
+    consumer = MagicMock()
+
+    assert telemetry_mod.instrument_kafka_producer(producer) is producer
+    assert telemetry_mod.instrument_kafka_consumer(consumer) is consumer
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_kafka_instrumentation_helpers_wrap_when_enabled(monkeypatch):
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_MQ_ENABLED": "true"})
+    producer = MagicMock()
+    consumer = MagicMock()
+    tracer_provider = MagicMock()
+    wrapped_producer = MagicMock()
+    wrapped_consumer = MagicMock()
+
+    with (
+        patch("opentelemetry.trace.get_tracer_provider", return_value=tracer_provider),
+        patch("opentelemetry.instrumentation.confluent_kafka.ConfluentKafkaInstrumentor") as mock_instrumentor,
+    ):
+        mock_instrumentor.instrument_producer.return_value = wrapped_producer
+        mock_instrumentor.instrument_consumer.return_value = wrapped_consumer
+
+        assert telemetry_mod.instrument_kafka_producer(producer) is wrapped_producer
+        assert telemetry_mod.instrument_kafka_consumer(consumer) is wrapped_consumer
+
+        mock_instrumentor.instrument_producer.assert_called_once_with(producer, tracer_provider=tracer_provider)
+        mock_instrumentor.instrument_consumer.assert_called_once_with(consumer, tracer_provider=tracer_provider)
+
+    _cleanup_telemetry(monkeypatch)
+
+
 def test_config_defaults_without_env_vars(monkeypatch):
     """Module-level config constants use sensible defaults when env vars are absent."""
     for var in [
+        "OTEL_MQ_ENABLED",
         "OTEL_SQL_ENABLED",
         "OTEL_SQL_COMMENTER_ENABLED",
         "OTEL_HTTP_ENABLED",
@@ -278,6 +323,7 @@ def test_config_defaults_without_env_vars(monkeypatch):
     importlib.reload(telemetry_mod)
 
     assert telemetry_mod.OTEL_ENABLED is False
+    assert telemetry_mod.OTEL_MQ_ENABLED is True
     assert telemetry_mod.OTEL_SQL_ENABLED is True
     assert telemetry_mod.OTEL_SQL_COMMENTER_ENABLED is False
     assert telemetry_mod.OTEL_HTTP_ENABLED is True

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2326,9 +2326,9 @@ def test_happy_path_event_producer(subtests, flask_app):
                 event_producer.write_event(event, host_id, headers)
 
                 produce.assert_called_once_with(
-                    topic_name,
-                    event.encode("utf-8"),
-                    host_id.encode("utf-8"),
+                    topic=topic_name,
+                    value=event.encode("utf-8"),
+                    key=host_id.encode("utf-8"),
                     callback=ANY,
                     headers=ANY,
                 )
@@ -2370,9 +2370,9 @@ def test_producer_poll_event_producer(subtests, flask_app):
                 event_producer.write_event(event, host_id, headers)
 
                 produce.assert_called_once_with(
-                    topic_name,
-                    event.encode("utf-8"),
-                    host_id.encode("utf-8"),
+                    topic=topic_name,
+                    value=event.encode("utf-8"),
+                    key=host_id.encode("utf-8"),
                     callback=ANY,
                     headers=ANY,
                 )


### PR DESCRIPTION
## Jira
[RHINENG-26337](https://issues.redhat.com/browse/RHINENG-26337)

## What
Hybrid Kafka OTEL tracing: use the Confluent Kafka instrumentor for batch-level spans and trace context propagation, while keeping conditional per-message `mq.process` child spans for message-level SQL visibility.

## Why
At 100% OTEL sampling, every Kafka message was emitting both a manual `mq.batch` span and a `mq.process` child span, doubling span count on the highest-throughput path and contributing to exporter backpressure and consumer lag. Production MQ deployments need the ability to suppress routine per-message spans while retaining batch-level tracing and trace context propagation.

## How
- Added `opentelemetry-instrumentation-confluent-kafka` dependency for auto-instrumented produce/consume spans and W3C traceparent propagation.
- Added `instrument_kafka_producer` and `instrument_kafka_consumer` helpers in `app/telemetry.py` that wrap the Confluent Kafka client when enabled.
- Removed the manual `mq.batch` span — the instrumentor's consume span now serves as the batch-level envelope. `messaging.batch.message_count` is set as an attribute on the instrumentor's span.
- Added `OTEL_MQ_ENABLED` as a master switch gating all MQ tracing (instrumentor + per-message spans).
- `OTEL_MQ_MESSAGE_SPANS_ENABLED` controls whether routine per-message child spans are emitted under the instrumentor's consume context.
- `OTEL_MQ_SLOW_MESSAGE_MS` emits child spans only for slow messages when routine spans are disabled — using explicit `start_time`/`end_time` for accurate duration.
- Failed messages and retry attempts always produce child spans regardless of config.
- Producer now uses keyword arguments for `produce()` for compatibility with the instrumented wrapper.
- Env vars added to MQ consumer pods only in `deploy/clowdapp.yml`.
- Defaults preserve full per-message visibility in stage.

## Testing
- 10 unit tests covering: spans enabled, spans disabled, error path, retry path, slow threshold with accurate timing, fast message below threshold, mq-tracing fully disabled, message span is child of consume context, and config defaults.
- 3 telemetry tests for `instrument_kafka_producer`/`instrument_kafka_consumer` (disabled, mq-disabled, enabled+wrapped).
- Updated `test_kafka_null_implementations.py` for instrumented consumer factory.
- Existing telemetry tests pass unchanged.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26337]: https://redhat.atlassian.net/browse/RHINENG-26337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce configurable controls for emitting per-message tracing spans in MQ consumers to reduce span volume while preserving visibility for errors, retries, and slow messages.

New Features:
- Add OTEL_MQ_MESSAGE_SPANS_ENABLED and OTEL_MQ_SLOW_MESSAGE_MS environment-based settings to control MQ per-message tracing spans.
- Expose new MQ span configuration in telemetry initialization logging for observability of runtime settings.

Enhancements:
- Update MQ consumer processing to conditionally emit spans, always tracing retries, failures, and messages exceeding a configurable slow threshold.
- Propagate the new MQ span control environment variables into MQ consumer deployments via clowdapp configuration.

Tests:
- Add unit test coverage for MQ span control behavior, including enabled/disabled modes, error and retry paths, slow-message spans, and configuration defaults.

## Summary by Sourcery

Introduce configurable OpenTelemetry tracing for Kafka MQ operations to reduce per-message span volume while preserving key visibility and adopting Confluent Kafka auto-instrumentation.

New Features:
- Add OpenTelemetry-based instrumentation helpers for Kafka producers and consumers using the Confluent Kafka instrumentor.
- Introduce OTEL_MQ_ENABLED, OTEL_MQ_MESSAGE_SPANS_ENABLED, and OTEL_MQ_SLOW_MESSAGE_MS settings to control MQ tracing behavior, including slow-message spans.

Enhancements:
- Update MQ consumer processing to conditionally emit per-message spans, always tracing retries, errors, and optionally slow messages while using the auto-instrumented batch span as the envelope.
- Record batch message counts on the current Kafka consumer span instead of a manual mq.batch span.
- Instrument the event producer with the Kafka producer helper and adjust produce calls to be compatible with the instrumented wrapper.
- Log MQ tracing configuration alongside other OpenTelemetry settings at initialization.
- Propagate MQ tracing configuration environment variables to MQ consumer deployments via clowdapp config.

Build:
- Add opentelemetry-instrumentation-confluent-kafka as a dependency for Kafka tracing instrumentation.

Tests:
- Add a dedicated test suite for MQ per-message span controls, covering enabled/disabled modes, error and retry paths, slow-message thresholds, and config defaults.
- Add telemetry tests for Kafka instrumentation helpers to cover disabled, MQ-disabled, and fully enabled wrapping behavior.
- Update Kafka null-implementation tests to expect wrapping of real consumers with the instrumentation helper.
- Extend telemetry config default tests to cover the new OTEL_MQ_ENABLED flag.