### PR TITLE
migrate HBI's test_get_hosts_by_updated_incorrect_format IQE test into unit tests

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_get.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_get.py
@@ -6,7 +6,6 @@ from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 from itertools import combinations
-from typing import Any
 
 import pytest
 
@@ -18,7 +17,6 @@ from iqe_host_inventory.utils import flatten
 from iqe_host_inventory.utils.api_utils import raises_apierror
 from iqe_host_inventory.utils.datagen_utils import _CORRECT_REGISTERED_WITH_VALUES
 from iqe_host_inventory.utils.datagen_utils import _CORRECT_SYSTEM_TYPE_VALUES
-from iqe_host_inventory.utils.datagen_utils import INCORRECT_DATETIMES
 from iqe_host_inventory.utils.datagen_utils import gen_tag
 from iqe_host_inventory.utils.datagen_utils import generate_display_name
 from iqe_host_inventory.utils.datagen_utils import generate_uuid
@@ -1092,31 +1090,6 @@ def test_get_hosts_by_updated_not_created(host_inventory: ApplicationHostInvento
     assert len(response_hosts) >= 1
     assert host2.id in response_ids
     assert len(response_ids.intersection({host1.id, host3.id})) == 0
-
-
-@pytest.mark.ephemeral
-@pytest.mark.parametrize("param", ["updated_start", "updated_end"])
-@pytest.mark.parametrize("value", INCORRECT_DATETIMES)
-def test_get_hosts_by_updated_incorrect_format(
-    host_inventory: ApplicationHostInventory, param: str, value: Any
-):
-    """
-    https://issues.redhat.com/browse/ESSNTL-4356
-
-    metadata:
-      requirements: inv-hosts-filter-by-updated, inv-api-validation
-      assignee: fstavela
-      importance: low
-      negative: true
-      title: Get hosts with wrong format of updated_start and updated_end parameters
-    """
-    host_inventory.kafka.create_host()
-    if isinstance(value, str):
-        value = value.replace("'", "").replace('"', "").replace("\\", "")
-    api_param = {param: value}
-    error_value = f'\\"{value}\\"' if (isinstance(value, list) and len(value)) else f"'{value}'"
-    with raises_apierror(400, f"{error_value} is not a 'date-time'"):
-        host_inventory.apis.hosts.get_hosts(**api_param)
 
 
 @pytest.mark.ephemeral

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1100,10 +1100,10 @@ def test_query_hosts_filter_last_check_in_both_same(mq_create_or_update_host, ap
     assert response_data["results"][0]["id"] != nomatch_host.id
 
 
-def test_query_hosts_filter_last_check_in_invalid_format(api_get, subtests):
+def test_query_hosts_filter_last_check_in_and_updated_invalid_format(api_get, subtests):
     invalid_formats = ("foobar", "{}", "[]", generate_uuid(), [datetime.now(), datetime.now() - timedelta(days=7)])
     for invalid_format in invalid_formats:
-        for param in ("last_check_in_start", "last_check_in_end"):
+        for param in ("last_check_in_start", "last_check_in_end", "updated_start", "updated_end"):
             with subtests.test(invalid_format=invalid_format, param=param):
                 url = build_hosts_url(query=f"?{param}={invalid_format}")
                 response_status, response_data = api_get(url)


### PR DESCRIPTION
## What
<!-- Short description of the change -->
Migrate HBI's `test_get_hosts_by_updated_incorrect_format()` IQE test into unit tests
There was already and existing unit test which covered this partially `test_query_hosts_filter_last_check_in_invalid_format` since it tested `last_check_in_start` and `last_check_in_end`
I added `updated_start` and `updated_end` to this unit test and renamed it to `test_query_hosts_filter_last_check_in_and_updated_invalid_format()`

## Why
<!-- Reason for change / linked ticket -->
Since IQE tests take time to run, modifying unit tests which includes all four times of checks.
- `last_check_in_start`
- `last_check_in_end` 
- `updated_start`
- `updated_end`

## How
<!-- Brief explanation of approach -->
- Added updated_start and updated_end in the existing unit test
- Renamed the test function name to reflect this new changed
- Removed the integration test for the same functionality

## Testing
<!-- How was this tested? -->
I tested it using the command which is successful.
`pytest -v -k test_query_hosts_filter_last_check_in_and_updated_invalid_format`

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Migrate validation of incorrectly formatted updated_* query parameters from an IQE integration test into an existing unit test covering invalid date-time filters.

Enhancements:
- Expand the last_check_in invalid format unit test to also cover updated_start and updated_end parameters, consolidating validation coverage.
- Remove the redundant IQE test that validated incorrect updated_* parameter formats in favor of the expanded unit test.

Tests:
- Extend the API hosts GET unit test to validate error handling for invalid formats of updated_start and updated_end alongside last_check_in_start and last_check_in_end.