### PR TITLE
feat(RHINENG-25611): Authenticate RBAC requests with service account

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_post.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_post.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 )
 @pytest.mark.ephemeral
 def test_groups_create_response(
+    request,
     host_inventory: ApplicationHostInventory,
     hbi_default_org_id: str,
     hbi_default_account_number: str,
@@ -73,8 +74,7 @@ def test_groups_create_response(
     assert group.account == hbi_default_account_number
     assert group.ungrouped is False
     assert time1 < group.created < time2
-    # With kessel sync it will take longer
-    time_delta = 500
+    time_delta = 2000 if request.config.getoption("--kessel") else 500
     assert_datetimes_equal(group.updated, group.created, timedelta(milliseconds=time_delta))
 
     if not assigned_hosts:

--- a/lib/kessel.py
+++ b/lib/kessel.py
@@ -25,19 +25,34 @@ from lib.feature_flags import get_flag_value
 logger = get_logger(__name__)
 
 
+_oauth2_credentials = None
+
+
+def get_kessel_oauth2_credentials(config: Config) -> OAuth2ClientCredentials:
+    global _oauth2_credentials
+    if _oauth2_credentials is None:
+        discovery = fetch_oidc_discovery(config.kessel_auth_oidc_issuer)
+        _oauth2_credentials = OAuth2ClientCredentials(
+            client_id=config.kessel_auth_client_id,
+            client_secret=config.kessel_auth_client_secret,
+            token_endpoint=discovery.token_endpoint,
+        )
+        logger.info(
+            "OAuth2 credentials initialized",
+            extra={
+                "client_id": config.kessel_auth_client_id,
+                "token_endpoint": discovery.token_endpoint,
+            },
+        )
+    return _oauth2_credentials
+
+
 class Kessel:
     def __init__(self, config: Config):
         client_builder = ClientBuilder(config.kessel_inventory_api_endpoint)
 
         if config.kessel_auth_enabled:
-            # Configure Kessel Oauth2 credentials
-            discovery = fetch_oidc_discovery(config.kessel_auth_oidc_issuer)
-            auth_credentials = OAuth2ClientCredentials(
-                client_id=config.kessel_auth_client_id,
-                client_secret=config.kessel_auth_client_secret,
-                token_endpoint=discovery.token_endpoint,
-            )
-
+            auth_credentials = get_kessel_oauth2_credentials(config)
             client_builder = client_builder.oauth2_client_authenticated(auth_credentials)
 
         if config.kessel_insecure:

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -40,6 +40,7 @@ from lib.feature_flags import FLAG_INVENTORY_API_READ_ONLY
 from lib.feature_flags import FLAG_RBAC_WORKSPACES
 from lib.feature_flags import get_flag_value
 from lib.kessel import get_kessel_client
+from lib.kessel import get_kessel_oauth2_credentials
 
 logger = get_logger(__name__)
 
@@ -85,12 +86,77 @@ def get_rbac_private_url() -> str:
     return inventory_config().rbac_endpoint + RBAC_PRIVATE_UNGROUPED_ROUTE
 
 
+def _get_rbac_access_token() -> str:
+    """
+    Get a valid OAuth2 access token for RBAC v2 API calls.
+
+    Returns:
+        str: Valid OAuth2 access token
+
+    Note:
+        OAuth2ClientCredentials.get_token() has built-in caching with a 300-second refresh buffer.
+    """
+
+    config = inventory_config()
+    oauth_client = get_kessel_oauth2_credentials(config)
+    try:
+        token_response = oauth_client.get_token()
+        return token_response.access_token
+    except Exception:
+        logger.exception("Failed to get RBAC access token")
+        raise
+
+
 def _build_rbac_request_headers(identity_header: str | None = None, request_id_header: str | None = None) -> dict:
+    """
+    Build request headers for RBAC API calls.
+
+    Args:
+        identity_header: Base64-encoded x-rh-identity (defaults to current request)
+        request_id_header: Request ID for tracing (defaults to current request)
+
+    Returns:
+        dict: Request headers with authentication
+    """
     request_headers = {
         IDENTITY_HEADER: identity_header or request.headers[IDENTITY_HEADER],
         REQUEST_ID_HEADER: request_id_header or request.headers.get(REQUEST_ID_HEADER),
     }
     return request_headers
+
+
+def _build_rbac_auth_request_headers(org_id: str) -> dict:
+    """
+    Build request headers for service-to-service RBAC API calls.
+
+    Uses OAuth2 service account authentication with explicit org_id context.
+
+    Note:
+        It has a fallback to PSK when Kessel auth is not enabled.
+        The fallback should only be used for testing in ephemeral or development environments.
+    """
+
+    config = inventory_config()
+    headers = {
+        "X-RH-RBAC-ORG-ID": org_id,
+        "X-RH-RBAC-CLIENT-ID": "inventory",
+    }
+
+    # We're using the same auth as we do for kessel
+    # verify it's enabled before using
+    if config.kessel_auth_enabled:
+        access_token = _get_rbac_access_token()
+        headers["Authorization"] = f"Bearer {access_token}"
+    else:
+        # This branch should only be used for testing or development environments where Kessel auth is not enabled.
+        # TODO: enable Kessel auth for all environments and remove this fallback logic.
+        logger.warning(
+            "Kessel auth is not enabled, falling back to PSK for RBAC API authentication. "
+            "This is not recommended for production use."
+        )
+        psk = config.rbac_psk
+        headers["X-RH-RBAC-PSK"] = psk
+    return headers
 
 
 def _execute_rbac_http_request(  # type: ignore[return]
@@ -686,18 +752,25 @@ def post_rbac_workspace(name) -> UUID | None:
 
 
 def rbac_create_ungrouped_hosts_workspace(identity: Identity) -> UUID | None:
-    # Creates a new "ungrouped" workspace via the RBAC API, and returns its ID.
-    # If not using Kessel, returns None, so the DB will automatically generate the group ID.
+    """
+    Create a new "ungrouped" workspace via the RBAC API and return its ID.
+
+    Args:
+        identity: User identity (used for org_id context)
+
+    Returns:
+        UUID: Workspace ID from RBAC v2 API, or None if bypass_kessel is enabled
+
+    Note:
+        Uses OAuth2 service account for authentication instead of PSK.
+        PSK is used only as a fallback for testing environments.
+
+        If not using Kessel, returns None so the DB will automatically generate the group ID.
+    """
     if inventory_config().bypass_kessel:
         return None
 
-    # Get HBI's RBAC PSK from the config
-    psk = inventory_config().rbac_psk
-    request_headers = {
-        "X-RH-RBAC-PSK": psk,
-        "X-RH-RBAC-ORG-ID": identity.org_id,
-        "X-RH-RBAC-CLIENT-ID": "inventory",
-    }
+    request_headers = _build_rbac_auth_request_headers(identity.org_id)
 
     resp_data = rbac_get_request_using_endpoint_and_headers(get_rbac_private_url(), request_headers)
 

--- a/tests/fixtures/api_fixtures.py
+++ b/tests/fixtures/api_fixtures.py
@@ -244,8 +244,9 @@ def api_remove_hosts_from_diff_groups(flask_client):
 
 
 @pytest.fixture(scope="function")
-def enable_rbac(inventory_config):
+def enable_rbac(inventory_config, mocker):
     inventory_config.bypass_rbac = False
+    mocker.patch("lib.middleware._get_rbac_access_token", return_value="mock_access_token")
 
 
 @pytest.fixture(scope="function")
@@ -256,6 +257,21 @@ def enable_kessel(inventory_config):
 @pytest.fixture(scope="function")
 def _enable_unleash(inventory_config):
     inventory_config.unleash_token = "mockUnleashTokenValue"
+
+
+@pytest.fixture(scope="function")
+def mock_rbac_v2_middleware(mocker):
+    """Common RBAC v2 middleware setup for tests that go through the full HTTP middleware path."""
+    mock_mw_config = mocker.MagicMock()
+    mock_mw_config.bypass_rbac = False
+    mock_mw_config.rbac_endpoint = "http://rbac.test"
+    mocker.patch("lib.middleware.inventory_config", return_value=mock_mw_config)
+    mocker.patch("lib.middleware._get_rbac_access_token", return_value="mock_access_token")
+
+    mock_config = mocker.patch("api.group.inventory_config")
+    mock_config.return_value.bypass_kessel = False
+    mocker.patch("api.group.is_rbac_v2_enabled", return_value=True)
+    mocker.patch("lib.middleware.is_rbac_v2_enabled", return_value=True)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_api_groups_get.py
+++ b/tests/test_api_groups_get.py
@@ -682,6 +682,7 @@ def test_get_groups_rbac_v2_flag_toggle(mocker, db_create_group, api_get, flag_e
         ("updated", "Desc", "-modified"),
     ],
 )
+@pytest.mark.usefixtures("mock_rbac_v2_middleware")
 def test_get_groups_rbac_v2_with_ordering(mocker, api_get, order_by, order_how, expected_rbac_order_by):
     """
     Test GET /groups with RBAC v2 and ordering parameters.
@@ -690,16 +691,6 @@ def test_get_groups_rbac_v2_with_ordering(mocker, api_get, order_by, order_how, 
     GET request: field names (e.g. updated -> modified) and DESC as a leading hyphen on the
     order_by value (-field), per RBAC v2 workspace API conventions.
     """
-    mock_mw_config = mocker.MagicMock()
-    mock_mw_config.bypass_rbac = False
-    mock_mw_config.rbac_endpoint = "http://rbac.test"
-    mocker.patch("lib.middleware.inventory_config", return_value=mock_mw_config)
-
-    mock_config = mocker.patch("api.group.inventory_config")
-    mock_config.return_value.bypass_kessel = False
-    mocker.patch("api.group.is_rbac_v2_enabled", return_value=True)
-    mocker.patch("lib.middleware.is_rbac_v2_enabled", return_value=True)
-
     mock_rbac_http = mocker.patch(
         "lib.middleware.get_rbac_workspace_using_endpoint_and_headers",
         return_value={"data": [], "meta": {"count": 0}},
@@ -720,6 +711,7 @@ def test_get_groups_rbac_v2_with_ordering(mocker, api_get, order_by, order_how, 
         assert "order_how" not in parsed
 
 
+@pytest.mark.usefixtures("mock_rbac_v2_middleware")
 def test_get_groups_rbac_v2_strips_root_and_default_workspace_types(mocker, api_get):
     """
     RBAC may return root/default workspaces mixed with standard and ungrouped-hosts workspaces.
@@ -729,16 +721,6 @@ def test_get_groups_rbac_v2_strips_root_and_default_workspace_types(mocker, api_
     Scenario: user has 5 workspaces total (3 standard, 1 root, 1 default).
     per_page=3 -> limit sent to RBAC is 5 -> after stripping, exactly 3 standard remain.
     """
-    mock_mw_config = mocker.MagicMock()
-    mock_mw_config.bypass_rbac = False
-    mock_mw_config.rbac_endpoint = "http://rbac.test"
-    mocker.patch("lib.middleware.inventory_config", return_value=mock_mw_config)
-
-    mock_config = mocker.patch("api.group.inventory_config")
-    mock_config.return_value.bypass_kessel = False
-    mocker.patch("api.group.is_rbac_v2_enabled", return_value=True)
-    mocker.patch("lib.middleware.is_rbac_v2_enabled", return_value=True)
-
     standard_ids = [str(generate_uuid()) for _ in range(3)]
     rbac_payload = {
         "data": [
@@ -785,6 +767,7 @@ def test_get_groups_rbac_v2_strips_root_and_default_workspace_types(mocker, api_
         ("ungrouped-hosts", "ungrouped-hosts"),
     ],
 )
+@pytest.mark.usefixtures("mock_rbac_v2_middleware")
 def test_get_groups_rbac_v2_specific_type_filter_skips_stripping(mocker, api_get, group_type, workspace_type):
     """
     When the caller filters on a specific group_type (standard or ungrouped-hosts),
@@ -792,16 +775,6 @@ def test_get_groups_rbac_v2_specific_type_filter_skips_stripping(mocker, api_get
     returned. The middleware should NOT apply the extra-limit or post-filter stripping
     that it does for group_type=all.
     """
-    mock_mw_config = mocker.MagicMock()
-    mock_mw_config.bypass_rbac = False
-    mock_mw_config.rbac_endpoint = "http://rbac.test"
-    mocker.patch("lib.middleware.inventory_config", return_value=mock_mw_config)
-
-    mock_config = mocker.patch("api.group.inventory_config")
-    mock_config.return_value.bypass_kessel = False
-    mocker.patch("api.group.is_rbac_v2_enabled", return_value=True)
-    mocker.patch("lib.middleware.is_rbac_v2_enabled", return_value=True)
-
     ws_ids = [str(generate_uuid()) for _ in range(3)]
     rbac_payload = {
         "data": [

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -309,7 +309,7 @@ def test_handle_message_happy_path(
 def test_handle_message_kessel_private_endpoint(identity, mocker, ingress_message_consumer_mock, db_create_group):
     from uuid import UUID
 
-    mock_psk = "1234567890"
+    mock_access_token = "mock_sa_token_12345"
     workspace_uuid = generate_uuid()
     get_rbac_mock = mocker.patch(
         "lib.middleware.rbac_get_request_using_endpoint_and_headers", return_value={"id": str(workspace_uuid)}
@@ -317,11 +317,12 @@ def test_handle_message_kessel_private_endpoint(identity, mocker, ingress_messag
     mocker.patch(
         "lib.middleware.inventory_config",
         return_value=SimpleNamespace(
-            rbac_psk=mock_psk,
             bypass_kessel=False,
+            kessel_auth_enabled=True,
             rbac_endpoint="fake-rbac-endpoint:8080",
         ),
     )
+    mocker.patch("lib.middleware._get_rbac_access_token", return_value=mock_access_token)
 
     # Simulate the MQ consumer creating the group in the DB while we wait.
     def wait_and_create(workspace_id_str, *args, **kwargs):
@@ -337,9 +338,9 @@ def test_handle_message_kessel_private_endpoint(identity, mocker, ingress_messag
     assert result.event_type == EventType.created
     assert "/_private/_s2s/workspaces/ungrouped/" in get_rbac_mock.call_args_list[0][0][0]
     assert get_rbac_mock.call_args_list[0][0][1] == {
+        "Authorization": f"Bearer {mock_access_token}",
         "X-RH-RBAC-CLIENT-ID": "inventory",
         "X-RH-RBAC-ORG-ID": "test",
-        "X-RH-RBAC-PSK": mock_psk,
     }
     wait_mock.assert_called_once_with(
         str(workspace_uuid),
@@ -362,11 +363,12 @@ def test_handle_message_kessel_workspace_timeout(mocker, ingress_message_consume
     mocker.patch(
         "lib.middleware.inventory_config",
         return_value=SimpleNamespace(
-            rbac_psk="psk",
             bypass_kessel=False,
+            kessel_auth_enabled=True,
             rbac_endpoint="fake-rbac-endpoint:8080",
         ),
     )
+    mocker.patch("lib.middleware._get_rbac_access_token", return_value="mock_token")
     mocker.patch(
         "lib.group_repository.wait_for_workspace_event",
         side_effect=TimeoutError("No workspace creation message consumed in time."),

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from requests import exceptions
 
+import lib.middleware
 from tests.helpers.api_utils import RBACFilterOperation
 from tests.helpers.api_utils import assert_response_status
 from tests.helpers.api_utils import build_groups_url
@@ -214,3 +215,26 @@ def test_access_decorator_patch_nonexistent_host_with_permission_denied(mocker, 
 
     # Should return 404, not 403
     assert_response_status(response_status, 404)
+
+
+def test_build_rbac_auth_request_headers(mocker):
+    """
+    Test that _build_rbac_auth_request_headers produces correct headers with OAuth2 token
+    and org context, without x-rh-identity.
+
+    JIRA: RHINENG-25611
+    """
+    mocker.patch("lib.middleware._get_rbac_access_token", return_value="sa_token_abc")
+
+    mock_config = mocker.Mock()
+    mock_config.bypass_kessel = False
+    mock_config.kessel_auth_enabled = True
+    mocker.patch("lib.middleware.inventory_config", return_value=mock_config)
+
+    headers = lib.middleware._build_rbac_auth_request_headers("org-42")
+
+    assert headers["Authorization"] == "Bearer sa_token_abc"
+    assert headers["X-RH-RBAC-ORG-ID"] == "org-42"
+    assert headers["X-RH-RBAC-CLIENT-ID"] == "inventory"
+    assert len(headers) == 3
+    assert "x-rh-identity" not in {k.lower() for k in headers}


### PR DESCRIPTION
## Jira
[RHINENG-25611](https://issues.redhat.com/browse/RHINENG-25611)

## What

Use service account and Oauth2 to authenticate against RBAC service.

## Why

Improve security

## How

Change the authentication handling code.

[RHINENG-25611]: https://redhat.atlassian.net/browse/RHINENG-25611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Authenticate RBAC v2 service-to-service requests using OAuth2 service account credentials instead of PSK and update supporting tests and fixtures.

New Features:
- Introduce OAuth2-based service account authentication for RBAC v2 workspace API calls, including MQ-driven ungrouped workspace creation.

Enhancements:
- Add shared helper to initialize and cache OAuth2 client credentials for Kessel and RBAC, and centralize construction of RBAC auth request headers with org context and fallbacks for non-auth-enabled environments.

Tests:
- Update API, MQ service, and IQE tests to use OAuth2-based RBAC authentication mocks and add common RBAC v2 middleware and access-token fixtures for consistent setup.