### PR TITLE
fix(RHINENG-28061): Use savepoint so rollback doesn't revert entire transaction

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -483,18 +483,17 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
         logger.info(f"Received {operation} message for workspace ID {workspace['id']}")
 
         if operation == "create":
-            savepoint = db.session.begin_nested()
             try:
-                group = group_repository.add_group(
-                    group_name=workspace["name"],
-                    org_id=org_id,
-                    account=identity.account_number,
-                    group_id=workspace["id"],
-                    ungrouped=(validated_operation_msg["workspace"]["type"] == "ungrouped-hosts"),
-                    created_on=workspace.get("created"),
-                    modified_on=workspace.get("modified"),
-                )
-                savepoint.commit()
+                with db.session.begin_nested():
+                    group = group_repository.add_group(
+                        group_name=workspace["name"],
+                        org_id=org_id,
+                        account=identity.account_number,
+                        group_id=workspace["id"],
+                        ungrouped=(validated_operation_msg["workspace"]["type"] == "ungrouped-hosts"),
+                        created_on=workspace.get("created"),
+                        modified_on=workspace.get("modified"),
+                    )
                 return OperationResult(
                     group,
                     None,
@@ -504,7 +503,6 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
                 )
 
             except (IntegrityError, UniqueViolation):
-                savepoint.rollback()
                 logger.warning(f"Group with ID {workspace['id']} already exists; skipping creation")
 
         elif operation == "update":

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -483,6 +483,7 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
         logger.info(f"Received {operation} message for workspace ID {workspace['id']}")
 
         if operation == "create":
+            savepoint = db.session.begin_nested()
             try:
                 group = group_repository.add_group(
                     group_name=workspace["name"],
@@ -493,6 +494,7 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
                     created_on=workspace.get("created"),
                     modified_on=workspace.get("modified"),
                 )
+                savepoint.commit()
                 return OperationResult(
                     group,
                     None,
@@ -502,8 +504,8 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
                 )
 
             except (IntegrityError, UniqueViolation):
+                savepoint.rollback()
                 logger.warning(f"Group with ID {workspace['id']} already exists; skipping creation")
-                db.session.rollback()
 
         elif operation == "update":
             group_to_update = group_repository.get_group_by_id_from_db(str(workspace["id"]), org_id)

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -2777,6 +2777,27 @@ def test_workspace_bulk_mq_create_duplicate_skips(
     assert found_group.name == "bulk-workspace-original"
 
 
+def test_workspace_bulk_mq_duplicate_does_not_rollback_prior_creates(
+    db_create_group, workspace_message_consumer_mock, db_get_group_by_id
+):
+    """A duplicate create must not roll back new groups created earlier in the same batch/transaction."""
+    existing_group = db_create_group("pre-existing-workspace")
+
+    new_workspace_id = generate_uuid()
+    new_message = generate_kessel_workspace_message("create", new_workspace_id, "new-workspace")
+    workspace_message_consumer_mock.handle_message(json.dumps(new_message))
+
+    duplicate_message = generate_kessel_workspace_message("create", str(existing_group.id), "duplicate-workspace-name")
+    workspace_message_consumer_mock.handle_message(json.dumps(duplicate_message))
+
+    db.session.commit()
+
+    assert db_get_group_by_id(new_workspace_id) is not None
+    assert db_get_group_by_id(new_workspace_id).name == "new-workspace"
+
+    assert db_get_group_by_id(existing_group.id).name == "pre-existing-workspace"
+
+
 @pytest.mark.parametrize(
     "processed_rows,event_type,should_notify",
     [


### PR DESCRIPTION
## Jira
[RHINENG-28061](https://issues.redhat.com/browse/RHINENG-28061)

## What
Adds a savepoint to `handle_message`.

## Why
Without the savepoint, `rollback()` reverts the entire batch/transaction, not just its latest change.

## How
Added basic savepoint functionality.

## Testing
Added `test_workspace_bulk_mq_duplicate_does_not_rollback_prior_creates` to validate that previous changes are not lost upon rollback.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Ensure workspace create message handling only rolls back failed operations instead of the entire surrounding transaction.

Bug Fixes:
- Prevent duplicate workspace create messages from rolling back prior successful group creations in the same batch transaction.

Tests:
- Add a regression test verifying that a duplicate workspace create message does not undo earlier group creations within the same transaction.

[RHINENG-28061]: https://redhat.atlassian.net/browse/RHINENG-28061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Limit workspace create message rollbacks to the failing operation within a transaction.

Bug Fixes:
- Prevent a duplicate workspace create message from rolling back prior successful group creations within the same batch transaction.

Tests:
- Add a regression test ensuring duplicate workspace create messages do not undo earlier successful workspace group creations in the same transaction.