### PR TITLE
tests(RHINENG-27043): Re-use hosts and groups in groups ordering IQE tests

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/groups_fixtures.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/fixtures/groups_fixtures.py
@@ -60,11 +60,11 @@ def setup_empty_groups_primary(
     return host_inventory.apis.groups.create_n_empty_groups(110, cleanup_scope="class")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def setup_groups_for_ordering(
     host_inventory: ApplicationHostInventory,
 ) -> list[GroupOutWithHostCount]:
-    hosts = host_inventory.kafka.create_random_hosts(20)
+    hosts = host_inventory.kafka.create_random_hosts(20, cleanup_scope="module")
 
     # Create 10 groups, 2 with 0 hosts, 2 with 1 host, ..., 2 with 4 hosts.
     # 20 hosts required in total
@@ -76,4 +76,4 @@ def setup_groups_for_ordering(
                 GroupData(name=generate_display_name("hbi-ordering-test"), hosts=group_hosts)
             )
 
-    return host_inventory.apis.groups.create_groups(groups_data)
+    return host_inventory.apis.groups.create_groups(groups_data, cleanup_scope="module")


### PR DESCRIPTION
## Jira
[RHINENG-27043](https://issues.redhat.com/browse/RHINENG-27043)

## What
Re-use hosts and groups in groups ordering IQE tests

## Why
The setup for these tests is time-expensive, so by re-using the same resources we will save time.

## How
Set the fixture scope and the cleanup scope of the resources to "module"

## Testing
I ran all groups GET IQE tests in ephemeral and they passed.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-27043]: https://redhat.atlassian.net/browse/RHINENG-27043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Tests:
- Reuse randomly generated hosts and created groups across group ordering tests by setting fixtures and cleanup to module scope to reduce setup overhead.