### PR TITLE
perf(RHINENG-26749): short-circuit host list when count is zero

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -153,6 +153,9 @@ def _get_host_list_using_filters(
     # Count distinct host IDs to avoid overcountiung when JOINs are involved
     count_total = filtered_query.with_entities(func.count(Host.id.distinct())).scalar()
 
+    if count_total == 0:
+        return [], 0, additional_fields, system_profile_fields
+
     ordered_query = filtered_query.order_by(
         *params_to_order_by(param_order_by, param_order_how, allow_app_fields=allow_app_fields)
     )


### PR DESCRIPTION
## Jira
[RHINENG-26749](https://issues.redhat.com/browse/RHINENG-26749)

## What
Short-circuit the host list query to return immediately when the COUNT query yields zero results, avoiding the subsequent expensive ORDER BY + paginated SELECT.

## Why
When filtering produces no matching hosts, the planner can still choose a suboptimal index scan (e.g., `modified_on_id_idx`) to satisfy the ORDER BY clause, resulting in 20-30s query timeouts scanning entire partitions before discovering there are no rows.

## How
Added an early return in `_get_host_list_using_filters()` (`api/host_query_db.py`) that checks `count_total == 0` and returns an empty result tuple before constructing the ordered/paginated query.

## Testing
All 372 existing `test_api_hosts_get.py` tests pass, confirming no regressions for non-empty and empty result scenarios. Linting (ruff, mypy) and pre-commit hooks pass cleanly.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26749]: https://redhat.atlassian.net/browse/RHINENG-26749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Add an early return from the host list query when the distinct host count is zero to prevent running expensive ORDER BY and pagination logic for empty results.