### PR TITLE
test: Remove duplicate IQE test and enhance unit test instead

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_get.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_api_get.py
@@ -723,54 +723,6 @@ def test_get_hosts_by_registered_with_temp_old(host_inventory: ApplicationHostIn
 
 
 @pytest.mark.ephemeral
-@pytest.mark.parametrize(
-    "params",
-    [
-        ("display_name", "fqdn"),
-        ("display_name", "insights_id"),
-        ("display_name", "hostname_or_id"),
-        ("fqdn", "insights_id"),
-        ("fqdn", "hostname_or_id"),
-        ("insights_id", "hostname_or_id"),
-        ("display_name", "fqdn", "insights_id"),
-        ("display_name", "fqdn", "hostname_or_id"),
-        ("display_name", "insights_id", "hostname_or_id"),
-        ("fqdn", "insights_id", "hostname_or_id"),
-        ("display_name", "fqdn", "insights_id", "hostname_or_id"),
-    ],
-)
-def test_get_hosts_invalid_parameters_combinations(
-    host_inventory: ApplicationHostInventory, params: tuple[str]
-):
-    """
-    Test GET of host using invalid combination of parameters.
-
-    JIRA: https://issues.redhat.com/browse/ESSNTL-2193
-
-    metadata:
-        requirements: inv-hosts-get-list, inv-api-validation
-        assignee: fstavela
-        importance: low
-        title: Inventory: Test GET of host using invalid combination of parameters.
-    """
-    host = host_inventory.kafka.create_host()
-    parameters = {}
-    for param in params:
-        if param == "hostname_or_id":
-            parameters["hostname_or_id"] = host.fqdn
-        else:
-            parameters[param] = getattr(host, param)
-
-    with pytest.raises(ApiException) as err:
-        host_inventory.apis.hosts.get_hosts(**parameters)  # type: ignore[arg-type]
-    assert err.value.status == 400
-    assert (
-        "Only one of [fqdn, display_name, hostname_or_id, insights_id] may be provided at a time."
-        in err.value.body
-    )
-
-
-@pytest.mark.ephemeral
 @pytest.mark.usefixtures("hbi_staleness_cleanup")
 @pytest.mark.parametrize(
     "id_param_name",

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -496,14 +496,25 @@ def test_query_using_non_existent_fqdn(api_get):
         (f"display_name={generate_uuid()}&hostname_or_id={generate_uuid()}"),
         (f"display_name={generate_uuid()}&insights_id={generate_uuid()}"),
         (f"hostname_or_id={generate_uuid()}&insights_id={generate_uuid()}"),
+        (f"display_name={generate_uuid()}&fqdn={generate_uuid()}&insights_id={generate_uuid()}"),
+        (f"display_name={generate_uuid()}&fqdn={generate_uuid()}&hostname_or_id={generate_uuid()}"),
+        (f"display_name={generate_uuid()}&insights_id={generate_uuid()}&hostname_or_id={generate_uuid()}"),
+        (f"fqdn={generate_uuid()}&insights_id={generate_uuid()}&hostname_or_id={generate_uuid()}"),
+        (
+            f"display_name={generate_uuid()}&fqdn={generate_uuid()}&insights_id={generate_uuid()}&hostname_or_id={generate_uuid()}"
+        ),
     ),
 )
 def test_query_by_conflitcting_ids(api_get, query):
     # Not allowed to query on more than one of these fields at once
     url = build_hosts_url(query=f"?{query}")
-    response_status, _ = api_get(url)
+    response_status, response_body = api_get(url)
 
     assert response_status == 400
+    assert (
+        "Only one of [fqdn, display_name, hostname_or_id, insights_id] may be provided at a time."
+        in response_body["detail"]
+    )
 
 
 def test_query_using_display_name_substring(mq_create_three_specific_hosts, api_get, subtests):
@@ -1501,9 +1512,7 @@ def test_query_all_sp_filters_basic(db_create_host, api_get, sp_filter_param):
             "workloads": {
                 "sap": {"sap_system": True, "sids": ["ABC", "DEF"]},
                 "mssql": {"version": "15.3"},
-                "ansible": {
-                    "controller_version": "1.0",
-                },
+                "ansible": {"controller_version": "1.0"},
                 "rhel_ai": {
                     "rhel_ai_version_id": "v1.1.2",
                     "gpu_models": [
@@ -1720,11 +1729,7 @@ def test_query_all_sp_filters_not_found(db_create_host, api_get, sp_filter_param
     db_create_host(extra_data=nomatch_sp_data)
 
     # This host has none of the fields, so it shouldn't be returned either
-    nomatch_sp_data = {
-        "system_profile_facts": {
-            "bios_vendor": "ex1",
-        }
-    }
+    nomatch_sp_data = {"system_profile_facts": {"bios_vendor": "ex1"}}
     db_create_host(extra_data=nomatch_sp_data)
 
     url = build_hosts_url(query=f"?filter[system_profile]{sp_filter_param}")
@@ -1762,51 +1767,19 @@ def test_query_all_sp_filters_not_found(db_create_host, api_get, sp_filter_param
 )
 def test_query_all_sp_filters_operating_system(db_create_host, api_get, sp_filter_param):
     # Create host with this system profile
-    match_sp_data = {
-        "system_profile_facts": {
-            "operating_system": {
-                "name": "RHEL",
-                "major": "8",
-                "minor": "11",
-            }
-        }
-    }
+    match_sp_data = {"system_profile_facts": {"operating_system": {"name": "RHEL", "major": "8", "minor": "11"}}}
     match_host_id = str(db_create_host(extra_data=match_sp_data).id)
 
     # Create host with differing SP
-    nomatch_sp_data = {
-        "system_profile_facts": {
-            "operating_system": {
-                "name": "RHEL",
-                "major": "7",
-                "minor": "12",
-            }
-        }
-    }
+    nomatch_sp_data = {"system_profile_facts": {"operating_system": {"name": "RHEL", "major": "7", "minor": "12"}}}
     nomatch_host_id_1 = str(db_create_host(extra_data=nomatch_sp_data).id)
 
     # Create host with differing SP
-    nomatch_sp_data = {
-        "system_profile_facts": {
-            "operating_system": {
-                "name": "RHEL",
-                "major": "7",
-                "minor": "5",
-            }
-        }
-    }
+    nomatch_sp_data = {"system_profile_facts": {"operating_system": {"name": "RHEL", "major": "7", "minor": "5"}}}
     nomatch_host_id_2 = str(db_create_host(extra_data=nomatch_sp_data).id)
 
     # Create host with differing SP
-    nomatch_sp_data = {
-        "system_profile_facts": {
-            "operating_system": {
-                "name": "CentOS",
-                "major": "7",
-                "minor": "0",
-            }
-        }
-    }
+    nomatch_sp_data = {"system_profile_facts": {"operating_system": {"name": "CentOS", "major": "7", "minor": "0"}}}
     nomatch_host_id_3 = str(db_create_host(extra_data=nomatch_sp_data).id)
 
     url = build_hosts_url(query=f"?filter[system_profile][operating_system]{sp_filter_param}")
@@ -1836,27 +1809,11 @@ def test_query_all_sp_filters_operating_system(db_create_host, api_get, sp_filte
 )
 def test_query_sp_filters_operating_system_name(db_create_host, api_get, sp_filter_param, match):
     # Create host with this OS
-    match_sp_data = {
-        "system_profile_facts": {
-            "operating_system": {
-                "name": "CentOS",
-                "major": "8",
-                "minor": "11",
-            }
-        }
-    }
+    match_sp_data = {"system_profile_facts": {"operating_system": {"name": "CentOS", "major": "8", "minor": "11"}}}
     match_host_id = str(db_create_host(extra_data=match_sp_data).id)
 
     # Create host with differing OS
-    nomatch_sp_data = {
-        "system_profile_facts": {
-            "operating_system": {
-                "name": "RHEL",
-                "major": "7",
-                "minor": "12",
-            }
-        }
-    }
+    nomatch_sp_data = {"system_profile_facts": {"operating_system": {"name": "RHEL", "major": "7", "minor": "12"}}}
     nomatch_host_id = str(db_create_host(extra_data=nomatch_sp_data).id)
 
     url = build_hosts_url(query=f"?filter[system_profile][operating_system]{sp_filter_param}")
@@ -2167,35 +2124,15 @@ def test_query_sp_filters_query_on_object_with_is_successful_request(db_create_h
 
 def test_query_hosts_multiple_os(api_get, db_create_host, subtests):
     sp_facts_list = [
-        {
-            "operating_system": {"name": "RHEL", "major": 7, "minor": 7},
-            "host_type": "edge",
-        },
-        {
-            "operating_system": {"name": "RHEL", "major": 7, "minor": 8},
-            "host_type": "edge",
-        },
-        {
-            "operating_system": {"name": "RHEL", "major": 7, "minor": 7},
-        },
-        {
-            "operating_system": {"name": "RHEL", "major": 7, "minor": 8},
-        },
-        {
-            "operating_system": {"name": "RHEL", "major": 7, "minor": 8},
-        },
-        {
-            "operating_system": {"name": "RHEL", "major": 7, "minor": 10},
-        },
-        {
-            "operating_system": {"name": "RHEL", "major": 8, "minor": 0},
-        },
-        {
-            "operating_system": {"name": "RHEL", "major": 8, "minor": 5},
-        },
-        {
-            "operating_system": {"name": "RHEL", "major": 9, "minor": 1},
-        },
+        {"operating_system": {"name": "RHEL", "major": 7, "minor": 7}, "host_type": "edge"},
+        {"operating_system": {"name": "RHEL", "major": 7, "minor": 8}, "host_type": "edge"},
+        {"operating_system": {"name": "RHEL", "major": 7, "minor": 7}},
+        {"operating_system": {"name": "RHEL", "major": 7, "minor": 8}},
+        {"operating_system": {"name": "RHEL", "major": 7, "minor": 8}},
+        {"operating_system": {"name": "RHEL", "major": 7, "minor": 10}},
+        {"operating_system": {"name": "RHEL", "major": 8, "minor": 0}},
+        {"operating_system": {"name": "RHEL", "major": 8, "minor": 5}},
+        {"operating_system": {"name": "RHEL", "major": 9, "minor": 1}},
     ]
 
     for sp_facts in sp_facts_list:
@@ -2441,12 +2378,7 @@ def test_query_by_staleness(
     mocker: MockerFixture,
     subtests: SubTests,
 ) -> None:
-    expected_staleness_results_map = {
-        "fresh": 3,
-        "stale": 4,
-        "stale_warning": 2,
-        "culled": 10,
-    }
+    expected_staleness_results_map = {"fresh": 3, "stale": 4, "stale_warning": 2, "culled": 10}
     staleness_timestamp_map = {
         "fresh": now(),
         "stale": now() - timedelta(days=3),


### PR DESCRIPTION
## What
Removed the test_get_hosts_invalid_parameters_combinations IQE test.  And add the missing test scenarios(parameterization) an response body in the unit test.


## Why
The scenario covered by test_query_by_conflitcting_ids is already validated in the unit test suite by test_get_hosts_invalid_parameters_combinations. Keeping both test results in duplicate coverage and unnecessary test maintenance.

## How
Deleted the redundant test_get_hosts_invalid_parameters_combinations and relied on the existing unit test test_query_by_conflitcting_ids to cover the same behavior.



## Testing
Verified that the unit test test_query_by_conflitcting_ids continues to cover the intended validation.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Streamline and consolidate API host GET test coverage around invalid parameter combinations while keeping IQE tests aligned.

Tests:
- Expand unit test coverage for conflicting host identifier query parameters and verify the returned validation error message.
- Remove the redundant IQE test for invalid GET /hosts parameter combinations, relying on existing unit tests for this behavior.