### PR TITLE
feat(RHINENG-25828): Add inventory views repository with CRUD and visibility logic

### DIFF
--- a/app/serialization.py
+++ b/app/serialization.py
@@ -26,6 +26,7 @@ from app.models import LimitedHostSchema
 from app.models.constants import WORKLOADS_FIELDS
 from app.models.system_profile_transformer import DYNAMIC_FIELDS
 from app.models.system_profile_transformer import STATIC_FIELDS
+from app.models.views import InventoryView
 from app.staleness_serialization import AttrDict
 from app.staleness_serialization import get_staleness_timestamps
 from app.utils import Tag
@@ -583,6 +584,22 @@ def serialize_staleness_response(staleness):
         "immutable_time_to_delete": staleness.conventional_time_to_delete,
         "created": _serialize_datetime(staleness.created_on) if staleness.created_on is not None else None,
         "updated": _serialize_datetime(staleness.modified_on) if staleness.modified_on is not None else None,
+    }
+
+
+def serialize_view(view: InventoryView, username: str) -> dict:
+    return {
+        "id": serialize_uuid(view.id),
+        "org_id": view.org_id,
+        "name": view.name,
+        "description": view.description,
+        "is_system_view": view.is_system_view,
+        "configuration": view.configuration,
+        "org_wide": view.org_wide,
+        "is_owner": view.created_by == username,
+        "created_by": view.created_by,
+        "created_at": _serialize_datetime(view.created_on) if view.created_on else None,
+        "updated_at": _serialize_datetime(view.modified_on) if view.modified_on else None,
     }
 
 

--- a/lib/views_repository.py
+++ b/lib/views_repository.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from sqlalchemy import and_
+from sqlalchemy import or_
+
+from app.exceptions import InventoryException
+from app.logging import get_logger
+from app.models import InventoryView
+from app.models import db
+from app.models.views import MAX_VIEW_NAME_LENGTH
+from lib.db import session_guard
+
+logger = get_logger(__name__)
+
+__all__ = (
+    "get_views_list",
+    "get_view_by_id",
+    "create_view",
+    "update_view",
+    "delete_view",
+    "clone_view",
+)
+
+CLONE_NAME_PREFIX = "Copy of "
+
+
+class ViewNotFoundError(InventoryException):
+    def __init__(self, detail: str = "View not found."):
+        super().__init__(status=404, title="Not Found", detail=detail)
+
+
+class ViewPermissionError(InventoryException):
+    def __init__(self, detail: str):
+        super().__init__(status=403, title="Forbidden", detail=detail)
+
+
+def _visibility_filter(org_id: str, username: str):
+    """Return a SQLAlchemy filter for views visible to the given user.
+
+    Visible views are:
+    - System views (org_id IS NULL)
+    - Org-wide views in the same org
+    - Private views created by the user in the same org
+    """
+    return or_(
+        InventoryView.org_id.is_(None),
+        and_(
+            InventoryView.org_id == org_id,
+            or_(
+                InventoryView.created_by == username,
+                InventoryView.org_wide.is_(True),
+            ),
+        ),
+    )
+
+
+def _get_visible_view(view_id: str, org_id: str, username: str) -> InventoryView:
+    view = InventoryView.query.filter(
+        InventoryView.id == view_id,
+        _visibility_filter(org_id, username),
+    ).one_or_none()
+
+    if view is None:
+        raise ViewNotFoundError()
+
+    return view
+
+
+def get_views_list(org_id: str, username: str, page: int = 1, per_page: int = 50) -> tuple[list[InventoryView], int]:
+    query = InventoryView.query.filter(_visibility_filter(org_id, username)).order_by(InventoryView.modified_on.desc())
+
+    total = query.count()
+    views = query.offset((page - 1) * per_page).limit(per_page).all()
+
+    return views, total
+
+
+def get_view_by_id(view_id: str, org_id: str, username: str) -> InventoryView:
+    return _get_visible_view(view_id, org_id, username)
+
+
+def create_view(data: dict, org_id: str, username: str) -> InventoryView:
+    view = InventoryView(
+        org_id=org_id,
+        name=data["name"],
+        description=data.get("description"),
+        configuration=data["configuration"],
+        org_wide=data.get("org_wide", False),
+        created_by=username,
+    )
+
+    with session_guard(db.session, close=False):
+        db.session.add(view)
+
+    db.session.refresh(view)
+    logger.info("Created view %s for org %s by %s", view.id, org_id, username)
+    return view
+
+
+def update_view(view_id: str, data: dict, org_id: str, username: str) -> InventoryView:
+    view = _get_visible_view(view_id, org_id, username)
+
+    if view.is_system_view:
+        raise ViewPermissionError("System views cannot be modified.")
+
+    if view.created_by != username:
+        raise ViewPermissionError("Only the view creator can update this view.")
+
+    with session_guard(db.session, close=False):
+        view.patch(data)
+
+    db.session.refresh(view)
+    logger.info("Updated view %s by %s", view_id, username)
+    return view
+
+
+def delete_view(view_id: str, org_id: str, username: str) -> None:
+    view = _get_visible_view(view_id, org_id, username)
+
+    if view.is_system_view:
+        raise ViewPermissionError("System views cannot be deleted.")
+
+    if view.created_by != username:
+        raise ViewPermissionError("Only the view creator can delete this view.")
+
+    with session_guard(db.session):
+        db.session.delete(view)
+
+    logger.info("Deleted view %s by %s", view_id, username)
+
+
+def clone_view(view_id: str, org_id: str, username: str) -> InventoryView:
+    source = _get_visible_view(view_id, org_id, username)
+
+    clone_name = f"{CLONE_NAME_PREFIX}{source.name}"[:MAX_VIEW_NAME_LENGTH]
+
+    cloned = InventoryView(
+        org_id=org_id,
+        name=clone_name,
+        description=source.description,
+        configuration=deepcopy(source.configuration),
+        org_wide=False,
+        created_by=username,
+    )
+
+    with session_guard(db.session, close=False):
+        db.session.add(cloned)
+
+    db.session.refresh(cloned)
+    logger.info("Cloned view %s -> %s by %s", view_id, cloned.id, username)
+    return cloned

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -18,6 +18,7 @@ from app.environment import RuntimeEnvironment
 from app.models import Group
 from app.models import Host
 from app.models import HostGroupAssoc
+from app.models import InventoryView
 from app.models import Staleness
 from app.models import db
 from app.models.system_profile_dynamic import HostDynamicSystemProfile
@@ -354,3 +355,43 @@ def db_get_dynamic_system_profile(flask_app):  # noqa: ARG001
         ).first()
 
     return _get_dynamic_system_profile
+
+
+@pytest.fixture(scope="function")
+def db_create_view(flask_app):  # noqa: ARG001
+    def _db_create_view(
+        name="Test View",
+        org_id=SYSTEM_IDENTITY["org_id"],
+        created_by="testuser",
+        configuration=None,
+        org_wide=False,
+    ):
+        view = InventoryView(
+            org_id=org_id,
+            name=name,
+            configuration=configuration or {"columns": [{"key": "display_name", "visible": True}]},
+            org_wide=org_wide,
+            created_by=created_by,
+        )
+        db.session.add(view)
+        db.session.commit()
+        return view
+
+    return _db_create_view
+
+
+@pytest.fixture(scope="function")
+def db_create_system_view(flask_app):  # noqa: ARG001
+    def _db_create_system_view(name="Red Hat Default", configuration=None):
+        view = InventoryView(
+            org_id=None,
+            name=name,
+            configuration=configuration or {"columns": [{"key": "display_name", "visible": True}]},
+            org_wide=True,
+            created_by=None,
+        )
+        db.session.add(view)
+        db.session.commit()
+        return view
+
+    return _db_create_system_view

--- a/tests/test_views_repository.py
+++ b/tests/test_views_repository.py
@@ -1,0 +1,305 @@
+import uuid
+
+import pytest
+
+from app.models import InventoryView
+from app.models import db
+from app.serialization import serialize_view
+from lib.views_repository import CLONE_NAME_PREFIX
+from lib.views_repository import ViewNotFoundError
+from lib.views_repository import ViewPermissionError
+from lib.views_repository import clone_view
+from lib.views_repository import create_view
+from lib.views_repository import delete_view
+from lib.views_repository import get_view_by_id
+from lib.views_repository import get_views_list
+from lib.views_repository import update_view
+
+ORG_ID = "test-org-1"
+OTHER_ORG = "test-org-2"
+USERNAME = "testuser"
+OTHER_USER = "otheruser"
+
+VALID_CONFIG = {"columns": [{"key": "display_name", "visible": True}]}
+
+
+class TestGetViewsList:
+    def test_returns_own_private_views(self, db_create_view):
+        db_create_view(name="My Private View", org_id=ORG_ID, created_by=USERNAME, org_wide=False)
+
+        views, total = get_views_list(ORG_ID, USERNAME)
+
+        assert total == 1
+        assert views[0].name == "My Private View"
+
+    def test_returns_org_wide_views(self, db_create_view):
+        db_create_view(name="Shared View", org_id=ORG_ID, created_by=OTHER_USER, org_wide=True)
+
+        views, total = get_views_list(ORG_ID, USERNAME)
+
+        assert total == 1
+        assert views[0].name == "Shared View"
+
+    def test_returns_system_views(self, db_create_system_view):
+        db_create_system_view(name="System Default")
+
+        views, total = get_views_list(ORG_ID, USERNAME)
+
+        assert total == 1
+        assert views[0].name == "System Default"
+        assert views[0].is_system_view is True
+
+    def test_excludes_other_users_private_views(self, db_create_view):
+        db_create_view(name="Other Private", org_id=ORG_ID, created_by=OTHER_USER, org_wide=False)
+
+        views, total = get_views_list(ORG_ID, USERNAME)
+
+        assert total == 0
+        assert views == []
+
+    def test_excludes_other_org_views(self, db_create_view):
+        db_create_view(name="Other Org View", org_id=OTHER_ORG, created_by=OTHER_USER, org_wide=True)
+
+        views, total = get_views_list(ORG_ID, USERNAME)
+
+        assert total == 0
+
+    def test_pagination(self, db_create_view):
+        for i in range(5):
+            db_create_view(name=f"View {i}", org_id=ORG_ID, created_by=USERNAME)
+
+        views, total = get_views_list(ORG_ID, USERNAME, page=1, per_page=2)
+
+        assert total == 5
+        assert len(views) == 2
+
+    def test_ordered_by_modified_on_desc(self, db_create_view):
+        v1 = db_create_view(name="Old View", org_id=ORG_ID, created_by=USERNAME)
+        v2 = db_create_view(name="New View", org_id=ORG_ID, created_by=USERNAME)
+
+        views, _ = get_views_list(ORG_ID, USERNAME)
+
+        assert views[0].id == v2.id
+        assert views[1].id == v1.id
+
+    def test_is_owner_via_serialization(self, db_create_view):
+        db_create_view(name="Mine", org_id=ORG_ID, created_by=USERNAME, org_wide=True)
+        db_create_view(name="Theirs", org_id=ORG_ID, created_by=OTHER_USER, org_wide=True)
+
+        views, _ = get_views_list(ORG_ID, USERNAME)
+
+        by_name = {v.name: serialize_view(v, USERNAME) for v in views}
+        assert by_name["Mine"]["is_owner"] is True
+        assert by_name["Theirs"]["is_owner"] is False
+
+
+class TestGetViewById:
+    def test_returns_visible_view(self, db_create_view):
+        view = db_create_view(name="My View", org_id=ORG_ID, created_by=USERNAME)
+
+        result = get_view_by_id(str(view.id), ORG_ID, USERNAME)
+
+        assert result.name == "My View"
+        assert result.id == view.id
+
+    def test_returns_system_view(self, db_create_system_view):
+        view = db_create_system_view()
+
+        result = get_view_by_id(str(view.id), ORG_ID, USERNAME)
+
+        assert result.is_system_view is True
+
+    def test_raises_for_nonexistent_view(self, flask_app):  # noqa: ARG002
+        with pytest.raises(ViewNotFoundError):
+            get_view_by_id(str(uuid.uuid4()), ORG_ID, USERNAME)
+
+    def test_raises_for_other_users_private_view(self, db_create_view):
+        view = db_create_view(org_id=ORG_ID, created_by=OTHER_USER, org_wide=False)
+
+        with pytest.raises(ViewNotFoundError):
+            get_view_by_id(str(view.id), ORG_ID, USERNAME)
+
+
+class TestCreateView:
+    def test_creates_view(self, flask_app):  # noqa: ARG002
+        data = {"name": "New View", "configuration": VALID_CONFIG}
+
+        result = create_view(data, ORG_ID, USERNAME)
+
+        assert result.name == "New View"
+        assert result.org_id == ORG_ID
+        assert result.created_by == USERNAME
+        assert result.org_wide is False
+
+    def test_creates_org_wide_view(self, flask_app):  # noqa: ARG002
+        data = {"name": "Shared", "configuration": VALID_CONFIG, "org_wide": True}
+
+        result = create_view(data, ORG_ID, USERNAME)
+
+        assert result.org_wide is True
+
+    def test_ignores_client_provided_identity_fields(self, flask_app):  # noqa: ARG002
+        data = {
+            "name": "Sneaky",
+            "configuration": VALID_CONFIG,
+            "org_id": OTHER_ORG,
+            "created_by": OTHER_USER,
+        }
+
+        result = create_view(data, ORG_ID, USERNAME)
+
+        assert result.org_id == ORG_ID
+        assert result.created_by == USERNAME
+
+    def test_creates_view_with_description(self, flask_app):  # noqa: ARG002
+        data = {"name": "Described", "configuration": VALID_CONFIG, "description": "A test view"}
+
+        result = create_view(data, ORG_ID, USERNAME)
+
+        assert result.description == "A test view"
+
+
+class TestUpdateView:
+    def test_updates_name(self, db_create_view):
+        view = db_create_view(name="Old Name", org_id=ORG_ID, created_by=USERNAME)
+
+        result = update_view(str(view.id), {"name": "New Name"}, ORG_ID, USERNAME)
+
+        assert result.name == "New Name"
+
+    def test_updates_multiple_fields(self, db_create_view):
+        view = db_create_view(org_id=ORG_ID, created_by=USERNAME)
+
+        result = update_view(
+            str(view.id),
+            {"name": "Updated", "description": "New desc", "org_wide": True},
+            ORG_ID,
+            USERNAME,
+        )
+
+        assert result.name == "Updated"
+        assert result.description == "New desc"
+        assert result.org_wide is True
+
+    def test_raises_for_system_view(self, db_create_system_view):
+        view = db_create_system_view()
+
+        with pytest.raises(ViewPermissionError):
+            update_view(str(view.id), {"name": "Hacked"}, ORG_ID, USERNAME)
+
+    def test_raises_for_non_owner(self, db_create_view):
+        view = db_create_view(org_id=ORG_ID, created_by=OTHER_USER, org_wide=True)
+
+        with pytest.raises(ViewPermissionError):
+            update_view(str(view.id), {"name": "Hacked"}, ORG_ID, USERNAME)
+
+    def test_raises_for_nonexistent_view(self, flask_app):  # noqa: ARG002
+        with pytest.raises(ViewNotFoundError):
+            update_view(str(uuid.uuid4()), {"name": "X"}, ORG_ID, USERNAME)
+
+
+class TestDeleteView:
+    def test_deletes_own_view(self, db_create_view):
+        view = db_create_view(org_id=ORG_ID, created_by=USERNAME)
+
+        delete_view(str(view.id), ORG_ID, USERNAME)
+
+        assert db.session.get(InventoryView, view.id) is None
+
+    def test_raises_for_system_view(self, db_create_system_view):
+        view = db_create_system_view()
+
+        with pytest.raises(ViewPermissionError):
+            delete_view(str(view.id), ORG_ID, USERNAME)
+
+    def test_raises_for_non_owner(self, db_create_view):
+        view = db_create_view(org_id=ORG_ID, created_by=OTHER_USER, org_wide=True)
+
+        with pytest.raises(ViewPermissionError):
+            delete_view(str(view.id), ORG_ID, USERNAME)
+
+    def test_raises_for_nonexistent_view(self, flask_app):  # noqa: ARG002
+        with pytest.raises(ViewNotFoundError):
+            delete_view(str(uuid.uuid4()), ORG_ID, USERNAME)
+
+    def test_raises_for_view_from_other_org(self, db_create_view):
+        view = db_create_view(org_id=OTHER_ORG, created_by=OTHER_USER)
+
+        with pytest.raises(ViewNotFoundError):
+            delete_view(str(view.id), ORG_ID, USERNAME)
+
+
+class TestCloneView:
+    def test_clones_view(self, db_create_view):
+        original = db_create_view(name="Original", org_id=ORG_ID, created_by=OTHER_USER, org_wide=True)
+
+        result = clone_view(str(original.id), ORG_ID, USERNAME)
+
+        assert result.name == f"{CLONE_NAME_PREFIX}Original"
+        assert result.created_by == USERNAME
+        assert result.org_wide is False
+        assert result.configuration == VALID_CONFIG
+        assert result.id != original.id
+
+    def test_clones_system_view(self, db_create_system_view):
+        system = db_create_system_view(name="System View")
+
+        result = clone_view(str(system.id), ORG_ID, USERNAME)
+
+        assert result.name == f"{CLONE_NAME_PREFIX}System View"
+        assert result.org_id == ORG_ID
+        assert result.is_system_view is False
+
+    def test_clone_truncates_long_name(self, db_create_view):
+        from app.models.views import MAX_VIEW_NAME_LENGTH
+
+        long_name = "A" * MAX_VIEW_NAME_LENGTH
+        original = db_create_view(name=long_name, org_id=ORG_ID, created_by=USERNAME)
+
+        result = clone_view(str(original.id), ORG_ID, USERNAME)
+
+        assert len(result.name) == MAX_VIEW_NAME_LENGTH
+        assert result.name.startswith(CLONE_NAME_PREFIX)
+
+    def test_clone_deep_copies_configuration(self, db_create_view):
+        config = {"columns": [{"key": "id", "visible": True}], "filters": {"os": "RHEL"}}
+        original = db_create_view(configuration=config, org_id=ORG_ID, created_by=USERNAME)
+
+        result = clone_view(str(original.id), ORG_ID, USERNAME)
+
+        assert result.configuration == config
+
+    def test_raises_for_nonexistent_source(self, flask_app):  # noqa: ARG002
+        with pytest.raises(ViewNotFoundError):
+            clone_view(str(uuid.uuid4()), ORG_ID, USERNAME)
+
+
+class TestSerializeView:
+    def test_serializes_all_fields(self, db_create_view):
+        view = db_create_view(name="My View", org_id=ORG_ID, created_by=USERNAME)
+
+        result = serialize_view(view, USERNAME)
+
+        assert result["name"] == "My View"
+        assert result["org_id"] == ORG_ID
+        assert result["is_system_view"] is False
+        assert result["is_owner"] is True
+        assert result["created_by"] == USERNAME
+        assert "created_at" in result
+        assert "updated_at" in result
+
+    def test_is_owner_false_for_other_user(self, db_create_view):
+        view = db_create_view(org_id=ORG_ID, created_by=OTHER_USER, org_wide=True)
+
+        result = serialize_view(view, USERNAME)
+
+        assert result["is_owner"] is False
+
+    def test_system_view_serialization(self, db_create_system_view):
+        view = db_create_system_view()
+
+        result = serialize_view(view, USERNAME)
+
+        assert result["is_system_view"] is True
+        assert result["org_id"] is None
+        assert result["created_by"] is None


### PR DESCRIPTION
Jira
[RHINENG-25828](https://issues.redhat.com/browse/RHINENG-25828)

What
Add lib/views_repository.py with CRUD operations and visibility logic for inventory views.

Why
The endpoint handlers (RHINENG-25829–25833) need a data access layer to query, create, update, delete, and clone inventory views with proper visibility filtering and ownership enforcement.

How
Created lib/views_repository.py with 6 functions: get_views_list, get_view_by_id, create_view, update_view, delete_view, clone_view.
Visibility filter: system views (org_id IS NULL) + org-wide views + user's own private views.
Ownership check: only created_by user can update/delete (403).
Immutability check: system views cannot be updated/deleted (403).
Clone copies configuration (deep copy), sets name to "Copy of {name}" (truncated to 255), org_wide=False.
All responses include computed is_owner field.
Testing
29 unit tests in tests/test_views_repository.py covering visibility, pagination, CRUD, ownership/immutability guards, clone edge cases.
Full test suite: 2765 passed, 0 failed.
PR Guidelines
You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

PR Guideline checks

 Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

[RHINENG-25828]: https://redhat.atlassian.net/browse/RHINENG-25828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce a repository layer for inventory views with CRUD, cloning, and visibility/ownership enforcement, along with unit tests covering these behaviors.

New Features:
- Add views repository module providing list, detail, create, update, delete, and clone operations for inventory views with serialization helpers.
- Support visibility rules for system, org-wide, and user-private inventory views, including ownership flags and system-view detection.
- Allow cloning of existing inventory views into user-owned, org-scoped copies with deep-copied configuration and name truncation.

Tests:
- Add unit test suite for the views repository covering visibility filtering, pagination, CRUD behaviors, ownership and immutability checks, and cloning edge cases.