### PR TITLE
perf(RHINENG-26782): replace per_reporter_staleness GIN with reporters array

### DIFF
--- a/api/filtering/db_filters.py
+++ b/api/filtering/db_filters.py
@@ -242,7 +242,7 @@ def _stale_timestamp_per_reporter_filter(
             )
 
             rep_condition = or_(
-                not_(Host.per_reporter_staleness.has_key(rep)),  # No reporter
+                not_(Host.reporters.any(rep)),
                 reporter_culled,
             )
             and_conditions.append(rep_condition)
@@ -252,7 +252,7 @@ def _stale_timestamp_per_reporter_filter(
         # Positive: include hosts with this reporter (not culled)
         or_filter = []
         for rep in reporter_list:
-            conditions = [Host.per_reporter_staleness.has_key(rep)]
+            conditions = [Host.reporters.any(rep)]
 
             reporter_not_culled = and_(
                 func.jsonb_typeof(Host.per_reporter_staleness[rep]) == "string",

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -269,7 +269,7 @@ class LimitedHost(db.Model, HostTypeDeriver):
 class Host(LimitedHost):
     reporter = db.Column(db.String(255), nullable=False)
     per_reporter_staleness = db.Column(JSONB, nullable=False)
-    reporters = db.Column(ARRAY(db.String(255)), nullable=True)
+    reporters = db.Column(ARRAY(db.String(255)), nullable=False, server_default="{}")
     display_name_reporter = db.Column(db.String(255))
 
     def __init__(
@@ -463,8 +463,7 @@ class Host(LimitedHost):
 
         self.per_reporter_staleness[reporter] = self.last_check_in.isoformat()
         orm.attributes.flag_modified(self, "per_reporter_staleness")
-
-        self.reporters = sorted(self.per_reporter_staleness.keys())
+        self._sync_reporters()
 
     def _update_last_check_in_date(self):
         self.last_check_in = _time_now()
@@ -580,6 +579,10 @@ class Host(LimitedHost):
 
         logger.debug("Reports from %s are not stale", reporter)
         return False
+
+    def _sync_reporters(self):
+        """Keep the reporters array in sync with per_reporter_staleness keys."""
+        self.reporters = sorted(self.per_reporter_staleness.keys()) if self.per_reporter_staleness else []
 
     @validates("per_reporter_staleness")
     def _validate_per_reporter_staleness(self, _key, value):

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -9,6 +9,7 @@ from sqlalchemy import case
 from sqlalchemy import cast
 from sqlalchemy import func
 from sqlalchemy import orm
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -268,6 +269,7 @@ class LimitedHost(db.Model, HostTypeDeriver):
 class Host(LimitedHost):
     reporter = db.Column(db.String(255), nullable=False)
     per_reporter_staleness = db.Column(JSONB, nullable=False)
+    reporters = db.Column(ARRAY(db.String(255)), nullable=True)
     display_name_reporter = db.Column(db.String(255))
 
     def __init__(
@@ -462,6 +464,8 @@ class Host(LimitedHost):
         self.per_reporter_staleness[reporter] = self.last_check_in.isoformat()
         orm.attributes.flag_modified(self, "per_reporter_staleness")
 
+        self.reporters = sorted(self.per_reporter_staleness.keys())
+
     def _update_last_check_in_date(self):
         self.last_check_in = _time_now()
         orm.attributes.flag_modified(self, "last_check_in")
@@ -581,6 +585,7 @@ class Host(LimitedHost):
     def _validate_per_reporter_staleness(self, _key, value):
         out: dict[str, str] = {}
         if not value:
+            self.reporters = []
             return out
         for reporter, raw in dict(value).items():
             if isinstance(raw, dict):
@@ -597,6 +602,7 @@ class Host(LimitedHost):
                     f"Invalid per_reporter_staleness: reporter {reporter!r} value must be str or datetime, "
                     f"not {type(raw).__name__}."
                 )
+        self.reporters = sorted(out.keys())
         return out
 
     def __repr__(self):

--- a/migrations/versions/a1b2c3d4e5f7_add_reporters_array_column.py
+++ b/migrations/versions/a1b2c3d4e5f7_add_reporters_array_column.py
@@ -11,7 +11,7 @@ This migration:
 4. Drops the old 142GB GIN index on per_reporter_staleness
 
 Revision ID: a1b2c3d4e5f7
-Revises: e8f9a0b1c2d3
+Revises: f9a0b1c2d3e4
 Create Date: 2026-06-08 17:30:00.000000
 
 """
@@ -30,7 +30,7 @@ logger = get_logger(__name__)
 
 # revision identifiers, used by Alembic.
 revision = "a1b2c3d4e5f7"
-down_revision = "e8f9a0b1c2d3"
+down_revision = "f9a0b1c2d3e4"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/a1b2c3d4e5f7_add_reporters_array_column.py
+++ b/migrations/versions/a1b2c3d4e5f7_add_reporters_array_column.py
@@ -1,0 +1,94 @@
+"""Add reporters text[] column and replace per_reporter_staleness GIN index
+
+The idx_gin_per_reporter_staleness index (142GB in production) indexes the
+entire JSONB including unique timestamp values, causing massive bloat and
+write amplification. The only queries using it check key existence (has_key).
+
+This migration:
+1. Adds a derived reporters text[] column storing just the keys
+2. Backfills it from per_reporter_staleness keys
+3. Adds a GIN index on the reporters array (much smaller, ~2-3GB estimated)
+4. Drops the old 142GB GIN index on per_reporter_staleness
+
+Revision ID: a1b2c3d4e5f7
+Revises: b3e9f1a2d7c4
+Create Date: 2026-06-08 17:30:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+from app.logging import get_logger
+from app.models.constants import INVENTORY_SCHEMA
+from migrations.helpers import TABLE_NUM_PARTITIONS
+from utils.partitioned_table_index_helper import create_partitioned_table_index
+from utils.partitioned_table_index_helper import drop_partitioned_table_index
+
+logger = get_logger(__name__)
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f7"
+down_revision = "b3e9f1a2d7c4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Step 1: Add the reporters column
+    op.add_column(
+        "hosts",
+        sa.Column("reporters", sa.ARRAY(sa.String(255)), nullable=True),
+        schema=INVENTORY_SCHEMA,
+    )
+
+    # Step 2: Backfill reporters from per_reporter_staleness keys
+    logger.info("Backfilling reporters column from per_reporter_staleness keys...")
+    op.execute(
+        text(f"""
+            UPDATE {INVENTORY_SCHEMA}.hosts
+            SET reporters = (
+                SELECT ARRAY_AGG(key ORDER BY key)
+                FROM jsonb_object_keys(per_reporter_staleness) AS key
+            )
+            WHERE per_reporter_staleness IS NOT NULL
+              AND per_reporter_staleness != '{{}}'::jsonb
+        """)
+    )
+    logger.info("Backfill complete.")
+
+    # Step 3: Add GIN index on reporters array
+    create_partitioned_table_index(
+        table_name="hosts",
+        index_name="idx_hosts_reporters_gin",
+        index_definition="USING GIN (reporters)",
+        num_partitions=TABLE_NUM_PARTITIONS,
+    )
+
+    # Step 4: Drop the old bloated GIN index on per_reporter_staleness
+    drop_partitioned_table_index(
+        table_name="hosts",
+        index_name="idx_gin_per_reporter_staleness",
+        num_partitions=TABLE_NUM_PARTITIONS,
+    )
+
+
+def downgrade():
+    # Recreate the old GIN index on per_reporter_staleness
+    create_partitioned_table_index(
+        table_name="hosts",
+        index_name="idx_gin_per_reporter_staleness",
+        index_definition="USING GIN (per_reporter_staleness)",
+        num_partitions=TABLE_NUM_PARTITIONS,
+    )
+
+    # Drop the new GIN index on reporters
+    drop_partitioned_table_index(
+        table_name="hosts",
+        index_name="idx_hosts_reporters_gin",
+        num_partitions=TABLE_NUM_PARTITIONS,
+    )
+
+    # Drop the reporters column
+    op.drop_column("hosts", "reporters", schema=INVENTORY_SCHEMA)

--- a/migrations/versions/a1b2c3d4e5f7_add_reporters_array_column.py
+++ b/migrations/versions/a1b2c3d4e5f7_add_reporters_array_column.py
@@ -11,7 +11,7 @@ This migration:
 4. Drops the old 142GB GIN index on per_reporter_staleness
 
 Revision ID: a1b2c3d4e5f7
-Revises: b3e9f1a2d7c4
+Revises: e8f9a0b1c2d3
 Create Date: 2026-06-08 17:30:00.000000
 
 """
@@ -30,16 +30,21 @@ logger = get_logger(__name__)
 
 # revision identifiers, used by Alembic.
 revision = "a1b2c3d4e5f7"
-down_revision = "b3e9f1a2d7c4"
+down_revision = "e8f9a0b1c2d3"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    # Step 1: Add the reporters column
+    # Step 1: Add the reporters column with a server default of empty array
     op.add_column(
         "hosts",
-        sa.Column("reporters", sa.ARRAY(sa.String(255)), nullable=True),
+        sa.Column(
+            "reporters",
+            sa.ARRAY(sa.String(255)),
+            nullable=False,
+            server_default="{}",
+        ),
         schema=INVENTORY_SCHEMA,
     )
 
@@ -49,8 +54,8 @@ def upgrade():
         text(f"""
             UPDATE {INVENTORY_SCHEMA}.hosts
             SET reporters = (
-                SELECT ARRAY_AGG(key ORDER BY key)
-                FROM jsonb_object_keys(per_reporter_staleness) AS key
+                SELECT ARRAY_AGG(t.key ORDER BY t.key)
+                FROM jsonb_object_keys(per_reporter_staleness) AS t(key)
             )
             WHERE per_reporter_staleness IS NOT NULL
               AND per_reporter_staleness != '{{}}'::jsonb


### PR DESCRIPTION
## Jira
[RHINENG-26782](https://issues.redhat.com/browse/RHINENG-26782)

## What
Replace the 142GB `idx_gin_per_reporter_staleness` GIN index with a lightweight `reporters text[]` derived column and a small GIN index on the array (~2-3GB).

## Why
The existing GIN index on the full `per_reporter_staleness` JSONB column indexes unique timestamps that change on every host check-in, causing massive write amplification (~45-120M unnecessary page writes during nightly ingestion). The only queries that used this index were `has_key` checks in the `registered_with` filter — all other `per_reporter_staleness` accesses are subscript/timestamp extractions which GIN cannot accelerate.

## How
- **New column** (`app/models/host.py`): Added `reporters text[]` storing the sorted keys of `per_reporter_staleness`. Synced automatically via the `@validates("per_reporter_staleness")` hook.
- **Filter rewrite** (`api/filtering/db_filters.py`): Replaced `Host.per_reporter_staleness.has_key(rep)` with `Host.reporters.any(rep)` in the `registered_with` filter. Same semantics, uses the new GIN index.
- **Migration**: Adds the column, backfills from existing `per_reporter_staleness` keys, creates `idx_hosts_reporters_gin` (GIN on `reporters`), and drops the old 142GB index.
- The new GIN index is only written to when a **new reporter** checks in (reporter list changes), not on every update like the old index. During nightly ingestion from the same reporter, the array stays unchanged → zero GIN writes.

## Testing
- All 372 `test_api_hosts_get.py` tests pass (including `registered_with` filter tests).
- All 218 `test_host_mq_service.py`, 17 `test_custom_staleness.py`, and 216 `test_models.py` tests pass.
- Migration upgrade and downgrade verified against local PostgreSQL.
- Linting (ruff, ruff format, mypy) and pre-commit hooks pass cleanly.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26782]: https://redhat.atlassian.net/browse/RHINENG-26782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce a derived reporters array column to replace the large GIN index on per_reporter_staleness and update filters and schema accordingly.

New Features:
- Add a reporters text[] column on hosts storing sorted per_reporter_staleness keys for query optimization.

Enhancements:
- Synchronize reporters array with per_reporter_staleness updates and validation in the Host model.
- Rewrite registered_with-related filters to query the reporters array instead of the JSONB has_key on per_reporter_staleness.
- Add an Alembic migration to backfill reporters, create a new GIN index on it, and drop the old per_reporter_staleness GIN index.