### PR TITLE
refactor(RHINENG-25499): Drop Staleness indexes and columns

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -80,7 +80,6 @@ DEFAULT_COLUMNS = [
     Host.facts,
     Host.reporter,
     Host.per_reporter_staleness,
-    Host.stale_timestamp,
     Host.created_on,
     Host.modified_on,
     Host.groups,

--- a/app/instrumentation.py
+++ b/app/instrumentation.py
@@ -233,9 +233,6 @@ def log_add_host_attempt(logger, input_host, sp_fields_to_log, identity: Identit
                 "provider_id": input_host.provider_id,
                 "provider_type": input_host.provider_type,
                 "reporter": input_host.reporter,
-                "stale_timestamp": (
-                    input_host.stale_timestamp.isoformat() if input_host.stale_timestamp is not None else None
-                ),
                 "tags": json.dumps(input_host.tags),
                 "system_profile": json.dumps(sp_fields_to_log),
             },

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -266,9 +266,6 @@ class LimitedHost(db.Model, HostTypeDeriver):
 
 
 class Host(LimitedHost):
-    stale_timestamp = db.Column(db.DateTime(timezone=True), nullable=True)
-    deletion_timestamp = db.Column(db.DateTime(timezone=True))
-    stale_warning_timestamp = db.Column(db.DateTime(timezone=True))
     reporter = db.Column(db.String(255), nullable=False)
     per_reporter_staleness = db.Column(JSONB, nullable=False)
     display_name_reporter = db.Column(db.String(255))
@@ -284,7 +281,6 @@ class Host(LimitedHost):
         tags=None,
         tags_alt=None,
         system_profile_facts=None,
-        stale_timestamp=None,  # noqa: ARG002 - to be removed
         reporter=None,
         per_reporter_staleness=None,
         groups=None,

--- a/app/models/schemas/host.py
+++ b/app/models/schemas/host.py
@@ -460,7 +460,6 @@ class LimitedHostSchema(CanonicalFactsSchema):
 
 
 class HostSchema(LimitedHostSchema):
-    stale_timestamp = fields.AwareDateTime(required=False)
     reporter = fields.Str(required=True, validate=marshmallow_validate.Length(min=1, max=255))
 
     @staticmethod

--- a/app/models/schemas/host.py
+++ b/app/models/schemas/host.py
@@ -477,7 +477,6 @@ class HostSchema(LimitedHostSchema):
             tags=tags,
             tags_alt=tags_alt,
             system_profile_facts=data.get("system_profile", {}),
-            stale_timestamp=data.get("stale_timestamp"),
             reporter=data["reporter"],
             groups=data.get("groups", []),
             insights_id=data.get("insights_id"),

--- a/app/utils.py
+++ b/app/utils.py
@@ -162,14 +162,6 @@ class HostWrapper(HostTypeDeriver):
         self.__data["ansible_host"] = ansible_host
 
     @property
-    def stale_timestamp(self):
-        return self.__data.get("stale_timestamp", None)
-
-    @stale_timestamp.setter
-    def stale_timestamp(self, stale_timestamp):
-        self.__data["stale_timestamp"] = stale_timestamp
-
-    @property
     def reporter(self):
         return self.__data.get("reporter", None)
 

--- a/deploy/cji.yml
+++ b/deploy/cji.yml
@@ -93,6 +93,16 @@ objects:
     appName: host-inventory
     jobs:
       - remove-null-workload-values
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    labels:
+      app: host-inventory
+    name: update-staleness-${UPDATE_STALENESS_RUN_NUMBER}
+  spec:
+    appName: host-inventory
+    jobs:
+      - update-staleness
 parameters:
 - name: SYNCHRONIZER_RUN_NUMBER
   value: '1'
@@ -111,4 +121,6 @@ parameters:
 - name: POPULATE_HOST_TYPE_RUN_NUMBER
   value: '1'
 - name: REMOVE_NULL_WORKLOAD_VALUES_RUN_NUMBER
+  value: '1'
+- name: UPDATE_STALENESS_RUN_NUMBER
   value: '1'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2052,6 +2052,71 @@ objects:
           requests:
             cpu: ${CPU_REQUEST_POPULATE_HOST_TYPE_JOB}
             memory: ${MEMORY_REQUEST_POPULATE_HOST_TYPE_JOB}
+    - name: update-staleness
+      restartPolicy: Never
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        args: [ "./jobs/update_staleness.py" ]
+        env:
+          - name: PYTHONPATH
+            value: '/opt/app-root/src'
+          - name: INVENTORY_LOG_LEVEL
+            value: ${LOG_LEVEL}
+          - name: INVENTORY_DB_SSL_MODE
+            value: ${INVENTORY_DB_SSL_MODE}
+          - name: INVENTORY_DB_SSL_CERT
+            value: ${INVENTORY_DB_SSL_CERT}
+          - name: INVENTORY_DB_SCHEMA
+            value: "${INVENTORY_DB_SCHEMA}"
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            value: ${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}
+          - name: KAFKA_EVENT_TOPIC
+            value: ${KAFKA_EVENT_TOPIC}
+          - name: KAFKA_NOTIFICATION_TOPIC
+            value: ${KAFKA_NOTIFICATION_TOPIC}
+          - name: PAYLOAD_TRACKER_KAFKA_TOPIC
+            value: ${PAYLOAD_TRACKER_KAFKA_TOPIC}
+          - name: PAYLOAD_TRACKER_SERVICE_NAME
+            value: inventory-mq-service
+          - name: PAYLOAD_TRACKER_ENABLED
+            value: 'true'
+          - name: PROMETHEUS_PUSHGATEWAY
+            value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: KAFKA_PRODUCER_ACKS
+            value: ${KAFKA_PRODUCER_ACKS}
+          - name: KAFKA_PRODUCER_RETRIES
+            value: ${KAFKA_PRODUCER_RETRIES}
+          - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
+            value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
+          - name: KAFKA_SECURITY_PROTOCOL
+            value: ${KAFKA_SECURITY_PROTOCOL}
+          - name: KAFKA_SASL_MECHANISM
+            value: ${KAFKA_SASL_MECHANISM}
+          - <<: *namespaceFieldRef
+            name: NAMESPACE
+          - name: CLOWDER_ENABLED
+            value: "true"
+          - name: DRY_RUN
+            value: ${UPDATE_STALENESS_DRY_RUN}
+          - name: SUSPEND_JOB
+            value: ${UPDATE_STALENESS_SUSPEND_JOB}
+          - name: STALENESS_ORG_ID
+            value: ${UPDATE_STALENESS_ORG_ID}
+          - name: CONVENTIONAL_TIME_TO_STALE
+            value: ${UPDATE_STALENESS_TIME_TO_STALE}
+          - name: CONVENTIONAL_TIME_TO_STALE_WARNING
+            value: ${UPDATE_STALENESS_TIME_TO_STALE_WARNING}
+          - name: CONVENTIONAL_TIME_TO_DELETE
+            value: ${UPDATE_STALENESS_TIME_TO_DELETE}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_UPDATE_STALENESS_JOB}
+            memory: ${MEMORY_LIMIT_UPDATE_STALENESS_JOB}
+          requests:
+            cpu: ${CPU_REQUEST_UPDATE_STALENESS_JOB}
+            memory: ${MEMORY_REQUEST_UPDATE_STALENESS_JOB}
     - name: run-db-migrations
       restartPolicy: OnFailure
       podSpec:
@@ -2697,6 +2762,14 @@ parameters:
   value: 256Mi
 - name: MEMORY_LIMIT_POPULATE_HOST_TYPE_JOB
   value: 512Mi
+- name: CPU_REQUEST_UPDATE_STALENESS_JOB
+  value: 250m
+- name: CPU_LIMIT_UPDATE_STALENESS_JOB
+  value: 500m
+- name: MEMORY_REQUEST_UPDATE_STALENESS_JOB
+  value: 256Mi
+- name: MEMORY_LIMIT_UPDATE_STALENESS_JOB
+  value: 512Mi
 - name: CPU_REQUEST_DB_MIGRATIONS_JOB
   value: 250m
 - name: CPU_LIMIT_DB_MIGRATIONS_JOB
@@ -3022,6 +3095,26 @@ parameters:
 - name: POPULATE_HOST_TYPE_BATCH_SIZE
   description: Number of hosts to process per batch in the populate-host-type job
   value: '500'
+
+# -- Update staleness Job --
+- name: UPDATE_STALENESS_DRY_RUN
+  description: Whether the update-staleness job should run in dry-run mode
+  value: 'true'
+- name: UPDATE_STALENESS_SUSPEND_JOB
+  description: Whether the update-staleness job should be suspended
+  value: 'true'
+- name: UPDATE_STALENESS_ORG_ID
+  description: The org_id to create or update custom staleness for
+  value: ''
+- name: UPDATE_STALENESS_TIME_TO_STALE
+  description: conventional_time_to_stale value in seconds (optional)
+  value: ''
+- name: UPDATE_STALENESS_TIME_TO_STALE_WARNING
+  description: conventional_time_to_stale_warning value in seconds (optional)
+  value: ''
+- name: UPDATE_STALENESS_TIME_TO_DELETE
+  description: conventional_time_to_delete value in seconds (optional)
+  value: ''
 
 # -- Remove null values in workloads fields data Job --
 - name: REMOVE_NULL_VALUES_WORKLOADS_FIELDS_DRY_RUN

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -242,6 +242,8 @@ objects:
       podSpec:
         <<: [ *gunicornPodSpec, *readProbes ]
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: APP_NAME
             value: ${APP_NAME}
           - name: PATH_PREFIX
@@ -381,6 +383,8 @@ objects:
         <<: *gunicornPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: APP_NAME
             value: ${APP_NAME}
           - name: PATH_PREFIX
@@ -517,6 +521,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL
@@ -640,6 +646,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL
@@ -765,6 +773,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL
@@ -886,6 +896,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL
@@ -1016,6 +1028,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL
@@ -1146,6 +1160,8 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         args: ["./inv_export_service.py"]
         env:
+        - name: OPENSHIFT_BUILD_COMMIT
+          value: ${IMAGE_TAG}
         - name: INVENTORY_LOG_LEVEL
           value: DEBUG
         - name: INVENTORY_DB_SSL_MODE
@@ -1193,6 +1209,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL

--- a/docs/entity_relationship_diagram.pu
+++ b/docs/entity_relationship_diagram.pu
@@ -23,8 +23,6 @@ table(hbi.hosts) {
   jsonb(canonical_facts): jsonb <<not null>>
   jsonb(system_profile_facts): jsonb
   column(ansible_host): varchar(255)
-  column(stale_warning_timestamp): timestamp with time zone
-  column(deletion_timestamp): timestamp with time zone
   column(reporter): varchar(255) <<not null>>
   column(display_name_reporter): varchar(255)
   jsonb(per_reporter_staleness): jsonb <<not null>>

--- a/docs/entity_relationship_diagram.pu
+++ b/docs/entity_relationship_diagram.pu
@@ -23,7 +23,6 @@ table(hbi.hosts) {
   jsonb(canonical_facts): jsonb <<not null>>
   jsonb(system_profile_facts): jsonb
   column(ansible_host): varchar(255)
-  column(stale_timestamp): timestamp with time zone
   column(stale_warning_timestamp): timestamp with time zone
   column(deletion_timestamp): timestamp with time zone
   column(reporter): varchar(255) <<not null>>

--- a/iqe-host-inventory-plugin/iqe_host_inventory/conf/requirements.yaml
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/conf/requirements.yaml
@@ -338,7 +338,6 @@ inv-per-reporter-staleness:
   summary: Store staleness data for each reporter
   description: >
     Inventory should store staleness data for each reporter that updates the host.
-    Global `stale_timestamp` should be set after each update by any reporter.
   priority: high
 
 inv-db-schema:
@@ -658,7 +657,6 @@ inv-staleness-hosts:
     Then they are stale until their stale_warning_timestamp is older than current datetime.
     Then they are in a stale_warning state until their culled_timestamp is older than current datetime.
     Then they are in a culled state and will be deleted by the next run of host reaper.
-    stale_timestamp is set by the reporter when the host is created and is updated each time the host is updated.
     Usually, stale_timestamp is set to 28 hours in the future.
     stale_warning_timestamp is automatically set to stale_timestamp + 7 days.
     culled_timestamp is automatically set to stale_warning_timestamp + 16 days.

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/db/test_schema.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/db/test_schema.py
@@ -83,6 +83,7 @@ def test_db_rhsm_schema_changes(inventory_db_session):
         "from hosts h "
         "left join system_profiles_static sps on h.org_id = sps.org_id and h.id = sps.host_id "
         "left join system_profiles_dynamic spd on h.org_id = spd.org_id and h.id = spd.host_id "
+        "left join staleness s on h.org_id = s.org_id "
         "cross join lateral ( "
         "    select string_agg(items, ',') as products "
         "    from jsonb_array_elements_text(h.facts->'rhsm'->'RH_PROD') as items) rhsm_products "
@@ -98,6 +99,7 @@ def test_db_rhsm_schema_changes(inventory_db_session):
         "where h.org_id IN ('00000000')"
         "   and (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')"  # noqa: E501
         "   and (h.host_type IS NULL OR h.host_type <> 'edge')"
+        "   and h.last_check_in + make_interval(secs => coalesce(s.conventional_time_to_stale, 104400)) > NOW() - make_interval(days => 2592000)"
     )
 
     inventory_db_session.execute(query)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/db/test_schema.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/db/test_schema.py
@@ -99,7 +99,9 @@ def test_db_rhsm_schema_changes(inventory_db_session):
         "where h.org_id IN ('00000000')"
         "   and (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')"  # noqa: E501
         "   and (h.host_type IS NULL OR h.host_type <> 'edge')"
-        "   and h.last_check_in + make_interval(secs => coalesce(s.conventional_time_to_stale, 104400)) > NOW() - make_interval(days => 2592000)"
+        "   and h.last_check_in + make_interval(secs => coalesce(s.conventional_time_to_stale, "
+        "104400)) > NOW() - make_interval(secs => coalesce(s.conventional_time_to_delete, "
+        "2592000))"
     )
 
     inventory_db_session.execute(query)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/db/test_schema.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/db/test_schema.py
@@ -80,7 +80,6 @@ def test_db_rhsm_schema_changes(inventory_db_session):
         "qpc_prods.qpc_products, "
         "qpc_certs.qpc_product_ids, "
         "system_profile.system_profile_product_ids, "
-        "h.stale_timestamp "
         "from hosts h "
         "left join system_profiles_static sps on h.org_id = sps.org_id and h.id = sps.host_id "
         "left join system_profiles_dynamic spd on h.org_id = spd.org_id and h.id = spd.host_id "
@@ -99,8 +98,6 @@ def test_db_rhsm_schema_changes(inventory_db_session):
         "where h.org_id IN ('00000000')"
         "   and (h.facts->'rhsm'->>'BILLING_MODEL' IS NULL OR h.facts->'rhsm'->>'BILLING_MODEL' <> 'marketplace')"  # noqa: E501
         "   and (h.host_type IS NULL OR h.host_type <> 'edge')"
-        "   and (stale_timestamp is null "
-        "   or  (NOW() < stale_timestamp + make_interval(days => 30)))"
     )
 
     inventory_db_session.execute(query)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/cache/test_cache_insights_client.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/cache/test_cache_insights_client.py
@@ -437,7 +437,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_create_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    assert response[0].last_check_in != initial_timestamp
+    assert response[0].stale_timestamp != initial_timestamp
 
 
 @iqe_blocker(iqe_blocker.jira("RHINENG-18758", category=iqe_blocker.PRODUCT_ISSUE))
@@ -468,7 +468,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_update_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    initial_timestamp = response[0].last_check_in
+    initial_timestamp = response[0].stale_timestamp
 
     # Update staleness config to invalidate the cache
     host_inventory.apis.account_staleness.update_staleness(conventional_time_to_stale=100)
@@ -479,7 +479,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_update_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    assert response[0].last_check_in != initial_timestamp
+    assert response[0].stale_timestamp != initial_timestamp
 
 
 @iqe_blocker(iqe_blocker.jira("RHINENG-18758", category=iqe_blocker.PRODUCT_ISSUE))
@@ -510,7 +510,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_delete_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    initial_timestamp = response[0].last_check_in
+    initial_timestamp = response[0].stale_timestamp
 
     # Delete staleness config to invalidate the cache
     host_inventory.apis.account_staleness.delete_staleness()
@@ -521,7 +521,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_delete_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    assert response[0].last_check_in != initial_timestamp
+    assert response[0].stale_timestamp != initial_timestamp
 
 
 @pytest.mark.usefixtures("hbi_cert_auth_upload_prepare_host_module")

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/cache/test_cache_insights_client.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/cache/test_cache_insights_client.py
@@ -426,7 +426,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_create_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    initial_timestamp = response[0].last_check_in
+    initial_timestamp = response[0].stale_timestamp
 
     # Create staleness config to invalidate the cache
     host_inventory.apis.account_staleness.create_staleness(conventional_time_to_stale=100)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/cache/test_cache_insights_client.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/cache/test_cache_insights_client.py
@@ -426,7 +426,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_create_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    initial_timestamp = response[0].stale_timestamp
+    initial_timestamp = response[0].last_check_in
 
     # Create staleness config to invalidate the cache
     host_inventory.apis.account_staleness.create_staleness(conventional_time_to_stale=100)
@@ -437,7 +437,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_create_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    assert response[0].stale_timestamp != initial_timestamp
+    assert response[0].last_check_in != initial_timestamp
 
 
 @iqe_blocker(iqe_blocker.jira("RHINENG-18758", category=iqe_blocker.PRODUCT_ISSUE))
@@ -468,7 +468,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_update_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    initial_timestamp = response[0].stale_timestamp
+    initial_timestamp = response[0].last_check_in
 
     # Update staleness config to invalidate the cache
     host_inventory.apis.account_staleness.update_staleness(conventional_time_to_stale=100)
@@ -479,7 +479,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_update_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    assert response[0].stale_timestamp != initial_timestamp
+    assert response[0].last_check_in != initial_timestamp
 
 
 @iqe_blocker(iqe_blocker.jira("RHINENG-18758", category=iqe_blocker.PRODUCT_ISSUE))
@@ -510,7 +510,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_delete_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    initial_timestamp = response[0].stale_timestamp
+    initial_timestamp = response[0].last_check_in
 
     # Delete staleness config to invalidate the cache
     host_inventory.apis.account_staleness.delete_staleness()
@@ -521,7 +521,7 @@ def test_cache_invalidation_insights_client_get_hosts_list_delete_staleness(
     response = host_inventory_cert_auth.apis.hosts.get_hosts(insights_id=host.insights_id)
     assert len(response) == 1
     assert response[0].id == host.id
-    assert response[0].stale_timestamp != initial_timestamp
+    assert response[0].last_check_in != initial_timestamp
 
 
 @pytest.mark.usefixtures("hbi_cert_auth_upload_prepare_host_module")

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_per_reporter_staleness.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_per_reporter_staleness.py
@@ -103,7 +103,7 @@ def verify_staleness(
     assert reporter_staleness.check_in_succeeded
 
     assert_datetimes_equal(reporter_staleness.last_check_in, host.last_check_in)
-    # update to check for the calculatd values
+    # update to check for the calculated values
     assert_datetimes_equal(
         host.stale_timestamp,
         reporter_staleness.stale_timestamp,

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_per_reporter_staleness.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_per_reporter_staleness.py
@@ -57,7 +57,7 @@ def do_reporter_check_ins(
     host_data = host_inventory.datagen.create_host_data(
         host_type=host_type,
         reporter="puptoo",
-        stale_timestamp=generate_timestamp(delta=timedelta(days=5)),
+        last_check_in=generate_timestamp(delta=timedelta(days=5)),
     )
 
     host = host_inventory.kafka.create_host(host_data)
@@ -71,7 +71,7 @@ def do_reporter_check_ins(
 
     host_data.update(
         reporter="yupana",
-        stale_timestamp=generate_timestamp(delta=timedelta(days=3)),
+        last_check_in=generate_timestamp(delta=timedelta(days=3)),
         ansible_host=generate_display_name(),
     )
     host_inventory.kafka.create_host(host_data)
@@ -103,6 +103,7 @@ def verify_staleness(
     assert reporter_staleness.check_in_succeeded
 
     assert_datetimes_equal(reporter_staleness.last_check_in, host.last_check_in)
+    # update to check for the calculatd values
     assert_datetimes_equal(
         host.stale_timestamp,
         reporter_staleness.stale_timestamp,
@@ -436,7 +437,7 @@ def test_per_reporter_registered_with(
     host_data = host_inventory.datagen.create_host_data(
         host_type=host_type,
         reporter="puptoo",
-        stale_timestamp=generate_timestamp(delta=timedelta(days=5)),
+        last_check_in=generate_timestamp(delta=timedelta(days=5)),
     )
 
     host = host_inventory.kafka.create_host(host_data)
@@ -460,7 +461,7 @@ def test_per_reporter_registered_with(
 
     host_data.update(
         reporter="yupana",
-        stale_timestamp=generate_timestamp(delta=timedelta(days=3)),
+        last_check_in=generate_timestamp(delta=timedelta(days=3)),
         ansible_host=generate_display_name(),
     )
     host_inventory.kafka.create_host(host_data)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_staleness_culling.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_staleness_culling.py
@@ -137,7 +137,7 @@ def test_host_stale_warning_to_fresh(
     host_type: str,
 ) -> None:
     """
-    Verify stale warning host becomes fresh if its stale_timestamp was updated.
+    Verify stale warning host becomes fresh if its last_check_in was updated.
 
     1. Create a host in stale warning state
     2. Make sure host is returned by GET request with staleness="stale_warning".
@@ -171,7 +171,7 @@ def test_host_stale_warning_to_fresh(
     updated_host_data["display_name"] = generate_display_name()
     host = host_inventory.kafka.create_host(updated_host_data)
     logger.info(
-        f"Host id={host.id}, updated={host.updated}, display_name={host.display_name}, stale_timestamp={host.stale_timestamp}"  # noqa
+        f"Host id={host.id}, updated={host.updated}, display_name={host.display_name}, last_check_in={host.last_check_in}"  # noqa
     )
     host_inventory.apis.hosts.wait_for_updated(
         host, display_name=updated_host_data["display_name"]
@@ -190,7 +190,7 @@ def test_host_stale_to_fresh(
     host_type: str,
 ) -> None:
     """
-    Verify stale host becomes fresh if its stale_timestamp was updated.
+    Verify stale host becomes fresh if its last_check_in was updated.
 
     1. Create a "stale" host
     2. Make sure host is returned by GET request with staleness="stale".
@@ -201,7 +201,7 @@ def test_host_stale_to_fresh(
         requirements: inv-staleness-hosts, inv-hosts-filter-by-staleness
         assignee: fstavela
         importance: high
-        title: Inventory: Confirm stale host becomes fresh if its stale_timestamp was updated
+        title: Inventory: Confirm stale host becomes fresh if its last_check_in was updated
     """
     host_data = host_inventory.datagen.create_host_data(host_type=host_type)
 
@@ -223,7 +223,7 @@ def test_host_stale_to_fresh(
     updated_host_data["display_name"] = generate_display_name()
     host = host_inventory.kafka.create_host(updated_host_data)
     logger.info(
-        f"Host id={host.id}, updated={host.updated}, display_name={host.display_name}, stale_timestamp={host.stale_timestamp}"  # noqa
+        f"Host id={host.id}, updated={host.updated}, display_name={host.display_name}, last_check_in={host.last_check_in}"  # noqa
     )
     host_inventory.apis.hosts.wait_for_updated(
         host, display_name=updated_host_data["display_name"]

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_staleness_timestamps.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_staleness_timestamps.py
@@ -352,9 +352,7 @@ def test_staleness_timestamps_verify_payload_ignored(
     validate_staleness_response(response, hbi_staleness_defaults, settings)
 
     host_data = host_inventory.datagen.create_host_data(host_type=host_type)
-    host_data["stale_timestamp"] = (datetime.now(UTC) + timedelta(days=1)).isoformat()
-    host_data["stale_warning_timestamp"] = (datetime.now(UTC) + timedelta(days=2)).isoformat()
-    host_data["culled_timestamp"] = (datetime.now(UTC) + timedelta(days=3)).isoformat()
+    host_data["last_check_in"] = (datetime.now(UTC) + timedelta(days=1)).isoformat()
 
     host = host_inventory.kafka.create_host(host_data)
     validate_host_timestamps(host_inventory, host, host_type)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_delete.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_delete.py
@@ -442,17 +442,17 @@ def test_delete_bulk_all_hosts_correct_parameters(
         title: Inventory: Test DELETE on /hosts/all with all required parameters
     """
     hosts_data = host_inventory.datagen.create_n_hosts_data(6)
-    hosts_data[0]["stale_timestamp"] = gen_fresh_date().isoformat()
+    hosts_data[0]["last_check_in"] = gen_fresh_date().isoformat()
     hosts_data[0]["insights_id"] = generate_uuid()
-    hosts_data[1]["stale_timestamp"] = gen_fresh_date().isoformat()
+    hosts_data[1]["last_check_in"] = gen_fresh_date().isoformat()
     hosts_data[1].pop("insights_id", None)
-    hosts_data[2]["stale_timestamp"] = gen_stale_date().isoformat()
+    hosts_data[2]["last_check_in"] = gen_stale_date().isoformat()
     hosts_data[2]["insights_id"] = generate_uuid()
-    hosts_data[3]["stale_timestamp"] = gen_stale_date().isoformat()
+    hosts_data[3]["last_check_in"] = gen_stale_date().isoformat()
     hosts_data[3].pop("insights_id", None)
-    hosts_data[4]["stale_timestamp"] = gen_stale_warning_date().isoformat()
+    hosts_data[4]["last_check_in"] = gen_stale_warning_date().isoformat()
     hosts_data[4]["insights_id"] = generate_uuid()
-    hosts_data[5]["stale_timestamp"] = gen_stale_warning_date().isoformat()
+    hosts_data[5]["last_check_in"] = gen_stale_warning_date().isoformat()
     hosts_data[5].pop("insights_id", None)
     host_inventory.kafka.create_hosts(
         hosts_data=hosts_data, field_to_match=HostWrapper.subscription_manager_id

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_patch.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_patch.py
@@ -319,12 +319,6 @@ def test_patch_host_doesnt_update_last_check_in(
     assert host.org_id == hbi_default_org_id
     assert host_response.id == host.id
     assert_datetimes_equal(host_response.last_check_in, host_before_patch.last_check_in)
-    # make sure staleness timestamps are stayed the same
-    assert_datetimes_equal(host_response.stale_timestamp, host_before_patch.stale_timestamp)
-    assert_datetimes_equal(
-        host_response.stale_warning_timestamp, host_before_patch.stale_warning_timestamp
-    )
-    assert_datetimes_equal(host_response.culled_timestamp, host_before_patch.culled_timestamp)
 
     assert host_response.updated != host_before_patch.updated, (
         "Host's field 'updated' should be updated after patching host's name."

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_system_profile_topic.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_system_profile_topic.py
@@ -65,10 +65,6 @@ def _update_host_data(  # NOQA: C901
 ):
     # Non identifiers fields
     for key in list(host_data.keys()):
-        # ESSNTL-5571: Remove this stale_timestamp check once it's removed from host_data
-        if key == "stale_timestamp":
-            continue
-
         if key not in NO_UPDATE_FIELDS:
             if other_fields_action is FieldAction.scrub:
                 del host_data[key]
@@ -108,10 +104,6 @@ def _check_host_data(
     response_host = host_inventory.apis.hosts.get_hosts_by_id_response(host_id).results[0]
 
     for key, value in host_data.items():
-        # ESSNTL-5571:: Remove this stale_timestamp check once it's removed from host_data
-        if key == "stale_timestamp":
-            continue
-
         if key == "tags":
             response_value = host_inventory.apis.hosts.get_host_tags_response(host_id).results[
                 host_id

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/datagen_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/datagen_utils.py
@@ -341,14 +341,6 @@ HOST_FIELDS_ = [
         "max_len": 255,
     },
     {
-        "name": "stale_timestamp",
-        "type": "timestamp",
-        "is_required": False,
-        "is_canonical": False,
-        "is_id_fact": False,
-        "is_immutable": False,
-    },
-    {
         "name": "openshift_cluster_id",
         "type": "uuid",
         "is_required": False,
@@ -1024,7 +1016,6 @@ host_field_generators: dict[str, Callable[[], Any]] = {
     "facts": generate_facts,
     "tags": generate_tags,
     "system_profile": create_system_profile_facts,
-    "stale_timestamp": generate_timestamp,
     "reporter": generate_reporter,
     "openshift_cluster_id": generate_uuid,
 }
@@ -1338,7 +1329,6 @@ _EXAMPLE_PAYLOAD: dict[str, str | int | Sequence[object] | dict[str, object]] = 
     ],
     "tags": [],
     "reporter": "iqe-hbi",
-    "stale_timestamp": gen_stale_timestamp(),  # ESSNTL-5571: Remove this when changes are in Prod
 }
 _EXAMPLE_PAYLOAD_WITH_PROFILE_FACTS = copy.deepcopy(_EXAMPLE_PAYLOAD)
 _EXAMPLE_PAYLOAD_WITH_PROFILE_FACTS["system_profile"] = _EXAMPLE_SYSTEM_PROFILE_FACTS

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/db_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/db_utils.py
@@ -59,7 +59,6 @@ class Host(Base):
     tags_alt = Column(JSONB)
     groups = Column(JSONB)
     last_check_in = Column(DateTime(timezone=True))
-    stale_timestamp = Column(DateTime(timezone=True))
     reporter = Column(String())
     per_reporter_staleness = Column(JSONB)
 
@@ -133,7 +132,6 @@ def minimal_db_host(empty_strings: bool = False, **fields: Any) -> dict[str, Any
         "modified_on": datetime.now(UTC),
         "last_check_in": datetime.now(UTC),
         "groups": [],
-        "stale_timestamp": datetime.now(UTC),
         "reporter": "" if empty_strings else "iqe-hbi",
         **fields,
     }

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/kafka_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/kafka_utils.py
@@ -127,7 +127,6 @@ def check_host_timestamps(
     This function is used to check the host timestamps after an API update of a host."""
 
     def _extract_timestamps(data: dict) -> dict[str, datetime]:
-        # figure out what to do here
         timestamps = {
             "updated": data.pop("updated"),
             "stale_timestamp": data.pop("stale_timestamp"),

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/kafka_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/kafka_utils.py
@@ -127,6 +127,7 @@ def check_host_timestamps(
     This function is used to check the host timestamps after an API update of a host."""
 
     def _extract_timestamps(data: dict) -> dict[str, datetime]:
+        # figure out what to do here
         timestamps = {
             "updated": data.pop("updated"),
             "stale_timestamp": data.pop("stale_timestamp"),
@@ -391,9 +392,6 @@ def check_mq_create_or_update_event_host_data(
         culled_timestamp=event_host_data.pop("culled_timestamp"),
         staleness_settings=staleness_settings,
     )
-    expected_host_data.pop("stale_timestamp", None)
-    expected_host_data.pop("stale_warning_timestamp", None)
-    expected_host_data.pop("culled_timestamp", None)
 
     check_prs_timestamps(
         event_host_data.pop("per_reporter_staleness"),

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/staleness_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/staleness_utils.py
@@ -211,14 +211,8 @@ def validate_host_timestamps(
 
     logger.info(f"Host type: {host_type}")
     logger.info(f"Host last_check_in: {host.last_check_in}")
-    logger.info(f"Host stale timestamp: {host.stale_timestamp}")
-    logger.info(f"Host stale warning timestamp: {host.stale_warning_timestamp}")
-    logger.info(f"Host culled timestamp: {host.culled_timestamp}")
 
     assert host.last_check_in is not None, "last_check_in must not be None"
-    assert host.stale_timestamp is not None, "stale_timestamp must not be None"
-    assert host.stale_warning_timestamp is not None, "stale_warning_timestamp must not be None"
-    assert host.culled_timestamp is not None, "culled_timestamp must not be None"
 
     validate_staleness_timestamps(
         host.last_check_in,

--- a/jobs/update_staleness.py
+++ b/jobs/update_staleness.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Job to create or update a custom staleness row for a given org_id.
+
+Devs cannot directly modify Prod DB rows, and the existing staleness API
+requires authentication as the target org.  This CJI-triggered job allows
+SREs to set custom staleness values for any org_id via environment variables.
+
+Environment variables:
+    STALENESS_ORG_ID          - (required) The org_id to upsert staleness for
+    CONVENTIONAL_TIME_TO_STALE         - Seconds (optional; defaults to existing or system default)
+    CONVENTIONAL_TIME_TO_STALE_WARNING - Seconds (optional; defaults to existing or system default)
+    CONVENTIONAL_TIME_TO_DELETE        - Seconds (optional; defaults to existing or system default)
+    DRY_RUN=true      - Log what would change without writing (default: true)
+    SUSPEND_JOB=true  - Exit immediately as a safety gate (default: true)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from functools import partial
+from logging import Logger
+
+from connexion import FlaskApp
+from sqlalchemy.orm import Session
+
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+from app.logging import get_logger
+from app.logging import threadctx
+from app.models import Staleness
+from app.models.schemas.staleness import StalenessSchema
+from app.models.utils import StalenessCache
+from jobs.common import excepthook
+from jobs.common import job_setup
+from lib.db import session_guard
+
+PROMETHEUS_JOB = "update-staleness"
+LOGGER_NAME = "update_staleness"
+COLLECTED_METRICS: tuple = ()
+SUSPEND_JOB = os.environ.get("SUSPEND_JOB", "true").lower() == "true"
+
+SYSTEM_DEFAULTS = {
+    "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
+    "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
+    "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
+}
+
+STALENESS_FIELDS = (
+    "conventional_time_to_stale",
+    "conventional_time_to_stale_warning",
+    "conventional_time_to_delete",
+)
+
+
+def _read_env_staleness_values(logger: Logger) -> dict[str, int]:
+    """Read optional staleness env vars and return only those that are set.
+    At least one of these staleness env vars must be set.
+    """
+    env_mapping = {
+        "conventional_time_to_stale": "CONVENTIONAL_TIME_TO_STALE",
+        "conventional_time_to_stale_warning": "CONVENTIONAL_TIME_TO_STALE_WARNING",
+        "conventional_time_to_delete": "CONVENTIONAL_TIME_TO_DELETE",
+    }
+    values: dict[str, int] = {}
+    for field, env_var in env_mapping.items():
+        raw = os.environ.get(env_var)
+        if raw is not None and raw.strip():
+            try:
+                values[field] = int(raw)
+            except ValueError:
+                logger.error("%s must be an integer, got: %r", env_var, raw)
+                sys.exit(1)
+    return values
+
+
+def _merge_with_defaults(
+    explicit: dict[str, int],
+    existing_row: Staleness | None,
+) -> dict[str, int]:
+    """Fill in any missing fields from the existing row or system defaults."""
+    merged: dict[str, int] = {}
+    for field in STALENESS_FIELDS:
+        if field in explicit:
+            merged[field] = explicit[field]
+        elif existing_row is not None:
+            merged[field] = getattr(existing_row, field)
+        else:
+            merged[field] = SYSTEM_DEFAULTS[field]
+    return merged
+
+
+def run(
+    logger: Logger,
+    session: Session,
+    application: FlaskApp,
+) -> None:
+    org_id = os.environ.get("STALENESS_ORG_ID", "").strip()
+    if not org_id:
+        logger.error("STALENESS_ORG_ID is required but not set or empty.")
+        sys.exit(1)
+
+    dry_run = os.environ.get("DRY_RUN", "true").lower() == "true"
+
+    explicit_values = _read_env_staleness_values(logger)
+    if not explicit_values:
+        logger.error("At least one CONVENTIONAL_TIME_TO_* env var must be set.")
+        sys.exit(1)
+
+    with application.app.app_context():
+        threadctx.request_id = None
+
+        existing_row = session.query(Staleness).filter(Staleness.org_id == org_id).one_or_none()
+        merged = _merge_with_defaults(explicit_values, existing_row)
+
+        errors = StalenessSchema().validate(merged)
+        if errors:
+            logger.error("Validation failed: %s", errors)
+            sys.exit(1)
+
+        action = "update" if existing_row else "create"
+        logger.info(
+            "Will %s staleness for org_id=%s: stale=%d, warning=%d, delete=%d",
+            action,
+            org_id,
+            merged["conventional_time_to_stale"],
+            merged["conventional_time_to_stale_warning"],
+            merged["conventional_time_to_delete"],
+        )
+
+        if dry_run:
+            logger.info("DRY_RUN is enabled; no changes written.")
+            return
+
+        if existing_row:
+            with session_guard(session, close=False):
+                for field in STALENESS_FIELDS:
+                    setattr(existing_row, field, merged[field])
+            logger.info("Updated staleness row for org_id=%s", org_id)
+        else:
+            with session_guard(session, close=False):
+                new_row = Staleness(
+                    org_id=org_id,
+                    conventional_time_to_stale=merged["conventional_time_to_stale"],
+                    conventional_time_to_stale_warning=merged["conventional_time_to_stale_warning"],
+                    conventional_time_to_delete=merged["conventional_time_to_delete"],
+                )
+                session.add(new_row)
+            logger.info("Created staleness row for org_id=%s", org_id)
+
+        try:
+            StalenessCache.delete(org_id)
+            logger.info("Invalidated staleness cache for org_id=%s", org_id)
+        except Exception:
+            logger.exception("Failed to invalidate cache for org_id=%s (DB write succeeded)", org_id)
+
+
+if __name__ == "__main__":
+    logger = get_logger(LOGGER_NAME)
+    if SUSPEND_JOB:
+        logger.info("SUSPEND_JOB set to true; exiting.")
+        sys.exit(0)
+
+    job_type = "Update staleness"
+    sys.excepthook = partial(excepthook, logger, job_type)
+
+    _, session, _, _, _, application = job_setup(COLLECTED_METRICS, PROMETHEUS_JOB)
+
+    try:
+        run(logger, session, application)
+    except Exception as e:
+        logger.exception("Job failed: %s", e)
+        sys.exit(1)
+    finally:
+        session.close()

--- a/migrations/versions/f8a9b0c1d2e3_drop_hosts_staleness_columns_and_index.py
+++ b/migrations/versions/f8a9b0c1d2e3_drop_hosts_staleness_columns_and_index.py
@@ -1,0 +1,67 @@
+"""Drop hosts staleness columns and covering index
+
+Revision ID: f8a9b0c1d2e3
+Revises: d4f7a2b8c1e3
+Create Date: 2026-05-25 12:00:00.000000
+
+Phase 3 of compute-on-read: remove persisted staleness columns and the covering
+index used for group host-count queries (now derived from last_check_in).
+
+Space reclamation: DROP COLUMN removes catalog metadata immediately but does not
+reclaim disk from existing heap tuples until VACUUM FULL or pg_repack on the
+partitioned hosts table (and its partitions). Plan optional post-deploy maintenance
+with DBAs; do not run VACUUM FULL inside this migration.
+
+Downgrade: dev/ephemeral only. Restored columns are nullable and will be NULL until
+backfilled; the app no longer writes these fields in production.
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.models.constants import INVENTORY_SCHEMA
+from utils.partitioned_table_index_helper import create_partitioned_table_index
+from utils.partitioned_table_index_helper import drop_partitioned_table_index
+
+# revision identifiers, used by Alembic.
+revision = "f8a9b0c1d2e3"
+down_revision = "d4f7a2b8c1e3"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "idx_hosts_org_id_deletion_ts"
+STALENESS_COLUMNS = ("stale_timestamp", "stale_warning_timestamp", "deletion_timestamp")
+
+
+def upgrade():
+    drop_partitioned_table_index(
+        table_name="hosts",
+        index_name=INDEX_NAME,
+        if_exists=True,
+    )
+    for column_name in STALENESS_COLUMNS:
+        op.drop_column("hosts", column_name, schema=INVENTORY_SCHEMA)
+
+
+def downgrade():
+    op.add_column(
+        "hosts",
+        sa.Column("stale_timestamp", sa.DateTime(timezone=True), nullable=True),
+        schema=INVENTORY_SCHEMA,
+    )
+    op.add_column(
+        "hosts",
+        sa.Column("stale_warning_timestamp", sa.DateTime(timezone=True), nullable=True),
+        schema=INVENTORY_SCHEMA,
+    )
+    op.add_column(
+        "hosts",
+        sa.Column("deletion_timestamp", sa.DateTime(timezone=True), nullable=True),
+        schema=INVENTORY_SCHEMA,
+    )
+    create_partitioned_table_index(
+        table_name="hosts",
+        index_name=INDEX_NAME,
+        index_definition="(org_id, id, deletion_timestamp)",
+    )

--- a/migrations/versions/f8a9b0c1d2e3_drop_hosts_staleness_columns_and_index.py
+++ b/migrations/versions/f8a9b0c1d2e3_drop_hosts_staleness_columns_and_index.py
@@ -1,7 +1,7 @@
 """Drop hosts staleness columns and covering index
 
 Revision ID: f8a9b0c1d2e3
-Revises: d4f7a2b8c1e3
+Revises: b3e9f1a2d7c4
 Create Date: 2026-05-25 12:00:00.000000
 
 Phase 3 of compute-on-read: remove persisted staleness columns and the covering
@@ -26,7 +26,7 @@ from utils.partitioned_table_index_helper import drop_partitioned_table_index
 
 # revision identifiers, used by Alembic.
 revision = "f8a9b0c1d2e3"
-down_revision = "d4f7a2b8c1e3"
+down_revision = "b3e9f1a2d7c4"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/f8a9b0c1d2e3_drop_hosts_staleness_columns_and_index.py
+++ b/migrations/versions/f8a9b0c1d2e3_drop_hosts_staleness_columns_and_index.py
@@ -45,21 +45,12 @@ def upgrade():
 
 
 def downgrade():
-    op.add_column(
-        "hosts",
-        sa.Column("stale_timestamp", sa.DateTime(timezone=True), nullable=True),
-        schema=INVENTORY_SCHEMA,
-    )
-    op.add_column(
-        "hosts",
-        sa.Column("stale_warning_timestamp", sa.DateTime(timezone=True), nullable=True),
-        schema=INVENTORY_SCHEMA,
-    )
-    op.add_column(
-        "hosts",
-        sa.Column("deletion_timestamp", sa.DateTime(timezone=True), nullable=True),
-        schema=INVENTORY_SCHEMA,
-    )
+    for column_name in STALENESS_COLUMNS:
+        op.add_column(
+            "hosts",
+            sa.Column(column_name, sa.DateTime(timezone=True), nullable=True),
+            schema=INVENTORY_SCHEMA,
+        )
     create_partitioned_table_index(
         table_name="hosts",
         index_name=INDEX_NAME,

--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,23 @@
     "github>RedHatInsights/konflux-pipelines//renovate/foreman_satellite/renovate.json"
   ],
   "ignorePaths": [
-    "Pipfile.iqe"
+    "Pipfile.iqe",
+    ".hermetic_builds/**"
   ],
+  "constraints": {
+    "python": "3.12",
+    "uv": "0.11"
+  },
   "tekton": {
     "schedule": [
       "at any time"
     ]
+  },
+  "pip_requirements": {
+    "enabled": false
+  },
+  "pip-compile": {
+    "enabled": false
   },
   "packageRules": [
     {
@@ -21,8 +32,5 @@
       "groupName": "opentelemetry",
       "ignoreUnstable": false
     }
-  ],
-  "pip_requirements": {
-    "enabled": false
-  }
+  ]
 }

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -762,13 +762,8 @@ def create_host_with_reporter(
     db_create_host: Callable[..., Host],
     reporter: str,
     last_check_in: datetime,
-    stale_timestamp: datetime | None = None,
 ) -> Host:
-    """Create a host with flat PRS (ISO string per reporter) and a coherent host-level ``stale_timestamp``.
-
-    If ``stale_timestamp`` is omitted, it defaults to ``last_check_in`` plus
-    ``CONVENTIONAL_TIME_TO_STALE_SECONDS`` (global default culling offset).
-    """
+    """Create a host with flat PRS (ISO string per reporter) and ``last_check_in`` set."""
     host = db_create_host(
         extra_data={
             "reporter": reporter,
@@ -778,9 +773,5 @@ def create_host_with_reporter(
         },
     )
     host.last_check_in = last_check_in
-    if stale_timestamp is not None:
-        host.stale_timestamp = stale_timestamp
-    else:
-        host.stale_timestamp = last_check_in + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_SECONDS)
     db.session.commit()
     return host

--- a/tests/helpers/db_utils.py
+++ b/tests/helpers/db_utils.py
@@ -1,6 +1,4 @@
 import logging
-from datetime import timedelta
-from random import randint
 from typing import Any
 from typing import Literal
 
@@ -91,7 +89,6 @@ def db_host(**values):
         "mac_addresses": ["aa:bb:cc:dd:ee:ff"],
         "facts": {"ns1": {"key1": "value1"}},
         "tags": {"ns1": {"key1": ["val1", "val2"], "key2": ["val1"]}, "SPECIAL": {"tag": ["ToFind"]}},
-        "stale_timestamp": (now() + timedelta(days=randint(1, 7))),
         "reporter": "test-reporter",
         **values,
     }
@@ -123,16 +120,16 @@ def db_staleness_culling(**values):
     return Staleness(**data)
 
 
-def create_reference_host_in_db(insights_id, reporter, system_profile, stale_timestamp):
+def create_reference_host_in_db(insights_id, reporter, system_profile, last_check_in):
     host = Host(
         org_id=SYSTEM_IDENTITY["org_id"],
         insights_id=insights_id,
         display_name="display_name",
         reporter=reporter,
-        stale_timestamp=stale_timestamp,
     )
     db.session.add(host)
     db.session.flush()
+    host.last_check_in = last_check_in
     if system_profile:
         host.update_system_profile(system_profile)
     db.session.commit()

--- a/tests/helpers/host_field_utils.py
+++ b/tests/helpers/host_field_utils.py
@@ -127,7 +127,6 @@ INVALID_HOST_FIELDS: tuple[dict, ...] = (
     {"tags": None},
     {"system_profile": None},
     {"reporter": None},
-    {"stale_timestamp": None},
     # --- Invalid types ---
     {"display_name": ["list"]},
     {"display_name": {}},

--- a/tests/test_api_facts.py
+++ b/tests/test_api_facts.py
@@ -1,8 +1,6 @@
-from datetime import datetime
-from unittest.mock import patch
-
 import pytest
 
+from app.models import db
 from tests.helpers.api_utils import HOST_WRITE_ALLOWED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import HOST_WRITE_PROHIBITED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import RBACFilterOperation
@@ -125,22 +123,26 @@ def test_replace_empty_facts_on_multiple_hosts(db_create_multiple_hosts, db_get_
 
 
 @pytest.mark.system_culling
-def test_replace_facts_on_multiple_culled_hosts(db_create_multiple_hosts, api_put):
-    with patch("app.models.utils.datetime") as mock_datetime:
-        mock_datetime.now.return_value = datetime(year=2023, month=4, day=2)
-        mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+def test_replace_facts_on_multiple_culled_hosts(db_create_multiple_hosts, api_put, db_create_staleness_culling):
+    """Culled hosts are excluded via compute-on-read (``last_check_in`` + org delete window)."""
+    db_create_staleness_culling(
+        conventional_time_to_stale=1,
+        conventional_time_to_stale_warning=1,
+        conventional_time_to_delete=1,
+    )
 
-        staleness_timestamps = get_staleness_timestamps()
+    created_hosts = db_create_multiple_hosts(how_many=2, extra_data={"facts": DB_FACTS})
 
-        created_hosts = db_create_multiple_hosts(
-            how_many=2, extra_data={"facts": DB_FACTS, "stale_timestamp": staleness_timestamps["culled"]}
-        )
+    culled_last_check_in = get_staleness_timestamps()["culled"]
+    for host in created_hosts:
+        host.last_check_in = culled_last_check_in
+    db.session.commit()
 
-        facts_url = build_facts_url(host_list_or_id=created_hosts, namespace=DB_FACTS_NAMESPACE)
+    facts_url = build_facts_url(host_list_or_id=created_hosts, namespace=DB_FACTS_NAMESPACE)
 
-        # Try to replace the facts on a host that has been marked as culled
-        response_status, _ = api_put(facts_url, DB_NEW_FACTS)
-        assert_response_status(response_status, expected_status=404)
+    # Try to replace the facts on hosts that are culled by last_check_in
+    response_status, _ = api_put(facts_url, DB_NEW_FACTS)
+    assert_response_status(response_status, expected_status=404)
 
 
 @pytest.mark.usefixtures("enable_rbac", "event_producer_mock")

--- a/tests/test_api_hosts_update.py
+++ b/tests/test_api_hosts_update.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from app.auth.identity import from_auth_header
+from app.models import db
 from app.queue.event_producer import MessageDetails
 from app.serialization import deserialize_canonical_facts
 from app.serialization import serialize_canonical_facts
@@ -87,7 +88,6 @@ def test_checkin_canonical_facts(
     record = db_get_host(created_host.id)
 
     assert record.modified_on > updated_time
-    assert record.stale_timestamp == created_host.stale_timestamp
     assert record.reporter == created_host.reporter
 
     assert_patch_event_is_valid(
@@ -464,10 +464,12 @@ def test_add_facts_to_multiple_culled_hosts(db_create_multiple_hosts, api_patch,
             conventional_time_to_delete=1,
         )
 
-        staleness_timestamps = get_staleness_timestamps()
-        created_hosts = db_create_multiple_hosts(
-            how_many=2, extra_data={"facts": DB_FACTS, "stale_timestamp": staleness_timestamps["culled"]}
-        )
+        created_hosts = db_create_multiple_hosts(how_many=2, extra_data={"facts": DB_FACTS})
+
+        culled_last_check_in = get_staleness_timestamps()["culled"]
+        for host in created_hosts:
+            host.last_check_in = culled_last_check_in
+        db.session.commit()
 
         facts_url = build_facts_url(host_list_or_id=created_hosts, namespace=DB_FACTS_NAMESPACE)
 

--- a/tests/test_culling.py
+++ b/tests/test_culling.py
@@ -1,8 +1,5 @@
-from uuid import UUID
-
 import pytest
 
-from app.models import Host
 from tests.helpers.api_utils import FACTS
 from tests.helpers.api_utils import build_facts_url
 from tests.helpers.api_utils import build_host_tags_url
@@ -53,17 +50,6 @@ def test_delete_ignores_culled(mq_create_deleted_hosts, api_delete_host):
     response_status, _ = api_delete_host(culled_host.id)
 
     assert response_status == 404
-
-
-def test_mq_create_deleted_hosts_culled_has_null_staleness_columns(mq_create_deleted_hosts):
-    """Ingress does not persist staleness columns on MQ create."""
-    hw = mq_create_deleted_hosts["culled"]
-    orm_host = Host.query.filter_by(id=UUID(str(hw.id)), org_id=hw.org_id).first()
-    assert orm_host is not None
-
-    assert orm_host.stale_timestamp is None
-    assert orm_host.stale_warning_timestamp is None
-    assert orm_host.deletion_timestamp is None
 
 
 @pytest.mark.skip(reason="bypass until the issue, https://github.com/spec-first/connexion/issues/1920 is resolved")

--- a/tests/test_custom_staleness.py
+++ b/tests/test_custom_staleness.py
@@ -74,16 +74,14 @@ def _attrdict_from_custom_staleness(config: dict[str, int]) -> AttrDict:
 
 
 @patch("tests.helpers.api_utils.db.session.commit")
-def test_create_host_with_reporter_defaults_stale_timestamp_to_last_check_in_plus_conventional_delay(
-    _mock_commit,
-) -> None:
-    """When ``stale_timestamp`` is omitted, derive it from ``last_check_in`` and the conventional stale delay."""
+def test_create_host_with_reporter_sets_last_check_in(_mock_commit) -> None:
+    """``create_host_with_reporter`` persists PRS and ``last_check_in`` only (no staleness columns)."""
     last_check_in = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
     captured_kwargs: dict[str, Any] = {}
 
     def fake_db_create_host(**kwargs):
         captured_kwargs.update(kwargs)
-        return SimpleNamespace()
+        return SimpleNamespace(last_check_in=None)
 
     host = create_host_with_reporter(
         db_create_host=fake_db_create_host,
@@ -91,12 +89,10 @@ def test_create_host_with_reporter_defaults_stale_timestamp_to_last_check_in_plu
         last_check_in=last_check_in,
     )
 
-    expected_stale_timestamp = last_check_in + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_SECONDS)
-
     extra = captured_kwargs["extra_data"]
     assert extra["reporter"] == "some-reporter"
+    assert "stale_timestamp" not in extra
     assert host.last_check_in == last_check_in
-    assert host.stale_timestamp == expected_stale_timestamp
 
 
 def test_registered_with_filter_handles_multi_reporter_hosts(
@@ -237,7 +233,7 @@ def test_registered_with_staleness_filter_iso_string_values(
     assert len(resp["results"]) == 2
 
 
-def test_calculated_timestamps_match_stored_timestamps(
+def test_per_reporter_staleness_timestamps_match_host_level_timestamps(
     db_create_staleness_culling: Callable[..., object],
     db_create_host: Callable[..., Host],
     db_get_hosts: Callable[..., Query],
@@ -364,14 +360,7 @@ def test_registered_with_filter_puptoo_reporter_without_puptoo_prs(
         ).id
     )
 
-    normal_host_id = str(
-        create_host_with_reporter(
-            db_create_host,
-            "puptoo",
-            _now,
-            stale_timestamp=_now + timedelta(seconds=CUSTOM_STALENESS_HOST_BECAME_STALE["conventional_time_to_stale"]),
-        ).id
-    )
+    normal_host_id = str(create_host_with_reporter(db_create_host, "puptoo", _now).id)
 
     other_host_id = str(
         db_create_host(
@@ -403,7 +392,6 @@ def test_serialize_per_reporter_staleness_datetime_string_format(flask_app):
         host = Host(
             subscription_manager_id=generate_uuid(),
             reporter="puptoo",
-            stale_timestamp=datetime.now(UTC),
             org_id=USER_IDENTITY["org_id"],
         )
         host.per_reporter_staleness = {"puptoo": last_check_in_str}
@@ -426,7 +414,6 @@ def test_serialize_per_reporter_staleness_datetime_object_format(flask_app):
         host = Host(
             subscription_manager_id=generate_uuid(),
             reporter="puptoo",
-            stale_timestamp=datetime.now(UTC),
             org_id=USER_IDENTITY["org_id"],
         )
         host.per_reporter_staleness = {"puptoo": last_check_in_dt}
@@ -448,7 +435,6 @@ def test_serialize_per_reporter_staleness_multiple_flat_reporters(flask_app):
         host = Host(
             subscription_manager_id=generate_uuid(),
             reporter="puptoo",
-            stale_timestamp=datetime.now(UTC),
             org_id=USER_IDENTITY["org_id"],
         )
         host.per_reporter_staleness = {

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -1685,42 +1685,6 @@ def test_delete_host_tags(mq_create_or_update_host, db_get_host_by_insights_id, 
 
 
 @pytest.mark.usefixtures("event_datetime_mock")
-def test_add_host_stale_timestamp(mq_create_or_update_host):
-    """
-    Tests to see if the host is successfully created with both reporter
-    and stale_timestamp set.
-    """
-    expected_insights_id = generate_uuid()
-    stale_timestamp = now()
-
-    host = minimal_host(
-        account=SYSTEM_IDENTITY["account_number"],
-        insights_id=expected_insights_id,
-        stale_timestamp=stale_timestamp.isoformat(),
-    )
-
-    host_keys_to_check = ["reporter", "stale_timestamp", "culled_timestamp"]
-
-    key, event, _ = mq_create_or_update_host(host, return_all_data=True)
-    updated_timestamp = datetime.fromisoformat(event["host"]["last_check_in"])
-
-    host.stale_timestamp = (updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_SECONDS)).isoformat()
-    expected_results = {
-        "host": {
-            **host.data(),
-            "stale_warning_timestamp": (
-                updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS)
-            ).isoformat(),
-            "culled_timestamp": (
-                updated_timestamp + timedelta(seconds=CONVENTIONAL_TIME_TO_DELETE_SECONDS)
-            ).isoformat(),
-        }
-    }
-
-    assert_mq_host_data(key, event, expected_results, host_keys_to_check)
-
-
-@pytest.mark.usefixtures("event_datetime_mock")
 def test_add_host_without_stale_timestamp(mq_create_or_update_host):
     """
     Tests to see if the host is successfully created without stale_timestamp.

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -1088,22 +1088,6 @@ def test_add_host_with_operating_system_incorrect_format(mocker, mq_create_or_up
         mock_notification_event_producer.write_event.assert_called()
 
 
-@pytest.mark.parametrize("stale_timestamp", ("invalid", datetime.now().isoformat()))
-def test_add_host_with_invalid_stale_timestamp(stale_timestamp, mocker, mq_create_or_update_host):
-    mock_notification_event_producer = mocker.Mock()
-    insights_id = generate_uuid()
-    host = minimal_host(
-        account=SYSTEM_IDENTITY["account_number"],
-        insights_id=insights_id,
-        stale_timestamp=stale_timestamp,
-        system_profile={"owner_id": OWNER_ID},
-    )
-
-    with pytest.raises(ValidationException):
-        mq_create_or_update_host(host, notification_event_producer=mock_notification_event_producer)
-    mock_notification_event_producer.write_event.assert_called_once()
-
-
 @pytest.mark.xfail(
     reason="Legacy workloads backward compatibility fields (sap_sids, etc.) not yet normalized. "
     "Will be fixed by PR #3108: https://github.com/RedHatInsights/insights-host-inventory/pull/3108"
@@ -1767,29 +1751,6 @@ def test_add_host_missing_reporter_field(mocker, mq_create_or_update_host):
     mock_notification_event_producer.write_event.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    "additional_data",
-    (
-        {"stale_timestamp": "2019-12-16T10:10:06.754201+00:00", "reporter": ""},
-        {"stale_timestamp": "2019-12-16T10:10:06.754201+00:00", "reporter": None},
-        {"stale_timestamp": "not a timestamp", "reporter": "puptoo"},
-        {"stale_timestamp": "", "reporter": "puptoo"},
-        {"stale_timestamp": None, "reporter": "puptoo"},
-    ),
-)
-def test_add_host_stale_timestamp_invalid_culling_fields(mocker, additional_data, mq_create_or_update_host):
-    """
-    tests to check the API will reject a host if it doesn’t have both
-    culling fields. This should raise InventoryException.
-    """
-    mock_notification_event_producer = mocker.Mock()
-    host = minimal_host(account=SYSTEM_IDENTITY["account_number"], **additional_data)
-
-    with pytest.raises(InventoryException):
-        mq_create_or_update_host(host, notification_event_producer=mock_notification_event_producer)
-    mock_notification_event_producer.write_event.assert_called_once()
-
-
 def test_valid_string_is_ok():
     result = _sanitize_json_object_for_postgres("naïve fiancé 👰🏻")
     assert result == "naïve fiancé 👰🏻"
@@ -1959,7 +1920,6 @@ def test_update_system_profile(mq_create_or_update_host, db_get_host, id_type):
             "workloads": {"crowdstrike": {"falcon_version": "7.2.2"}},
         },
     )
-    input_host.stale_timestamp = None
     input_host.reporter = None
     second_host_from_event = mq_create_or_update_host(input_host, consumer_class=SystemProfileMessageConsumer)
     second_host_from_db = db_get_host(second_host_from_event.id)
@@ -2723,7 +2683,6 @@ def test_log_update_system_profile(mq_create_or_update_host, db_get_host, id_typ
     input_host = base_host(
         **{id_type: expected_ids[id_type]}, system_profile={"number_of_cpus": 4, "number_of_sockets": 8}
     )
-    input_host.stale_timestamp = None
     input_host.reporter = None
     second_host_from_event = mq_create_or_update_host(input_host, consumer_class=SystemProfileMessageConsumer)
     second_host_from_db = db_get_host(second_host_from_event.id)
@@ -3360,7 +3319,6 @@ def test_update_system_profile_bios_fields(mq_create_or_update_host, db_get_host
             "bios_version": "1.23",
         },
     )
-    input_host.stale_timestamp = None
     input_host.reporter = None
     second_host_from_event = mq_create_or_update_host(input_host, consumer_class=SystemProfileMessageConsumer)
     second_host_from_db = db_get_host(second_host_from_event.id)

--- a/tests/test_job_update_staleness.py
+++ b/tests/test_job_update_staleness.py
@@ -1,0 +1,283 @@
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+from app.models import Staleness
+from app.models import db
+from jobs.update_staleness import _merge_with_defaults
+from jobs.update_staleness import _read_env_staleness_values
+from jobs.update_staleness import run
+
+_logger = logging.getLogger("test_update_staleness")
+
+CUSTOM_ORG_ID = "update-staleness-test-org"
+CUSTOM_STALE = 200000
+CUSTOM_WARNING = 700000
+CUSTOM_DELETE = 3000000
+
+
+# -- _read_env_staleness_values -----------------------------------------------
+
+
+def test_read_env_no_vars_set():
+    with patch.dict("os.environ", {}, clear=True):
+        assert _read_env_staleness_values(_logger) == {}
+
+
+def test_read_env_all_vars_set():
+    env = {
+        "CONVENTIONAL_TIME_TO_STALE": "100",
+        "CONVENTIONAL_TIME_TO_STALE_WARNING": "200",
+        "CONVENTIONAL_TIME_TO_DELETE": "300",
+    }
+    with patch.dict("os.environ", env, clear=True):
+        result = _read_env_staleness_values(_logger)
+    assert result == {
+        "conventional_time_to_stale": 100,
+        "conventional_time_to_stale_warning": 200,
+        "conventional_time_to_delete": 300,
+    }
+
+
+def test_read_env_partial_vars():
+    env = {"CONVENTIONAL_TIME_TO_DELETE": "999"}
+    with patch.dict("os.environ", env, clear=True):
+        result = _read_env_staleness_values(_logger)
+    assert result == {"conventional_time_to_delete": 999}
+
+
+def test_read_env_non_integer_exits():
+    env = {"CONVENTIONAL_TIME_TO_STALE": "abc"}
+    with patch.dict("os.environ", env, clear=True), pytest.raises(SystemExit) as exc_info:
+        _read_env_staleness_values(_logger)
+    assert exc_info.value.code == 1
+
+
+# -- _merge_with_defaults -----------------------------------------------------
+
+
+def test_merge_no_existing_row_uses_system_defaults():
+    explicit = {"conventional_time_to_stale": 200000}
+    merged = _merge_with_defaults(explicit, None)
+    assert merged["conventional_time_to_stale"] == 200000
+    assert merged["conventional_time_to_stale_warning"] == CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+    assert merged["conventional_time_to_delete"] == CONVENTIONAL_TIME_TO_DELETE_SECONDS
+
+
+def test_merge_with_existing_row(flask_app):
+    with flask_app.app.app_context():
+        row = Staleness(
+            org_id="merge-test-org",
+            conventional_time_to_stale=111,
+            conventional_time_to_stale_warning=222,
+            conventional_time_to_delete=333,
+        )
+        explicit = {"conventional_time_to_delete": 999}
+        merged = _merge_with_defaults(explicit, row)
+    assert merged["conventional_time_to_stale"] == 111
+    assert merged["conventional_time_to_stale_warning"] == 222
+    assert merged["conventional_time_to_delete"] == 999
+
+
+def test_merge_all_explicit_ignores_defaults():
+    explicit = {
+        "conventional_time_to_stale": 1,
+        "conventional_time_to_stale_warning": 2,
+        "conventional_time_to_delete": 3,
+    }
+    merged = _merge_with_defaults(explicit, None)
+    assert merged == explicit
+
+
+# -- run() integration tests ---------------------------------------------------
+
+
+@pytest.fixture()
+def _staleness_env(monkeypatch):
+    """Set the minimal env for a valid run."""
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", str(CUSTOM_STALE))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE_WARNING", str(CUSTOM_WARNING))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", str(CUSTOM_DELETE))
+    monkeypatch.setenv("DRY_RUN", "false")
+
+
+def _get_staleness_row(org_id):
+    return Staleness.query.filter(Staleness.org_id == org_id).one_or_none()
+
+
+def test_run_creates_new_row(flask_app, _staleness_env):
+    with flask_app.app.app_context():
+        assert _get_staleness_row(CUSTOM_ORG_ID) is None
+
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache") as mock_cache:
+        run(_logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        row = _get_staleness_row(CUSTOM_ORG_ID)
+        assert row is not None
+        assert row.conventional_time_to_stale == CUSTOM_STALE
+        assert row.conventional_time_to_stale_warning == CUSTOM_WARNING
+        assert row.conventional_time_to_delete == CUSTOM_DELETE
+        mock_cache.delete.assert_called_once_with(CUSTOM_ORG_ID)
+
+
+def test_run_updates_existing_row(flask_app, _staleness_env, monkeypatch):
+    with flask_app.app.app_context():
+        existing = Staleness(
+            org_id=CUSTOM_ORG_ID,
+            conventional_time_to_stale=1,
+            conventional_time_to_stale_warning=2,
+            conventional_time_to_delete=3,
+        )
+        db.session.add(existing)
+        db.session.commit()
+
+    new_stale = 150000
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", str(new_stale))
+
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache") as mock_cache:
+        run(_logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        row = _get_staleness_row(CUSTOM_ORG_ID)
+        assert row is not None
+        assert row.conventional_time_to_stale == new_stale
+        assert row.conventional_time_to_stale_warning == CUSTOM_WARNING
+        assert row.conventional_time_to_delete == CUSTOM_DELETE
+        mock_cache.delete.assert_called_once_with(CUSTOM_ORG_ID)
+
+
+def test_run_partial_create_uses_system_defaults(flask_app, monkeypatch):
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", str(CUSTOM_STALE))
+    monkeypatch.setenv("DRY_RUN", "false")
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE_WARNING", raising=False)
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_DELETE", raising=False)
+
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache"):
+        run(_logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        row = _get_staleness_row(CUSTOM_ORG_ID)
+        assert row is not None
+        assert row.conventional_time_to_stale == CUSTOM_STALE
+        assert row.conventional_time_to_stale_warning == CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+        assert row.conventional_time_to_delete == CONVENTIONAL_TIME_TO_DELETE_SECONDS
+
+
+def test_run_partial_update_preserves_existing(flask_app, monkeypatch):
+    with flask_app.app.app_context():
+        existing = Staleness(
+            org_id=CUSTOM_ORG_ID,
+            conventional_time_to_stale=CUSTOM_STALE,
+            conventional_time_to_stale_warning=CUSTOM_WARNING,
+            conventional_time_to_delete=CUSTOM_DELETE,
+        )
+        db.session.add(existing)
+        db.session.commit()
+
+    new_delete = 5000000
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", str(new_delete))
+    monkeypatch.setenv("DRY_RUN", "false")
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE", raising=False)
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE_WARNING", raising=False)
+
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache"):
+        run(_logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        row = _get_staleness_row(CUSTOM_ORG_ID)
+        assert row is not None
+        assert row.conventional_time_to_stale == CUSTOM_STALE
+        assert row.conventional_time_to_stale_warning == CUSTOM_WARNING
+        assert row.conventional_time_to_delete == new_delete
+
+
+def test_run_dry_run_does_not_write(flask_app, monkeypatch):
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", str(CUSTOM_STALE))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE_WARNING", str(CUSTOM_WARNING))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", str(CUSTOM_DELETE))
+    monkeypatch.setenv("DRY_RUN", "true")
+
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache") as mock_cache:
+        run(_logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        assert _get_staleness_row(CUSTOM_ORG_ID) is None
+        mock_cache.delete.assert_not_called()
+
+
+def test_run_missing_org_id_exits(flask_app, monkeypatch):
+    monkeypatch.setenv("STALENESS_ORG_ID", "")
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", "100")
+
+    session = db.session
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(_logger, session, flask_app)
+    assert exc_info.value.code == 1
+
+
+def test_run_no_staleness_env_vars_exits(flask_app, monkeypatch):
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE", raising=False)
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE_WARNING", raising=False)
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_DELETE", raising=False)
+
+    session = db.session
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(_logger, session, flask_app)
+    assert exc_info.value.code == 1
+
+
+def test_run_invalid_values_exits(flask_app, monkeypatch):
+    """stale >= warning should fail schema validation."""
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", "500000")
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE_WARNING", "100")
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", "3000000")
+    monkeypatch.setenv("DRY_RUN", "false")
+
+    session = db.session
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(_logger, session, flask_app)
+    assert exc_info.value.code == 1
+
+    with flask_app.app.app_context():
+        assert _get_staleness_row(CUSTOM_ORG_ID) is None
+
+
+def test_run_dry_run_defaults_to_true_when_unset(flask_app, monkeypatch):
+    """DRY_RUN should default to true when the env var is not set."""
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", str(CUSTOM_STALE))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE_WARNING", str(CUSTOM_WARNING))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", str(CUSTOM_DELETE))
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache") as mock_cache:
+        run(_logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        assert _get_staleness_row(CUSTOM_ORG_ID) is None
+        mock_cache.delete.assert_not_called()

--- a/tests/test_jobs/test_synchronizer.py
+++ b/tests/test_jobs/test_synchronizer.py
@@ -9,7 +9,6 @@ from jobs.host_sync_group_data import run as host_group_sync_run
 from jobs.host_synchronizer import run as host_synchronizer_run
 from tests.helpers.db_utils import minimal_db_host
 from tests.helpers.mq_utils import assert_synchronize_event_is_valid
-from tests.helpers.test_utils import get_staleness_timestamps
 
 
 @pytest.mark.parametrize("ungrouped", [True, False])
@@ -24,9 +23,7 @@ def test_synchronize_host_event(
     inventory_config,
     ungrouped,
 ):
-    staleness_timestamps = get_staleness_timestamps()
-
-    host = minimal_db_host(stale_timestamp=staleness_timestamps["culled"], reporter="some reporter")
+    host = minimal_db_host(reporter="some reporter")
     created_host = db_create_host(host=host)
 
     created_group = db_create_group("sync-test-group", ungrouped=ungrouped)
@@ -87,9 +84,7 @@ def test_synchronize_grouped_host_event(
     inventory_config,
     ungrouped,
 ):
-    staleness_timestamps = get_staleness_timestamps()
-
-    host = minimal_db_host(stale_timestamp=staleness_timestamps["culled"], reporter="some reporter")
+    host = minimal_db_host(reporter="some reporter")
     created_host = db_create_host(host=host)
     created_host_id = created_host.id
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -254,24 +254,19 @@ def test_host_schema_invalid_tags(tags):
     assert error_messages["tags"] == {0: {"key": ["Missing data for required field."]}}
 
 
-@pytest.mark.parametrize("missing_field", ["reporter"])
-def test_host_models_missing_fields(missing_field):
+def test_host_models_missing_reporter_field():
     limited_values = {
         "account": USER_IDENTITY["account_number"],
         "fqdn": "foo.qoo.doo.noo",
         "system_profile_facts": {"number_of_cpus": 1},
     }
-    if missing_field in limited_values:
-        limited_values[missing_field] = None
 
-    # LimitedHost should be fine with these missing values
+    # LimitedHost should be fine with the missing reporter
     LimitedHost(**limited_values)
 
-    values = {**limited_values, "reporter": "reporter", "org_id": USER_IDENTITY["org_id"]}
-    if missing_field in values:
-        values[missing_field] = None
+    values = {**limited_values, "org_id": USER_IDENTITY["org_id"]}
 
-    # Host should complain about the missing values
+    # Host should complain about the missing reporter field
     with pytest.raises(ValidationException):
         Host(**values)
 
@@ -1180,24 +1175,6 @@ def test_delete_staleness_culling(db_create_staleness_culling, db_delete_stalene
     assert created_acc_st_cull
     db_delete_staleness_culling(created_acc_st_cull.org_id)
     assert not db_get_staleness_culling(acc_st_cull.org_id)
-
-
-def test_create_host_via_schema_ignores_stale_timestamp_in_payload(db_create_host, db_get_host):
-    """Ingress may still send ``stale_timestamp``; ORM create must not require or persist it."""
-    loaded = HostSchema().load(
-        {
-            "subscription_manager_id": generate_uuid(),
-            "reporter": "test_reporter",
-            "org_id": USER_IDENTITY["org_id"],
-            "stale_timestamp": now().isoformat(),
-        }
-    )
-    host = HostSchema.build_model(loaded, {}, {})
-    created_host = db_create_host(SYSTEM_IDENTITY, host=host)
-    retrieved_host = db_get_host(created_host.id)
-
-    assert retrieved_host.reporter == created_host.reporter
-    assert retrieved_host.last_check_in is not None
 
 
 def test_create_host_with_canonical_facts(db_create_host, db_get_host):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -271,20 +271,6 @@ def test_host_models_missing_reporter_field():
         Host(**values)
 
 
-def test_host_schema_timezone_enforced():
-    host = {
-        "fqdn": "scooby.doo.com",
-        "display_name": "display_name",
-        "account": USER_IDENTITY["account_number"],
-        "stale_timestamp": now().replace(tzinfo=None).isoformat(),
-        "reporter": "test",
-    }
-    with pytest.raises(MarshmallowValidationError) as exception:
-        HostSchema().load(host)
-
-    assert "Not a valid aware datetime" in str(exception.value)
-
-
 @pytest.mark.parametrize(
     "tags",
     [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -88,7 +88,6 @@ def test_update_existing_host_fix_display_name_using_existing_fqdn(db_create_hos
         insights_id=insights_id,
         display_name="",
         reporter="puptoo",
-        stale_timestamp=now(),
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host.update(input_host)
@@ -114,7 +113,6 @@ def test_update_existing_host_display_name_changing_fqdn(db_create_host):
         insights_id=insights_id,
         display_name="",
         reporter="puptoo",
-        stale_timestamp=now(),
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host.update(input_host)
@@ -136,7 +134,6 @@ def test_update_existing_host_update_display_name_from_id_using_existing_fqdn(db
         insights_id=insights_id,
         fqdn=expected_fqdn,
         reporter="puptoo",
-        stale_timestamp=now(),
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host.update(input_host)
@@ -163,7 +160,6 @@ def test_update_existing_host_fix_display_name_using_input_fqdn(db_create_host):
         subscription_manager_id=subman_id,
         display_name="",
         reporter="puptoo",
-        stale_timestamp=now(),
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host.update(input_host)
@@ -194,7 +190,6 @@ def test_update_existing_host_fix_display_name_using_id(db_create_host):
         insights_id=insights_id,
         display_name="",
         reporter="puptoo",
-        stale_timestamp=now(),
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host.update(input_host)
@@ -259,7 +254,7 @@ def test_host_schema_invalid_tags(tags):
     assert error_messages["tags"] == {0: {"key": ["Missing data for required field."]}}
 
 
-@pytest.mark.parametrize("missing_field", ["stale_timestamp", "reporter"])
+@pytest.mark.parametrize("missing_field", ["reporter"])
 def test_host_models_missing_fields(missing_field):
     limited_values = {
         "account": USER_IDENTITY["account_number"],
@@ -272,7 +267,7 @@ def test_host_models_missing_fields(missing_field):
     # LimitedHost should be fine with these missing values
     LimitedHost(**limited_values)
 
-    values = {**limited_values, "stale_timestamp": now(), "reporter": "reporter", "org_id": USER_IDENTITY["org_id"]}
+    values = {**limited_values, "reporter": "reporter", "org_id": USER_IDENTITY["org_id"]}
     if missing_field in values:
         values[missing_field] = None
 
@@ -410,7 +405,6 @@ def test_host_model_default_id(db_create_host):
         account=USER_IDENTITY["account_number"],
         subscription_manager_id=generate_uuid(),
         reporter="yupana",
-        stale_timestamp=now(),
         org_id=USER_IDENTITY["org_id"],
     )
     db_create_host(host=host)
@@ -423,7 +417,6 @@ def test_host_model_default_timestamps(db_create_host):
         account=USER_IDENTITY["account_number"],
         subscription_manager_id=generate_uuid(),
         reporter="yupana",
-        stale_timestamp=now(),
         org_id=USER_IDENTITY["org_id"],
     )
 
@@ -437,48 +430,11 @@ def test_host_model_default_timestamps(db_create_host):
     assert host.modified_on < after_commit
 
 
-def test_host_stale_timestamp_nullable_on_insert(db_create_host):
-    """The hosts table allows inserting a row with stale_timestamp NULL."""
-    host = Host(
-        account=USER_IDENTITY["account_number"],
-        subscription_manager_id=generate_uuid(),
-        reporter="yupana",
-        org_id=USER_IDENTITY["org_id"],
-    )
-    host.stale_timestamp = None
-    db_create_host(host=host)
-    db.session.refresh(host)
-    assert host.stale_timestamp is None
-
-
-def test_host_stale_timestamp_nullable_update_to_null(db_create_host):
-    """An existing row may update stale_timestamp from a value to NULL."""
-    host = Host(
-        account=USER_IDENTITY["account_number"],
-        subscription_manager_id=generate_uuid(),
-        reporter="yupana",
-        org_id=USER_IDENTITY["org_id"],
-    )
-    db_create_host(host=host)
-    assert host.stale_timestamp is None
-
-    host.stale_timestamp = now()
-    db.session.commit()
-    db.session.refresh(host)
-    assert host.stale_timestamp is not None
-
-    host.stale_timestamp = None
-    db.session.commit()
-    db.session.refresh(host)
-    assert host.stale_timestamp is None
-
-
 def test_host_model_updated_timestamp(db_create_host):
     host = Host(
         account=USER_IDENTITY["account_number"],
         subscription_manager_id=generate_uuid(),
         reporter="yupana",
-        stale_timestamp=now(),
         org_id=USER_IDENTITY["org_id"],
     )
 
@@ -499,7 +455,6 @@ def test_host_model_timestamp_timezones(db_create_host):
     host = Host(
         account=USER_IDENTITY["account_number"],
         subscription_manager_id=generate_uuid(),
-        stale_timestamp=now(),
         reporter="ingress",
         org_id=USER_IDENTITY["org_id"],
     )
@@ -518,7 +473,6 @@ def test_host_model_constraints(field, value, db_create_host):
     values = {
         "account": USER_IDENTITY["account_number"],
         "subscription_manager_id": generate_uuid(),
-        "stale_timestamp": now(),
         "org_id": USER_IDENTITY["org_id"],
         **{field: value},
     }
@@ -533,13 +487,10 @@ def test_host_model_constraints(field, value, db_create_host):
 
 
 def test_create_host_sets_per_reporter_staleness(db_create_host, models_datetime_mock):
-    stale_timestamp = models_datetime_mock + timedelta(days=1)
-
     input_host = Host(
         subscription_manager_id=generate_uuid(),
         display_name="display_name",
         reporter="puptoo",
-        stale_timestamp=stale_timestamp,
         org_id=USER_IDENTITY["org_id"],
     )
     created_host = db_create_host(host=input_host)
@@ -549,14 +500,11 @@ def test_create_host_sets_per_reporter_staleness(db_create_host, models_datetime
 
 
 def test_update_per_reporter_staleness(db_create_host, models_datetime_mock):
-    puptoo_stale_timestamp = models_datetime_mock + timedelta(days=1)
-
     subman_id = generate_uuid()
     input_host = Host(
         subscription_manager_id=subman_id,
         display_name="display_name",
         reporter="puptoo",
-        stale_timestamp=puptoo_stale_timestamp,
         org_id=USER_IDENTITY["org_id"],
     )
 
@@ -565,13 +513,10 @@ def test_update_per_reporter_staleness(db_create_host, models_datetime_mock):
     # per_reporter_staleness now stores only last_check_in timestamp strings
     assert existing_host.per_reporter_staleness == {"puptoo": models_datetime_mock.isoformat()}
 
-    puptoo_stale_timestamp += timedelta(days=1)
-
     update_host = Host(
         subscription_manager_id=subman_id,
         display_name="display_name",
         reporter="puptoo",
-        stale_timestamp=puptoo_stale_timestamp,
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host.update(update_host)
@@ -579,13 +524,10 @@ def test_update_per_reporter_staleness(db_create_host, models_datetime_mock):
     # datetime will not change because the datetime.now() method is patched
     assert existing_host.per_reporter_staleness == {"puptoo": models_datetime_mock.isoformat()}
 
-    yupana_stale_timestamp = puptoo_stale_timestamp + timedelta(days=1)
-
     update_host = Host(
         subscription_manager_id=subman_id,
         display_name="display_name",
         reporter="yupana",
-        stale_timestamp=yupana_stale_timestamp,
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host.update(update_host)
@@ -599,26 +541,21 @@ def test_update_per_reporter_staleness(db_create_host, models_datetime_mock):
 
 @pytest.mark.parametrize("new_reporter", ("satellite", "discovery"))
 def test_update_per_reporter_staleness_yupana_replacement(db_create_host, models_datetime_mock, new_reporter):
-    yupana_stale_timestamp = models_datetime_mock + timedelta(days=1)
     subman_id = generate_uuid()
     input_host = Host(
         subscription_manager_id=subman_id,
         display_name="display_name",
         reporter="yupana",
-        stale_timestamp=yupana_stale_timestamp,
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host = db_create_host(host=input_host)
 
     assert existing_host.per_reporter_staleness == {"yupana": models_datetime_mock.isoformat()}
 
-    yupana_stale_timestamp += timedelta(days=1)
-
     update_host = Host(
         subscription_manager_id=subman_id,
         display_name="display_name",
         reporter=new_reporter,
-        stale_timestamp=yupana_stale_timestamp,
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host.update(update_host)
@@ -630,13 +567,11 @@ def test_update_per_reporter_staleness_yupana_replacement(db_create_host, models
 
 def test_reporter_stale_non_string_scalar_errors(db_create_host):
     """Non-string JSONB values must not be treated as stale; reject with ValidationException."""
-    stale_timestamp = now() + timedelta(days=1)
     host = db_create_host(
         host=Host(
             subscription_manager_id=generate_uuid(),
             display_name="display_name",
             reporter="puptoo",
-            stale_timestamp=stale_timestamp,
             org_id=USER_IDENTITY["org_id"],
         )
     )
@@ -1247,20 +1182,22 @@ def test_delete_staleness_culling(db_create_staleness_culling, db_delete_stalene
     assert not db_get_staleness_culling(acc_st_cull.org_id)
 
 
-def test_create_host_validate_staleness(db_create_host, db_get_host):
-    host_data = {
-        "subscription_manager_id": generate_uuid(),
-        "stale_timestamp": now(),
-        "reporter": "test_reporter",
-    }
-
-    created_host = db_create_host(SYSTEM_IDENTITY, extra_data=host_data)
+def test_create_host_via_schema_ignores_stale_timestamp_in_payload(db_create_host, db_get_host):
+    """Ingress may still send ``stale_timestamp``; ORM create must not require or persist it."""
+    loaded = HostSchema().load(
+        {
+            "subscription_manager_id": generate_uuid(),
+            "reporter": "test_reporter",
+            "org_id": USER_IDENTITY["org_id"],
+            "stale_timestamp": now().isoformat(),
+        }
+    )
+    host = HostSchema.build_model(loaded, {}, {})
+    created_host = db_create_host(SYSTEM_IDENTITY, host=host)
     retrieved_host = db_get_host(created_host.id)
 
-    assert retrieved_host.stale_timestamp is None
-    assert retrieved_host.stale_warning_timestamp is None
-    assert retrieved_host.deletion_timestamp is None
-    assert retrieved_host.reporter == host_data["reporter"]
+    assert retrieved_host.reporter == created_host.reporter
+    assert retrieved_host.last_check_in is not None
 
 
 def test_create_host_with_canonical_facts(db_create_host, db_get_host):
@@ -1831,7 +1768,6 @@ def test_host_init_raises_when_no_canonical_facts():
             account=USER_IDENTITY["account_number"],
             org_id=USER_IDENTITY["org_id"],
             reporter="test",
-            stale_timestamp=now(),
         )
 
 
@@ -1846,7 +1782,6 @@ def test_host_init_raises_when_only_non_id_canonical_facts():
             account=USER_IDENTITY["account_number"],
             org_id=USER_IDENTITY["org_id"],
             reporter="test",
-            stale_timestamp=now(),
             fqdn="only-fqdn.example.com",
         )
 
@@ -1866,7 +1801,6 @@ def test_host_init_with_subscription_manager_id_sets_id(flask_app):
             account=USER_IDENTITY["account_number"],
             org_id=USER_IDENTITY["org_id"],
             reporter="test",
-            stale_timestamp=now(),
             subscription_manager_id=subscription_manager_id,
         )
 
@@ -2698,14 +2632,13 @@ def test_host_schema_logs_partial_migration_state(mocker):
     assert "sending_both_formats=True" in call_args  # Mixed state
 
 
-def test_update_display_name_skips_when_unchanged(db_create_host, models_datetime_mock):
+def test_update_display_name_skips_when_unchanged(db_create_host):
     """When display_name and reporter are the same, no assignment should happen."""
     insights_id = generate_uuid()
     input_host = Host(
         insights_id=insights_id,
         display_name="my-host",
         reporter="puptoo",
-        stale_timestamp=models_datetime_mock + timedelta(days=1),
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host = db_create_host(host=input_host)
@@ -2722,14 +2655,13 @@ def test_update_display_name_skips_when_unchanged(db_create_host, models_datetim
     assert existing_host.display_name_reporter == original_reporter
 
 
-def test_update_display_name_writes_when_changed(db_create_host, models_datetime_mock):
+def test_update_display_name_writes_when_changed(db_create_host):
     """When display_name differs, it should be updated."""
     insights_id = generate_uuid()
     input_host = Host(
         insights_id=insights_id,
         display_name="old-name",
         reporter="puptoo",
-        stale_timestamp=models_datetime_mock + timedelta(days=1),
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host = db_create_host(host=input_host)
@@ -2740,14 +2672,13 @@ def test_update_display_name_writes_when_changed(db_create_host, models_datetime
     assert existing_host.display_name_reporter == "puptoo"
 
 
-def test_update_display_name_writes_when_reporter_changed(db_create_host, models_datetime_mock):
+def test_update_display_name_writes_when_reporter_changed(db_create_host):
     """When display_name is the same but reporter differs, it should update."""
     insights_id = generate_uuid()
     input_host = Host(
         insights_id=insights_id,
         display_name="my-host",
         reporter="puptoo",
-        stale_timestamp=models_datetime_mock + timedelta(days=1),
         org_id=USER_IDENTITY["org_id"],
     )
     existing_host = db_create_host(host=input_host)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1784,17 +1784,17 @@ def test_stale_timestamp_config_serialization_serialize_host_compound(subtests, 
                 for k, v in (("id", uuid4()), ("created_on", now()), ("modified_on", now())):
                     setattr(host, k, v)
 
-            staleness = get_sys_default_staleness()
-            serialized = serialize_host(host, staleness, False)
+                staleness = get_sys_default_staleness()
+                serialized = serialize_host(host, staleness, False)
 
-            assert (
-                _timestamp_to_str(_add_seconds(host.last_check_in, stale_warning_offset_seconds))
-                == serialized["stale_warning_timestamp"]
-            )
-            assert (
-                _timestamp_to_str(_add_seconds(host.last_check_in, culled_offset_seconds))
-                == serialized["culled_timestamp"]
-            )
+                assert (
+                    _timestamp_to_str(_add_seconds(host.last_check_in, stale_warning_offset_seconds))
+                    == serialized["stale_warning_timestamp"]
+                )
+                assert (
+                    _timestamp_to_str(_add_seconds(host.last_check_in, culled_offset_seconds))
+                    == serialized["culled_timestamp"]
+                )
 
 
 def test_serialize_host_lifecycle_fields_from_last_check_in(flask_app):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1190,7 +1190,6 @@ def test_with_all_fields_serialization_deserialize_host_mocked(
             tags=deserialize_tags.return_value,
             tags_alt=[],
             system_profile_facts=host_input["system_profile"],
-            stale_timestamp=host_input["stale_timestamp"],
             reporter=host_input["reporter"],
             groups=host_input["groups"],
             insights_id=host_input.get("insights_id"),
@@ -1268,7 +1267,6 @@ def test_without_facts_serialization_deserialize_host_mocked(
             tags=deserialize_tags.return_value,
             tags_alt=[],
             system_profile_facts=host_input["system_profile"],
-            stale_timestamp=host_input["stale_timestamp"],
             reporter=host_input["reporter"],
             groups=host_input["groups"],
             insights_id=host_input.get("insights_id"),
@@ -1346,7 +1344,6 @@ def test_without_tags_serialization_deserialize_host_mocked(
             tags=deserialize_tags.return_value,
             tags_alt=[],
             system_profile_facts=host_input["system_profile"],
-            stale_timestamp=host_input["stale_timestamp"],
             reporter=host_input["reporter"],
             groups=host_input["groups"],
             insights_id=host_input.get("insights_id"),
@@ -1427,7 +1424,6 @@ def test_without_display_name_serialization_deserialize_host_mocked(
             tags=deserialize_tags.return_value,
             tags_alt=[],
             system_profile_facts=host_input["system_profile"],
-            stale_timestamp=host_input["stale_timestamp"],
             reporter=host_input["reporter"],
             groups=host_input["groups"],
             insights_id=host_input.get("insights_id"),
@@ -1503,7 +1499,6 @@ def test_without_system_profile_serialization_deserialize_host_mocked(
             tags=deserialize_tags.return_value,
             tags_alt=[],
             system_profile_facts={},
-            stale_timestamp=host_input["stale_timestamp"],
             reporter=host_input["reporter"],
             groups=host_input["groups"],
             insights_id=host_input.get("insights_id"),
@@ -1567,7 +1562,6 @@ def test_without_groups_serialization_deserialize_host_mocked(
             tags=deserialize_tags.return_value,
             tags_alt=[],
             system_profile_facts=host_input["system_profile"],
-            stale_timestamp=host_input["stale_timestamp"],
             reporter=host_input["reporter"],
             groups=[],
             insights_id=host_input.get("insights_id"),
@@ -1650,7 +1644,6 @@ def test_with_all_fields_serialization_serialize_host_compound(flask_app):
                 "some namespace": {"some key": "some value"},
                 "another namespace": {"another key": "another value"},
             },
-            "stale_timestamp": now(),
             "tags": {
                 "some namespace": {"some key": ["some value", "another value"], "another key": ["value"]},
                 "another namespace": {"key": ["value"]},
@@ -1717,7 +1710,6 @@ def test_with_only_required_fields_serialization_serialize_host_compound(subtest
                     "reporter": "yupana",
                 }
                 host_init_data = {
-                    "stale_timestamp": now(),
                     "subscription_manager_id": generate_uuid(),
                     **unchanged_data,
                     "facts": {},
@@ -1781,17 +1773,16 @@ def test_stale_timestamp_config_serialization_serialize_host_compound(subtests, 
                 stale_warning_offset_seconds=stale_warning_offset_seconds,
                 culled_offset_seconds=culled_offset_seconds,
             ):
-                stale_timestamp = now() + timedelta(days=1)
-            host = Host(
-                subscription_manager_id=generate_uuid(),
-                facts={},
-                stale_timestamp=stale_timestamp,
-                reporter="some reporter",
-                org_id=USER_IDENTITY["org_id"],
-            )
+                host = Host(
+                    subscription_manager_id=generate_uuid(),
+                    facts={},
+                    reporter="some reporter",
+                    org_id=USER_IDENTITY["org_id"],
+                )
+                host.last_check_in = now() + timedelta(days=1)
 
-            for k, v in (("id", uuid4()), ("created_on", now()), ("modified_on", now())):
-                setattr(host, k, v)
+                for k, v in (("id", uuid4()), ("created_on", now()), ("modified_on", now())):
+                    setattr(host, k, v)
 
             staleness = get_sys_default_staleness()
             serialized = serialize_host(host, staleness, False)
@@ -1806,8 +1797,8 @@ def test_stale_timestamp_config_serialization_serialize_host_compound(subtests, 
             )
 
 
-def test_serialize_host_lifecycle_fields_ignore_persisted_staleness_columns(flask_app):
-    """Serialize API lifecycle timestamps from last_check_in + org offsets, not ORM staleness columns."""
+def test_serialize_host_lifecycle_fields_from_last_check_in(flask_app):
+    """Serialize API lifecycle timestamps from last_check_in + org offsets (compute-on-read)."""
     with flask_app.app.app_context():
         ref = datetime(2019, 6, 15, 8, 30, 0, tzinfo=UTC)
         host = Host(
@@ -1820,16 +1811,9 @@ def test_serialize_host_lifecycle_fields_ignore_persisted_staleness_columns(flas
         host.created_on = now()
         host.modified_on = now()
         host.last_check_in = ref
-        bogus = now() + timedelta(days=365 * 12)
-        host.stale_timestamp = bogus
-        host.stale_warning_timestamp = bogus + timedelta(days=1)
-        host.deletion_timestamp = bogus + timedelta(days=2)
 
         staleness = get_sys_default_staleness()
         expected = get_staleness_timestamps(host, staleness)
-        assert host.stale_timestamp != expected["stale_timestamp"]
-        assert host.stale_warning_timestamp != expected["stale_warning_timestamp"]
-        assert host.deletion_timestamp != expected["culled_timestamp"]
 
         expected_state = Conditions.find_host_state(
             expected["stale_timestamp"],
@@ -1868,8 +1852,6 @@ def test_with_all_fields_serialization_serialize_host_mocked(
             {"namespace": "some namespace", "key": "another key", "value": "value"},
             {"namespace": "another namespace", "key": "key", "value": "value"},
         ]
-        stale_timestamp = now()
-
         unchanged_data = {
             "display_name": "some display name",
             "ansible_host": "some ansible host",
@@ -1883,7 +1865,6 @@ def test_with_all_fields_serialization_serialize_host_mocked(
             **canonical_facts,
             **unchanged_data,
             "facts": facts,
-            "stale_timestamp": stale_timestamp,
             "tags": {
                 "some namespace": {"some key": ["some value", "another value"], "another key": ["value"]},
                 "another namespace": {"key": ["value"]},
@@ -1944,7 +1925,6 @@ def test_non_empty_profile_is_not_changed_serialization_serialize_host_system_pr
             subscription_manager_id=generate_uuid(),
             display_name="some display name",
             system_profile_facts=system_profile_facts,
-            stale_timestamp=now(),
             reporter="yupana",
             org_id=USER_IDENTITY["org_id"],
         )
@@ -1960,7 +1940,6 @@ def test_empty_profile_is_empty_dict_serialization_serialize_host_system_profile
         host = Host(
             subscription_manager_id=generate_uuid(),
             display_name="some display name",
-            stale_timestamp=now(),
             reporter="yupana",
             org_id=USER_IDENTITY["org_id"],
         )


### PR DESCRIPTION
## Jira
[RHINENG-25499](https://issues.redhat.com/browse/RHINENG-25499)

## What
Phase 3 of the compute-on-read migration: drop persisted staleness columns and the covering index on hbi.hosts, and remove application code that depended on them.

## Why
Staleness is now derived at read time from last_check_in and per_reporter_staleness (Stories 1–2). The three timestamp columns and idx_hosts_org_id_deletion_ts (built for (org_id, id, deletion_timestamp)) are redundant and add write/index maintenance cost. This change completes the migration by removing them from the schema and codebase.

## How

1. Alembic upgrade() drops the partitioned index first, then the three columns on hbi.hosts (parent table; propagates to partitions).
2. Host model no longer defines or accepts persisted staleness fields.
3. Culled-host tests set host.last_check_in after create (same pattern as MQ fixtures / group host-count tests) instead of seeding stale_timestamp in extra_data.
4. IQE plugin tests and utilities updated to stop asserting or seeding removed DB columns.

## Testing

- unit tests and IQE tests were adjusted to reflect the new model.
- all tests pass.
**Note**: Downgrade restores nullable columns and the index for dev/ephemeral use only; production rollback is not supported once compute-on-read is the sole source of truth.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-25499]: https://redhat.atlassian.net/browse/RHINENG-25499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Remove persisted staleness columns and index from the hosts data model in favor of compute-on-read based on last_check_in, and update application/test code and IQE plugin accordingly.

Enhancements:
- Drop stale_timestamp, stale_warning_timestamp, and deletion_timestamp columns from the hosts table and remove the covering index used for host staleness queries.
- Update the Host ORM model, schemas, query projections, utilities, and instrumentation to stop exposing or depending on persisted staleness columns and rely on last_check_in and per_reporter_staleness instead.
- Adjust IQE host-inventory plugin data generation, DB models, Kafka helpers, and staleness utilities to treat last_check_in as the source for lifecycle timestamps and staleness behavior.

Documentation:
- Clarify staleness-related requirements in the IQE plugin requirements to remove references to reporters setting a global stale_timestamp and persisted staleness columns.

Tests:
- Refactor unit, API, MQ, culling, staleness, and job synchronizer tests to stop seeding or asserting stale_timestamp-related fields and validate behavior based on last_check_in and per_reporter_staleness.
- Update IQE REST and cache tests to use last_check_in in payloads and expectations, and relax assertions that previously required non-null DB staleness columns.

[SWATCH-5008]: https://redhat.atlassian.net/browse/SWATCH-5008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Remove persisted staleness fields from the host data model and rely on last_check_in and per_reporter_staleness for lifecycle computation.

Enhancements:
- Drop host-level staleness columns from the ORM model, query projections, and instrumentation, and stop accepting stale_timestamp in API payloads.
- Adjust helper utilities and serializers to compute lifecycle timestamps from last_check_in and per_reporter_staleness instead of persisted staleness columns.
- Update culling, synchronization, and custom staleness flows to use last_check_in when marking or filtering culled hosts.

Documentation:
- Refresh IQE plugin requirements and helper comments to remove references to reporters setting global stale_timestamp or persisted staleness columns.

Tests:
- Refactor unit, MQ, API, culling, and job synchronizer tests to stop seeding or asserting stale_timestamp-related fields and validate behavior based on last_check_in and per_reporter_staleness.
- Update IQE plugin DB models, data generators, REST tests, and staleness utilities to remove dependencies on persisted staleness columns and to assert behavior using last_check_in-driven staleness.

Chores:
- Add an Alembic migration that drops the hosts staleness columns and the covering index, with a dev-only downgrade path that restores nullable columns and the index.