### PR TITLE
fix(RHINENG-26700): populate threadctx.org_id before span enrichment

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -474,10 +474,10 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
     def handle_message(self, message: str | bytes, headers: list[tuple[str, bytes]] | None = None):
         payload_schema = parse_operation_message(message, DebeziumEnvelopeSchema)
         validated_operation_msg = parse_operation_message(payload_schema["payload"], WorkspaceOperationSchema)
-        initialize_thread_local_storage(None)  # No request_id for workspace MQ
-        operation = validated_operation_msg["operation"]
         org_id = validated_operation_msg["org_id"]
+        operation = validated_operation_msg["operation"]
         workspace = validated_operation_msg["workspace"]
+        initialize_thread_local_storage(None, org_id=org_id)
         identity = create_mock_identity_with_org_id(org_id)
         identity.account_number = validated_operation_msg["account_number"]
         logger.info(f"Received {operation} message for workspace ID {workspace['id']}")
@@ -556,7 +556,8 @@ class HostMessageConsumer(HBIMessageConsumerBase):
         platform_metadata = validated_operation_msg.get("platform_metadata", {})
 
         request_id = platform_metadata.get("request_id")
-        initialize_thread_local_storage(request_id)
+        host_data = validated_operation_msg["data"]
+        initialize_thread_local_storage(request_id, org_id=host_data.get("org_id"))
 
         payload_tracker = get_payload_tracker(request_id=request_id)
 
@@ -564,7 +565,7 @@ class HostMessageConsumer(HBIMessageConsumerBase):
             payload_tracker, received_status_message="message received", current_operation="handle_message"
         ):
             try:
-                host = validated_operation_msg["data"]
+                host = host_data
                 if host.get("reporter") in ["rhsm-conduit", "rhsm-system-profile-bridge"] and get_flag_value(
                     FLAG_INVENTORY_REJECT_RHSM_PAYLOADS, host["org_id"]
                 ):
@@ -762,8 +763,6 @@ class HostAppMessageConsumer(HBIMessageConsumerBase):
             metrics.host_app_data_failure.labels(application=application_str, reason="unknown_application").inc()
             raise ValidationException(str(e)) from e
 
-        initialize_thread_local_storage(request_id)
-
         validated_msg = parse_operation_message(
             message,
             HostAppOperationSchema,
@@ -772,6 +771,7 @@ class HostAppMessageConsumer(HBIMessageConsumerBase):
             application=application,
         )
 
+        initialize_thread_local_storage(request_id, org_id=validated_msg.get("org_id"))
         return self.process_message(application, validated_msg)
 
     def process_message(self, application: ConsumerApplication, validated_msg: dict[str, Any]) -> OperationResult:


### PR DESCRIPTION
## Jira
[RHINENG-26700](https://issues.redhat.com/browse/RHINENG-26700)

## What
Pass `org_id` to `initialize_thread_local_storage()` across all three MQ consumers so that `rh.org_id` is available on OpenTelemetry spans.

## Why
After merging the MQ span enrichment feature (#4371), `rh.org_id` was missing from spans in stage because `threadctx.org_id` was never populated before the span context managers read it. Only `request_id` was being passed to `initialize_thread_local_storage()`, and `org_id` was set later (or not at all in some consumer paths).

## How
- **`HostMessageConsumer`**: Extract `host_data` earlier and pass `org_id` to `initialize_thread_local_storage()` before span enrichment runs.
- **`WorkspaceMessageConsumer`**: Pass `org_id` to `initialize_thread_local_storage()` instead of calling it with `None`.
- **`HostAppMessageConsumer`**: Move `initialize_thread_local_storage()` after `parse_operation_message()` so `org_id` is available from the validated message.

## Testing
- All 13 `test_mq_message_spans.py` tests pass.
- Verified in stage via Tempo: `rh.org_id` and `rh.request_id` are present on `mq.process` spans across multiple traces.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Ensure MQ consumers populate thread-local org_id so OpenTelemetry span enrichment includes organization context.

Bug Fixes:
- Populate thread-local org_id in workspace MQ consumer before processing messages so spans have the correct organization.
- Pass org_id from host message data into thread-local storage when handling host MQ messages so enriched spans include rh.org_id.
- Initialize thread-local storage with org_id for HostApp MQ messages after validation so span enrichment can read the organization.

Enhancements:
- Refactor host MQ message handling to reuse extracted host data after initializing thread-local storage.

[RHINENG-26700]: https://redhat.atlassian.net/browse/RHINENG-26700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ