### PR TITLE
fix(deps): Make Konflux dependency PRs update the lockfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,23 @@
     "github>RedHatInsights/konflux-pipelines//renovate/foreman_satellite/renovate.json"
   ],
   "ignorePaths": [
-    "Pipfile.iqe"
+    "Pipfile.iqe",
+    ".hermetic_builds/**"
   ],
+  "constraints": {
+    "python": "3.12",
+    "uv": "0.11"
+  },
   "tekton": {
     "schedule": [
       "at any time"
     ]
+  },
+  "pip_requirements": {
+    "enabled": false
+  },
+  "pip-compile": {
+    "enabled": false
   },
   "packageRules": [
     {
@@ -21,8 +32,5 @@
       "groupName": "opentelemetry",
       "ignoreUnstable": false
     }
-  ],
-  "pip_requirements": {
-    "enabled": false
-  }
+  ]
 }


### PR DESCRIPTION
## Jira
None

## What

- Make Konflux lock dependencies updating one
- Explicitly ignore hermetic builds when considering which deps to update

## Why

Konflux PRs haven't been updating the lockfile

## How
- Pin python & uv versions in constraints. Not having this may have led to silent failures while locking dependencies.
- Add `.hermetic_builds/**` to ignored paths.

## Testing
n/a

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Build:
- Adjust Renovate configuration so Konflux dependency updates also regenerate the lockfile and exclude hermetic build artifacts from consideration.