### PR TITLE
chore(tests): Move to timeout kwarg for wait_for

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/resilience/test_graceful_shutdown.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/resilience/test_graceful_shutdown.py
@@ -226,7 +226,7 @@ def assert_hosts_created_in_database(inventory_db_session, hosts_ids):
     logger.info("Waiting for all hosts to be saved in the database...")
     assert wait_for(
         _assert_hosts_in_database,
-        num_sec=300,
+        timeout=300,
         delay=5,
         message="wait for all hosts to appear in DB",
     )[0]


### PR DESCRIPTION
v2.0 will drop num_sec support

## Jira
None

## What
Use the timeout kwarg in wait_for calls

## Why
Compatible with current v1.2, and forward compatible with v2.0 which will drop num_sec
https://github.com/RedHatQE/wait_for/pull/46

## How
just change the kwarg name. timeout takes int/float

## Testing
ran tests locally that include the timeout

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Tests:
- Switch wait_for calls in resilience tests from the deprecated num_sec argument to the timeout argument.