### PR TITLE
chore(deps): Update uv to 0.11.21

### DIFF
--- a/iqe-host-inventory-plugin/pyproject.toml
+++ b/iqe-host-inventory-plugin/pyproject.toml
@@ -135,7 +135,7 @@ dev = [
 [tool.uv]
 package = true
 default-groups = "all"
-required-version = "0.11.19"
+required-version = "0.11.21"
 system-certs = true
 
 [[tool.uv.index]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ ignore_errors = true
 [tool.uv]
 package = false
 default-groups = "all"
-required-version = "0.11.19"
+required-version = "0.11.21"
 
 [[tool.uv.index]]
 name = "pypi"

--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,7 @@
     ".hermetic_builds/**"
   ],
   "constraints": {
-    "python": "3.12",
-    "uv": "0.11"
+    "python": "3.12"
   },
   "tekton": {
     "schedule": [
@@ -22,6 +21,15 @@
   "pip-compile": {
     "enabled": false
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)pyproject\\.toml$", "(^|/)iqe-host-inventory-plugin/pyproject\\.toml$"],
+      "matchStrings": ["required-version\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "astral-sh/uv",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
   "packageRules": [
     {
       "matchPackagePatterns": ["^openapi-"],


### PR DESCRIPTION
## Jira
None

## What
Updates the required uv version from 0.11.19 to 0.11.21.

## Why
To match the version used by Konflux/MintMaker.

## How
I just updated the version number.

## Testing
`uv self update 0.11.21`

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.
