### PR TITLE
feat(RHINENG-26700): add rh.org_id and rh.request_id to MQ spans

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -267,6 +267,7 @@ class HBIMessageConsumerBase:
             attributes=self._message_span_attrs(msg, **{"hbi.slow_message": True, "hbi.duration_ms": duration_ms}),
             start_time=start_ns,
         )
+        self._enrich_span_from_threadctx(span)
         span.end(end_time=end_ns)
 
     def _process_single_message(self, msg) -> None:
@@ -284,6 +285,20 @@ class HBIMessageConsumerBase:
         else:
             self._process_message_without_span(msg)
 
+    def _enrich_span_from_threadctx(self, span) -> None:
+        """Add rh.org_id and rh.request_id to a span from thread-local storage.
+
+        Must be called after handle_message(), which populates threadctx.
+        """
+        if not span or not span.is_recording():
+            return
+        org_id = getattr(threadctx, "org_id", None)
+        if org_id:
+            span.set_attribute("rh.org_id", org_id)
+        request_id = getattr(threadctx, "request_id", None)
+        if request_id:
+            span.set_attribute("rh.request_id", request_id)
+
     def _process_message_with_span(self, msg) -> None:
         """Process a message with a full tracing span (used when spans are enabled or on retry)."""
         with tracer.start_as_current_span(
@@ -294,12 +309,15 @@ class HBIMessageConsumerBase:
                 self.processed_rows.append(self.handle_message(msg.value(), headers=msg.headers()))
                 metrics.consumed_message_size.observe(len(str(msg).encode("utf-8")))
                 self.success_metric.inc()
+                self._enrich_span_from_threadctx(span)
             except OperationalError as oe:
+                self._enrich_span_from_threadctx(span)
                 span.set_status(StatusCode.ERROR, str(oe))
                 span.record_exception(oe)
                 logger.error(f"Could not access DB {str(oe)}")
                 sys.exit(3)
             except Exception as exc:
+                self._enrich_span_from_threadctx(span)
                 span.set_status(StatusCode.ERROR, str(exc))
                 span.record_exception(exc)
                 self.failure_metric.inc()
@@ -335,6 +353,7 @@ class HBIMessageConsumerBase:
             attributes=self._message_span_attrs(msg, **{"hbi.error": True}),
             start_time=start_ns,
         )
+        self._enrich_span_from_threadctx(span)
         span.set_status(StatusCode.ERROR, str(exc))
         span.record_exception(exc)
         span.end(end_time=end_ns)

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -6,6 +6,7 @@ import sys
 import time
 import uuid
 from collections.abc import Callable
+from contextlib import contextmanager
 from contextlib import suppress
 from copy import deepcopy
 from datetime import datetime
@@ -254,6 +255,39 @@ class HBIMessageConsumerBase:
         attrs.update(extra)
         return attrs
 
+    @contextmanager
+    def _message_span(self, msg, **extra_attrs):
+        """Create a per-message span that automatically enriches from threadctx on exit.
+
+        Enrichment is deferred to span exit because handle_message() populates
+        threadctx during processing. Using this context manager means callers
+        never need to call _enrich_span_from_threadctx manually.
+        """
+        with tracer.start_as_current_span(
+            f"mq.process {msg.topic()}",
+            attributes=self._message_span_attrs(msg, **extra_attrs),
+        ) as span:
+            try:
+                yield span
+            finally:
+                self._enrich_span_from_threadctx(span)
+
+    @contextmanager
+    def _retroactive_span(self, msg, start_ns: int, **extra_attrs):
+        """Create a retroactive span that automatically enriches from threadctx.
+
+        Unlike _message_span, retroactive spans are always created after
+        handle_message() has already run (or raised), so threadctx is
+        already populated and enrichment can happen eagerly.
+        """
+        span = tracer.start_span(
+            f"mq.process {msg.topic()}",
+            attributes=self._message_span_attrs(msg, **extra_attrs),
+            start_time=start_ns,
+        )
+        self._enrich_span_from_threadctx(span)
+        yield span
+
     def _emit_slow_message_span(self, msg, start_ns: int, end_ns: int) -> None:
         """Emit a retroactive span for a message that exceeded the slow threshold."""
         if not OTEL_MQ_ENABLED:
@@ -262,13 +296,9 @@ class HBIMessageConsumerBase:
         if duration_ms < OTEL_MQ_SLOW_MESSAGE_MS:
             return
 
-        span = tracer.start_span(
-            f"mq.process {msg.topic()}",
-            attributes=self._message_span_attrs(msg, **{"hbi.slow_message": True, "hbi.duration_ms": duration_ms}),
-            start_time=start_ns,
-        )
-        self._enrich_span_from_threadctx(span)
-        span.end(end_time=end_ns)
+        extra = {"hbi.slow_message": True, "hbi.duration_ms": duration_ms}
+        with self._retroactive_span(msg, start_ns, **extra) as span:
+            span.end(end_time=end_ns)
 
     def _process_single_message(self, msg) -> None:
         """Process a single Kafka message, conditionally emitting a child span.
@@ -288,7 +318,7 @@ class HBIMessageConsumerBase:
     def _enrich_span_from_threadctx(self, span) -> None:
         """Add rh.org_id and rh.request_id to a span from thread-local storage.
 
-        Must be called after handle_message(), which populates threadctx.
+        Called automatically by _message_span and _retroactive_span context managers.
         """
         if not span or not span.is_recording():
             return
@@ -301,23 +331,17 @@ class HBIMessageConsumerBase:
 
     def _process_message_with_span(self, msg) -> None:
         """Process a message with a full tracing span (used when spans are enabled or on retry)."""
-        with tracer.start_as_current_span(
-            f"mq.process {msg.topic()}",
-            attributes=self._message_span_attrs(msg, **{"hbi.retry": self._is_retry}),
-        ) as span:
+        with self._message_span(msg, **{"hbi.retry": self._is_retry}) as span:
             try:
                 self.processed_rows.append(self.handle_message(msg.value(), headers=msg.headers()))
                 metrics.consumed_message_size.observe(len(str(msg).encode("utf-8")))
                 self.success_metric.inc()
-                self._enrich_span_from_threadctx(span)
             except OperationalError as oe:
-                self._enrich_span_from_threadctx(span)
                 span.set_status(StatusCode.ERROR, str(oe))
                 span.record_exception(oe)
                 logger.error(f"Could not access DB {str(oe)}")
                 sys.exit(3)
             except Exception as exc:
-                self._enrich_span_from_threadctx(span)
                 span.set_status(StatusCode.ERROR, str(exc))
                 span.record_exception(exc)
                 self.failure_metric.inc()
@@ -348,15 +372,10 @@ class HBIMessageConsumerBase:
         if not OTEL_MQ_ENABLED:
             return
         end_ns = time.time_ns()
-        span = tracer.start_span(
-            f"mq.process {msg.topic()}",
-            attributes=self._message_span_attrs(msg, **{"hbi.error": True}),
-            start_time=start_ns,
-        )
-        self._enrich_span_from_threadctx(span)
-        span.set_status(StatusCode.ERROR, str(exc))
-        span.record_exception(exc)
-        span.end(end_time=end_ns)
+        with self._retroactive_span(msg, start_ns, **{"hbi.error": True}) as span:
+            span.set_status(StatusCode.ERROR, str(exc))
+            span.record_exception(exc)
+            span.end(end_time=end_ns)
 
     def _process_batch(self) -> None:
         """Process a single batch of messages from Kafka.

--- a/tests/test_mq_message_spans.py
+++ b/tests/test_mq_message_spans.py
@@ -1,5 +1,6 @@
 """Tests for MQ per-message span controls (OTEL_MQ_MESSAGE_SPANS_ENABLED / OTEL_MQ_SLOW_MESSAGE_MS)."""
 
+import contextlib
 import importlib
 from unittest.mock import MagicMock
 
@@ -44,6 +45,17 @@ def consumer():
             return self._handler(message, headers=headers)
 
     return _TestConsumer()
+
+
+@pytest.fixture(autouse=True)
+def _clean_threadctx():
+    """Ensure threadctx.org_id and request_id don't leak between tests."""
+    yield
+    from app.logging import threadctx
+
+    for attr in ("org_id", "request_id"):
+        with contextlib.suppress(AttributeError):
+            delattr(threadctx, attr)
 
 
 def test_span_emitted_when_enabled(otel_spans, consumer, monkeypatch):
@@ -153,6 +165,70 @@ def test_no_spans_when_mq_tracing_disabled(otel_spans, consumer, monkeypatch):
     consumer._process_single_message(FakeMessage())
 
     assert len(otel_spans.get_finished_spans()) == 0
+
+
+def test_span_includes_org_id_and_request_id_from_threadctx(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
+
+    from app.logging import threadctx
+
+    def populate_threadctx(*args, **kwargs):
+        threadctx.org_id = "test_org_123"
+        threadctx.request_id = "req-abc-456"
+        return consumer._handler.return_value
+
+    consumer._handler.side_effect = populate_threadctx
+
+    consumer._process_single_message(FakeMessage())
+
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes["rh.org_id"] == "test_org_123"
+    assert spans[0].attributes["rh.request_id"] == "req-abc-456"
+
+
+def test_error_span_includes_org_id_from_threadctx(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
+
+    from app.logging import threadctx
+
+    def raise_with_threadctx(*args, **kwargs):
+        threadctx.org_id = "error_org"
+        threadctx.request_id = "error_req"
+        raise ValueError("boom")
+
+    consumer._handler.side_effect = raise_with_threadctx
+
+    consumer._process_single_message(FakeMessage())
+
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == trace.StatusCode.ERROR
+    assert spans[0].attributes["rh.org_id"] == "error_org"
+    assert spans[0].attributes["rh.request_id"] == "error_req"
+
+
+def test_span_without_threadctx_has_no_rh_attributes(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
+
+    from app.logging import threadctx
+
+    for attr in ("org_id", "request_id"):
+        with contextlib.suppress(AttributeError):
+            delattr(threadctx, attr)
+
+    consumer._process_single_message(FakeMessage())
+
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 1
+    assert "rh.org_id" not in spans[0].attributes
+    assert "rh.request_id" not in spans[0].attributes
 
 
 def test_config_defaults(monkeypatch):

--- a/tests/test_mq_message_spans.py
+++ b/tests/test_mq_message_spans.py
@@ -212,6 +212,39 @@ def test_error_span_includes_org_id_from_threadctx(otel_spans, consumer, monkeyp
     assert spans[0].attributes["rh.request_id"] == "error_req"
 
 
+def test_slow_span_includes_org_id_and_request_id_from_threadctx(otel_spans, consumer, monkeypatch):
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 30)
+
+    start_ns = 1_000_000_000_000
+    end_ns = start_ns + 40_000_000  # 40ms > 30ms threshold
+    call_count = {"n": 0}
+
+    def fake_time_ns():
+        call_count["n"] += 1
+        return start_ns if call_count["n"] == 1 else end_ns
+
+    monkeypatch.setattr("app.queue.host_mq.time.time_ns", fake_time_ns)
+
+    from app.logging import threadctx
+
+    def populate_threadctx(*args, **kwargs):
+        threadctx.org_id = "slow_org"
+        threadctx.request_id = "slow_req"
+        return consumer._handler.return_value
+
+    consumer._handler.side_effect = populate_threadctx
+
+    consumer._process_single_message(FakeMessage())
+
+    spans = otel_spans.get_finished_spans()
+    slow_spans = [s for s in spans if s.attributes.get("hbi.slow_message")]
+    assert len(slow_spans) == 1
+    assert slow_spans[0].attributes["rh.org_id"] == "slow_org"
+    assert slow_spans[0].attributes["rh.request_id"] == "slow_req"
+
+
 def test_span_without_threadctx_has_no_rh_attributes(otel_spans, consumer, monkeypatch):
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", True)


### PR DESCRIPTION
## Jira
[RHINENG-26700](https://issues.redhat.com/browse/RHINENG-26700)

## What
Add `rh.org_id` and `rh.request_id` attributes to MQ per-message trace spans so they can be filtered and correlated in Grafana/Tempo.

## Why
MQ consumer spans lacked tenant context — unlike HTTP request spans (which extract org_id from the `x-rh-identity` header), MQ spans had no way to filter traces by org or link them to a specific platform request_id. This made it difficult to investigate issues for a specific tenant or trace a message back to the ingress request that produced it as the ingress service still not OTEL instrumented.

## How
- Added a helper method `_enrich_span_from_threadctx()` on `HBIMessageConsumerBase` that reads `org_id` and `request_id` from thread-local storage (`threadctx`) and sets them as `rh.org_id` and `rh.request_id` span attributes.
- Called the helper after `handle_message()` in `_process_message_with_span` (success and error paths), `_emit_error_span`, and `_emit_slow_message_span` — this covers all code paths that produce per-message spans.
- The helper is safe to call when threadctx is unpopulated (e.g., early validation failures) — it simply skips setting the attribute if the value is `None`.

## Testing
- Added 3 unit tests in `tests/test_mq_message_spans.py`:
  - `test_span_includes_org_id_and_request_id_from_threadctx` — verifies both attributes on the success path
  - `test_error_span_includes_org_id_from_threadctx` — verifies attributes on error spans
  - `test_span_without_threadctx_has_no_rh_attributes` — verifies no spurious attributes when threadctx is empty
- Verified end-to-end locally by sending a Kafka message through the dev stack and confirming `rh.org_id` and `rh.request_id` appear on the `mq.process` span in Tempo.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26700]: https://redhat.atlassian.net/browse/RHINENG-26700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add tenant and request context attributes to MQ message tracing spans and cover the behavior with tests.

New Features:
- Propagate rh.org_id and rh.request_id from thread-local storage onto MQ per-message tracing spans, including success, error, and slow-message spans.

Tests:
- Add unit tests verifying MQ spans include rh.org_id and rh.request_id when thread-local context is populated and omit them when it is not.