### PR TITLE
feat(RHINENG-26680): add missing sortable fields for inventory views api

### DIFF
--- a/app/models/host_app_data.py
+++ b/app/models/host_app_data.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect as python_inspect
 from functools import cache
 
+from sqlalchemy import Computed
 from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy import PrimaryKeyConstraint
 from sqlalchemy import inspect
@@ -158,6 +159,7 @@ class HostAppDataPatch(HostAppDataMixin, db.Model):
         "packages_installable",
         "packages_applicable",
         "packages_installed",
+        "template_name",
     )
     __filterable_fields__ = (
         "advisories_rhsa_installable",
@@ -192,7 +194,6 @@ class HostAppDataPatch(HostAppDataMixin, db.Model):
     packages_installable = db.Column(db.Integer, nullable=True)
     packages_installed = db.Column(db.Integer, nullable=True)
 
-    # Template info (not sortable - string/UUID fields)
     template_name = db.Column(db.String(255), nullable=True)
     template_uuid = db.Column(UUID(as_uuid=True), nullable=True)
 
@@ -209,20 +210,21 @@ class HostAppDataRemediations(HostAppDataMixin, db.Model):
 class HostAppDataCompliance(HostAppDataMixin, db.Model):
     __tablename__ = "hosts_app_data_compliance"
     __app_name__ = "compliance"
-    __sortable_fields__ = ("last_scan",)
+    __sortable_fields__ = ("last_scan", "policies_count")
     __filterable_fields__ = ("last_scan",)
 
     policies = db.Column(JSONB, nullable=True)
+    policies_count = db.Column(db.Integer, Computed("jsonb_array_length(COALESCE(policies, '[]'::jsonb))"))
     last_scan = db.Column(db.DateTime(timezone=True), nullable=True)
 
 
 class HostAppDataMalware(HostAppDataMixin, db.Model):
     __tablename__ = "hosts_app_data_malware"
     __app_name__ = "malware"
-    __sortable_fields__ = ("last_matches", "total_matches", "last_scan")
+    __sortable_fields__ = ("last_matches", "total_matches", "last_scan", "last_status")
     __filterable_fields__ = ("last_matches", "total_matches", "last_scan", "last_status")
 
-    last_status = db.Column(db.String(50), nullable=True)  # Not sortable - string field
+    last_status = db.Column(db.String(50), nullable=True)
     last_matches = db.Column(db.Integer, nullable=True)
     total_matches = db.Column(db.Integer, nullable=True)
     last_scan = db.Column(db.DateTime(timezone=True), nullable=True)

--- a/migrations/versions/b3e9f1a2d7c4_add_compliance_policies_count.py
+++ b/migrations/versions/b3e9f1a2d7c4_add_compliance_policies_count.py
@@ -1,0 +1,35 @@
+"""add compliance policies_count generated column
+
+Revision ID: b3e9f1a2d7c4
+Revises: d4f7a2b8c1e3
+Create Date: 2026-05-28 15:10:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.models.constants import INVENTORY_SCHEMA
+
+# revision identifiers, used by Alembic.
+revision = "b3e9f1a2d7c4"
+down_revision = "d4f7a2b8c1e3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "hosts_app_data_compliance",
+        sa.Column(
+            "policies_count",
+            sa.Integer(),
+            sa.Computed("jsonb_array_length(COALESCE(policies, '[]'::jsonb))"),
+            nullable=False,
+        ),
+        schema=INVENTORY_SCHEMA,
+    )
+
+
+def downgrade():
+    op.drop_column("hosts_app_data_compliance", "policies_count", schema=INVENTORY_SCHEMA)

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -1680,14 +1680,34 @@ components:
           # App fields
           - advisor:recommendations
           - advisor:incidents
+          - advisor:critical
+          - advisor:important
+          - advisor:moderate
+          - advisor:low
           - vulnerability:total_cves
           - vulnerability:critical_cves
+          - vulnerability:high_severity_cves
+          - vulnerability:cves_with_security_rules
+          - vulnerability:cves_with_known_exploits
           - patch:advisories_rhsa_installable
+          - patch:advisories_rhba_installable
+          - patch:advisories_rhea_installable
+          - patch:advisories_other_installable
+          - patch:advisories_rhsa_applicable
+          - patch:advisories_rhba_applicable
+          - patch:advisories_rhea_applicable
+          - patch:advisories_other_applicable
           - patch:packages_installable
+          - patch:packages_applicable
+          - patch:packages_installed
+          - patch:template_name
           - remediations:remediations_plans
           - compliance:last_scan
+          - compliance:policies_count
           - malware:last_matches
+          - malware:total_matches
           - malware:last_scan
+          - malware:last_status
     confirmDeleteAll:
       in: query
       name: confirm_delete_all
@@ -2319,6 +2339,10 @@ components:
           nullable: true
           items:
             type: object
+        policies_count:
+          type: integer
+          minimum: 0
+          description: Number of compliance policies (computed from policies array length)
         last_scan:
           type: string
           format: date-time
@@ -2435,35 +2459,75 @@ components:
         **Advisor**
         - `advisor:recommendations` - Number of Advisor recommendations
         - `advisor:incidents` - Number of Advisor incidents
+        - `advisor:critical` - Critical severity recommendations
+        - `advisor:important` - Important severity recommendations
+        - `advisor:moderate` - Moderate severity recommendations
+        - `advisor:low` - Low severity recommendations
 
         **Vulnerability**
         - `vulnerability:total_cves` - Total CVE count
         - `vulnerability:critical_cves` - Critical severity CVEs
+        - `vulnerability:high_severity_cves` - High severity CVEs
+        - `vulnerability:cves_with_security_rules` - CVEs with security rules
+        - `vulnerability:cves_with_known_exploits` - CVEs with known exploits
 
         **Patch**
         - `patch:advisories_rhsa_installable` - Number of RHSA installable advisories
+        - `patch:advisories_rhba_installable` - Number of RHBA installable advisories
+        - `patch:advisories_rhea_installable` - Number of RHEA installable advisories
+        - `patch:advisories_other_installable` - Number of other installable advisories
+        - `patch:advisories_rhsa_applicable` - Number of RHSA applicable advisories
+        - `patch:advisories_rhba_applicable` - Number of RHBA applicable advisories
+        - `patch:advisories_rhea_applicable` - Number of RHEA applicable advisories
+        - `patch:advisories_other_applicable` - Number of other applicable advisories
         - `patch:packages_installable` - Number of installable packages
+        - `patch:packages_applicable` - Number of applicable packages
+        - `patch:packages_installed` - Number of installed packages
+        - `patch:template_name` - Patch template name
 
         **Remediations**
         - `remediations:remediations_plans` - Active remediation plans count
 
         **Compliance**
         - `compliance:last_scan` - Last compliance scan timestamp
+        - `compliance:policies_count` - Number of compliance policies
 
         **Malware**
         - `malware:last_matches` - Malware matches count
+        - `malware:total_matches` - Total malware matches count
         - `malware:last_scan` - Last malware scan timestamp
+        - `malware:last_status` - Last malware detection status
       enum:
         - advisor:recommendations
         - advisor:incidents
+        - advisor:critical
+        - advisor:important
+        - advisor:moderate
+        - advisor:low
         - vulnerability:total_cves
         - vulnerability:critical_cves
+        - vulnerability:high_severity_cves
+        - vulnerability:cves_with_security_rules
+        - vulnerability:cves_with_known_exploits
         - patch:advisories_rhsa_installable
+        - patch:advisories_rhba_installable
+        - patch:advisories_rhea_installable
+        - patch:advisories_other_installable
+        - patch:advisories_rhsa_applicable
+        - patch:advisories_rhba_applicable
+        - patch:advisories_rhea_applicable
+        - patch:advisories_other_applicable
         - patch:packages_installable
+        - patch:packages_applicable
+        - patch:packages_installed
+        - patch:template_name
         - remediations:remediations_plans
         - compliance:last_scan
+        - compliance:policies_count
         - malware:last_matches
+        - malware:total_matches
         - malware:last_scan
+        - malware:last_status
     SystemProfileByHostOut:
       title: A host system profile query result
       description: Structure of the output of the host system profile query

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -2536,14 +2536,34 @@
             "last_check_in",
             "advisor:recommendations",
             "advisor:incidents",
+            "advisor:critical",
+            "advisor:important",
+            "advisor:moderate",
+            "advisor:low",
             "vulnerability:total_cves",
             "vulnerability:critical_cves",
+            "vulnerability:high_severity_cves",
+            "vulnerability:cves_with_security_rules",
+            "vulnerability:cves_with_known_exploits",
             "patch:advisories_rhsa_installable",
+            "patch:advisories_rhba_installable",
+            "patch:advisories_rhea_installable",
+            "patch:advisories_other_installable",
+            "patch:advisories_rhsa_applicable",
+            "patch:advisories_rhba_applicable",
+            "patch:advisories_rhea_applicable",
+            "patch:advisories_other_applicable",
             "patch:packages_installable",
+            "patch:packages_applicable",
+            "patch:packages_installed",
+            "patch:template_name",
             "remediations:remediations_plans",
             "compliance:last_scan",
+            "compliance:policies_count",
             "malware:last_matches",
-            "malware:last_scan"
+            "malware:total_matches",
+            "malware:last_scan",
+            "malware:last_status"
           ]
         }
       },
@@ -3424,6 +3444,11 @@
               "type": "object"
             }
           },
+          "policies_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of compliance policies (computed from policies array length)"
+          },
           "last_scan": {
             "type": "string",
             "format": "date-time",
@@ -3551,18 +3576,38 @@
       },
       "AppSortableFields": {
         "type": "string",
-        "description": "Application data fields available for sorting in the /hosts-view endpoint.\nUse format `app_name:field_name` with the `order_by` parameter.\n\n**Advisor**\n- `advisor:recommendations` - Number of Advisor recommendations\n- `advisor:incidents` - Number of Advisor incidents\n\n**Vulnerability**\n- `vulnerability:total_cves` - Total CVE count\n- `vulnerability:critical_cves` - Critical severity CVEs\n\n**Patch**\n- `patch:advisories_rhsa_installable` - Number of RHSA installable advisories\n- `patch:packages_installable` - Number of installable packages\n\n**Remediations**\n- `remediations:remediations_plans` - Active remediation plans count\n\n**Compliance**\n- `compliance:last_scan` - Last compliance scan timestamp\n\n**Malware**\n- `malware:last_matches` - Malware matches count\n- `malware:last_scan` - Last malware scan timestamp\n",
+        "description": "Application data fields available for sorting in the /hosts-view endpoint.\nUse format `app_name:field_name` with the `order_by` parameter.\n\n**Advisor**\n- `advisor:recommendations` - Number of Advisor recommendations\n- `advisor:incidents` - Number of Advisor incidents\n- `advisor:critical` - Critical severity recommendations\n- `advisor:important` - Important severity recommendations\n- `advisor:moderate` - Moderate severity recommendations\n- `advisor:low` - Low severity recommendations\n\n**Vulnerability**\n- `vulnerability:total_cves` - Total CVE count\n- `vulnerability:critical_cves` - Critical severity CVEs\n- `vulnerability:high_severity_cves` - High severity CVEs\n- `vulnerability:cves_with_security_rules` - CVEs with security rules\n- `vulnerability:cves_with_known_exploits` - CVEs with known exploits\n\n**Patch**\n- `patch:advisories_rhsa_installable` - Number of RHSA installable advisories\n- `patch:advisories_rhba_installable` - Number of RHBA installable advisories\n- `patch:advisories_rhea_installable` - Number of RHEA installable advisories\n- `patch:advisories_other_installable` - Number of other installable advisories\n- `patch:advisories_rhsa_applicable` - Number of RHSA applicable advisories\n- `patch:advisories_rhba_applicable` - Number of RHBA applicable advisories\n- `patch:advisories_rhea_applicable` - Number of RHEA applicable advisories\n- `patch:advisories_other_applicable` - Number of other applicable advisories\n- `patch:packages_installable` - Number of installable packages\n- `patch:packages_applicable` - Number of applicable packages\n- `patch:packages_installed` - Number of installed packages\n- `patch:template_name` - Patch template name\n\n**Remediations**\n- `remediations:remediations_plans` - Active remediation plans count\n\n**Compliance**\n- `compliance:last_scan` - Last compliance scan timestamp\n- `compliance:policies_count` - Number of compliance policies\n\n**Malware**\n- `malware:last_matches` - Malware matches count\n- `malware:total_matches` - Total malware matches count\n- `malware:last_scan` - Last malware scan timestamp\n- `malware:last_status` - Last malware detection status\n",
         "enum": [
           "advisor:recommendations",
           "advisor:incidents",
+          "advisor:critical",
+          "advisor:important",
+          "advisor:moderate",
+          "advisor:low",
           "vulnerability:total_cves",
           "vulnerability:critical_cves",
+          "vulnerability:high_severity_cves",
+          "vulnerability:cves_with_security_rules",
+          "vulnerability:cves_with_known_exploits",
           "patch:advisories_rhsa_installable",
+          "patch:advisories_rhba_installable",
+          "patch:advisories_rhea_installable",
+          "patch:advisories_other_installable",
+          "patch:advisories_rhsa_applicable",
+          "patch:advisories_rhba_applicable",
+          "patch:advisories_rhea_applicable",
+          "patch:advisories_other_applicable",
           "patch:packages_installable",
+          "patch:packages_applicable",
+          "patch:packages_installed",
+          "patch:template_name",
           "remediations:remediations_plans",
           "compliance:last_scan",
+          "compliance:policies_count",
           "malware:last_matches",
-          "malware:last_scan"
+          "malware:total_matches",
+          "malware:last_scan",
+          "malware:last_status"
         ]
       },
       "SystemProfileByHostOut": {

--- a/tests/test_api_host_views.py
+++ b/tests/test_api_host_views.py
@@ -1430,6 +1430,104 @@ class TestHostViewAppDataSorting:
         assert results[0]["app_data"]["malware"]["last_matches"] == 5
         assert results[1]["app_data"]["malware"]["last_matches"] == 0
 
+    def test_sort_by_malware_last_status(self, api_get, db_create_host, db_create_host_app_data):
+        """Sort by malware:last_status should work correctly."""
+        host1 = db_create_host(extra_data={"display_name": "host1.example.com"})
+        host2 = db_create_host(extra_data={"display_name": "host2.example.com"})
+
+        db_create_host_app_data(host1.id, host1.org_id, "malware", last_status="clean")
+        db_create_host_app_data(host2.id, host2.org_id, "malware", last_status="infected")
+
+        url = build_host_view_url(query="?order_by=malware:last_status&order_how=ASC")
+        response_status, response_data = api_get(url)
+
+        assert_response_status(response_status, 200)
+        results = response_data["results"]
+        assert results[0]["app_data"]["malware"]["last_status"] == "clean"
+        assert results[1]["app_data"]["malware"]["last_status"] == "infected"
+
+    def test_sort_by_compliance_policies_count(self, api_get, db_create_host, db_create_host_app_data):
+        """Sort by compliance:policies_count should order hosts by number of policies."""
+        host_few = db_create_host(extra_data={"display_name": "host-few.example.com"})
+        host_many = db_create_host(extra_data={"display_name": "host-many.example.com"})
+
+        db_create_host_app_data(host_few.id, host_few.org_id, "compliance", policies=[{"name": "alpha"}])
+        db_create_host_app_data(
+            host_many.id, host_many.org_id, "compliance", policies=[{"name": "beta"}, {"name": "gamma"}]
+        )
+
+        url = build_host_view_url(query="?order_by=compliance:policies_count&order_how=DESC")
+        response_status, response_data = api_get(url)
+
+        assert_response_status(response_status, 200)
+        results = response_data["results"]
+        assert results[0]["display_name"] == "host-many.example.com"
+        assert results[1]["display_name"] == "host-few.example.com"
+
+    def test_sort_by_patch_template_name(self, api_get, db_create_host, db_create_host_app_data):
+        """Sort by patch:template_name should work correctly."""
+        host1 = db_create_host(extra_data={"display_name": "host1.example.com"})
+        host2 = db_create_host(extra_data={"display_name": "host2.example.com"})
+
+        db_create_host_app_data(host1.id, host1.org_id, "patch", template_name="alpha-template")
+        db_create_host_app_data(host2.id, host2.org_id, "patch", template_name="zeta-template")
+
+        url = build_host_view_url(query="?order_by=patch:template_name&order_how=ASC")
+        response_status, response_data = api_get(url)
+
+        assert_response_status(response_status, 200)
+        results = response_data["results"]
+        assert results[0]["app_data"]["patch"]["template_name"] == "alpha-template"
+        assert results[1]["app_data"]["patch"]["template_name"] == "zeta-template"
+
+    def test_sort_by_vulnerability_high_severity_cves(self, api_get, db_create_host, db_create_host_app_data):
+        """Sort by vulnerability:high_severity_cves should work correctly."""
+        host1 = db_create_host(extra_data={"display_name": "host1.example.com"})
+        host2 = db_create_host(extra_data={"display_name": "host2.example.com"})
+
+        db_create_host_app_data(host1.id, host1.org_id, "vulnerability", high_severity_cves=3)
+        db_create_host_app_data(host2.id, host2.org_id, "vulnerability", high_severity_cves=15)
+
+        url = build_host_view_url(query="?order_by=vulnerability:high_severity_cves&order_how=DESC")
+        response_status, response_data = api_get(url)
+
+        assert_response_status(response_status, 200)
+        results = response_data["results"]
+        assert results[0]["app_data"]["vulnerability"]["high_severity_cves"] == 15
+        assert results[1]["app_data"]["vulnerability"]["high_severity_cves"] == 3
+
+    def test_sort_by_vulnerability_cves_with_security_rules(self, api_get, db_create_host, db_create_host_app_data):
+        """Sort by vulnerability:cves_with_security_rules should work correctly."""
+        host1 = db_create_host(extra_data={"display_name": "host1.example.com"})
+        host2 = db_create_host(extra_data={"display_name": "host2.example.com"})
+
+        db_create_host_app_data(host1.id, host1.org_id, "vulnerability", cves_with_security_rules=1)
+        db_create_host_app_data(host2.id, host2.org_id, "vulnerability", cves_with_security_rules=8)
+
+        url = build_host_view_url(query="?order_by=vulnerability:cves_with_security_rules&order_how=DESC")
+        response_status, response_data = api_get(url)
+
+        assert_response_status(response_status, 200)
+        results = response_data["results"]
+        assert results[0]["app_data"]["vulnerability"]["cves_with_security_rules"] == 8
+        assert results[1]["app_data"]["vulnerability"]["cves_with_security_rules"] == 1
+
+    def test_sort_by_vulnerability_cves_with_known_exploits(self, api_get, db_create_host, db_create_host_app_data):
+        """Sort by vulnerability:cves_with_known_exploits should work correctly."""
+        host1 = db_create_host(extra_data={"display_name": "host1.example.com"})
+        host2 = db_create_host(extra_data={"display_name": "host2.example.com"})
+
+        db_create_host_app_data(host1.id, host1.org_id, "vulnerability", cves_with_known_exploits=2)
+        db_create_host_app_data(host2.id, host2.org_id, "vulnerability", cves_with_known_exploits=12)
+
+        url = build_host_view_url(query="?order_by=vulnerability:cves_with_known_exploits&order_how=DESC")
+        response_status, response_data = api_get(url)
+
+        assert_response_status(response_status, 200)
+        results = response_data["results"]
+        assert results[0]["app_data"]["vulnerability"]["cves_with_known_exploits"] == 12
+        assert results[1]["app_data"]["vulnerability"]["cves_with_known_exploits"] == 2
+
     def test_sort_default_order_how_is_asc(self, api_get, db_create_host, db_create_host_app_data):
         """When order_how is not specified, default to ASC for app sort fields."""
         host_low = db_create_host(extra_data={"display_name": "host-low.example.com"})

--- a/tests/test_filtering_app_data_sorting.py
+++ b/tests/test_filtering_app_data_sorting.py
@@ -67,6 +67,54 @@ class TestResolveAppSort:
         assert model is HostAppDataMalware
         assert column.key == "last_matches"
 
+    def test_malware_last_status(self):
+        """malware:last_status should resolve to correct model and column."""
+        result = resolve_app_sort("malware:last_status")
+        assert result is not None
+        model, column = result
+        assert model is HostAppDataMalware
+        assert column.key == "last_status"
+
+    def test_compliance_policies_count(self):
+        """compliance:policies_count should resolve to correct model and column."""
+        result = resolve_app_sort("compliance:policies_count")
+        assert result is not None
+        model, column = result
+        assert model is HostAppDataCompliance
+        assert column.key == "policies_count"
+
+    def test_patch_template_name(self):
+        """patch:template_name should resolve to correct model and column."""
+        result = resolve_app_sort("patch:template_name")
+        assert result is not None
+        model, column = result
+        assert model is HostAppDataPatch
+        assert column.key == "template_name"
+
+    def test_vulnerability_high_severity_cves(self):
+        """vulnerability:high_severity_cves should resolve to correct model and column."""
+        result = resolve_app_sort("vulnerability:high_severity_cves")
+        assert result is not None
+        model, column = result
+        assert model is HostAppDataVulnerability
+        assert column.key == "high_severity_cves"
+
+    def test_vulnerability_cves_with_security_rules(self):
+        """vulnerability:cves_with_security_rules should resolve to correct model and column."""
+        result = resolve_app_sort("vulnerability:cves_with_security_rules")
+        assert result is not None
+        model, column = result
+        assert model is HostAppDataVulnerability
+        assert column.key == "cves_with_security_rules"
+
+    def test_vulnerability_cves_with_known_exploits(self):
+        """vulnerability:cves_with_known_exploits should resolve to correct model and column."""
+        result = resolve_app_sort("vulnerability:cves_with_known_exploits")
+        assert result is not None
+        model, column = result
+        assert model is HostAppDataVulnerability
+        assert column.key == "cves_with_known_exploits"
+
     # --- Non-app fields return None ---
 
     def test_none_returns_none(self):
@@ -211,6 +259,7 @@ class TestAppSortFieldMap:
             "patch:packages_installable",
             "patch:packages_applicable",
             "patch:packages_installed",
+            "patch:template_name",
         }
 
     def test_exact_remediations_fields(self):
@@ -227,6 +276,7 @@ class TestAppSortFieldMap:
         comp_keys = {k for k in field_map if k.startswith("compliance:")}
         assert comp_keys == {
             "compliance:last_scan",
+            "compliance:policies_count",
         }
 
     def test_exact_malware_fields(self):
@@ -237,6 +287,7 @@ class TestAppSortFieldMap:
             "malware:last_matches",
             "malware:total_matches",
             "malware:last_scan",
+            "malware:last_status",
         }
 
     def test_no_unexpected_app_namespaces(self):


### PR DESCRIPTION
## Jira
[RHINENG-26680](https://issues.redhat.com/browse/RHINENG-26680)

## What
Add new sortable fields for host apps on the `/beta/hosts-view` endpoint, bring the Swagger spec into full alignment with all runtime-sortable fields, and introduce a `policies_count` generated column for efficient compliance policy sorting.

## Why
Several host app fields were either not sortable or sortable at runtime but missing from the OpenAPI spec, preventing consumers from discovering and using them via the API documentation. The compliance `policies` field (JSONB) needed a dedicated integer column to enable meaningful and performant sorting by policy count.

## How
- **Model changes** (`app/models/host_app_data.py`): Added `last_status` (Malware) and `template_name` (Patch) to `__sortable_fields__`. For Compliance, added a PostgreSQL stored generated column `policies_count` (computed from `jsonb_array_length`) instead of sorting by the raw JSONB `policies` column.
- **Migration** (`migrations/versions/b3e9f1a2d7c4`): Adds the `policies_count` generated column to `hosts_app_data_compliance`. Existing rows are backfilled automatically by PostgreSQL during the ALTER TABLE.
- **Swagger spec sync** (`swagger/api.spec.yaml`, `swagger/openapi.json`): Updated both `hostViewOrderByParam` and `AppSortableFields` enums to include all 30 runtime-sortable fields. Added `policies_count` to the `ComplianceAppData` response schema. Previously missing fields:
  - Advisor: `critical`, `important`, `moderate`, `low`
  - Vulnerability: `high_severity_cves`, `cves_with_security_rules`, `cves_with_known_exploits`
  - Patch: 9 advisory/package count fields + `template_name`
  - Malware: `total_matches`, `last_status`
  - Compliance: `policies_count`
- No changes to the query or ingestion layers — sorting is picked up automatically via the `__sortable_fields__` dynamic field map, and the generated column is maintained by PostgreSQL on every write.

## Testing
- 31 unit tests in `test_filtering_app_data_sorting.py` (7 new `resolve_app_sort` tests + 3 updated exact-set assertions)
- 24 integration tests in `test_api_host_views.py::TestHostViewAppDataSorting` (7 new sort tests covering each new field, including `policies_count` with order assertion)
- All pre-commit hooks pass (ruff, mypy, swagger-validation, redoc)

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26680]: https://redhat.atlassian.net/browse/RHINENG-26680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add support and documentation for sorting host views by additional application fields across malware, compliance, patch, advisor, and vulnerability data.

New Features:
- Enable sorting by malware last_status, compliance policies, and patch template_name in host app data models and host views API.
- Expose all runtime-sortable Advisor, Vulnerability, Patch, Compliance, and Malware app fields in the /beta/hosts-view OpenAPI sort parameters.

Tests:
- Extend unit tests for app sort resolution to cover new sortable fields and update exact field-set assertions.
- Add integration tests to verify sorting behavior for each newly supported app field on the hosts-view endpoint.