### PR TITLE
fix(RHINENG-26686): reject empty org_id and improve host app data logging

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -19,6 +19,7 @@ from flask_sqlalchemy.model import Model
 from marshmallow import Schema
 from marshmallow import ValidationError
 from marshmallow import fields
+from marshmallow import validate
 from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 from psycopg2.errors import UniqueViolation
@@ -171,7 +172,7 @@ class HostAppDataSchema(Schema):
 
 
 class HostAppOperationSchema(Schema):
-    org_id = fields.Str(required=True)
+    org_id = fields.Str(required=True, validate=validate.Length(min=1, max=36))
     timestamp = fields.DateTime(required=True)
     hosts = fields.List(fields.Nested(HostAppDataSchema), required=True)
 
@@ -833,6 +834,17 @@ class HostAppMessageConsumer(HBIMessageConsumerBase):
             }
             valid_hosts_list.append(row_data)
 
+            logger.info(
+                "Validated host app data for %s",
+                application,
+                extra={
+                    "application": str(application),
+                    "org_id": org_id,
+                    "host_id": str(host_id),
+                    "validated_data": validated_data,
+                },
+            )
+
         return valid_hosts_list
 
     def _upsert_hosts(
@@ -1063,7 +1075,6 @@ def parse_operation_message(
             _inc_parsing_failure(parsing_failure_metric, "error", application)
             raise
 
-        logger.debug("parsed_message: %s", parsed_operation)
         return parsed_operation
 
 

--- a/tests/test_host_app_mq_service.py
+++ b/tests/test_host_app_mq_service.py
@@ -108,6 +108,14 @@ class TestHostAppMessageConsumerValidation:
         with pytest.raises(ValidationError):
             host_app_consumer.handle_message(json.dumps(message), headers=headers)
 
+    def test_empty_org_id_raises_validation_error(self, host_app_consumer):
+        """Test that an empty org_id is rejected during schema validation."""
+        message = create_host_app_message(org_id="", host_id=generate_uuid(), data={"cves_by_severity_total": 0})
+
+        headers = [("application", b"advisor"), ("request_id", generate_uuid().encode("utf-8"))]
+        with pytest.raises(ValidationError, match="org_id"):
+            host_app_consumer.handle_message(json.dumps(message), headers=headers)
+
 
 class TestHostAppMessageConsumerAllApplications:
     """Test HostAppMessageConsumer with all application types using parametrized tests."""


### PR DESCRIPTION
## Jira
[RHINENG-26686](https://issues.redhat.com/browse/RHINENG-26686)

## What
Reject host app data messages with empty `org_id` at schema validation and add structured INFO-level logging for validated payloads.

## Why
Downstream services were sending Kafka messages with an empty `org_id`, causing the `INSERT ... ON CONFLICT (org_id, host_id) DO UPDATE` to fail silently. The upsert found no conflict (existing row has a valid `org_id`), attempted an INSERT that violated the FK constraint, and logged a misleading "Host no longer exists" warning — even though the host existed. This made fields like `template_uuid` and `policies` appear stale with no clear indication of why. Additionally, when investigating data mismatches (e.g., Malware), there was no way to see the actual payload HBI received because the log was at DEBUG level and not shipped to Kibana.

## How
- Added `validate=validate=validate.Length(min=1, max=36)` to the `org_id` field in `HostAppOperationSchema`, which is shared by all six host app data consumers (Advisor, Vulnerability, Patch, Remediations, Compliance, Malware). Empty `org_id` messages now fail fast with a clear `ValidationError`.
- Added an INFO-level log in `_validate_and_prepare_hosts` with structured `extra` fields (`host_id`, `application`, `org_id`, `validated_data`) so payloads are searchable in Kibana.
- Removed the redundant generic `parsed_message` DEBUG log from `parse_operation_message`.

## Testing
- Added `test_empty_org_id_raises_validation_error` to verify that empty `org_id` is rejected with a `ValidationError`.
- All 38 existing and new tests pass (`uv run pytest tests/test_host_app_mq_service.py`).
- `make style` passes (ruff, mypy, swagger validation).

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26686]: https://redhat.atlassian.net/browse/RHINENG-26686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure host app data messages validate org_id and improve logging of validated payloads.

Bug Fixes:
- Reject host app data messages with an empty org_id via schema validation to prevent invalid upserts from reaching the database.

Enhancements:
- Add structured INFO-level logging of validated host app data, including application, org_id, host_id, and payload details.
- Remove redundant DEBUG-level logging of parsed host app messages to reduce log noise.

Tests:
- Add a test to verify that host app messages with an empty org_id raise a ValidationError during schema validation.