### PR TITLE
fix(RHINENG-26863): set OPENSHIFT_BUILD_COMMIT in all deployments

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -242,6 +242,8 @@ objects:
       podSpec:
         <<: [ *gunicornPodSpec, *readProbes ]
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: APP_NAME
             value: ${APP_NAME}
           - name: PATH_PREFIX
@@ -381,6 +383,8 @@ objects:
         <<: *gunicornPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: APP_NAME
             value: ${APP_NAME}
           - name: PATH_PREFIX
@@ -517,6 +521,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL
@@ -640,6 +646,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL
@@ -765,6 +773,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL
@@ -886,6 +896,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL
@@ -1016,6 +1028,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL
@@ -1146,6 +1160,8 @@ objects:
         image: ${IMAGE}:${IMAGE_TAG}
         args: ["./inv_export_service.py"]
         env:
+        - name: OPENSHIFT_BUILD_COMMIT
+          value: ${IMAGE_TAG}
         - name: INVENTORY_LOG_LEVEL
           value: DEBUG
         - name: INVENTORY_DB_SSL_MODE
@@ -1193,6 +1209,8 @@ objects:
         <<: *mqPodSpec
         initContainers: *migrationWaitInitContainer
         env:
+          - name: OPENSHIFT_BUILD_COMMIT
+            value: ${IMAGE_TAG}
           - name: CONSOLEDOT_HOSTNAME
             value: ${CONSOLEDOT_HOSTNAME}
           - name: INVENTORY_LOG_LEVEL


### PR DESCRIPTION
## Jira
[RHINENG-26863](https://issues.redhat.com/browse/RHINENG-26863)

## What
Inject `OPENSHIFT_BUILD_COMMIT` environment variable (set to `${IMAGE_TAG}`) into all trace-emitting deployments in the ClowdApp so that the OTel `service.version` resource attribute carries the actual git SHA.

## Why
Since the migration from OpenShift S2I builds to Clowder + Quay, `OPENSHIFT_BUILD_COMMIT` has not been set in the container environment. The existing `get_build_version()` function reads this var for the OTel resource, resulting in every trace showing `service.version = "Unknown"` — making it impossible to correlate traces with deployed code.

## How
Added `OPENSHIFT_BUILD_COMMIT: ${IMAGE_TAG}` as the first env entry in 9 trace-emitting deployments:
- service-reads
- service-writes
- mq-pmin
- mq-p1
- mq-sp
- mq-workspaces
- mq-workspaces-bulk
- export-service
- mq-host-app-data
No code changes needed — `app/common.py:get_build_version()` already reads this env var.

## Testing
- Verified the YAML passes `check-yaml` pre-commit hook
- After deployment, confirm in Tempo that traces show `service.version` = git SHA (not "Unknown")

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26863]: https://redhat.atlassian.net/browse/RHINENG-26863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Ensure OpenTelemetry traces carry the actual deployed git SHA instead of reporting service.version as Unknown by setting OPENSHIFT_BUILD_COMMIT in relevant deployments.