### PR TITLE
refactor(IQE-4019): Migrate to iqe-core kafka integration

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/__init__.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/__init__.py
@@ -4,9 +4,13 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 import attr
+from iqe.base._kafka import declare_shared_consumer
 from iqe.base.application.plugins import ApplicationPlugin
 from iqe.base.application.plugins import ApplicationPluginException
 from iqe.base.application.plugins.service_objects import RESTPluginService
+
+from .modeling.kafka_interaction import HBI_REQUESTED_KAFKA_PARSER
+from .modeling.kafka_interaction import HBI_REQUESTED_KAFKA_TOPICS
 
 if TYPE_CHECKING:
     from . import modeling
@@ -38,6 +42,10 @@ class ApplicationHostInventory(ApplicationPlugin):
 
     v7_notifications_v1 = RESTPluginService.declare("v7_notifications_v1")
     v7_integrations_v1 = RESTPluginService.declare("v7_integrations_v1")
+
+    kafka_consumer = declare_shared_consumer(
+        HBI_REQUESTED_KAFKA_PARSER, HBI_REQUESTED_KAFKA_TOPICS
+    )
 
     @cached_property
     def datagen(self) -> kafka_interaction.HBIKafkaDatagen:

--- a/iqe-host-inventory-plugin/iqe_host_inventory/__init__.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/__init__.py
@@ -9,8 +9,10 @@ from iqe.base.application.plugins import ApplicationPlugin
 from iqe.base.application.plugins import ApplicationPluginException
 from iqe.base.application.plugins.service_objects import RESTPluginService
 
-from .modeling.kafka_interaction import HBI_REQUESTED_KAFKA_PARSER
-from .modeling.kafka_interaction import HBI_REQUESTED_KAFKA_TOPICS
+from .modeling.kafka_interaction import HBI_EVENTS_KAFKA_PARSER
+from .modeling.kafka_interaction import HBI_EVENTS_KAFKA_TOPICS
+from .modeling.kafka_interaction import HBI_KESSEL_KAFKA_PARSER
+from .modeling.kafka_interaction import HBI_KESSEL_KAFKA_TOPICS
 
 if TYPE_CHECKING:
     from . import modeling
@@ -43,8 +45,9 @@ class ApplicationHostInventory(ApplicationPlugin):
     v7_notifications_v1 = RESTPluginService.declare("v7_notifications_v1")
     v7_integrations_v1 = RESTPluginService.declare("v7_integrations_v1")
 
-    kafka_consumer = declare_shared_consumer(
-        HBI_REQUESTED_KAFKA_PARSER, HBI_REQUESTED_KAFKA_TOPICS
+    kafka_consumer = declare_shared_consumer(HBI_EVENTS_KAFKA_PARSER, HBI_EVENTS_KAFKA_TOPICS)
+    kessel_outbox_consumer = declare_shared_consumer(
+        HBI_KESSEL_KAFKA_PARSER, HBI_KESSEL_KAFKA_TOPICS
     )
 
     @cached_property

--- a/iqe-host-inventory-plugin/iqe_host_inventory/deprecations.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/deprecations.py
@@ -20,19 +20,6 @@ DEPRECATE_MQ_FIXTURES = deprecated(
     "v25.6.1.0",
 )
 
-DEPRECATE_MQ_CREATE_OR_UPDATE_HOST = deprecated(
-    "mq_create_or_update_host will be removed.",
-    "app.host_inventory.kafka.create_host",
-    "v25.6.1.0",
-)
-
-DEPRECATE_FIND_MQ_HOST_MSGS = deprecated(
-    "find_mq_host_msgs will be removed.",
-    "app.host_inventory.kafka.wait_for_filtered_host_messages",
-    "v25.6.1.0",
-)
-
-
 # Kafka interactions
 
 DEPRECATE_MAKE_HOST_EVENTS = deprecated(

--- a/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/kafka_fixtures.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/kafka_fixtures.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
-from collections.abc import Callable
 from collections.abc import Generator
 from random import choice
 from random import randint
@@ -12,114 +10,11 @@ from random import randint
 import pytest
 
 from iqe_host_inventory import ApplicationHostInventory
-from iqe_host_inventory.deprecations import DEPRECATE_FIND_MQ_HOST_MSGS
-from iqe_host_inventory.deprecations import DEPRECATE_MQ_CREATE_OR_UPDATE_HOST
-from iqe_host_inventory.fixtures.cleanup_fixtures import HBICleanupRegistry
 from iqe_host_inventory.modeling.groups_api import GroupData
-from iqe_host_inventory.modeling.wrappers import HostMessageWrapper
 from iqe_host_inventory.modeling.wrappers import HostWrapper
-from iqe_host_inventory.modeling.wrappers import KafkaMessageNotFoundError
 from iqe_host_inventory.utils.datagen_utils import generate_display_name
-from iqe_host_inventory.utils.kafka_utils import log_consumed_host_message
-from iqe_host_inventory.utils.kafka_utils import match_hosts
-from iqe_host_inventory.utils.kafka_utils import wrap_payload
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture
-def mq_create_or_update_host(
-    produce_msgs: Callable,
-    find_mq_host_msgs: Callable,
-    host_inventory: ApplicationHostInventory,
-    hbi_cleanup_function: HBICleanupRegistry,
-) -> Callable:
-    warnings.warn(DEPRECATE_MQ_CREATE_OR_UPDATE_HOST, stacklevel=2)
-
-    def _mq_create_or_update_host(
-        host_data: dict | None = None,
-        extra_data: dict | None = None,
-        metadata: dict | None = None,
-        operation_args: dict | None = None,
-        omit_metadata: bool = False,
-        omit_identity: bool = False,
-        omit_request_id: bool = False,
-        field_to_match: str = "insights_id",
-        timeout_in_seconds: int = 10,
-        host_inventory_app: ApplicationHostInventory = host_inventory,
-        return_events_message: bool = False,
-        wait_for_existing: bool = False,
-        retain_hosts: bool = False,
-    ) -> HostWrapper | HostMessageWrapper:
-        extra_data = extra_data or {}
-        host_data = host_data or host_inventory_app.datagen.create_host_data(**extra_data)
-        host_message = wrap_payload(
-            host_data,
-            identity=host_inventory_app.kafka.identity,
-            metadata=metadata,
-            operation_args=operation_args,
-            omit_identity=omit_identity,
-            omit_metadata=omit_metadata,
-            omit_request_id=omit_request_id,
-        )
-
-        logger.info(
-            f"Creating/Updating a host via MQ to {host_inventory_app.kafka.ingress_topic} topic"
-        )
-        produce_msgs(host_inventory_app.kafka.ingress_topic, [host_message])
-        logger.info(f"Delivered message: {host_message}")
-
-        logger.info("Consuming a host via MQ")
-        consumed_host_message = find_mq_host_msgs(
-            field_to_match=field_to_match,
-            values_to_match=[host_data[field_to_match]],
-            timeout_in_seconds=timeout_in_seconds,
-        )
-        log_consumed_host_message(consumed_host_message, field_to_match)
-
-        host = consumed_host_message.host
-
-        # todo: mq support
-        if not retain_hosts:
-            hbi_cleanup_function(host_inventory_app)
-            host_inventory_app.cleanup.add_hosts(host)
-        if wait_for_existing:
-            host_inventory_app.apis.hosts.wait_for_created(host)
-        if not return_events_message:
-            return host
-
-        return consumed_host_message
-
-    return _mq_create_or_update_host
-
-
-@pytest.fixture
-def find_mq_host_msgs(find_msgs: Callable, host_inventory: ApplicationHostInventory) -> Callable:
-    warnings.warn(DEPRECATE_FIND_MQ_HOST_MSGS, stacklevel=2)
-
-    def _find_mq_host_msgs(
-        field_to_match: str,
-        values_to_match: list[object],
-        timeout_in_seconds: int = 10,
-    ) -> HostMessageWrapper | list[HostMessageWrapper]:
-        result = find_msgs(
-            topic=host_inventory.kafka.events_topic,
-            data_to_match={"field": field_to_match, "values": values_to_match},
-            num_matches=len(values_to_match),
-            matching_func=match_hosts,
-            timeout_in_seconds=timeout_in_seconds,
-        )
-
-        if isinstance(result, list):
-            if not result:
-                raise KafkaMessageNotFoundError(
-                    HostMessageWrapper, field_to_match, values_to_match
-                )
-            return [HostMessageWrapper.from_message(message) for message in result]
-
-        return HostMessageWrapper.from_message(result)
-
-    return _find_mq_host_msgs
 
 
 @pytest.fixture

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/groups_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/groups_api.py
@@ -9,13 +9,13 @@ from collections.abc import Generator
 from dataclasses import dataclass
 from functools import cached_property
 from time import sleep
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import TypedDict
 
 import attr
 from iqe.base.modeling import BaseEntity
 
-from iqe_host_inventory import ApplicationHostInventory
 from iqe_host_inventory.modeling.hosts_api import HOST_OR_HOSTS
 from iqe_host_inventory.modeling.hosts_api import _ids_from_hosts
 from iqe_host_inventory.utils import is_global_account
@@ -31,6 +31,9 @@ from iqe_host_inventory_api import GroupOutWithHostCount
 from iqe_host_inventory_api import GroupQueryOutput
 from iqe_host_inventory_api import GroupsApi
 from iqe_host_inventory_api import HostOut
+
+if TYPE_CHECKING:
+    from iqe_host_inventory import ApplicationHostInventory
 
 GROUP_NOT_CREATED_ERROR = Exception("Group wasn't successfully created")
 GROUP_NOT_UPDATED_ERROR = Exception("Group wasn't successfully updated")

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/kafka_interaction.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/kafka_interaction.py
@@ -58,12 +58,6 @@ REQUESTED_EVENTS_TOPIC = "platform.inventory.events"
 REQUESTED_NOTIFICATIONS_TOPIC = "platform.notifications.ingress"
 REQUESTED_KESSEL_OUTBOX_TOPIC = "outbox.event.kessel.resources"
 
-HBI_REQUESTED_KAFKA_TOPICS = {
-    REQUESTED_EVENTS_TOPIC: "host-inventory",
-    REQUESTED_NOTIFICATIONS_TOPIC: "host-inventory",
-    REQUESTED_KESSEL_OUTBOX_TOPIC: "",  # empty = auto-discover from any ClowdApp
-}
-
 
 # These ParsedMessage subclasses are required by declare_shared_consumer to define
 # topic subscriptions. HBI performs its own message wrapping in _walk_events_with_wrappers
@@ -78,11 +72,16 @@ class NotificationParsedMessage(ParsedMessage, requested_topic=REQUESTED_NOTIFIC
 class KesselOutboxParsedMessage(ParsedMessage, requested_topic=REQUESTED_KESSEL_OUTBOX_TOPIC): ...
 
 
-HBI_REQUESTED_KAFKA_PARSER = make_parser(
-    HostEventParsedMessage,
-    NotificationParsedMessage,
-    KesselOutboxParsedMessage,
-)
+HBI_EVENTS_KAFKA_TOPICS = {
+    REQUESTED_EVENTS_TOPIC: "host-inventory",
+    REQUESTED_NOTIFICATIONS_TOPIC: "host-inventory",
+}
+HBI_EVENTS_KAFKA_PARSER = make_parser(HostEventParsedMessage, NotificationParsedMessage)
+
+HBI_KESSEL_KAFKA_TOPICS = {
+    REQUESTED_KESSEL_OUTBOX_TOPIC: "",  # empty = auto-discover from any ClowdApp
+}
+HBI_KESSEL_KAFKA_PARSER = make_parser(KesselOutboxParsedMessage)
 
 
 if TYPE_CHECKING:
@@ -97,7 +96,6 @@ T = TypeVar(
     DeleteNotificationWrapper,
     RegisteredNotificationWrapper,
     StaleNotificationWrapper,
-    KesselOutboxWrapper,
 )
 
 SAP_FILTER_DISPLAY_NAME = ".HBI-FILTER-TEST"
@@ -375,14 +373,11 @@ type _WrappedMessage = (
     | DeleteNotificationWrapper
     | RegisteredNotificationWrapper
     | StaleNotificationWrapper
-    | KesselOutboxWrapper
 )
 
 
 @attr.s
 class HBIKafkaActions(BaseEntity):
-    _pending_messages: list[_WrappedMessage] = attr.ib(factory=list, init=False, repr=False)
-
     @cached_property
     def _host_inventory(self) -> ApplicationHostInventory:
         return self.application.host_inventory
@@ -403,6 +398,12 @@ class HBIKafkaActions(BaseEntity):
     def _consumer(self) -> MessagesSearch:
         # IQE-3555: mini_drain was previously attempted here but was ineffective
         return self._host_inventory.kafka_consumer
+
+    @cached_property
+    def _kessel_outbox_consumer(self) -> MessagesSearch:
+        """Separate consumer for kessel events -- otherwise they are consumed
+        while waiting for host events and are lost by the time we look for them."""
+        return self._host_inventory.kessel_outbox_consumer
 
     @cached_property
     def _producer(self) -> IQEKafkaProducer:
@@ -651,10 +652,6 @@ class HBIKafkaActions(BaseEntity):
         yield from self._consumer.walk_events(timeout=timeout)
 
     def _walk_events_with_wrappers(self, *, timeout: int) -> Iterator[_WrappedMessage]:
-        pending = self._pending_messages
-        self._pending_messages = []
-        yield from pending
-
         for message in self._walk_events(timeout=timeout):
             if message.topic() == self.events_topic:
                 yield HostMessageWrapper.from_message(message)
@@ -675,8 +672,6 @@ class HBIKafkaActions(BaseEntity):
                     yield StaleNotificationWrapper.from_message(message)
                 else:
                     yield BaseNotificationWrapper.from_message(message)
-            elif message.topic() == self.kessel_outbox_topic:
-                yield KesselOutboxWrapper.from_message(message)
             else:
                 yield message
 
@@ -686,13 +681,9 @@ class HBIKafkaActions(BaseEntity):
     def _walk_messages(
         self, requested_type: type[T] | tuple[type[T], ...], *, timeout: int | None = None
     ) -> Iterator[T]:
-        stash: list[_WrappedMessage] = []
         for message in self.walk_messages(timeout=timeout):
             if isinstance(message, requested_type):
                 yield cast(T, message)
-            else:
-                stash.append(message)
-        self._pending_messages.extend(stash)
 
     def _walk_messages_with_value(
         self,
@@ -802,7 +793,10 @@ class HBIKafkaActions(BaseEntity):
         return self._walk_messages(ErrorNotificationWrapper, timeout=timeout)
 
     def walk_kessel_messages(self, *, timeout: int | None = None) -> Iterator[KesselOutboxWrapper]:
-        return self._walk_messages(KesselOutboxWrapper, timeout=timeout)
+        for message in self._kessel_outbox_consumer.walk_events(
+            timeout=timeout or self._events_wait_time
+        ):
+            yield KesselOutboxWrapper.from_message(message)
 
     def walk_filtered_kessel_messages(
         self, host_ids: Collection[str], *, timeout: int | None = None

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/kafka_interaction.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/kafka_interaction.py
@@ -19,9 +19,11 @@ import attr
 import pytest
 from confluent_kafka import Message
 from dynaconf.utils.boxing import DynaBox
+from iqe.base._kafka._kafka_producer import IQEKafkaProducer
+from iqe.base._kafka.modeling import MessagesSearch
+from iqe.base._kafka.modeling import ParsedMessage
+from iqe.base._kafka.modeling import make_parser
 from iqe.base.modeling import BaseEntity
-from iqe_mq._kafka_consumer import IQEKafkaConsumer
-from iqe_mq._kafka_producer import IQEKafkaProducer
 
 from iqe_host_inventory.deprecations import DEPRECATE_MAKE_HOST_DATA
 from iqe_host_inventory.deprecations import DEPRECATE_MAKE_HOST_EVENTS
@@ -51,6 +53,37 @@ from iqe_host_inventory.utils.datagen_utils import get_clamped_timestamp
 from iqe_host_inventory.utils.kafka_utils import wrap_payload
 
 log = logging.getLogger(__name__)
+
+REQUESTED_EVENTS_TOPIC = "platform.inventory.events"
+REQUESTED_NOTIFICATIONS_TOPIC = "platform.notifications.ingress"
+REQUESTED_KESSEL_OUTBOX_TOPIC = "outbox.event.kessel.resources"
+
+HBI_REQUESTED_KAFKA_TOPICS = {
+    REQUESTED_EVENTS_TOPIC: "host-inventory",
+    REQUESTED_NOTIFICATIONS_TOPIC: "host-inventory",
+    REQUESTED_KESSEL_OUTBOX_TOPIC: "",  # empty = auto-discover from any ClowdApp
+}
+
+
+# These ParsedMessage subclasses are required by declare_shared_consumer to define
+# topic subscriptions. HBI performs its own message wrapping in _walk_events_with_wrappers
+# rather than using the iqe-core parser pipeline, because of the complex topic-based
+# dispatch logic (notification filtering by application, event_type branching, etc.).
+class HostEventParsedMessage(ParsedMessage, requested_topic=REQUESTED_EVENTS_TOPIC): ...
+
+
+class NotificationParsedMessage(ParsedMessage, requested_topic=REQUESTED_NOTIFICATIONS_TOPIC): ...
+
+
+class KesselOutboxParsedMessage(ParsedMessage, requested_topic=REQUESTED_KESSEL_OUTBOX_TOPIC): ...
+
+
+HBI_REQUESTED_KAFKA_PARSER = make_parser(
+    HostEventParsedMessage,
+    NotificationParsedMessage,
+    KesselOutboxParsedMessage,
+)
+
 
 if TYPE_CHECKING:
     from iqe_host_inventory import ApplicationHostInventory
@@ -334,8 +367,22 @@ def _sort_kessel_messages(
     return sorted_messages
 
 
+type _WrappedMessage = (
+    Message
+    | HostMessageWrapper
+    | BaseNotificationWrapper
+    | ErrorNotificationWrapper
+    | DeleteNotificationWrapper
+    | RegisteredNotificationWrapper
+    | StaleNotificationWrapper
+    | KesselOutboxWrapper
+)
+
+
 @attr.s
 class HBIKafkaActions(BaseEntity):
+    _pending_messages: list[_WrappedMessage] = attr.ib(factory=list, init=False, repr=False)
+
     @cached_property
     def _host_inventory(self) -> ApplicationHostInventory:
         return self.application.host_inventory
@@ -353,26 +400,13 @@ class HBIKafkaActions(BaseEntity):
         return int(self._kafka_config.events_timeout)
 
     @cached_property
-    def _consumer(self) -> IQEKafkaConsumer:
-        consumer = self.application.mq.get_consumer_for_plugin(self._host_inventory)
-        consumer.subscribe([self.events_topic, self.notifications_topic])
-        # flush hack
-        # Unfortunately, the mini_drain doesn't work: https://issues.redhat.com/browse/IQE-3555
-        consumer.mini_drain()
-        return consumer
-
-    @cached_property
-    def _kessel_outbox_consumer(self) -> IQEKafkaConsumer:
-        """We need a separate consumer for the kessel events, otherwise they are consumed at the
-        time when we are waiting for host events produced by HBI, and then we can't see them."""
-        consumer = self.application.mq.get_consumer_for_plugin(self._host_inventory)
-        consumer.subscribe([self.kessel_outbox_topic])
-        consumer.mini_drain()
-        return consumer
+    def _consumer(self) -> MessagesSearch:
+        # IQE-3555: mini_drain was previously attempted here but was ineffective
+        return self._host_inventory.kafka_consumer
 
     @cached_property
     def _producer(self) -> IQEKafkaProducer:
-        return self.application.mq.producer
+        return self.application.kafka.producer
 
     @cached_property
     def ingress_topic(self) -> str:
@@ -417,9 +451,6 @@ class HBIKafkaActions(BaseEntity):
         quiet: bool = False,
         key: str | None = None,
     ) -> None:
-        # Unfortunately, the mini_drain doesn't work: https://issues.redhat.com/browse/IQE-3555
-        self._consumer.mini_drain()  # ensure we drain
-
         for host_data in hosts_data:
             host_message = wrap_payload(
                 host_data,
@@ -617,19 +648,13 @@ class HBIKafkaActions(BaseEntity):
             log.info(f"flush completed, {res} still in queue")
 
     def _walk_events(self, *, timeout: int) -> Iterator[Message]:
-        yield from self._consumer.walk_messages(timeout=timeout, wrap=False)
+        yield from self._consumer.walk_events(timeout=timeout)
 
-    def _walk_events_with_wrappers(
-        self, *, timeout: int
-    ) -> Iterator[
-        Message
-        | HostMessageWrapper
-        | BaseNotificationWrapper
-        | ErrorNotificationWrapper
-        | DeleteNotificationWrapper
-        | RegisteredNotificationWrapper
-        | StaleNotificationWrapper
-    ]:
+    def _walk_events_with_wrappers(self, *, timeout: int) -> Iterator[_WrappedMessage]:
+        pending = self._pending_messages
+        self._pending_messages = []
+        yield from pending
+
         for message in self._walk_events(timeout=timeout):
             if message.topic() == self.events_topic:
                 yield HostMessageWrapper.from_message(message)
@@ -650,28 +675,24 @@ class HBIKafkaActions(BaseEntity):
                     yield StaleNotificationWrapper.from_message(message)
                 else:
                     yield BaseNotificationWrapper.from_message(message)
+            elif message.topic() == self.kessel_outbox_topic:
+                yield KesselOutboxWrapper.from_message(message)
             else:
                 yield message
 
-    def walk_messages(
-        self, *, timeout: int | None = None
-    ) -> Iterator[
-        Message
-        | HostMessageWrapper
-        | BaseNotificationWrapper
-        | ErrorNotificationWrapper
-        | DeleteNotificationWrapper
-        | RegisteredNotificationWrapper
-        | StaleNotificationWrapper
-    ]:
+    def walk_messages(self, *, timeout: int | None = None) -> Iterator[_WrappedMessage]:
         yield from self._walk_events_with_wrappers(timeout=timeout or self._events_wait_time)
 
     def _walk_messages(
         self, requested_type: type[T] | tuple[type[T], ...], *, timeout: int | None = None
     ) -> Iterator[T]:
+        stash: list[_WrappedMessage] = []
         for message in self.walk_messages(timeout=timeout):
             if isinstance(message, requested_type):
                 yield cast(T, message)
+            else:
+                stash.append(message)
+        self._pending_messages.extend(stash)
 
     def _walk_messages_with_value(
         self,
@@ -781,10 +802,7 @@ class HBIKafkaActions(BaseEntity):
         return self._walk_messages(ErrorNotificationWrapper, timeout=timeout)
 
     def walk_kessel_messages(self, *, timeout: int | None = None) -> Iterator[KesselOutboxWrapper]:
-        for message in self._kessel_outbox_consumer.walk_messages(
-            timeout=timeout or self._events_wait_time, wrap=False
-        ):
-            yield KesselOutboxWrapper.from_message(message)
+        return self._walk_messages(KesselOutboxWrapper, timeout=timeout)
 
     def walk_filtered_kessel_messages(
         self, host_ids: Collection[str], *, timeout: int | None = None

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/rbac_api.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Sequence
 from copy import deepcopy
 from functools import cached_property
+from typing import TYPE_CHECKING
 
 import attr
 from iqe.base.modeling import BaseEntity
@@ -39,7 +40,6 @@ from iqe_bindings.v7.rbac_v2 import RoleBindingsUpdateRoleBindingsRequest
 from iqe_bindings.v7.rbac_v2 import RolesBatchDeleteRolesRequest
 from iqe_bindings.v7.rbac_v2 import RolesCreateOrUpdateRoleRequest
 
-from iqe_host_inventory import ApplicationHostInventory
 from iqe_host_inventory.modeling.groups_api import GROUP_OR_ID
 from iqe_host_inventory.modeling.groups_api import _ids_from_groups
 from iqe_host_inventory.schemas import RBACRestClient
@@ -50,6 +50,9 @@ from iqe_host_inventory.utils.rbac_utils import RBACRoles
 from iqe_host_inventory.utils.rbac_utils import get_role_id
 from iqe_host_inventory.utils.rbac_utils import permission_to_v2
 from iqe_host_inventory.utils.rbac_utils import wait_for_kessel_sync
+
+if TYPE_CHECKING:
+    from iqe_host_inventory import ApplicationHostInventory
 
 logger = logging.getLogger(__name__)
 

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/workspaces_api.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/workspaces_api.py
@@ -7,6 +7,7 @@ from collections.abc import Collection
 from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import cached_property
+from typing import TYPE_CHECKING
 
 import attr
 from iqe.base.modeling import BaseEntity
@@ -25,11 +26,13 @@ from iqe_bindings.v7.rbac_v2 import WorkspacesWorkspaceTypesQueryParam
 from iqe_bindings.v7.rbac_v2.exceptions import ApiException
 from iqe_bindings.v7.rbac_v2.exceptions import NotFoundException
 
-from iqe_host_inventory import ApplicationHostInventory
 from iqe_host_inventory.utils import is_global_account
 from iqe_host_inventory.utils.api_utils import FORBIDDEN_OR_NOT_FOUND
 from iqe_host_inventory.utils.api_utils import accept_when
 from iqe_host_inventory.utils.datagen_utils import generate_display_name
+
+if TYPE_CHECKING:
+    from iqe_host_inventory import ApplicationHostInventory
 
 WORKSPACE_NOT_CREATED_ERROR = Exception("Workspace wasn't successfully created")
 WORKSPACE_NOT_UPDATED_ERROR = Exception("Workspace wasn't successfully updated")

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/wrappers.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/wrappers.py
@@ -14,8 +14,6 @@ from typing import overload
 if TYPE_CHECKING:
     from confluent_kafka import Message
 
-from iqe_mq._transforms import MessageWrapper as MqMessageWrapper
-
 from iqe_host_inventory.schemas import PER_REPORTER_STALENESS
 
 HOST_DATA_OUT = TypeVar("HOST_DATA_OUT")
@@ -173,7 +171,7 @@ class HostMessageWrapper:
     _raw_message: Message | None = None
 
     @classmethod
-    def from_message(cls, msg: Message | MqMessageWrapper):
+    def from_message(cls, msg: Message):
         value = cast(dict[str, Any], msg.value())
         data = {
             "host": HostWrapper(value.get("host", value)),

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/db/test_host_reaper.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/db/test_host_reaper.py
@@ -38,8 +38,8 @@ def check_events_and_notifications(
 ) -> None:
     logger.info("Searching deletion events and notifications")
     all_hosts_ids = {host.id for staleness in hosts.keys() for host in hosts[staleness]}
-    found_host_events = set()
-    found_notifications = set()
+    found_host_events: set[HostMessageWrapper] = set()
+    found_notifications: set[DeleteNotificationWrapper] = set()
 
     # Get all host event messages and notifications
     for msg in host_inventory.kafka.walk_messages(timeout=5):

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/notifications/kafka/test_notifications_kafka_registered.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/notifications/kafka/test_notifications_kafka_registered.py
@@ -41,8 +41,9 @@ def find_host_and_notification_messages(
     hosts = []
     notifications = []
     for msg in host_inventory.kafka.walk_messages():
-        if isinstance(msg, HostMessageWrapper) and msg.host.provider_id in provider_ids:
-            hosts.append(msg.host)
+        if isinstance(msg, HostMessageWrapper) and msg.value.get("type") in ("created", "updated"):
+            if getattr(msg.host, "provider_id", None) in provider_ids:
+                hosts.append(msg.host)
         elif isinstance(msg, RegisteredNotificationWrapper):
             notifications.append(msg)
         if len(hosts) == len(provider_ids):

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_mq_host_creation.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_mq_host_creation.py
@@ -8,6 +8,7 @@ from time import sleep
 import pytest
 
 from iqe_host_inventory import ApplicationHostInventory
+from iqe_host_inventory.modeling.wrappers import HostWrapper
 from iqe_host_inventory.utils import assert_datetimes_equal
 from iqe_host_inventory.utils.datagen_utils import fake
 from iqe_host_inventory.utils.datagen_utils import generate_display_name
@@ -757,6 +758,10 @@ def test_rhsm_update_display_name_ignored_after_updated_by_api(
     # Update the display_name via API
     api_display_name = generate_display_name()
     host_inventory.apis.hosts.patch_hosts(host, display_name=api_display_name)
+
+    # Drain the Kafka "updated" event produced by the API PATCH so it doesn't
+    # interfere with the next create_host call's event matching.
+    host_inventory.kafka.wait_for_filtered_host_message(HostWrapper.insights_id, host.insights_id)
 
     response_host = host_inventory.apis.hosts.get_host_by_id(host)
     assert response_host.display_name == api_display_name

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/api_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/api_utils.py
@@ -18,7 +18,6 @@ from urllib.parse import quote
 import pytest
 from _pytest._code.code import ExceptionInfo
 
-from iqe_host_inventory import ApplicationHostInventory
 from iqe_host_inventory.deprecations import DEPRECATE_ASYNC_GET_MULTIPLE_HOSTS
 from iqe_host_inventory.schemas import PER_REPORTER_STALENESS
 from iqe_host_inventory.utils import get_org_id
@@ -35,6 +34,7 @@ from iqe_host_inventory_api_v7 import ApiException as ApiException_V7
 from .retrying import accept_when
 
 if TYPE_CHECKING:
+    from iqe_host_inventory import ApplicationHostInventory
     from iqe_host_inventory.modeling import HBI_API_WRAPPER
 
 

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/kafka_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/kafka_utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import warnings
 from base64 import b64decode
 from base64 import b64encode
 from collections.abc import Callable
@@ -12,15 +11,11 @@ from datetime import timedelta
 from time import sleep
 from typing import Any
 from typing import TypeVar
-from typing import cast
 from uuid import UUID
 
 import pytest
 from confluent_kafka.error import ConsumeError
-from iqe_mq._transforms import MessageWrapper as MqMessageWrapper
 
-from iqe_host_inventory.deprecations import DEPRECATE_FIND_MQ_HOST_MSGS
-from iqe_host_inventory.deprecations import DEPRECATE_MQ_CREATE_OR_UPDATE_HOST
 from iqe_host_inventory.modeling.wrappers import HostMessageWrapper
 from iqe_host_inventory.modeling.wrappers import HostWrapper
 from iqe_host_inventory.modeling.wrappers import KafkaMessageNotFoundError
@@ -65,23 +60,6 @@ def wrap_payload(
         result["platform_metadata"] = metadata
 
     return result
-
-
-def match_hosts(message: dict, data_to_match: dict):
-    warnings.warn(DEPRECATE_FIND_MQ_HOST_MSGS, stacklevel=2)
-    if not isinstance(message, dict) or not isinstance(data_to_match, dict):
-        return None
-
-    field_to_match = data_to_match.get("field")
-
-    for field_value in data_to_match.get("values", ()):
-        if message.get("host"):
-            message_field_value = message["host"].get(field_to_match)
-        else:
-            message_field_value = message.get(field_to_match)
-
-        if field_value == message_field_value:
-            return message
 
 
 def events_message_expected_headers() -> set[str]:
@@ -466,27 +444,6 @@ def stripped_identity(identity: str | dict) -> dict:
 
 def prepare_identity_metadata(identity: dict) -> dict:
     return {"b64_identity": encode_identity(identity)}
-
-
-def log_consumed_host_message(
-    message: HostMessageWrapper | MqMessageWrapper | list[HostMessageWrapper], field_to_match: str
-):
-    warnings.warn(DEPRECATE_MQ_CREATE_OR_UPDATE_HOST, stacklevel=2)
-    if isinstance(message, list):
-        for msg in message:
-            log_consumed_host_message(msg, field_to_match)
-    else:
-        if isinstance(message, MqMessageWrapper):
-            host = HostWrapper(cast(dict[str, Any], message.value()))
-            logger.warning("old host message wrapper for %s", host.id)
-        else:
-            host = message.host
-        logger.info(
-            "Consumed host message for %s=%r: Host ID=%s",
-            field_to_match,
-            getattr(host, field_to_match),
-            host.id,
-        )
 
 
 T = TypeVar("T")

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import logging
 from enum import Enum
 from time import sleep
+from typing import TYPE_CHECKING
 
 from iqe_bindings.v7.rbac_v1 import RoleOutDynamic
 from iqe_bindings.v7.rbac_v1 import RoleWithAccess
 from iqe_bindings.v7.rbac_v2 import Permission as RBACV2Permission
 from iqe_bindings.v7.rbac_v2 import Role as RBACV2Role
 
-from iqe_host_inventory import ApplicationHostInventory
+if TYPE_CHECKING:
+    from iqe_host_inventory import ApplicationHostInventory
 
 logger = logging.getLogger(__name__)
 

--- a/iqe-host-inventory-plugin/pyproject.toml
+++ b/iqe-host-inventory-plugin/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
   "iqe-core>=24.11.29.1",
   "iqe-export-service-plugin",
   "iqe-kessel-sync-plugin",
-  "iqe-mq-plugin>=24.11.29",
   "iqe-turnpike-plugin",
   "lxml",
   "ocdeployer",

--- a/iqe-host-inventory-plugin/pyproject.toml
+++ b/iqe-host-inventory-plugin/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "google-api-python-client",
   "google-auth",
   "iqe-bindings",
-  "iqe-core>=24.11.29.1",
+  "iqe-core>=26.06.18.0",
   "iqe-export-service-plugin",
   "iqe-kessel-sync-plugin",
   "iqe-turnpike-plugin",

--- a/iqe-host-inventory-plugin/pyproject.toml
+++ b/iqe-host-inventory-plugin/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "google-api-python-client",
   "google-auth",
   "iqe-bindings",
-  "iqe-core>=26.06.18.0",
+  "iqe-core>=26.06.22.0",
   "iqe-export-service-plugin",
   "iqe-kessel-sync-plugin",
   "iqe-turnpike-plugin",

--- a/iqe-host-inventory-plugin/uv.lock
+++ b/iqe-host-inventory-plugin/uv.lock
@@ -976,45 +976,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fastavro"
-version = "1.12.2"
-source = { registry = "https://nexus.corp.redhat.com/repository/cqt-pypi/simple" }
-sdist = { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2.tar.gz", hash = "sha256:3c79502d56cf6b76210032e1c53494ddfbc73c140bccf2ef4092b3f0825323ab" }
-wheels = [
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e331896e8efffc72fa03e63b87ebfc37960113127da8e0f5152d91664ffed68" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f01ebaada59d74fdf6d28e5031a961a413b3752e9edb0c03866fa18480cf4c8" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25ef6855935f67582740ffa6bb978e40ec51be876117a3555c36fa2488dcdf25" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:84a4f76a0aece0aa72b5ed8162ba2ff8c78908b8361b5a5d92ddd161977ccb74" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:81e8da77d201916f6771fc357fda8267c2a256d7aa11923d43bc5f2fc155878b" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:1924349c74666c89417bd5cc2749f598e2f15f1d56ee81428b2317ab02c88aae" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:4c346cf449baf3b113e997c34151ad205e7135bc429469b005b180ade7e65e28" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:57bb6b908cb2e05baab63b04c3a31be3b4545a10bfab9748b8763016b5256704" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a007f95cc682f56e6d83f1d17c29c00bf719d6fe8e003282b535af3a1ba09c0" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e90460b0cd21f62be3cb26087e706e2cebb7b3fcef9e05b4473b61bb0415b5e" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7ccd15966b8218d41b06ec3e7c2556be89a8a693026c771e6564d2e40bbaf8ea" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06b6971d3dae10cb34353b857d16ad21ebd6f0ea394e86c96abdcad109005d6e" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:98dfcdfaf1498ae2f0e2fafe900a82e8320cc81d8ae5a95b8b8879eaa3298c39" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:3888ef7a51adc77cdf07251bc762566a1be36211e1cff689f13980f3776a2f36" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:283dcd3129b632021894425974bedd0eb6db3bbf5994e448ccad10db4d803d31" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d125e210d5a0a1f701f12c0ecad9a03f1b04b5eddbce6ca36a1fc217da977ef" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d4d66afad78e8f47feaa307728a6b71fe3effc63ba2b9eeb109ee687c9bd397" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2328ec07925c04c89719e3971c9068a165c7fd474ea87675b1204de0440e71ff" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55dea7e74b834d4b70467fc19c5b9ccb5509fe39abc4d26891187c1b22176423" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8d37c87826ae7195cfbd20fcd448801f2f563bb38f2691ec6574e39cb9eca6c8" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c463a3701f293e30d3d62e71e1989f112028d07f87432baf4507eeb57ec3831" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f604ba83498e209fff4c7ecc5063a39421dc538dace694bc592f9f338254f3dc" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bfac2dada8ddc002e8b7d8289d6fad4f070bc1fec20371cec684a7d10d932e96" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57594b72cf663bbd0f3ad8a319a999fc3d7c71065a6799b2c1d1a6a137894c5b" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370" },
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/fastavro/1.12.2/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:afede7324822800e4f90e96b9514188a237a60f35e8e7a10b2129c10c78f6e4d" },
-]
-
-[[package]]
 name = "fauxfactory"
 version = "4.2.2"
 source = { registry = "https://nexus.corp.redhat.com/repository/cqt-pypi/simple" }
@@ -1685,7 +1646,7 @@ wheels = [
 
 [[package]]
 name = "iqe-core"
-version = "26.6.19.0"
+version = "26.6.22.0"
 source = { registry = "https://nexus.corp.redhat.com/repository/cqt-pypi/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1766,7 +1727,7 @@ dependencies = [
     { name = "widgetastic-core" },
 ]
 wheels = [
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/iqe-core/26.6.19.0/iqe_core-26.6.19.0-py3-none-any.whl", hash = "sha256:6a77d7229c65b5fde6531574a078b5e878c3f6b6944f5b690572f07ed50f016a" },
+    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/iqe-core/26.6.22.0/iqe_core-26.6.22.0-py3-none-any.whl", hash = "sha256:42df915a45499843fb4d927fdac987c3a4613ecc01eda41717acea2b1c14c9ef" },
 ]
 
 [[package]]
@@ -1811,7 +1772,6 @@ dependencies = [
     { name = "iqe-core" },
     { name = "iqe-export-service-plugin" },
     { name = "iqe-kessel-sync-plugin" },
-    { name = "iqe-mq-plugin" },
     { name = "iqe-turnpike-plugin" },
     { name = "lxml" },
     { name = "ocdeployer" },
@@ -1837,10 +1797,9 @@ requires-dist = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "iqe-bindings" },
-    { name = "iqe-core", specifier = ">=24.11.29.1" },
+    { name = "iqe-core", specifier = ">=26.6.22.0" },
     { name = "iqe-export-service-plugin" },
     { name = "iqe-kessel-sync-plugin" },
-    { name = "iqe-mq-plugin", specifier = ">=24.11.29" },
     { name = "iqe-turnpike-plugin" },
     { name = "lxml" },
     { name = "ocdeployer" },
@@ -1886,21 +1845,6 @@ dependencies = [
 ]
 wheels = [
     { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/iqe-metadata-linting/26.4.10.0/iqe_metadata_linting-26.4.10.0-py3-none-any.whl", hash = "sha256:59b6e082a0e86ccf017acbdec2f6da37a966c117f7863c1db0b83ddc591a5161" },
-]
-
-[[package]]
-name = "iqe-mq-plugin"
-version = "25.5.13.0"
-source = { registry = "https://nexus.corp.redhat.com/repository/cqt-pypi/simple" }
-dependencies = [
-    { name = "confluent-kafka" },
-    { name = "fastavro" },
-    { name = "iqe-core" },
-    { name = "orjson" },
-    { name = "pytest-html" },
-]
-wheels = [
-    { url = "https://nexus.corp.redhat.com/repository/cqt-pypi/packages/iqe-mq-plugin/25.5.13.0/iqe_mq_plugin-25.5.13.0-py2.py3-none-any.whl", hash = "sha256:60ae617069f53544a2579bc43b298a78d83a79ed4b66c4531eb1d7a488078a00" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Jira
[IQE-4019](https://redhat.atlassian.net/browse/IQE-4019)

## What
Remove iqe-mq-plugin depedency

## Dependencies
https://gitlab.cee.redhat.com/insights-qe/iqe-core/-/merge_requests/2463

## Why
The tools have been migrated to iqe-core with an improved pattern for reading the topics

## How
Using previous migrations to other IQE plugins as example, and the iqe-core-docs pages on the kafka integration in IQE

## Testing
clowder_smoke in CJI

<details>

`-m "backend and not resilience and not cert_auth and not rbac_dependent" iqe_host_inventory/tests`

```
=== 3501 passed, 64 skipped, 587 deselected, 10 xfailed, 137 warnings, 3 manual in 1812.38s (0:30:12) ===
```

iqe_host_inventory/tests/rest/test_mq_host_creation.py
```
=== 58 passed, 42 warnings, 3 manual in 56.94s ===
```

iqe_host_inventory/tests/rest/test_hosts_mq_events.py
```
=== 119 passed, 42 warnings in 70.94s (0:01:10) ===
```

iqe_host_inventory/tests/rest/test_mq_host_apps_data.py
```
=== 20 passed, 42 warnings in 50.75s ===
```

iqe_host_inventory/tests/rest/test_mq_operation_args.py
```
=== 13 passed, 4 xfailed, 42 warnings in 54.38s ===
```

iqe_host_inventory/tests/rest/notifications/kafka/*
```
=== 75 passed, 87 warnings in 223.36s (0:03:43) ===
```

iqe_host_inventory/tests/rest/groups/test_groups_mq_events.py
```
=== 45 passed, 42 warnings in 82.04s (0:01:22) ===
```



</details>

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[IQE-4019]: https://redhat.atlassian.net/browse/IQE-4019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Refactor the host-inventory IQE plugin to use iqe-core’s Kafka integration and shared consumer instead of the deprecated iqe-mq plugin, simplifying Kafka consumption and message handling.

Enhancements:
- Introduce shared Kafka consumer configuration for host-inventory using iqe-core’s parser and topic declarations.
- Unify event, notification, and kessel outbox message consumption through a single messages search interface and parser-based wrappers.
- Simplify host message wrapping and logging utilities by removing legacy mq message wrapper handling and deprecated MQ fixtures.

Build:
- Remove iqe-mq-plugin from the plugin’s runtime dependencies.

## Summary by Sourcery

Migrate the host-inventory IQE plugin to iqe-core’s Kafka integration and shared consumers while removing legacy mq-based utilities and dependencies.

New Features:
- Introduce shared Kafka consumers for host events/notifications and Kessel outbox topics using iqe-core parser declarations.

Bug Fixes:
- Adjust notification tests to ignore non-created/updated host events and tolerate missing provider IDs, preventing spurious failures.
- Ensure Kafka event drainage in a display-name test so previously emitted events do not interfere with subsequent host event matching.

Enhancements:
- Refactor HBIKafkaActions to use iqe-core MessagesSearch-based consumers for events and Kessel outbox messages instead of iqe-mq plugin consumers.
- Simplify host message wrapping APIs by dropping mq-specific wrappers and deprecated helpers, and tightening Kafka wrapper type hints.
- Limit certain imports of ApplicationHostInventory to type-checking-only to avoid unnecessary runtime dependencies.

Build:
- Bump iqe-core dependency to a newer version and drop iqe-mq-plugin from runtime dependencies.

Tests:
- Update Kafka-driven notification and host reaper tests to work with the new shared consumer and event stream semantics.