### PR TITLE
test: Removed the duplicate from IQE test

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_get.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_get.py
@@ -1120,25 +1120,6 @@ def test_get_hosts_by_updated_incorrect_format(
 
 
 @pytest.mark.ephemeral
-def test_get_hosts_by_updated_start_after_end(host_inventory: ApplicationHostInventory):
-    """
-    https://issues.redhat.com/browse/ESSNTL-4356
-
-    metadata:
-      requirements: inv-hosts-filter-by-updated, inv-api-validation
-      assignee: fstavela
-      importance: low
-      negative: true
-      title: Get hosts with updated_start bigger than updated_end
-    """
-    host = host_inventory.kafka.create_host()
-    time_start = host.updated + timedelta(hours=1)
-    time_end = host.updated - timedelta(hours=1)
-    with raises_apierror(400, "updated_start cannot be after updated_end."):
-        host_inventory.apis.hosts.get_hosts(updated_start=time_start, updated_end=time_end)
-
-
-@pytest.mark.ephemeral
 @pytest.mark.parametrize(
     "time_format",
     ["%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S.%f+00:00", "%Y-%m-%dT%H:%M:%S.%fZ"],


### PR DESCRIPTION
## What
Removed the test_get_hosts_by_updated_start_after_end IQE test.

## Why
The scenario covered by test_get_hosts_by_updated_start_after_end is already validated in the unit test suite by test_query_hosts_filter_updated_last_check_in_start_after_end. Keeping both test results in duplicate coverage and unnecessary test maintenance.

## How
Deleted the redundant IQE test test_get_hosts_by_updated_start_after_end and relied on the existing unit test test_query_hosts_filter_updated_last_check_in_start_after_end to cover the same behavior.

## Testing
Verified that the unit test test_query_hosts_filter_updated_last_check_in_start_after_end continues to cover the intended validation.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Tests:
- Delete the IQE test_get_hosts_by_updated_start_after_end REST API test that is already covered by an existing unit test.