### PR TITLE
fix(RHINENG-22292): Replace stale Insights docs links with Lightspeed docs in OpenAPI specs

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/data/api.host_inventory.api.spec.json
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/data/api.host_inventory.api.spec.json
@@ -12,8 +12,8 @@
     }
   ],
   "externalDocs": {
-    "description": "How to use the Red Hat Insights API",
-    "url": "https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/using_the_red_hat_insights_api/index"
+    "description": "Using APIs to configure Red Hat Lightspeed services",
+    "url": "https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html-single/using_apis_to_configure_red_hat_lightspeed_services/index"
   },
   "paths": {
     "/hosts": {

--- a/iqe-host-inventory-plugin/iqe_host_inventory/data/api.host_inventory.api_v7.spec.json
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/data/api.host_inventory.api_v7.spec.json
@@ -12,8 +12,8 @@
     }
   ],
   "externalDocs": {
-    "description": "How to use the Red Hat Insights API",
-    "url": "https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/using_the_red_hat_insights_api/index"
+    "description": "Using APIs to configure Red Hat Lightspeed services",
+    "url": "https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html-single/using_apis_to_configure_red_hat_lightspeed_services/index"
   },
   "paths": {
     "/hosts": {

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -8,8 +8,8 @@ servers:
   - url: /api/inventory/v1
     description: API server
 externalDocs:
-  description: How to use the Red Hat Insights API
-  url: https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/using_the_red_hat_insights_api/index
+  description: Using APIs to configure Red Hat Lightspeed services
+  url: https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html-single/using_apis_to_configure_red_hat_lightspeed_services/index
 paths:
   /hosts:
     get:

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -12,8 +12,8 @@
     }
   ],
   "externalDocs": {
-    "description": "How to use the Red Hat Insights API",
-    "url": "https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/using_the_red_hat_insights_api/index"
+    "description": "Using APIs to configure Red Hat Lightspeed services",
+    "url": "https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html-single/using_apis_to_configure_red_hat_lightspeed_services/index"
   },
   "paths": {
     "/hosts": {


### PR DESCRIPTION
## Jira
[RHINENG-22292](https://redhat.atlassian.net/browse/RHINENG-22292)

## What
Update of stale `docs.redhat.com` documentation references in the Host Inventory OpenAPI from Red Hat Insights to the current Red Hat Lightspeed API documentation.

## Why
The previous `red_hat_insights` documentation URL no longer resolves after the Lightspeed rebrand.

## How
Updated the top-level `exernalDocs.description` and `externalDocs.url` in `swagger/api.spec.yaml`, regenerated `swagger/openapi.json`, and manually synced the same `externalDocs` block in the IQE spec JSON files.

## Testing
Verified the updated `externalDocs` values in the app and IQE specs.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-22292]: https://redhat.atlassian.net/browse/RHINENG-22292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Documentation:
- Refresh externalDocs metadata in Swagger and IQE Host Inventory API specs to point to Red Hat Lightspeed documentation instead of the deprecated Red Hat Insights docs.