### PR TITLE
fix(RHINENG-26699): rename Kafka batch span from recv to topic

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -370,6 +370,8 @@ class HBIMessageConsumerBase:
 
         batch_span = trace.get_current_span()
         if OTEL_MQ_ENABLED and batch_span.is_recording():
+            topic = valid_messages[0].topic() or "unknown"
+            batch_span.update_name(f"{topic} process")
             batch_span.set_attribute("messaging.batch.message_count", len(valid_messages))
 
         with no_expire_on_commit(db.session):


### PR DESCRIPTION
## Jira
[RHINENG-26699](https://issues.redhat.com/browse/RHINENG-26699)

## What
Rename the Kafka batch consume span from the generic `recv` to `{topic} process` (e.g., `platform.inventory.host-ingress process`).

## Why
The `ConfluentKafkaInstrumentor` hardcodes `recv` as the span name for all consumer operations, making every MQ trace indistinguishable in Grafana. With multiple consumer groups (ingress, system-profile, workspaces, host-app-data), it's impossible to tell which topic a trace belongs to without clicking into each one.

## How
Call `batch_span.update_name(f"{topic} process")` on the current span in `_process_batch()` after messages are consumed. The topic is extracted from the first message in the batch. The naming follows the OpenTelemetry messaging semantic conventions (`{destination} {operation}`). The rename is gated behind the existing `OTEL_MQ_ENABLED` check and only fires when the span is recording.

## Testing
-

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26699]: https://redhat.atlassian.net/browse/RHINENG-26699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Update Kafka batch consume spans to use a `{topic} process` name derived from the first valid message when MQ tracing is enabled.