### PR TITLE
fix(RHINENG-23380): Rename remove-null-values-in-workloads-fields-data job

### DIFF
--- a/deploy/cji.yml
+++ b/deploy/cji.yml
@@ -88,11 +88,11 @@ objects:
   metadata:
     labels:
       app: host-inventory
-    name: remove-null-values-in-workloads-fields-data-${REMOVE_NULL_VALUES_IN_WORKLOADS_FIELDS_DATA_RUN_NUMBER}
+    name: remove-null-workload-values-${REMOVE_NULL_WORKLOAD_VALUES_RUN_NUMBER}
   spec:
     appName: host-inventory
     jobs:
-      - remove-null-values-in-workloads-fields-data
+      - remove-null-workload-values
 parameters:
 - name: SYNCHRONIZER_RUN_NUMBER
   value: '1'
@@ -110,5 +110,5 @@ parameters:
   value: '1'
 - name: POPULATE_HOST_TYPE_RUN_NUMBER
   value: '1'
-- name: REMOVE_NULL_VALUES_IN_WORKLOADS_FIELDS_DATA_RUN_NUMBER
+- name: REMOVE_NULL_WORKLOAD_VALUES_RUN_NUMBER
   value: '1'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -1782,7 +1782,7 @@ objects:
           - name: ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE
             value: ${ASSIGN_UNGROUPED_GROUPS_BATCH_SIZE}
         resources: *ungroupedHostResources
-    - name: remove-null-values-in-workloads-fields-data
+    - name: remove-null-workload-values
       restartPolicy: OnFailure
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
@@ -2856,13 +2856,13 @@ parameters:
 
 # -- Remove null values in workloads fields data Job --
 - name: REMOVE_NULL_VALUES_WORKLOADS_FIELDS_DRY_RUN
-  description: Whether the remove-null-values-in-workloads-fields-data script should run in dry-run mode
+  description: Whether the remove-null-workload-values script should run in dry-run mode
   value: 'true'
 - name: REMOVE_NULL_VALUES_WORKLOADS_FIELDS_BATCH_SIZE
-  description: The batch size to use for the remove-null-values-in-workloads-fields-data script.
+  description: The batch size to use for the remove-null-workload-values script.
   value: '500'
 - name: REMOVE_NULL_VALUES_WORKLOADS_FIELDS_SUSPEND_JOB
-  description: Whether to suspend the remove-null-values-in-workloads-fields-data job
+  description: Whether to suspend the remove-null-workload-values job
   value: 'true'
 
 # -- Downgrade Alembic revision Job --


### PR DESCRIPTION
## Jira
[RHINENG-23380](https://issues.redhat.com/browse/RHINENG-23380)

## What
Renames `remove-null-values-in-workloads-fields-data` to `remove-null-workload-values`. Also renames related field names.

## Why
The OpenShift job could not spawn because the name was too long.

## How
I shortened the name.

## Testing
N/A

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-23380]: https://redhat.atlassian.net/browse/RHINENG-23380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Update job and parameter names in deployment and CJI templates to reflect the new remove-null-workload-values job name.