### PR TITLE
perf(RHINENG-26958): add OTEL spans to host serialization

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -10,6 +10,7 @@ from ratelimit import RateLimitException
 from api.metrics import api_request_count
 from api.segmentio import segmentio_track
 from app.logging import get_logger
+from app.telemetry import get_tracer
 
 __all__ = ["api_operation"]
 
@@ -19,6 +20,7 @@ PROCESSING_TIME = "processing_time"
 ESCAPE_CHARS = '.?+*|{}[]()"\\#@&<>~$'
 
 logger = get_logger(__name__)
+tracer = get_tracer(__name__)
 
 
 def api_operation(old_func):
@@ -70,7 +72,10 @@ def _get_status_code(results):
 
 
 def flask_json_response(json_data, status=HTTPStatus.OK):
-    return flask.Response(ujson.dumps(json_data), status=status, mimetype="application/json")
+    with tracer.start_as_current_span("ujson_encode") as span:
+        body = ujson.dumps(json_data)
+        span.set_attribute("payload_size_bytes", len(body))
+    return flask.Response(body, status=status, mimetype="application/json")
 
 
 def build_collection_response(data, page, per_page, total):

--- a/api/host_query.py
+++ b/api/host_query.py
@@ -1,8 +1,11 @@
 from api.staleness_query import get_staleness_obj
 from app.auth import get_current_identity
 from app.serialization import serialize_host
+from app.telemetry import get_tracer
 
 __all__ = ("build_paginated_host_list_response",)
+
+tracer = get_tracer(__name__)
 
 
 def build_paginated_host_list_response(
@@ -13,9 +16,10 @@ def build_paginated_host_list_response(
 
     json_host_list = host_list
     if serialize_hosts:
-        json_host_list = [
-            serialize_host(host, staleness, False, additional_fields, system_profile_fields) for host in host_list
-        ]
+        with tracer.start_as_current_span("serialize_host_list", attributes={"host_count": len(host_list)}):
+            json_host_list = [
+                serialize_host(host, staleness, False, additional_fields, system_profile_fields) for host in host_list
+            ]
     return {
         "total": total,
         "count": len(json_host_list),


### PR DESCRIPTION
## Jira
[RHINENG-26958](https://issues.redhat.com/browse/RHINENG-26958)

## What
Add OpenTelemetry spans to the host list serialization and JSON encoding paths to diagnose a high latency gap observed in production traces.

## Why
Some production traces shows `GET /api/inventory/v1/hosts` taking ~7.9s, yet all DB queries complete in 44ms and the RBAC call in 217ms. The remaining 7.5s is entirely uninstrumented, making it impossible to determine whether the bottleneck is Python serialization, JSON encoding, or CPU throttling.

## How
- **`api/host_query.py`**: Wrap the `serialize_host` loop in a `serialize_host_list` span with a `host_count` attribute.
- **`api/__init__.py`**: Wrap `ujson.dumps` in `flask_json_response` with a `ujson_encode` span.
- Both use the existing `get_tracer()` helper, which returns a no-op tracer when OTEL is disabled (zero overhead in production if turned off).

## Testing
- Unit tests: `pytest tests/test_api_hosts_get.py` — 374 passed.
- Local Docker Compose with OTEL enabled: confirmed both spans appear in Tempo traces with correct attributes and timing.


## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Instrument host serialization and JSON response encoding with OpenTelemetry spans to diagnose latency in host list responses.

Enhancements:
- Add an OpenTelemetry span around host list serialization with a host_count attribute to measure serialization performance.
- Add an OpenTelemetry span around JSON encoding in flask_json_response to track ujson.dumps latency.

[RHINENG-26958]: https://redhat.atlassian.net/browse/RHINENG-26958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ