### PR TITLE
Revert "chore: add expected-image-tag annotation to CJI"

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -2146,8 +2146,6 @@ objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    annotations:
-      clowder.redhat.com/expected-image-tag: ${IMAGE_TAG}
     labels:
       app: host-inventory
     name: run-db-migrations-${IMAGE_TAG}


### PR DESCRIPTION
Reverts RedHatInsights/insights-host-inventory#4415

## Summary by Sourcery

Build:
- Update ClowdApp deployment config to stop setting the clowder.redhat.com/expected-image-tag annotation on the migrations CJI.