### PR TITLE
perf(RHINENG-26783): drop redundant idx_hosts_last_check_in_id

### DIFF
--- a/migrations/versions/e8f9a0b1c2d3_drop_redundant_last_check_in_id_index.py
+++ b/migrations/versions/e8f9a0b1c2d3_drop_redundant_last_check_in_id_index.py
@@ -23,7 +23,7 @@ from utils.partitioned_table_index_helper import drop_partitioned_table_index
 
 # revision identifiers, used by Alembic.
 revision = "e8f9a0b1c2d3"
-down_revision = "d7e8f9a0b1c2"
+down_revision = "f8a9b0c1d2e3"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/e8f9a0b1c2d3_drop_redundant_last_check_in_id_index.py
+++ b/migrations/versions/e8f9a0b1c2d3_drop_redundant_last_check_in_id_index.py
@@ -1,0 +1,49 @@
+"""Drop redundant idx_hosts_last_check_in_id index
+
+This index on (last_check_in, id) is superseded by idx_hosts_org_id_last_check_in
+which provides (org_id, last_check_in DESC). Since all queries that filter on
+last_check_in also filter on org_id (tenant isolation), the composite index
+with org_id as a leading column is strictly superior.
+
+Production evidence:
+  - idx_hosts_last_check_in_id: 0 index scans on primary, 0 on replica
+    (7+ months of stats since idx_hosts_org_id_last_check_in was created)
+  - The index adds unnecessary write amplification on every host update
+    that modifies last_check_in (~800M+ writes/month across partitions)
+
+Revision ID: e8f9a0b1c2d3
+Revises: d7e8f9a0b1c2
+Create Date: 2026-06-08 17:10:00.000000
+
+"""
+
+from migrations.helpers import TABLE_NUM_PARTITIONS
+from utils.partitioned_table_index_helper import create_partitioned_table_index
+from utils.partitioned_table_index_helper import drop_partitioned_table_index
+
+# revision identifiers, used by Alembic.
+revision = "e8f9a0b1c2d3"
+down_revision = "d7e8f9a0b1c2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Drop redundant idx_hosts_last_check_in_id from partitioned hosts table."""
+
+    drop_partitioned_table_index(
+        table_name="hosts",
+        index_name="idx_hosts_last_check_in_id",
+        num_partitions=TABLE_NUM_PARTITIONS,
+    )
+
+
+def downgrade():
+    """Recreate idx_hosts_last_check_in_id on partitioned hosts table."""
+
+    create_partitioned_table_index(
+        table_name="hosts",
+        index_name="idx_hosts_last_check_in_id",
+        index_definition="(last_check_in, id)",
+        num_partitions=TABLE_NUM_PARTITIONS,
+    )

--- a/migrations/versions/e8f9a0b1c2d3_drop_redundant_last_check_in_id_index.py
+++ b/migrations/versions/e8f9a0b1c2d3_drop_redundant_last_check_in_id_index.py
@@ -12,7 +12,7 @@ Production evidence:
     that modifies last_check_in (~800M+ writes/month across partitions)
 
 Revision ID: e8f9a0b1c2d3
-Revises: d7e8f9a0b1c2
+Revises: f8a9b0c1d2e3
 Create Date: 2026-06-08 17:10:00.000000
 
 """


### PR DESCRIPTION
## Jira
[RHINENG-26783](https://issues.redhat.com/browse/RHINENG-26783)

## What
Drop the redundant `idx_hosts_last_check_in_id` index from the `hbi.hosts` partitioned table.

## Why
This index on `(last_check_in, id)` has recorded 0 scans on both primary and replica over 7+ months since `idx_hosts_org_id_last_check_in` (`org_id, last_check_in DESC`) was introduced. All queries filtering on `last_check_in` also filter on `org_id` (tenant isolation), making the older index strictly inferior. Keeping it adds unnecessary write amplification on every host update that modifies `last_check_in` (~800M+ writes/month across partitions).

## How
- New Alembic migration using the `drop_partitioned_table_index` helper, which drops the parent index (cascading to all attached partition indexes) and cleans up any orphaned partition indexes.
- Downgrade recreates the index using `create_partitioned_table_index`.

## Testing
- Migration upgrade and downgrade verified against local PostgreSQL.
- All 590 tests (`test_api_hosts_get.py` + `test_host_mq_service.py`) pass after the index is removed.
- Linting (ruff, mypy) and pre-commit hooks pass cleanly.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26783]: https://redhat.atlassian.net/browse/RHINENG-26783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Add an Alembic migration to remove the redundant idx_hosts_last_check_in_id index from the hbi.hosts partitioned table and recreate it on downgrade.