### PR TITLE
feat(RHINENG-26645): add staleness upsert CJI job

### DIFF
--- a/deploy/cji.yml
+++ b/deploy/cji.yml
@@ -93,6 +93,16 @@ objects:
     appName: host-inventory
     jobs:
       - remove-null-workload-values
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    labels:
+      app: host-inventory
+    name: update-staleness-${UPDATE_STALENESS_RUN_NUMBER}
+  spec:
+    appName: host-inventory
+    jobs:
+      - update-staleness
 parameters:
 - name: SYNCHRONIZER_RUN_NUMBER
   value: '1'
@@ -111,4 +121,6 @@ parameters:
 - name: POPULATE_HOST_TYPE_RUN_NUMBER
   value: '1'
 - name: REMOVE_NULL_WORKLOAD_VALUES_RUN_NUMBER
+  value: '1'
+- name: UPDATE_STALENESS_RUN_NUMBER
   value: '1'

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2034,6 +2034,71 @@ objects:
           requests:
             cpu: ${CPU_REQUEST_POPULATE_HOST_TYPE_JOB}
             memory: ${MEMORY_REQUEST_POPULATE_HOST_TYPE_JOB}
+    - name: update-staleness
+      restartPolicy: Never
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG}
+        args: [ "./jobs/update_staleness.py" ]
+        env:
+          - name: PYTHONPATH
+            value: '/opt/app-root/src'
+          - name: INVENTORY_LOG_LEVEL
+            value: ${LOG_LEVEL}
+          - name: INVENTORY_DB_SSL_MODE
+            value: ${INVENTORY_DB_SSL_MODE}
+          - name: INVENTORY_DB_SSL_CERT
+            value: ${INVENTORY_DB_SSL_CERT}
+          - name: INVENTORY_DB_SCHEMA
+            value: "${INVENTORY_DB_SCHEMA}"
+          - name: KAFKA_BOOTSTRAP_SERVERS
+            value: ${KAFKA_BOOTSTRAP_HOST}:${KAFKA_BOOTSTRAP_PORT}
+          - name: KAFKA_EVENT_TOPIC
+            value: ${KAFKA_EVENT_TOPIC}
+          - name: KAFKA_NOTIFICATION_TOPIC
+            value: ${KAFKA_NOTIFICATION_TOPIC}
+          - name: PAYLOAD_TRACKER_KAFKA_TOPIC
+            value: ${PAYLOAD_TRACKER_KAFKA_TOPIC}
+          - name: PAYLOAD_TRACKER_SERVICE_NAME
+            value: inventory-mq-service
+          - name: PAYLOAD_TRACKER_ENABLED
+            value: 'true'
+          - name: PROMETHEUS_PUSHGATEWAY
+            value: ${PROMETHEUS_PUSHGATEWAY}
+          - name: KAFKA_PRODUCER_ACKS
+            value: ${KAFKA_PRODUCER_ACKS}
+          - name: KAFKA_PRODUCER_RETRIES
+            value: ${KAFKA_PRODUCER_RETRIES}
+          - name: KAFKA_PRODUCER_RETRY_BACKOFF_MS
+            value: ${KAFKA_PRODUCER_RETRY_BACKOFF_MS}
+          - name: KAFKA_SECURITY_PROTOCOL
+            value: ${KAFKA_SECURITY_PROTOCOL}
+          - name: KAFKA_SASL_MECHANISM
+            value: ${KAFKA_SASL_MECHANISM}
+          - <<: *namespaceFieldRef
+            name: NAMESPACE
+          - name: CLOWDER_ENABLED
+            value: "true"
+          - name: DRY_RUN
+            value: ${UPDATE_STALENESS_DRY_RUN}
+          - name: SUSPEND_JOB
+            value: ${UPDATE_STALENESS_SUSPEND_JOB}
+          - name: STALENESS_ORG_ID
+            value: ${UPDATE_STALENESS_ORG_ID}
+          - name: CONVENTIONAL_TIME_TO_STALE
+            value: ${UPDATE_STALENESS_TIME_TO_STALE}
+          - name: CONVENTIONAL_TIME_TO_STALE_WARNING
+            value: ${UPDATE_STALENESS_TIME_TO_STALE_WARNING}
+          - name: CONVENTIONAL_TIME_TO_DELETE
+            value: ${UPDATE_STALENESS_TIME_TO_DELETE}
+          - name: REPLICA_NAMESPACE
+            value: ${REPLICA_NAMESPACE}
+        resources:
+          limits:
+            cpu: ${CPU_LIMIT_UPDATE_STALENESS_JOB}
+            memory: ${MEMORY_LIMIT_UPDATE_STALENESS_JOB}
+          requests:
+            cpu: ${CPU_REQUEST_UPDATE_STALENESS_JOB}
+            memory: ${MEMORY_REQUEST_UPDATE_STALENESS_JOB}
     - name: run-db-migrations
       restartPolicy: OnFailure
       podSpec:
@@ -2681,6 +2746,14 @@ parameters:
   value: 256Mi
 - name: MEMORY_LIMIT_POPULATE_HOST_TYPE_JOB
   value: 512Mi
+- name: CPU_REQUEST_UPDATE_STALENESS_JOB
+  value: 250m
+- name: CPU_LIMIT_UPDATE_STALENESS_JOB
+  value: 500m
+- name: MEMORY_REQUEST_UPDATE_STALENESS_JOB
+  value: 256Mi
+- name: MEMORY_LIMIT_UPDATE_STALENESS_JOB
+  value: 512Mi
 - name: CPU_REQUEST_DB_MIGRATIONS_JOB
   value: 250m
 - name: CPU_LIMIT_DB_MIGRATIONS_JOB
@@ -3006,6 +3079,26 @@ parameters:
 - name: POPULATE_HOST_TYPE_BATCH_SIZE
   description: Number of hosts to process per batch in the populate-host-type job
   value: '500'
+
+# -- Update staleness Job --
+- name: UPDATE_STALENESS_DRY_RUN
+  description: Whether the update-staleness job should run in dry-run mode
+  value: 'true'
+- name: UPDATE_STALENESS_SUSPEND_JOB
+  description: Whether the update-staleness job should be suspended
+  value: 'true'
+- name: UPDATE_STALENESS_ORG_ID
+  description: The org_id to create or update custom staleness for
+  value: ''
+- name: UPDATE_STALENESS_TIME_TO_STALE
+  description: conventional_time_to_stale value in seconds (optional)
+  value: ''
+- name: UPDATE_STALENESS_TIME_TO_STALE_WARNING
+  description: conventional_time_to_stale_warning value in seconds (optional)
+  value: ''
+- name: UPDATE_STALENESS_TIME_TO_DELETE
+  description: conventional_time_to_delete value in seconds (optional)
+  value: ''
 
 # -- Remove null values in workloads fields data Job --
 - name: REMOVE_NULL_VALUES_WORKLOADS_FIELDS_DRY_RUN

--- a/jobs/update_staleness.py
+++ b/jobs/update_staleness.py
@@ -55,7 +55,7 @@ STALENESS_FIELDS = (
 )
 
 
-def _read_env_staleness_values() -> dict[str, int]:
+def _read_env_staleness_values(logger: Logger) -> dict[str, int]:
     """Read optional staleness env vars and return only those that are set."""
     env_mapping = {
         "conventional_time_to_stale": "CONVENTIONAL_TIME_TO_STALE",
@@ -66,7 +66,11 @@ def _read_env_staleness_values() -> dict[str, int]:
     for field, env_var in env_mapping.items():
         raw = os.environ.get(env_var)
         if raw is not None:
-            values[field] = int(raw)
+            try:
+                values[field] = int(raw)
+            except ValueError:
+                logger.error("%s must be an integer, got: %r", env_var, raw)
+                sys.exit(1)
     return values
 
 
@@ -98,7 +102,7 @@ def run(
 
     dry_run = os.environ.get("DRY_RUN", "true").lower() == "true"
 
-    explicit_values = _read_env_staleness_values()
+    explicit_values = _read_env_staleness_values(logger)
     if not explicit_values:
         logger.error("At least one CONVENTIONAL_TIME_TO_* env var must be set.")
         sys.exit(1)

--- a/jobs/update_staleness.py
+++ b/jobs/update_staleness.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Job to create or update a custom staleness row for a given org_id.
+
+Devs cannot directly modify Prod DB rows, and the existing staleness API
+requires authentication as the target org.  This CJI-triggered job allows
+SREs to set custom staleness values for any org_id via environment variables.
+
+Environment variables:
+    STALENESS_ORG_ID          - (required) The org_id to upsert staleness for
+    CONVENTIONAL_TIME_TO_STALE         - Seconds (optional; defaults to existing or system default)
+    CONVENTIONAL_TIME_TO_STALE_WARNING - Seconds (optional; defaults to existing or system default)
+    CONVENTIONAL_TIME_TO_DELETE        - Seconds (optional; defaults to existing or system default)
+    DRY_RUN=true      - Log what would change without writing (default: true)
+    SUSPEND_JOB=true  - Exit immediately as a safety gate (default: true)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from functools import partial
+from logging import Logger
+
+from connexion import FlaskApp
+from sqlalchemy.orm import Session
+
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+from app.logging import get_logger
+from app.logging import threadctx
+from app.models import Staleness
+from app.models.schemas.staleness import StalenessSchema
+from app.models.utils import StalenessCache
+from jobs.common import excepthook
+from jobs.common import job_setup
+from lib.db import session_guard
+
+PROMETHEUS_JOB = "update-staleness"
+LOGGER_NAME = "update_staleness"
+COLLECTED_METRICS: tuple = ()
+SUSPEND_JOB = os.environ.get("SUSPEND_JOB", "true").lower() == "true"
+
+SYSTEM_DEFAULTS = {
+    "conventional_time_to_stale": CONVENTIONAL_TIME_TO_STALE_SECONDS,
+    "conventional_time_to_stale_warning": CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS,
+    "conventional_time_to_delete": CONVENTIONAL_TIME_TO_DELETE_SECONDS,
+}
+
+STALENESS_FIELDS = (
+    "conventional_time_to_stale",
+    "conventional_time_to_stale_warning",
+    "conventional_time_to_delete",
+)
+
+
+def _read_env_staleness_values() -> dict[str, int]:
+    """Read optional staleness env vars and return only those that are set."""
+    env_mapping = {
+        "conventional_time_to_stale": "CONVENTIONAL_TIME_TO_STALE",
+        "conventional_time_to_stale_warning": "CONVENTIONAL_TIME_TO_STALE_WARNING",
+        "conventional_time_to_delete": "CONVENTIONAL_TIME_TO_DELETE",
+    }
+    values: dict[str, int] = {}
+    for field, env_var in env_mapping.items():
+        raw = os.environ.get(env_var)
+        if raw is not None:
+            values[field] = int(raw)
+    return values
+
+
+def _merge_with_defaults(
+    explicit: dict[str, int],
+    existing_row: Staleness | None,
+) -> dict[str, int]:
+    """Fill in any missing fields from the existing row or system defaults."""
+    merged: dict[str, int] = {}
+    for field in STALENESS_FIELDS:
+        if field in explicit:
+            merged[field] = explicit[field]
+        elif existing_row is not None:
+            merged[field] = getattr(existing_row, field)
+        else:
+            merged[field] = SYSTEM_DEFAULTS[field]
+    return merged
+
+
+def run(
+    logger: Logger,
+    session: Session,
+    application: FlaskApp,
+) -> None:
+    org_id = os.environ.get("STALENESS_ORG_ID", "").strip()
+    if not org_id:
+        logger.error("STALENESS_ORG_ID is required but not set or empty.")
+        sys.exit(1)
+
+    dry_run = os.environ.get("DRY_RUN", "true").lower() == "true"
+
+    explicit_values = _read_env_staleness_values()
+    if not explicit_values:
+        logger.error("At least one CONVENTIONAL_TIME_TO_* env var must be set.")
+        sys.exit(1)
+
+    with application.app.app_context():
+        threadctx.request_id = None
+
+        existing_row = session.query(Staleness).filter(Staleness.org_id == org_id).one_or_none()
+        merged = _merge_with_defaults(explicit_values, existing_row)
+
+        errors = StalenessSchema().validate(merged)
+        if errors:
+            logger.error("Validation failed: %s", errors)
+            sys.exit(1)
+
+        action = "update" if existing_row else "create"
+        logger.info(
+            "Will %s staleness for org_id=%s: stale=%d, warning=%d, delete=%d",
+            action,
+            org_id,
+            merged["conventional_time_to_stale"],
+            merged["conventional_time_to_stale_warning"],
+            merged["conventional_time_to_delete"],
+        )
+
+        if dry_run:
+            logger.info("DRY_RUN is enabled; no changes written.")
+            return
+
+        if existing_row:
+            with session_guard(session, close=False):
+                for field in STALENESS_FIELDS:
+                    setattr(existing_row, field, merged[field])
+            logger.info("Updated staleness row for org_id=%s", org_id)
+        else:
+            with session_guard(session, close=False):
+                new_row = Staleness(
+                    org_id=org_id,
+                    conventional_time_to_stale=merged["conventional_time_to_stale"],
+                    conventional_time_to_stale_warning=merged["conventional_time_to_stale_warning"],
+                    conventional_time_to_delete=merged["conventional_time_to_delete"],
+                )
+                session.add(new_row)
+            logger.info("Created staleness row for org_id=%s", org_id)
+
+        StalenessCache.delete(org_id)
+        logger.info("Invalidated staleness cache for org_id=%s", org_id)
+
+
+if __name__ == "__main__":
+    logger = get_logger(LOGGER_NAME)
+    if SUSPEND_JOB:
+        logger.info("SUSPEND_JOB set to true; exiting.")
+        sys.exit(0)
+
+    job_type = "Update staleness"
+    sys.excepthook = partial(excepthook, logger, job_type)
+
+    _, session, _, _, _, application = job_setup(COLLECTED_METRICS, PROMETHEUS_JOB)
+
+    try:
+        run(logger, session, application)
+    except Exception as e:
+        logger.exception("Job failed: %s", e)
+        sys.exit(1)
+    finally:
+        session.close()

--- a/jobs/update_staleness.py
+++ b/jobs/update_staleness.py
@@ -56,7 +56,9 @@ STALENESS_FIELDS = (
 
 
 def _read_env_staleness_values(logger: Logger) -> dict[str, int]:
-    """Read optional staleness env vars and return only those that are set."""
+    """Read optional staleness env vars and return only those that are set.
+    At least one of these staleness env vars must be set.
+    """
     env_mapping = {
         "conventional_time_to_stale": "CONVENTIONAL_TIME_TO_STALE",
         "conventional_time_to_stale_warning": "CONVENTIONAL_TIME_TO_STALE_WARNING",

--- a/tests/test_job_update_staleness.py
+++ b/tests/test_job_update_staleness.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -10,6 +11,8 @@ from jobs.update_staleness import _merge_with_defaults
 from jobs.update_staleness import _read_env_staleness_values
 from jobs.update_staleness import run
 
+_logger = logging.getLogger("test_update_staleness")
+
 CUSTOM_ORG_ID = "update-staleness-test-org"
 CUSTOM_STALE = 200000
 CUSTOM_WARNING = 700000
@@ -21,7 +24,7 @@ CUSTOM_DELETE = 3000000
 
 def test_read_env_no_vars_set():
     with patch.dict("os.environ", {}, clear=True):
-        assert _read_env_staleness_values() == {}
+        assert _read_env_staleness_values(_logger) == {}
 
 
 def test_read_env_all_vars_set():
@@ -31,7 +34,7 @@ def test_read_env_all_vars_set():
         "CONVENTIONAL_TIME_TO_DELETE": "300",
     }
     with patch.dict("os.environ", env, clear=True):
-        result = _read_env_staleness_values()
+        result = _read_env_staleness_values(_logger)
     assert result == {
         "conventional_time_to_stale": 100,
         "conventional_time_to_stale_warning": 200,
@@ -42,8 +45,22 @@ def test_read_env_all_vars_set():
 def test_read_env_partial_vars():
     env = {"CONVENTIONAL_TIME_TO_DELETE": "999"}
     with patch.dict("os.environ", env, clear=True):
-        result = _read_env_staleness_values()
+        result = _read_env_staleness_values(_logger)
     assert result == {"conventional_time_to_delete": 999}
+
+
+def test_read_env_non_integer_exits():
+    env = {"CONVENTIONAL_TIME_TO_STALE": "abc"}
+    with patch.dict("os.environ", env, clear=True), pytest.raises(SystemExit) as exc_info:
+        _read_env_staleness_values(_logger)
+    assert exc_info.value.code == 1
+
+
+def test_read_env_empty_string_exits():
+    env = {"CONVENTIONAL_TIME_TO_DELETE": ""}
+    with patch.dict("os.environ", env, clear=True), pytest.raises(SystemExit) as exc_info:
+        _read_env_staleness_values(_logger)
+    assert exc_info.value.code == 1
 
 
 # -- _merge_with_defaults -----------------------------------------------------
@@ -103,13 +120,10 @@ def test_run_creates_new_row(flask_app, _staleness_env):
     with flask_app.app.app_context():
         assert _get_staleness_row(CUSTOM_ORG_ID) is None
 
-    import logging
-
-    logger = logging.getLogger("test_update_staleness")
     session = db.session
 
     with patch("jobs.update_staleness.StalenessCache") as mock_cache:
-        run(logger, session, flask_app)
+        run(_logger, session, flask_app)
 
     with flask_app.app.app_context():
         row = _get_staleness_row(CUSTOM_ORG_ID)
@@ -134,13 +148,10 @@ def test_run_updates_existing_row(flask_app, _staleness_env, monkeypatch):
     new_stale = 150000
     monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", str(new_stale))
 
-    import logging
-
-    logger = logging.getLogger("test_update_staleness")
     session = db.session
 
-    with patch("jobs.update_staleness.StalenessCache"):
-        run(logger, session, flask_app)
+    with patch("jobs.update_staleness.StalenessCache") as mock_cache:
+        run(_logger, session, flask_app)
 
     with flask_app.app.app_context():
         row = _get_staleness_row(CUSTOM_ORG_ID)
@@ -148,6 +159,7 @@ def test_run_updates_existing_row(flask_app, _staleness_env, monkeypatch):
         assert row.conventional_time_to_stale == new_stale
         assert row.conventional_time_to_stale_warning == CUSTOM_WARNING
         assert row.conventional_time_to_delete == CUSTOM_DELETE
+        mock_cache.delete.assert_called_once_with(CUSTOM_ORG_ID)
 
 
 def test_run_partial_create_uses_system_defaults(flask_app, monkeypatch):
@@ -157,13 +169,10 @@ def test_run_partial_create_uses_system_defaults(flask_app, monkeypatch):
     monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE_WARNING", raising=False)
     monkeypatch.delenv("CONVENTIONAL_TIME_TO_DELETE", raising=False)
 
-    import logging
-
-    logger = logging.getLogger("test_update_staleness")
     session = db.session
 
     with patch("jobs.update_staleness.StalenessCache"):
-        run(logger, session, flask_app)
+        run(_logger, session, flask_app)
 
     with flask_app.app.app_context():
         row = _get_staleness_row(CUSTOM_ORG_ID)
@@ -191,13 +200,10 @@ def test_run_partial_update_preserves_existing(flask_app, monkeypatch):
     monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE", raising=False)
     monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE_WARNING", raising=False)
 
-    import logging
-
-    logger = logging.getLogger("test_update_staleness")
     session = db.session
 
     with patch("jobs.update_staleness.StalenessCache"):
-        run(logger, session, flask_app)
+        run(_logger, session, flask_app)
 
     with flask_app.app.app_context():
         row = _get_staleness_row(CUSTOM_ORG_ID)
@@ -214,13 +220,10 @@ def test_run_dry_run_does_not_write(flask_app, monkeypatch):
     monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", str(CUSTOM_DELETE))
     monkeypatch.setenv("DRY_RUN", "true")
 
-    import logging
-
-    logger = logging.getLogger("test_update_staleness")
     session = db.session
 
     with patch("jobs.update_staleness.StalenessCache") as mock_cache:
-        run(logger, session, flask_app)
+        run(_logger, session, flask_app)
 
     with flask_app.app.app_context():
         assert _get_staleness_row(CUSTOM_ORG_ID) is None
@@ -231,13 +234,10 @@ def test_run_missing_org_id_exits(flask_app, monkeypatch):
     monkeypatch.setenv("STALENESS_ORG_ID", "")
     monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", "100")
 
-    import logging
-
-    logger = logging.getLogger("test_update_staleness")
     session = db.session
 
     with pytest.raises(SystemExit) as exc_info:
-        run(logger, session, flask_app)
+        run(_logger, session, flask_app)
     assert exc_info.value.code == 1
 
 
@@ -247,13 +247,10 @@ def test_run_no_staleness_env_vars_exits(flask_app, monkeypatch):
     monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE_WARNING", raising=False)
     monkeypatch.delenv("CONVENTIONAL_TIME_TO_DELETE", raising=False)
 
-    import logging
-
-    logger = logging.getLogger("test_update_staleness")
     session = db.session
 
     with pytest.raises(SystemExit) as exc_info:
-        run(logger, session, flask_app)
+        run(_logger, session, flask_app)
     assert exc_info.value.code == 1
 
 
@@ -265,14 +262,29 @@ def test_run_invalid_values_exits(flask_app, monkeypatch):
     monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", "3000000")
     monkeypatch.setenv("DRY_RUN", "false")
 
-    import logging
-
-    logger = logging.getLogger("test_update_staleness")
     session = db.session
 
     with pytest.raises(SystemExit) as exc_info:
-        run(logger, session, flask_app)
+        run(_logger, session, flask_app)
     assert exc_info.value.code == 1
 
     with flask_app.app.app_context():
         assert _get_staleness_row(CUSTOM_ORG_ID) is None
+
+
+def test_run_dry_run_defaults_to_true_when_unset(flask_app, monkeypatch):
+    """DRY_RUN should default to true when the env var is not set."""
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", str(CUSTOM_STALE))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE_WARNING", str(CUSTOM_WARNING))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", str(CUSTOM_DELETE))
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache") as mock_cache:
+        run(_logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        assert _get_staleness_row(CUSTOM_ORG_ID) is None
+        mock_cache.delete.assert_not_called()

--- a/tests/test_job_update_staleness.py
+++ b/tests/test_job_update_staleness.py
@@ -1,0 +1,278 @@
+from unittest.mock import patch
+
+import pytest
+
+from app.culling import CONVENTIONAL_TIME_TO_DELETE_SECONDS
+from app.culling import CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+from app.models import Staleness
+from app.models import db
+from jobs.update_staleness import _merge_with_defaults
+from jobs.update_staleness import _read_env_staleness_values
+from jobs.update_staleness import run
+
+CUSTOM_ORG_ID = "update-staleness-test-org"
+CUSTOM_STALE = 200000
+CUSTOM_WARNING = 700000
+CUSTOM_DELETE = 3000000
+
+
+# -- _read_env_staleness_values -----------------------------------------------
+
+
+def test_read_env_no_vars_set():
+    with patch.dict("os.environ", {}, clear=True):
+        assert _read_env_staleness_values() == {}
+
+
+def test_read_env_all_vars_set():
+    env = {
+        "CONVENTIONAL_TIME_TO_STALE": "100",
+        "CONVENTIONAL_TIME_TO_STALE_WARNING": "200",
+        "CONVENTIONAL_TIME_TO_DELETE": "300",
+    }
+    with patch.dict("os.environ", env, clear=True):
+        result = _read_env_staleness_values()
+    assert result == {
+        "conventional_time_to_stale": 100,
+        "conventional_time_to_stale_warning": 200,
+        "conventional_time_to_delete": 300,
+    }
+
+
+def test_read_env_partial_vars():
+    env = {"CONVENTIONAL_TIME_TO_DELETE": "999"}
+    with patch.dict("os.environ", env, clear=True):
+        result = _read_env_staleness_values()
+    assert result == {"conventional_time_to_delete": 999}
+
+
+# -- _merge_with_defaults -----------------------------------------------------
+
+
+def test_merge_no_existing_row_uses_system_defaults():
+    explicit = {"conventional_time_to_stale": 200000}
+    merged = _merge_with_defaults(explicit, None)
+    assert merged["conventional_time_to_stale"] == 200000
+    assert merged["conventional_time_to_stale_warning"] == CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+    assert merged["conventional_time_to_delete"] == CONVENTIONAL_TIME_TO_DELETE_SECONDS
+
+
+def test_merge_with_existing_row(flask_app):
+    with flask_app.app.app_context():
+        row = Staleness(
+            org_id="merge-test-org",
+            conventional_time_to_stale=111,
+            conventional_time_to_stale_warning=222,
+            conventional_time_to_delete=333,
+        )
+        explicit = {"conventional_time_to_delete": 999}
+        merged = _merge_with_defaults(explicit, row)
+    assert merged["conventional_time_to_stale"] == 111
+    assert merged["conventional_time_to_stale_warning"] == 222
+    assert merged["conventional_time_to_delete"] == 999
+
+
+def test_merge_all_explicit_ignores_defaults():
+    explicit = {
+        "conventional_time_to_stale": 1,
+        "conventional_time_to_stale_warning": 2,
+        "conventional_time_to_delete": 3,
+    }
+    merged = _merge_with_defaults(explicit, None)
+    assert merged == explicit
+
+
+# -- run() integration tests ---------------------------------------------------
+
+
+@pytest.fixture()
+def _staleness_env(monkeypatch):
+    """Set the minimal env for a valid run."""
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", str(CUSTOM_STALE))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE_WARNING", str(CUSTOM_WARNING))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", str(CUSTOM_DELETE))
+    monkeypatch.setenv("DRY_RUN", "false")
+
+
+def _get_staleness_row(org_id):
+    return Staleness.query.filter(Staleness.org_id == org_id).one_or_none()
+
+
+def test_run_creates_new_row(flask_app, _staleness_env):
+    with flask_app.app.app_context():
+        assert _get_staleness_row(CUSTOM_ORG_ID) is None
+
+    import logging
+
+    logger = logging.getLogger("test_update_staleness")
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache") as mock_cache:
+        run(logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        row = _get_staleness_row(CUSTOM_ORG_ID)
+        assert row is not None
+        assert row.conventional_time_to_stale == CUSTOM_STALE
+        assert row.conventional_time_to_stale_warning == CUSTOM_WARNING
+        assert row.conventional_time_to_delete == CUSTOM_DELETE
+        mock_cache.delete.assert_called_once_with(CUSTOM_ORG_ID)
+
+
+def test_run_updates_existing_row(flask_app, _staleness_env, monkeypatch):
+    with flask_app.app.app_context():
+        existing = Staleness(
+            org_id=CUSTOM_ORG_ID,
+            conventional_time_to_stale=1,
+            conventional_time_to_stale_warning=2,
+            conventional_time_to_delete=3,
+        )
+        db.session.add(existing)
+        db.session.commit()
+
+    new_stale = 150000
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", str(new_stale))
+
+    import logging
+
+    logger = logging.getLogger("test_update_staleness")
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache"):
+        run(logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        row = _get_staleness_row(CUSTOM_ORG_ID)
+        assert row is not None
+        assert row.conventional_time_to_stale == new_stale
+        assert row.conventional_time_to_stale_warning == CUSTOM_WARNING
+        assert row.conventional_time_to_delete == CUSTOM_DELETE
+
+
+def test_run_partial_create_uses_system_defaults(flask_app, monkeypatch):
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", str(CUSTOM_STALE))
+    monkeypatch.setenv("DRY_RUN", "false")
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE_WARNING", raising=False)
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_DELETE", raising=False)
+
+    import logging
+
+    logger = logging.getLogger("test_update_staleness")
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache"):
+        run(logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        row = _get_staleness_row(CUSTOM_ORG_ID)
+        assert row is not None
+        assert row.conventional_time_to_stale == CUSTOM_STALE
+        assert row.conventional_time_to_stale_warning == CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS
+        assert row.conventional_time_to_delete == CONVENTIONAL_TIME_TO_DELETE_SECONDS
+
+
+def test_run_partial_update_preserves_existing(flask_app, monkeypatch):
+    with flask_app.app.app_context():
+        existing = Staleness(
+            org_id=CUSTOM_ORG_ID,
+            conventional_time_to_stale=CUSTOM_STALE,
+            conventional_time_to_stale_warning=CUSTOM_WARNING,
+            conventional_time_to_delete=CUSTOM_DELETE,
+        )
+        db.session.add(existing)
+        db.session.commit()
+
+    new_delete = 5000000
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", str(new_delete))
+    monkeypatch.setenv("DRY_RUN", "false")
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE", raising=False)
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE_WARNING", raising=False)
+
+    import logging
+
+    logger = logging.getLogger("test_update_staleness")
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache"):
+        run(logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        row = _get_staleness_row(CUSTOM_ORG_ID)
+        assert row is not None
+        assert row.conventional_time_to_stale == CUSTOM_STALE
+        assert row.conventional_time_to_stale_warning == CUSTOM_WARNING
+        assert row.conventional_time_to_delete == new_delete
+
+
+def test_run_dry_run_does_not_write(flask_app, monkeypatch):
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", str(CUSTOM_STALE))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE_WARNING", str(CUSTOM_WARNING))
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", str(CUSTOM_DELETE))
+    monkeypatch.setenv("DRY_RUN", "true")
+
+    import logging
+
+    logger = logging.getLogger("test_update_staleness")
+    session = db.session
+
+    with patch("jobs.update_staleness.StalenessCache") as mock_cache:
+        run(logger, session, flask_app)
+
+    with flask_app.app.app_context():
+        assert _get_staleness_row(CUSTOM_ORG_ID) is None
+        mock_cache.delete.assert_not_called()
+
+
+def test_run_missing_org_id_exits(flask_app, monkeypatch):
+    monkeypatch.setenv("STALENESS_ORG_ID", "")
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", "100")
+
+    import logging
+
+    logger = logging.getLogger("test_update_staleness")
+    session = db.session
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(logger, session, flask_app)
+    assert exc_info.value.code == 1
+
+
+def test_run_no_staleness_env_vars_exits(flask_app, monkeypatch):
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE", raising=False)
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_STALE_WARNING", raising=False)
+    monkeypatch.delenv("CONVENTIONAL_TIME_TO_DELETE", raising=False)
+
+    import logging
+
+    logger = logging.getLogger("test_update_staleness")
+    session = db.session
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(logger, session, flask_app)
+    assert exc_info.value.code == 1
+
+
+def test_run_invalid_values_exits(flask_app, monkeypatch):
+    """stale >= warning should fail schema validation."""
+    monkeypatch.setenv("STALENESS_ORG_ID", CUSTOM_ORG_ID)
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE", "500000")
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_STALE_WARNING", "100")
+    monkeypatch.setenv("CONVENTIONAL_TIME_TO_DELETE", "3000000")
+    monkeypatch.setenv("DRY_RUN", "false")
+
+    import logging
+
+    logger = logging.getLogger("test_update_staleness")
+    session = db.session
+
+    with pytest.raises(SystemExit) as exc_info:
+        run(logger, session, flask_app)
+    assert exc_info.value.code == 1
+
+    with flask_app.app.app_context():
+        assert _get_staleness_row(CUSTOM_ORG_ID) is None


### PR DESCRIPTION
## Summary
- Add a new `update-staleness` ClowdJob + CJI that allows SREs to create or update custom staleness rows for any org_id via environment variables
- The job reads `STALENESS_ORG_ID` and optional `CONVENTIONAL_TIME_TO_*` env vars, validates with `StalenessSchema`, and performs an upsert with Redis cache invalidation
- Safe by default: `DRY_RUN=true` and `SUSPEND_JOB=true`; partial updates merge missing fields with existing row values or system defaults

## Jira
[RHINENG-26645](https://issues.redhat.com/browse/RHINENG-26645)

## Changes
- New `jobs/update_staleness.py` — job script with upsert logic, validation, dry-run mode, and cache invalidation
- `deploy/clowdapp.yml` — new `update-staleness` job definition with parameterized env vars and resource limits
- `deploy/cji.yml` — new `ClowdJobInvocation` for ad-hoc triggering via app-interface
- New `tests/test_job_update_staleness.py` — 14 unit/integration tests covering create, update, partial updates, dry-run, validation errors, and missing args

## Testing
- All 14 tests pass locally (`uv run pytest tests/test_job_update_staleness.py -v`)
- `make style` passes (pre-commit, ruff, mypy, swagger validation)
- Tests cover: new row creation, existing row update, partial create/update with defaults merging, dry-run no-write, missing org_id exit, missing staleness vars exit, validation rejection (stale >= warning)

Made with [Cursor](https://cursor.com)

[RHINENG-26645]: https://redhat.atlassian.net/browse/RHINENG-26645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a new ad-hoc job and ClowdJobInvocation to create or update custom staleness settings per org via environment variables, with safety defaults and validation-backed upsert logic.

New Features:
- Introduce an update-staleness job script to upsert per-org staleness rows based on environment-provided values with validation and cache invalidation.
- Expose a new update-staleness ClowdApp job and ClowdJobInvocation, configurable via parameters for org_id, staleness timings, and safety controls like dry-run and suspend flags.

Tests:
- Add unit and integration tests covering env parsing, default merging, upsert behavior, dry-run semantics, validation failures, and exit conditions for the update-staleness job.