### PR TITLE
tests(RHINENG-27086): Fix flaky ephemeral tests

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/db/test_host_reaper.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/db/test_host_reaper.py
@@ -47,6 +47,8 @@ def check_events_and_notifications(
             found_host_events.add(msg)
         elif isinstance(msg, DeleteNotificationWrapper) and msg.inventory_id in all_hosts_ids:
             found_notifications.add(msg)
+        if len(found_host_events) == len(found_notifications) == len(hosts["culled"]):
+            break
 
     # Check host event messages
     culled_hosts_ids = {host.id for host in hosts["culled"]}
@@ -104,7 +106,7 @@ def test_reaper_script(
         stale_hosts_data,
         stale_warning_hosts_data,
         culled_hosts_data,
-        deltas=(40, 80, 120),
+        deltas=(50, 100, 150),
     )
 
     fresh_hosts_ids = {host.id for host in hosts["fresh"]}

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_staleness_post.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/staleness/test_staleness_post.py
@@ -1,5 +1,4 @@
 import logging
-from random import randint
 from typing import Any
 
 import pytest
@@ -9,7 +8,6 @@ from iqe_host_inventory.utils.api_utils import api_disabled_validation
 from iqe_host_inventory.utils.api_utils import raises_apierror
 from iqe_host_inventory.utils.staleness_utils import DAY_SECS
 from iqe_host_inventory.utils.staleness_utils import MIN_DELTA
-from iqe_host_inventory.utils.staleness_utils import STALENESS_DEFAULTS
 from iqe_host_inventory.utils.staleness_utils import STALENESS_LIMITS
 from iqe_host_inventory.utils.staleness_utils import TIME_TO_DELETE
 from iqe_host_inventory.utils.staleness_utils import TIME_TO_STALE
@@ -45,24 +43,9 @@ def test_staleness_create_random_data(
 @pytest.mark.parametrize(
     "field,value",
     [
-        (
-            TIME_TO_STALE,
-            randint(MIN_DELTA, STALENESS_DEFAULTS[TIME_TO_STALE]),
-        ),
-        (
-            TIME_TO_STALE_WARNING,
-            randint(
-                STALENESS_DEFAULTS[TIME_TO_STALE] + 1,
-                STALENESS_DEFAULTS[TIME_TO_STALE_WARNING],
-            ),
-        ),
-        (
-            TIME_TO_DELETE,
-            randint(
-                STALENESS_DEFAULTS[TIME_TO_STALE_WARNING] + 1,
-                STALENESS_LIMITS[TIME_TO_DELETE],
-            ),
-        ),
+        (TIME_TO_STALE, 432000),
+        (TIME_TO_STALE_WARNING, 864000),
+        (TIME_TO_DELETE, 31536000),
     ],
 )
 def test_staleness_create_single_field(

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/datagen_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/datagen_utils.py
@@ -831,8 +831,8 @@ class FactNamespace(TypedDict):
 
 def generate_facts(num_facts: int = 2) -> list[FactNamespace]:
     """Generate some facts."""
-    facts = {}
-    for _ in range(num_facts):
+    facts: dict[str, str] = {}
+    while len(facts) < num_facts:
         facts[fake.domain_word()] = fake.domain_word()
 
     result = FactNamespace(namespace=fake.domain_word(), facts=facts)


### PR DESCRIPTION
## Jira
[RHINENG-27086](https://issues.redhat.com/browse/RHINENG-27086)

## What
Fix flaky tests in ephemeral

## Why
To reduce the amount of retesting we need to do

## How
- Stop searching for kafka events in the reaper script once we have all the messages to reduce the amount of time before doing API requests + increase the deltas between staleness states to account for abnormal reaper execution time
- Don't use randomized staleness values in `test_staleness_create_single_field` - sometimes it picked a value that's close to the default value (within 3600 seconds) and HBI ignored it and kept the default value
- Update `generate_facts` function to keep adding more facts until we have the requested amount. When we used for cycle, there was a chance that `fake.domain_word()` generated the same string multiple times, so the value in the dict got rewritten instead of adding a new one

## Testing
I tested the affected tests in ephemeral and they work

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-27086]: https://redhat.atlassian.net/browse/RHINENG-27086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Stabilize flaky staleness and reaper tests in the host inventory test suite.

Bug Fixes:
- Use fixed staleness values in single-field staleness creation tests to avoid collisions with default configuration and ignored overrides.
- Stop scanning for Kafka reaper events once all expected host events and notifications are found to reduce timing-related flakiness.
- Ensure generated facts contain the requested number of unique entries by looping until the desired count is reached.
- Increase staleness delta values in the reaper script test to provide a larger timing margin for host state transitions.

Tests:
- Adjust staleness POST and host reaper tests to be less timing-sensitive and more deterministic in ephemeral environments.