### PR TITLE
fix(deps): Re-add pip_requirements config to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,5 +20,8 @@
       "matchPackagePatterns": ["^opentelemetry-"],
       "groupName": "opentelemetry"
     }
-  ]
+  ],
+  "pip_requirements": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
## Jira
N/A

## What
Re-adds the "pip_requirements" config to renovate.json

## Why
Removing this config may be the cause of the Konflux bot automatically opening PRs for hermetic builds

## How
I just re-added it

## Testing
None

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Build:
- Reintroduce the pip_requirements configuration block in renovate.json to reinstate expected handling of Python requirement files.