### PR TITLE
refactor(RHINENG-26658): split OTEL_HTTP_ENABLED into inbound/outbound

### DIFF
--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -34,7 +34,8 @@ logger = get_logger(__name__)
 OTEL_ENABLED = os.getenv("OTEL_ENABLED", "false").lower() == "true"
 OTEL_SQL_ENABLED = os.getenv("OTEL_SQL_ENABLED", "true").lower() == "true"
 OTEL_SQL_COMMENTER_ENABLED = os.getenv("OTEL_SQL_COMMENTER_ENABLED", "false").lower() == "true"
-OTEL_HTTP_ENABLED = os.getenv("OTEL_HTTP_ENABLED", "true").lower() == "true"
+OTEL_HTTP_INBOUND_ENABLED = os.getenv("OTEL_HTTP_INBOUND_ENABLED", "true").lower() == "true"
+OTEL_HTTP_OUTBOUND_ENABLED = os.getenv("OTEL_HTTP_OUTBOUND_ENABLED", "true").lower() == "true"
 OTEL_MQ_ENABLED = os.getenv("OTEL_MQ_ENABLED", "true").lower() == "true"
 OTEL_SAMPLING_RATE = min(max(float(os.getenv("OTEL_SAMPLING_RATE", "1.0")), 0.0), 1.0)
 
@@ -132,7 +133,7 @@ def init_otel(service_name: str, service_version: str = "unknown"):
     _otel_initialized_pid = os.getpid()
     logger.info("OpenTelemetry initialized for service=%s version=%s", service_name, service_version)
     logger.info(
-        "OpenTelemetry config: sampling=%.2f sql=%s commenter=%s http=%s "
+        "OpenTelemetry config: sampling=%.2f sql=%s commenter=%s http_inbound=%s http_outbound=%s "
         "bsp_queue=%d bsp_batch=%d bsp_delay=%dms bsp_timeout=%dms "
         "compression=%s attr_limit=%d attr_len_limit=%d "
         "mq_enabled=%s "
@@ -140,7 +141,8 @@ def init_otel(service_name: str, service_version: str = "unknown"):
         OTEL_SAMPLING_RATE,
         OTEL_SQL_ENABLED,
         OTEL_SQL_COMMENTER_ENABLED,
-        OTEL_HTTP_ENABLED,
+        OTEL_HTTP_INBOUND_ENABLED,
+        OTEL_HTTP_OUTBOUND_ENABLED,
         OTEL_BSP_MAX_QUEUE_SIZE,
         OTEL_BSP_MAX_EXPORT_BATCH_SIZE,
         OTEL_BSP_SCHEDULE_DELAY,
@@ -160,7 +162,7 @@ def instrument_flask_app(flask_app):
     Each HTTP request becomes a span with method, path, status code,
     plus HBI-specific attributes (org_id, request_id).
     """
-    if not OTEL_ENABLED:
+    if not OTEL_ENABLED or not OTEL_HTTP_INBOUND_ENABLED:
         return
 
     from opentelemetry.instrumentation.flask import FlaskInstrumentor
@@ -231,11 +233,11 @@ def instrument_kafka_consumer(consumer):
 def instrument_outbound_http():
     """Instrument outbound HTTP calls (e.g., RBAC) with OpenTelemetry.
 
-    Controlled by OTEL_HTTP_ENABLED. Automatically creates spans for all
+    Controlled by OTEL_HTTP_OUTBOUND_ENABLED. Automatically creates spans for all
     requests made via the `requests` library, including trace context
     propagation to downstream services.
     """
-    if not OTEL_ENABLED or not OTEL_HTTP_ENABLED:
+    if not OTEL_ENABLED or not OTEL_HTTP_OUTBOUND_ENABLED:
         return
 
     from opentelemetry.instrumentation.requests import RequestsInstrumentor

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -276,8 +276,10 @@ objects:
             value: ${OTEL_SQL_ENABLED}
           - name: OTEL_SQL_COMMENTER_ENABLED
             value: ${OTEL_SQL_COMMENTER_ENABLED}
-          - name: OTEL_HTTP_ENABLED
-            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_HTTP_INBOUND_ENABLED
+            value: ${OTEL_HTTP_INBOUND_ENABLED}
+          - name: OTEL_HTTP_OUTBOUND_ENABLED
+            value: ${OTEL_HTTP_OUTBOUND_ENABLED}
           - name: OTEL_SAMPLING_RATE
             value: ${OTEL_SAMPLING_RATE}
           - name: OTEL_BSP_MAX_QUEUE_SIZE
@@ -413,8 +415,10 @@ objects:
             value: ${OTEL_SQL_ENABLED}
           - name: OTEL_SQL_COMMENTER_ENABLED
             value: ${OTEL_SQL_COMMENTER_ENABLED}
-          - name: OTEL_HTTP_ENABLED
-            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_HTTP_INBOUND_ENABLED
+            value: ${OTEL_HTTP_INBOUND_ENABLED}
+          - name: OTEL_HTTP_OUTBOUND_ENABLED
+            value: ${OTEL_HTTP_OUTBOUND_ENABLED}
           - name: OTEL_SAMPLING_RATE
             value: ${OTEL_SAMPLING_RATE}
           - name: OTEL_BSP_MAX_QUEUE_SIZE
@@ -569,8 +573,10 @@ objects:
             value: ${OTEL_SQL_ENABLED}
           - name: OTEL_SQL_COMMENTER_ENABLED
             value: ${OTEL_SQL_COMMENTER_ENABLED}
-          - name: OTEL_HTTP_ENABLED
-            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_HTTP_INBOUND_ENABLED
+            value: ${OTEL_HTTP_INBOUND_ENABLED}
+          - name: OTEL_HTTP_OUTBOUND_ENABLED
+            value: ${OTEL_HTTP_OUTBOUND_ENABLED}
           - name: OTEL_SAMPLING_RATE
             value: ${OTEL_SAMPLING_RATE}
           - name: OTEL_BSP_MAX_QUEUE_SIZE
@@ -672,8 +678,10 @@ objects:
             value: ${OTEL_SQL_ENABLED}
           - name: OTEL_SQL_COMMENTER_ENABLED
             value: ${OTEL_SQL_COMMENTER_ENABLED}
-          - name: OTEL_HTTP_ENABLED
-            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_HTTP_INBOUND_ENABLED
+            value: ${OTEL_HTTP_INBOUND_ENABLED}
+          - name: OTEL_HTTP_OUTBOUND_ENABLED
+            value: ${OTEL_HTTP_OUTBOUND_ENABLED}
           - name: OTEL_SAMPLING_RATE
             value: ${OTEL_SAMPLING_RATE}
           - name: OTEL_BSP_MAX_QUEUE_SIZE
@@ -813,8 +821,10 @@ objects:
             value: ${OTEL_SQL_ENABLED}
           - name: OTEL_SQL_COMMENTER_ENABLED
             value: ${OTEL_SQL_COMMENTER_ENABLED}
-          - name: OTEL_HTTP_ENABLED
-            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_HTTP_INBOUND_ENABLED
+            value: ${OTEL_HTTP_INBOUND_ENABLED}
+          - name: OTEL_HTTP_OUTBOUND_ENABLED
+            value: ${OTEL_HTTP_OUTBOUND_ENABLED}
           - name: OTEL_SAMPLING_RATE
             value: ${OTEL_SAMPLING_RATE}
           - name: OTEL_BSP_MAX_QUEUE_SIZE
@@ -912,8 +922,10 @@ objects:
             value: ${OTEL_SQL_ENABLED}
           - name: OTEL_SQL_COMMENTER_ENABLED
             value: ${OTEL_SQL_COMMENTER_ENABLED}
-          - name: OTEL_HTTP_ENABLED
-            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_HTTP_INBOUND_ENABLED
+            value: ${OTEL_HTTP_INBOUND_ENABLED}
+          - name: OTEL_HTTP_OUTBOUND_ENABLED
+            value: ${OTEL_HTTP_OUTBOUND_ENABLED}
           - name: OTEL_SAMPLING_RATE
             value: ${OTEL_SAMPLING_RATE}
           - name: OTEL_BSP_MAX_QUEUE_SIZE
@@ -1085,8 +1097,10 @@ objects:
             value: ${OTEL_SQL_ENABLED}
           - name: OTEL_SQL_COMMENTER_ENABLED
             value: ${OTEL_SQL_COMMENTER_ENABLED}
-          - name: OTEL_HTTP_ENABLED
-            value: ${OTEL_HTTP_ENABLED}
+          - name: OTEL_HTTP_INBOUND_ENABLED
+            value: ${OTEL_HTTP_INBOUND_ENABLED}
+          - name: OTEL_HTTP_OUTBOUND_ENABLED
+            value: ${OTEL_HTTP_OUTBOUND_ENABLED}
           - name: OTEL_SAMPLING_RATE
             value: ${OTEL_SAMPLING_RATE}
           - name: OTEL_BSP_MAX_QUEUE_SIZE
@@ -2907,8 +2921,11 @@ parameters:
 - name: OTEL_SQL_COMMENTER_ENABLED
   description: Enable SQLCommenter (adds trace context to SQL comments)
   value: 'false'
-- name: OTEL_HTTP_ENABLED
-  description: Enable outbound HTTP request tracing
+- name: OTEL_HTTP_INBOUND_ENABLED
+  description: Enable Flask inbound HTTP request tracing
+  value: 'true'
+- name: OTEL_HTTP_OUTBOUND_ENABLED
+  description: Enable outbound HTTP request tracing (requests library)
   value: 'true'
 - name: OTEL_SAMPLING_RATE
   description: Trace sampling ratio (0.0-1.0). 1.0 = all traces

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -118,6 +118,32 @@ def test_instrument_flask_app_excludes_ops_urls_but_traces_other_routes(monkeypa
         importlib.reload(telemetry_mod)
 
 
+def test_flask_instrumentation_skipped_when_inbound_disabled(monkeypatch):
+    """instrument_flask_app is a no-op when OTEL_HTTP_INBOUND_ENABLED=false."""
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_HTTP_INBOUND_ENABLED": "false"})
+
+    with patch("opentelemetry.instrumentation.flask.FlaskInstrumentor") as mock_instrumentor:
+        flask_app = MagicMock()
+        telemetry_mod.instrument_flask_app(flask_app)
+        mock_instrumentor.assert_not_called()
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_flask_instrumentation_runs_when_inbound_enabled(monkeypatch):
+    """instrument_flask_app instruments when OTEL_HTTP_INBOUND_ENABLED=true."""
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_HTTP_INBOUND_ENABLED": "true"})
+
+    with patch("opentelemetry.instrumentation.flask.FlaskInstrumentor") as mock_cls:
+        instance = MagicMock()
+        mock_cls.return_value = instance
+        flask_app = MagicMock()
+        telemetry_mod.instrument_flask_app(flask_app)
+        instance.instrument_app.assert_called_once()
+
+    _cleanup_telemetry(monkeypatch)
+
+
 def _reload_telemetry(monkeypatch, env_overrides):
     """Reload the telemetry module with the given env var overrides applied."""
     for key, value in env_overrides.items():
@@ -232,8 +258,8 @@ def test_sql_commenter_toggled_by_env(monkeypatch):
 
 
 def test_http_instrumentation_skipped_when_disabled(monkeypatch):
-    """instrument_outbound_http is a no-op when OTEL_HTTP_ENABLED=false."""
-    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_HTTP_ENABLED": "false"})
+    """instrument_outbound_http is a no-op when OTEL_HTTP_OUTBOUND_ENABLED=false."""
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_HTTP_OUTBOUND_ENABLED": "false"})
 
     with patch("opentelemetry.instrumentation.requests.RequestsInstrumentor") as mock_instrumentor:
         telemetry_mod.instrument_outbound_http()
@@ -243,8 +269,8 @@ def test_http_instrumentation_skipped_when_disabled(monkeypatch):
 
 
 def test_http_instrumentation_runs_when_enabled(monkeypatch):
-    """instrument_outbound_http instruments when OTEL_HTTP_ENABLED=true."""
-    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_HTTP_ENABLED": "true"})
+    """instrument_outbound_http instruments when OTEL_HTTP_OUTBOUND_ENABLED=true."""
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_HTTP_OUTBOUND_ENABLED": "true"})
 
     with patch("opentelemetry.instrumentation.requests.RequestsInstrumentor") as mock_cls:
         instance = MagicMock()
@@ -305,7 +331,8 @@ def test_config_defaults_without_env_vars(monkeypatch):
         "OTEL_MQ_ENABLED",
         "OTEL_SQL_ENABLED",
         "OTEL_SQL_COMMENTER_ENABLED",
-        "OTEL_HTTP_ENABLED",
+        "OTEL_HTTP_INBOUND_ENABLED",
+        "OTEL_HTTP_OUTBOUND_ENABLED",
         "OTEL_SAMPLING_RATE",
         "OTEL_BSP_MAX_QUEUE_SIZE",
         "OTEL_BSP_MAX_EXPORT_BATCH_SIZE",
@@ -326,7 +353,8 @@ def test_config_defaults_without_env_vars(monkeypatch):
     assert telemetry_mod.OTEL_MQ_ENABLED is True
     assert telemetry_mod.OTEL_SQL_ENABLED is True
     assert telemetry_mod.OTEL_SQL_COMMENTER_ENABLED is False
-    assert telemetry_mod.OTEL_HTTP_ENABLED is True
+    assert telemetry_mod.OTEL_HTTP_INBOUND_ENABLED is True
+    assert telemetry_mod.OTEL_HTTP_OUTBOUND_ENABLED is True
     assert telemetry_mod.OTEL_SAMPLING_RATE == 1.0
     assert telemetry_mod.OTEL_BSP_MAX_QUEUE_SIZE == 8192
     assert telemetry_mod.OTEL_BSP_MAX_EXPORT_BATCH_SIZE == 256


### PR DESCRIPTION
## Jira
[RHINENG-26658](https://issues.redhat.com/browse/RHINENG-26658)

## What
Split `OTEL_HTTP_ENABLED` into two independent toggles: `OTEL_HTTP_INBOUND_ENABLED` (Flask request spans) and `OTEL_HTTP_OUTBOUND_ENABLED` (outbound `requests` library spans). Both default to `true` for backward compatibility.

## Why
The existing `OTEL_HTTP_ENABLED` only controlled outbound HTTP tracing, but its name implied it also governed inbound Flask request spans. Flask instrumentation was always active when `OTEL_ENABLED=true` with no way to disable it independently, making phased production rollouts confusing — setting `OTEL_HTTP_ENABLED=false` appeared to disable all HTTP tracing but inbound spans were still emitted.

## How
- Replaced the single `OTEL_HTTP_ENABLED` env var with `OTEL_HTTP_INBOUND_ENABLED` and `OTEL_HTTP_OUTBOUND_ENABLED` in `app/telemetry.py`
- Added an early return in `instrument_flask_app()` when `OTEL_HTTP_INBOUND_ENABLED=false`
- Updated the `instrument_outbound_http()` guard to check `OTEL_HTTP_OUTBOUND_ENABLED`
- Updated the `init_otel` startup log to reflect both new variable names
- Renamed the parameter and added the new one across all 7 deployments in `deploy/clowdapp.yml`

## Testing
- Updated existing outbound HTTP toggle tests to use the new variable name
- Added `test_flask_instrumentation_skipped_when_inbound_disabled` and `test_flask_instrumentation_runs_when_inbound_enabled`
- Updated `test_config_defaults_without_env_vars` to assert both new defaults
- All 23 tests pass

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26658]: https://redhat.atlassian.net/browse/RHINENG-26658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Split HTTP OpenTelemetry configuration into separate inbound and outbound toggles and update telemetry wiring, defaults, and tests accordingly.

New Features:
- Introduce OTEL_HTTP_INBOUND_ENABLED to control Flask inbound HTTP tracing independently of other telemetry.
- Introduce OTEL_HTTP_OUTBOUND_ENABLED to control outbound HTTP tracing via the requests library separately from inbound tracing.

Enhancements:
- Update OpenTelemetry initialization logging to report separate inbound and outbound HTTP tracing flags instead of a single HTTP flag.
- Replace the legacy OTEL_HTTP_ENABLED environment variable across telemetry code and deployment configuration with the new inbound and outbound HTTP toggles.

Tests:
- Extend telemetry tests to cover the new inbound HTTP toggle and adjust existing outbound HTTP toggle tests and default configuration assertions for the split flags.