### PR TITLE
fix: parameterize CJI expected-image-tag for ephemeral

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2147,7 +2147,7 @@ objects:
   kind: ClowdJobInvocation
   metadata:
     annotations:
-      clowder.redhat.com/expected-image-tag: ${IMAGE_TAG}
+      clowder.redhat.com/expected-image-tag: ${EXPECTED_IMAGE_TAG}
     labels:
       app: host-inventory
     name: run-db-migrations-${IMAGE_TAG}
@@ -2487,6 +2487,9 @@ parameters:
 - description: Image tag
   name: IMAGE_TAG
   required: true
+- description: Expected image tag for migration CJI gate. Leave empty to skip the check (e.g. ephemeral).
+  name: EXPECTED_IMAGE_TAG
+  value: ""
 - name: APP_NAME
   value: inventory
 - name: LOG_LEVEL


### PR DESCRIPTION
## Jira
N/A (operational fix)

## What
Parameterize the `clowder.redhat.com/expected-image-tag` annotation on the `run-db-migrations` ClowdJobInvocation so it can be left empty in ephemeral environments.

## Why
Bonfire deploys images using sha256 digests in ephemeral clusters. Clowder's `expected-image-tag` check compares a tag string against the job image suffix, which never matches a digest reference. This causes the migration CJI to perpetually requeue, leaving init containers stuck waiting for a DB revision that never arrives, and breaking all HBI deployments in ephemeral.

## How
- Replaced the hardcoded `${IMAGE_TAG}` in the CJI annotation with a new `${EXPECTED_IMAGE_TAG}` parameter
- The parameter defaults to empty (`""`), which makes Clowder skip the check entirely (per its source: `ok && expectedTag != ""`)
- For stage/prod, the saas-file should set `EXPECTED_IMAGE_TAG` to `${IMAGE_TAG}` to preserve the existing gating behavior

## Testing
- Verified Clowder source confirms the annotation is skipped when empty
- Template renders correctly (pre-commit YAML validation passes)

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Enhancements:
- Introduce an EXPECTED_IMAGE_TAG parameter for the migration ClowdJobInvocation, defaulting to empty to allow deployments that use digest-based images.