### PR TITLE
fix: Add libcap to fix the grype scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR $APP_ROOT
 
 RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $pgRepo) && \
     microdnf install --setopt=tsflags=nodocs -y postgresql python3.12 python3.12-pip rsync tar procps-ng make git && \
-    microdnf update -y gnupg2 glib2 && \
+    microdnf update -y gnupg2 glib2 libcap && \
     rpm -qa | sort > packages-before-devel-install.txt && \
     microdnf install --setopt=tsflags=nodocs -y libpq-devel python3.12-devel gcc libatomic cargo rust glibc-devel krb5-libs krb5-devel libffi-devel gcc-c++ make zlib zlib-devel openssl-libs openssl-devel libzstd libzstd-devel unzip which diffutils && \
     rpm -qa | sort > packages-after-devel-install.txt && \


### PR DESCRIPTION
The Grype security scan was failing due to CVE-2026-4878 (High severity) in libcap 2.48-10.el9 from the base UBI image. Added libcap to the existing microdnf update line to pull in the patched version (2.48-10.el9_8.1).