### PR TITLE
fix(deps): bump starlette to 1.0.1 (CVE-2026-48710)

### DIFF
--- a/.hermetic_builds/requirements.txt
+++ b/.hermetic_builds/requirements.txt
@@ -654,9 +654,9 @@ sqlalchemy==2.0.49 \
     #   alembic
     #   flask-sqlalchemy
     #   insights-host-inventory
-starlette==1.0.0 \
-    --hash=sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149 \
-    --hash=sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b
+starlette==1.0.1 \
+    --hash=sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f \
+    --hash=sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd
     # via connexion
 swagger-ui-bundle==1.1.0 \
     --hash=sha256:20673c3431c8733d5d1615ecf79d9acf30cff75202acaf21a7d9c7f489714529 \


### PR DESCRIPTION
Bumps starlette to 1.0.1 to fix CVE-2026-48710.

**CVE:** CVE-2026-48710 — Starlette: Security restriction bypass via malformed HTTP Host header. Missing Host header validation poisons `request.url.path`, allowing path-based security checks to be bypassed.

**Fix version:** starlette 1.0.1
**Advisory:** https://github.com/Kludex/starlette/security/advisories/GHSA-86qp-5c8j-p5mr