### PR TITLE
perf(RHINENG-26778): add composite index (org_id, provider_id)

### DIFF
--- a/migrations/versions/d7e8f9a0b1c2_add_composite_index_org_id_provider_id.py
+++ b/migrations/versions/d7e8f9a0b1c2_add_composite_index_org_id_provider_id.py
@@ -1,0 +1,45 @@
+"""Add composite index (org_id, provider_id) on hosts table
+
+This index optimizes the MQ host deduplication query pattern:
+  WHERE org_id = ? AND provider_id = ? ORDER BY modified_on DESC LIMIT 1
+
+Without this index, PostgreSQL performs a sequential scan or bitmap
+combine on the org_id partition, causing 750ms+ latencies for orgs
+with many hosts sharing the same canonical facts.
+
+Revision ID: d7e8f9a0b1c2
+Revises: c5d6e7f8a9b0
+Create Date: 2026-06-08 17:00:00.000000
+
+"""
+
+from migrations.helpers import TABLE_NUM_PARTITIONS
+from utils.partitioned_table_index_helper import create_partitioned_table_index
+from utils.partitioned_table_index_helper import drop_partitioned_table_index
+
+# revision identifiers, used by Alembic.
+revision = "d7e8f9a0b1c2"
+down_revision = "c5d6e7f8a9b0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Create index idx_hosts_org_id_provider_id on partitioned hosts table."""
+
+    create_partitioned_table_index(
+        table_name="hosts",
+        index_name="idx_hosts_org_id_provider_id",
+        index_definition="(org_id, provider_id)",
+        num_partitions=TABLE_NUM_PARTITIONS,
+    )
+
+
+def downgrade():
+    """Drop index idx_hosts_org_id_provider_id from partitioned hosts table."""
+
+    drop_partitioned_table_index(
+        table_name="hosts",
+        index_name="idx_hosts_org_id_provider_id",
+        num_partitions=TABLE_NUM_PARTITIONS,
+    )


### PR DESCRIPTION
## Jira
[RHINENG-26778](https://issues.redhat.com/browse/RHINENG-26778)

## What
Add a composite B-tree index `(org_id, provider_id)` on the `hbi.hosts` partitioned table.

## Why
The MQ host deduplication query (`WHERE org_id = ? AND provider_id = ? ORDER BY modified_on DESC LIMIT 1`) lacks a selective index for `provider_id`. Without it, PostgreSQL falls back to scanning the org partition or bitmap-combining less selective indexes, causing 750ms+ latencies for large orgs.

## How
- New Alembic migration using the `create_partitioned_table_index` helper, which in production creates indexes `CONCURRENTLY` on each partition before attaching to the parent table (zero downtime).
- Index name: `idx_hosts_org_id_provider_id`
- The two-column index is sufficient since `provider_id` is near-unique per org — sorting 1-2 rows by `modified_on` is trivial, avoiding write amplification from a wider index.
- Downgrade drops the index from parent and all partitions.

## Testing
- Migration upgrade and downgrade verified against local PostgreSQL.
- All 218 `test_host_mq_service.py` tests and 6 migration tests pass.
- Linting (ruff, mypy) and pre-commit hooks pass cleanly.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26778]: https://redhat.atlassian.net/browse/RHINENG-26778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a database migration to introduce a composite index on the partitioned hosts table to improve performance of host deduplication queries.

Enhancements:
- Add a composite B-tree index on (org_id, provider_id) for the partitioned hosts table via an Alembic migration to optimize host lookup performance.

Build:
- Wire a new Alembic migration revision that can be upgraded and downgraded to manage the new composite index on all partitions.