### PR TITLE
test: add IQE requirement IDs for host-views SP tests

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/conf/requirements.yaml
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/conf/requirements.yaml
@@ -807,3 +807,11 @@ inv-host-views-sorting:
 inv-host-views-sparse-fields:
   summary: Users can request specific fields through the `GET /beta/hosts-view` endpoint using sparse fieldsets
   priority: high
+
+inv-host-views-sp-filter:
+  summary: Users can filter by system_profile fields on the `GET /beta/hosts-view` endpoint
+  priority: high
+
+inv-host-views-sp-fields:
+  summary: Users can request specific system_profile fields on the `GET /beta/hosts-view` endpoint
+  priority: high


### PR DESCRIPTION
## Jira
N/A

## What
Add missing IQE test requirement IDs `inv-host-views-sp-filter` and `inv-host-views-sp-fields` to `requirements.yaml`.

## Why
The `iqe-tests-metadata` pre-commit hook fails with M767 errors because 6 tests in `test_host_views_filter.py` and `test_host_views_sparse_fields.py` reference these requirement IDs, but they are not defined in the requirements registry.

## How
Added the two new requirement entries to `iqe_host_inventory/conf/requirements.yaml` with a summary and `priority: high`, matching the conventions of the existing host-views requirements.

## Testing
Verified that the requirement IDs referenced in all 6 failing test docstrings now match entries in `requirements.yaml`.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Tests:
- Align test requirement metadata by adding registry entries for host-views system_profile filter and sparse fields coverage.