### PR TITLE
perf(RHINENG-26963): skip groups JOIN on system_profile endpoint

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -810,9 +810,9 @@ def get_sparse_system_profile(
 
     all_filters = host_id_list_filter(host_id_list, identity.org_id) + rbac_permissions_filter(rbac_filter)
 
-    query_base = (
-        db.session.query(Host).outerjoin(HostGroupAssoc).outerjoin(Group).filter(Host.org_id == identity.org_id)
-    )
+    query_base = db.session.query(Host).filter(Host.org_id == identity.org_id)
+    if rbac_filter and "groups" in rbac_filter:
+        query_base = query_base.outerjoin(HostGroupAssoc).outerjoin(Group)
     if needs_static_join:
         query_base = query_base.outerjoin(HostStaticSystemProfile)
     if needs_dynamic_join:


### PR DESCRIPTION
## Jira
[RHINENG-26963](https://issues.redhat.com/browse/RHINENG-26963)

## What
Skip the unnecessary `LEFT OUTER JOIN` on `hosts_groups` and `groups` tables in the `GET /hosts/<ids>/system_profile` endpoint when no group-based RBAC restriction is active.

## Why
Production trace `1a7eac6723c350b608afe2c90335cb2a` shows this endpoint taking 5.6s for 50+ hosts in a specific org. The `hosts_groups` JOIN is the dominant cost — it scans a large index per host even though the result is never used. The JOIN is only required when `rbac_filter` contains `"groups"` (i.e., the user has group-restricted RBAC permissions), which triggers `rbac_permissions_filter` to add a WHERE clause referencing `HostGroupAssoc.group_id`.

## How
- Made the `outerjoin(HostGroupAssoc).outerjoin(Group)` in `get_sparse_system_profile` conditional on `rbac_filter and "groups" in rbac_filter`.
- No other part of the function references `HostGroupAssoc` or `Group` columns — the selected columns, staleness filters, ordering, and `update_query_for_owner_id` all operate exclusively on `Host` and `SystemProfile` tables.
- Same pattern already applied in RHINENG-26922 for the groups list endpoint.

## Testing
- Unit tests: `pytest tests/test_system_profile.py` — 64 passed; all `system_profile` keyword tests (479 passed); all RBAC tests (138 passed).
- `EXPLAIN ANALYZE` comparison: 30ms → 0.1ms locally by eliminating the groups index scan.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26963]: https://redhat.atlassian.net/browse/RHINENG-26963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Skip the hosts_groups and groups outer joins on the system_profile endpoint unless group-based RBAC restrictions are present, reducing unnecessary query overhead.