### PR TITLE
fix(RHINENG-28041): Fix error looping and extend consumer's MAX_POLL

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -11,7 +11,6 @@ from sqlalchemy import Integer
 from sqlalchemy import and_
 from sqlalchemy import case
 from sqlalchemy import func
-from sqlalchemy import select
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Query
@@ -942,12 +941,11 @@ def get_hosts_to_export(
     export_host_query = export_host_query.execution_options(yield_per=batch_size)
 
     try:
-        num_hosts_query = select(func.count()).select_from(export_host_query.subquery())
-        num_hosts = db.session.scalar(num_hosts_query)
-        logger.debug(f"Number of hosts to be exported: {num_hosts}")
-
+        exported = 0
         for host in db.session.scalars(export_host_query):
             yield serialize_host_for_export_svc(host, staleness=staleness)
+            exported += 1
+        logger.debug(f"Number of hosts exported: {exported}")
 
     except SQLAlchemyError as e:  # Most likely ObjectDeletedError, but catching all DB errors
         raise InventoryException(title="DB Error", detail=str(e)) from e

--- a/app/config.py
+++ b/app/config.py
@@ -297,11 +297,11 @@ class Config:
         }
 
         self.export_service_kafka_consumer = {
+            **self.base_consumer_config,
             "auto.offset.reset": "earliest",
             "enable.auto.commit": False,
             "partition.assignment.strategy": "cooperative-sticky",
             "max.poll.interval.ms": int(os.environ.get("KAFKA_EXPORT_SERVICE_MAX_POLL_INTERVAL_MS", "1200000")),
-            **self.base_consumer_config,
         }
 
         self.validator_kafka_consumer = {

--- a/app/config.py
+++ b/app/config.py
@@ -296,6 +296,14 @@ class Config:
             **self.base_consumer_config,
         }
 
+        self.export_service_kafka_consumer = {
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": False,
+            "partition.assignment.strategy": "cooperative-sticky",
+            "max.poll.interval.ms": int(os.environ.get("KAFKA_EXPORT_SERVICE_MAX_POLL_INTERVAL_MS", "1200000")),
+            **self.base_consumer_config,
+        }
+
         self.validator_kafka_consumer = {
             "group.id": "inventory-sp-validator",
             "enable.auto.commit": False,

--- a/app/queue/export_service.py
+++ b/app/queue/export_service.py
@@ -191,7 +191,7 @@ def _handle_export_response(response: Response, exportUUID: UUID, exportFormat: 
     if response.status_code == HTTPStatus.ACCEPTED:
         if response.text != "":
             logger.info(f"{response.text} for export ID {str(exportUUID)} in {exportFormat.upper()} format")
-    elif response.status_code == HTTPStatus.BAD_REQUEST and "already been processed" in (response.text or ""):
+    elif response.status_code == HTTPStatus.BAD_REQUEST and "already been processed" in (response.text or "").lower():
         logger.warning(f"Export {exportUUID} was already processed (duplicate delivery); treating as success")
     else:
         raise InventoryException(detail=response.text)

--- a/app/queue/export_service.py
+++ b/app/queue/export_service.py
@@ -176,20 +176,25 @@ def _handle_export_error(
     exportFormat: str,
 ):
     logger.error(error_message)
-    response = session.post(
-        url=request_url,
-        headers=request_headers,
-        data=json.dumps({"message": error_message, "error": status_code}),
-    )
-    _handle_export_response(response, exportUUID, exportFormat)
+    try:
+        response = session.post(
+            url=request_url,
+            headers=request_headers,
+            data=json.dumps({"message": error_message, "error": status_code}),
+        )
+        _handle_export_response(response, exportUUID, exportFormat)
+    except Exception:
+        logger.exception(f"Failed to report export error to export-service for export {exportUUID}")
 
 
-# This function is used by create_export, needs improvement
 def _handle_export_response(response: Response, exportUUID: UUID, exportFormat: str):
-    if response.status_code != HTTPStatus.ACCEPTED:
+    if response.status_code == HTTPStatus.ACCEPTED:
+        if response.text != "":
+            logger.info(f"{response.text} for export ID {str(exportUUID)} in {exportFormat.upper()} format")
+    elif response.status_code == HTTPStatus.BAD_REQUEST and "already been processed" in (response.text or ""):
+        logger.warning(f"Export {exportUUID} was already processed (duplicate delivery); treating as success")
+    else:
         raise InventoryException(detail=response.text)
-    elif response.text != "":
-        logger.info(f"{response.text} for export ID {str(exportUUID)} in {exportFormat.upper()} format")
 
 
 def _format_export_data(data: list[dict], exportFormat: str) -> str:

--- a/inv_export_service.py
+++ b/inv_export_service.py
@@ -39,8 +39,7 @@ def main():
         {
             "group.id": config.inv_export_service_consumer_group,
             "bootstrap.servers": config.bootstrap_servers,
-            "auto.offset.reset": "earliest",
-            **config.kafka_consumer,
+            **config.export_service_kafka_consumer,
         }
     )
     consumer.subscribe([config.export_service_topic])

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -3,14 +3,19 @@ import json
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
+from http import HTTPStatus
 from unittest import mock
+from uuid import uuid4
 
 import pytest
 from marshmallow.exceptions import ValidationError
 from sqlalchemy.orm.exc import ObjectDeletedError
 
 from app.auth.identity import Identity
+from app.exceptions import InventoryException
 from app.queue.export_service import _format_export_data
+from app.queue.export_service import _handle_export_error
+from app.queue.export_service import _handle_export_response
 from app.queue.export_service import create_export
 from app.queue.export_service import get_host_list
 from app.queue.export_service_mq import parse_export_service_message
@@ -250,3 +255,68 @@ def test_export_catches_db_error(flask_app, inventory_config, mocker):
 
         create_export(validated_msg, base64_x_rh_identity, inventory_config)
         handle_export_error_mock.assert_called_once()
+
+
+def _make_response(status_code, text=""):
+    resp = mock.Mock()
+    resp.status_code = status_code
+    resp.text = text
+    return resp
+
+
+class TestHandleExportResponse:
+    def test_accepted_response(self):
+        _handle_export_response(_make_response(HTTPStatus.ACCEPTED, "payload delivered"), uuid4(), "json")
+
+    def test_already_processed_does_not_raise(self):
+        resp = _make_response(
+            HTTPStatus.BAD_REQUEST,
+            '{"detail": "this resource has already been processed", "status": 400}',
+        )
+        _handle_export_response(resp, uuid4(), "csv")
+
+    def test_other_400_still_raises(self):
+        resp = _make_response(HTTPStatus.BAD_REQUEST, '{"detail": "some other error"}')
+        with pytest.raises(InventoryException):
+            _handle_export_response(resp, uuid4(), "json")
+
+    def test_server_error_raises(self):
+        resp = _make_response(HTTPStatus.INTERNAL_SERVER_ERROR, "internal error")
+        with pytest.raises(InventoryException):
+            _handle_export_response(resp, uuid4(), "json")
+
+
+class TestHandleExportError:
+    def test_error_handler_does_not_propagate_post_failure(self):
+        session = mock.Mock()
+        session.post.side_effect = ConnectionError("network down")
+        _handle_export_error("some error", 500, "http://example.com/error", session, {}, uuid4(), "json")
+
+    def test_error_handler_does_not_propagate_response_error(self):
+        session = mock.Mock()
+        session.post.return_value = _make_response(HTTPStatus.INTERNAL_SERVER_ERROR, "boom")
+        _handle_export_error("some error", 500, "http://example.com/error", session, {}, uuid4(), "json")
+
+    def test_error_handler_succeeds_normally(self):
+        session = mock.Mock()
+        session.post.return_value = _make_response(HTTPStatus.ACCEPTED)
+        _handle_export_error("some error", 500, "http://example.com/error", session, {}, uuid4(), "json")
+        session.post.assert_called_once()
+
+
+@mock.patch("requests.Session.post", autospec=True)
+def test_create_export_already_processed_returns_true(mock_post, db_create_host, flask_app, inventory_config):
+    """When the upload gets 'already processed', create_export should return True (not raise)."""
+    with flask_app.app.app_context():
+        db_create_host()
+
+        mock_post.return_value.status_code = HTTPStatus.BAD_REQUEST
+        mock_post.return_value.text = (
+            '{"detail": "this resource has already been processed", "status": 400, "title": null}'
+        )
+
+        validated_msg = parse_export_service_message(es_utils.create_export_message_mock())
+        base64_x_rh_identity = validated_msg["data"]["resource_request"]["x_rh_identity"]
+
+        result = create_export(validated_msg, base64_x_rh_identity, inventory_config)
+        assert result is True


### PR DESCRIPTION
## Jira
[RHINENG-28041](https://issues.redhat.com/browse/RHINENG-28041)

## What

- Treats "already been processed" error messages as successes.
- Increases the export service consumer's max-poll-interval to 20m (from the default of 5m).
- Removes an unnecessary `COUNT(*)` query.

## Why

- "already been processed" error messages indicate that we no longer need to process that payload, meaning we should treat it as a success so it doesn't fail and retry later.
- Some large queries (returning >100K hosts) have recently taken ~12 mins, which is longer than the consumer's 5-minute max-poll interval. This causes a kafka commit failure, and kicks the consumer out of the consumer group.
- The `COUNT(*)` query adds a significant amount of extra time to large exports.

## How

- Added logic specific to "already been processed" errors to the export-service's exception handling.
- Made kafka-consumer config specific to the export-service, and set its `max.poll.interval.ms` to 1200000 (20 minutes).
- Replaced the `COUNT(*)` query with a counter that increments for each host processed.

## Testing

Added tests to `test_export_service.py` which validate the different exception behaviors.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-28041]: https://redhat.atlassian.net/browse/RHINENG-28041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Treat duplicate export deliveries as successful and make export-service consumption more resilient.

Bug Fixes:
- Handle 'already been processed' export-service responses as successful instead of raising errors.
- Ensure export error reporting failures are logged but do not propagate and break processing.

Enhancements:
- Introduce a dedicated export-service Kafka consumer configuration with an extended max poll interval for long-running exports.
- Stream host export counting by logging the number of yielded hosts instead of issuing a separate count query.

Tests:
- Add unit tests covering export response handling, error reporting behavior, and 'already processed' scenarios in the export service.

## Summary by Sourcery

Handle duplicate export deliveries as successful and make export error reporting and consumption more resilient.

Bug Fixes:
- Treat 'already been processed' export responses as successful instead of raising inventory exceptions.
- Prevent failures while reporting export errors from propagating and interrupting processing.

Enhancements:
- Introduce a dedicated Kafka consumer configuration for the export service with an extended max poll interval and related settings.
- Replace the COUNT-based pre-query for export host totals with streaming counting during export to reduce query overhead.

Tests:
- Add unit tests covering export response handling, export error reporting behavior, and 'already processed' scenarios in the export service.