### PR TITLE
chore: add expected-image-tag annotation to CJI

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2146,6 +2146,8 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
+    annotations:
+      clowder.redhat.com/expected-image-tag: ${IMAGE_TAG}
     labels:
       app: host-inventory
     name: run-db-migrations-${IMAGE_TAG}


### PR DESCRIPTION
## Jira
N/A

## What
Add the `clowder.redhat.com/expected-image-tag` annotation to the DB migration `ClowdJobInvocation` in the ClowdApp deployment template.

## Why
There is a race condition where the migration CJI can be reconciled before the ClowdApp has been updated with the new image, causing the job to run with an outdated container image. The Clowder controller now supports an `expected-image-tag` annotation ([RedHatInsights/clowder#1779](https://github.com/RedHatInsights/clowder/pull/1779)) that makes the CJI wait until the ClowdApp's job image matches the expected tag before creating the Job.

## How
Added `annotations.clowder.redhat.com/expected-image-tag: ${IMAGE_TAG}` to the `ClowdJobInvocation` metadata in `deploy/clowdapp.yml`. The deployment pipeline already provides `IMAGE_TAG` as a parameter, so the CJI controller will now verify the ClowdApp image matches before proceeding.

## Testing
Relies on the Clowder-side unit tests in [RedHatInsights/clowder#1779](https://github.com/RedHatInsights/clowder/pull/1779) covering mismatch (requeue), match (proceed), and no-annotation (skip) scenarios. The annotation is a passthrough parameter with no application-level logic changes.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


Ref: https://github.com/RedHatInsights/clowder/pull/1779

## Summary by Sourcery

Enhancements:
- Annotate the DB migration ClowdJobInvocation with the expected image tag so its job execution is gated on the ClowdApp using the matching image.