### PR TITLE
chore(deps): Create groups for openapi and otel packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,14 @@
       "at any time"
     ]
   },
-  "pip_requirements": {
-    "enabled": false
-  }
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["^openapi-"],
+      "groupName": "openapi"
+    },
+    {
+      "matchPackagePatterns": ["^opentelemetry-"],
+      "groupName": "opentelemetry"
+    }
+  ]
 }


### PR DESCRIPTION
## Jira
N/A

## What
Updates `renovate.json` with the following changes:

- Create groups for openapi and otel packages
- Remove pip_requirements

## Why
When Konflux tries to update these packages separately, it causes issues dependency chain issues (see #4306).
And I removed the `pip_requirements` config because we no longer update pip dependencies via konflux.

## How
In `renovate.json`, I created a group for openapi and a group for opentelemetry. I also removed the `pip_requirements` config.

## Testing
N/A. After this merges, I'll close the old OTel PR and allow Konflux to open a new one.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Adjust Renovate configuration for dependency update grouping and cleanup.

Build:
- Group OpenAPI-related dependencies together in Renovate to be updated in a single PR.
- Group OpenTelemetry-related dependencies together in Renovate to be updated in a single PR.
- Remove the pip_requirements configuration from Renovate now that pip dependencies are no longer managed via Konflux.