### PR TITLE
ci(RHINENG-28345): Fix workflows that are breaking due to verified-signature restriction

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
+          base: master
           commit-message: 'chore(image): update base image'
           title: 'chore(image): update base image'
           committer: 'Update-a-Bot <insights@redhat.com>'

--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
-          base: master
+          base: ${{ github.event.repository.default_branch }}
           commit-message: 'chore(image): update base image'
           title: 'chore(image): update base image'
           committer: 'Update-a-Bot <insights@redhat.com>'

--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -8,31 +8,36 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-      - name: Install skopeo
-        run: sudo apt-get install -y skopeo
-      - name: Check change
-        run: |
-          base=$(grep -Po '(?<=FROM )[^\s]+' Dockerfile | tail -1)
-          skopeo inspect "docker://$base" | jq .Digest --raw-output > .baseimagedigest
-      - name: Do change if the digest changed
-        run: |
-          git config user.name 'Update-a-Bot'
-          git config user.email 'insights@redhat.com'
-          git add .baseimagedigest
-          git commit -m "chore(image): update base image" || echo "No new changes"
-      - name: Create pull request
-        id: cpr
-        uses: peter-evans/create-pull-request@v8
-        with:
-          title: 'chore(image): update base image'
       - name: Generate token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.AUTOMERGE_APP_ID }}
           private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install skopeo
+        run: sudo apt-get install -y skopeo
+
+      - name: Check change
+        run: |
+          base=$(grep -Po '(?<=FROM )[^\s]+' Dockerfile | tail -1)
+          skopeo inspect "docker://$base" | jq .Digest --raw-output > .baseimagedigest
+
+      - name: Create pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          sign-commits: true
+          commit-message: 'chore(image): update base image'
+          title: 'chore(image): update base image'
+          committer: 'Update-a-Bot <insights@redhat.com>'
+
       - name: Approve and enable auto-merge for the base image PR
         if: ${{ steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated' }}
         run: |

--- a/.github/workflows/hermetic-updates.yaml
+++ b/.github/workflows/hermetic-updates.yaml
@@ -39,48 +39,36 @@ jobs:
           source $APP_ROOT/bin/activate
           make generate-hermetic-lockfiles BASE_IMAGE=local
 
-      - name: Commit and push changes with gh
-        id: commit-changes
+      - name: Check for changes
+        id: check-changes
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          git config --global user.name "insights-inventory-bot[bot]"
-          git config --global user.email "insights-inventory-bot[bot]@users.noreply.github.com"
           git add .
-
-          git commit -m "$COMMIT_TITLE"
-          changes_made=$?
-          echo "changes_made=$changes_made" >> $GITHUB_OUTPUT
-
-          if [ $changes_made -gt 1 ]; then
-            echo "Error checking for changes"
-            exit 1
+          if git diff --cached --quiet; then
+            echo "changes_made=false" >> $GITHUB_OUTPUT
+          else
+            echo "changes_made=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Generate token
         id: app-token
-        if: steps.commit-changes.outputs.changes_made == '0'
+        if: steps.check-changes.outputs.changes_made == 'true'
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.AUTOMERGE_APP_ID }}
           private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
 
-      - name: Push changes and create PR
-        if: steps.commit-changes.outputs.changes_made == '0'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          PATH=$PATH:/mnt/usrbin
-          gh repo set-default ${{ github.repository }}
-
-          # Push to hermetic_updates branch, force overwrite
-          git push --force https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }} HEAD:hermetic_updates
-
-          # Check if PR exists from hermetic_updates to default branch, if not, create one
-          if ! gh pr list --base ${{ github.ref_name }} --head hermetic_updates --state open | grep .; then
-            gh pr create --base ${{ github.ref_name }} --head hermetic_updates \
-              --title "$PR_TITLE" \
-              --body "$PR_BODY";
-          fi;
+      - name: Create pull request
+        if: steps.check-changes.outputs.changes_made == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          sign-commits: true
+          commit-message: ${{ env.COMMIT_TITLE }}
+          title: ${{ env.PR_TITLE }}
+          body: ${{ env.PR_BODY }}
+          branch: hermetic_updates
+          committer: 'insights-inventory-bot[bot] <insights-inventory-bot[bot]@users.noreply.github.com>'
 
       - name: Unsubscribe (cleanup)
         if: always()

--- a/.github/workflows/hermetic-updates.yaml
+++ b/.github/workflows/hermetic-updates.yaml
@@ -64,6 +64,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
+          base: ${{ github.ref_name }}
           commit-message: ${{ env.COMMIT_TITLE }}
           title: ${{ env.PR_TITLE }}
           body: ${{ env.PR_BODY }}

--- a/.github/workflows/konflux-rebase.yaml
+++ b/.github/workflows/konflux-rebase.yaml
@@ -16,47 +16,24 @@ jobs:
           app-id: ${{ secrets.AUTOMERGE_APP_ID }}
           private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
 
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          fetch-depth: 0
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
       - name: Rebase Konflux PRs that are behind
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
-          # Find all open PRs from Konflux
           gh pr list --repo "$REPO" --author "app/red-hat-konflux" --state open --json number,headRefName,headRefOid --jq '.[] | "\(.number) \(.headRefName) \(.headRefOid)"' | while read -r pr_number branch_name head_sha; do
             if [ -n "$pr_number" ]; then
-              # Check if the PR branch is behind master
               behind_count=$(gh api "repos/$REPO/compare/master...$head_sha" --jq '.behind_by' 2>/dev/null || echo "0")
 
               if [ "$behind_count" -gt 0 ]; then
-                echo "PR #$pr_number ($branch_name) is $behind_count commits behind, rebasing..."
+                echo "PR #$pr_number ($branch_name) is $behind_count commits behind, rebasing via API..."
 
-                # Fetch the PR branch
-                git fetch origin "$branch_name"
-                git checkout "$branch_name"
-
-                # Rebase onto master
-                if git rebase origin/master; then
-                  # Force push the rebased branch
-                  git push --force-with-lease origin "$branch_name"
-                  echo "Successfully rebased PR #$pr_number"
-                else
-                  echo "Failed to rebase PR #$pr_number, aborting"
-                  git rebase --abort
-                fi
-
-                # Return to master for next iteration
-                git checkout master
+                # Use the GitHub API to rebase — produces verified (signed) commits
+                response=$(gh api "repos/$REPO/pulls/$pr_number/update-branch" \
+                  --method PUT \
+                  --field update_method=rebase 2>&1) && \
+                  echo "Successfully rebased PR #$pr_number" || \
+                  echo "Failed to rebase PR #$pr_number: $response"
               else
                 echo "PR #$pr_number is up to date"
               fi

--- a/.github/workflows/pr-review-reminder.yaml
+++ b/.github/workflows/pr-review-reminder.yaml
@@ -456,9 +456,6 @@ jobs:
 
           DATA_JSON=$(base64 -w0 /tmp/metrics_data.json)
 
-          # Get current gh-pages HEAD (or empty if branch doesn't exist)
-          BRANCH_SHA=$(gh api "repos/$REPO/git/ref/heads/gh-pages" --jq '.object.sha' 2>/dev/null || echo "")
-
           # Build file additions
           ADDITIONS="[{\"path\":\"data.json\",\"contents\":\"$DATA_JSON\"}"
           if [ -n "$INDEX_HTML" ]; then
@@ -466,29 +463,39 @@ jobs:
           fi
           ADDITIONS="$ADDITIONS]"
 
-          if [ -z "$BRANCH_SHA" ]; then
-            # Create gh-pages branch from an empty tree via the API
-            EMPTY_TREE=$(gh api "repos/$REPO/git/trees" --method POST --field 'tree=[{"path":".gitkeep","mode":"100644","type":"blob","content":""}]' --jq '.sha')
-            BRANCH_SHA=$(gh api "repos/$REPO/git/commits" --method POST --field "message=init gh-pages" --field "tree=$EMPTY_TREE" --jq '.sha')
-            gh api "repos/$REPO/git/refs" --method POST --field "ref=refs/heads/gh-pages" --field "sha=$BRANCH_SHA" > /dev/null
-          fi
+          # Use createCommitOnBranch to produce a verified commit (with retry for races)
+          for attempt in 1 2 3; do
+            BRANCH_SHA=$(gh api "repos/$REPO/git/ref/heads/gh-pages" --jq '.object.sha' 2>/dev/null || echo "")
+            if [ -z "$BRANCH_SHA" ]; then
+              EMPTY_TREE=$(gh api "repos/$REPO/git/trees" --method POST --field 'tree=[{"path":".gitkeep","mode":"100644","type":"blob","content":""}]' --jq '.sha')
+              BRANCH_SHA=$(gh api "repos/$REPO/git/commits" --method POST --field "message=init gh-pages" --field "tree=$EMPTY_TREE" --jq '.sha')
+              gh api "repos/$REPO/git/refs" --method POST --field "ref=refs/heads/gh-pages" --field "sha=$BRANCH_SHA" > /dev/null
+            fi
 
-          # Use createCommitOnBranch to produce a verified commit
-          gh api graphql -f query='
-            mutation($input: CreateCommitOnBranchInput!) {
-              createCommitOnBranch(input: $input) {
-                commit { oid }
-              }
-            }' -f "variables=$(jq -n \
-              --arg repo "$REPO" \
-              --arg oid "$BRANCH_SHA" \
-              --arg msg "chore: update PR metrics for $TODAY" \
-              --argjson additions "$ADDITIONS" \
-              '{input: {
-                branch: {repositoryNameWithOwner: $repo, branchName: "gh-pages"},
-                message: {headline: $msg},
-                fileChanges: {additions: $additions},
-                expectedHeadOid: $oid
-              }}')" > /dev/null
+            if gh api graphql -f query='
+              mutation($input: CreateCommitOnBranchInput!) {
+                createCommitOnBranch(input: $input) {
+                  commit { oid }
+                }
+              }' -f "variables=$(jq -n \
+                --arg repo "$REPO" \
+                --arg oid "$BRANCH_SHA" \
+                --arg msg "chore: update PR metrics for $TODAY" \
+                --argjson additions "$ADDITIONS" \
+                '{input: {
+                  branch: {repositoryNameWithOwner: $repo, branchName: "gh-pages"},
+                  message: {headline: $msg},
+                  fileChanges: {additions: $additions},
+                  expectedHeadOid: $oid
+                }}')" > /dev/null 2>&1; then
+              echo "Pushed verified commit to gh-pages"
+              break
+            fi
 
-          echo "Pushed verified commit to gh-pages"
+            echo "Attempt $attempt failed (likely stale expectedHeadOid), retrying..."
+            sleep 3
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Failed to push to gh-pages after 3 attempts"
+              exit 1
+            fi
+          done

--- a/.github/workflows/pr-review-reminder.yaml
+++ b/.github/workflows/pr-review-reminder.yaml
@@ -467,9 +467,12 @@ jobs:
           for attempt in 1 2 3; do
             BRANCH_SHA=$(gh api "repos/$REPO/git/ref/heads/gh-pages" --jq '.object.sha' 2>/dev/null || echo "")
             if [ -z "$BRANCH_SHA" ]; then
-              EMPTY_TREE=$(gh api "repos/$REPO/git/trees" --method POST --field 'tree=[{"path":".gitkeep","mode":"100644","type":"blob","content":""}]' --jq '.sha')
-              BRANCH_SHA=$(gh api "repos/$REPO/git/commits" --method POST --field "message=init gh-pages" --field "tree=$EMPTY_TREE" --jq '.sha')
-              gh api "repos/$REPO/git/refs" --method POST --field "ref=refs/heads/gh-pages" --field "sha=$BRANCH_SHA" > /dev/null
+              EMPTY_TREE=$(jq -n '{tree: [{path: ".gitkeep", mode: "100644", type: "blob", content: ""}]}' \
+                | gh api "repos/$REPO/git/trees" --method POST --input - --jq '.sha')
+              BRANCH_SHA=$(jq -n --arg tree "$EMPTY_TREE" '{message: "init gh-pages", tree: $tree}' \
+                | gh api "repos/$REPO/git/commits" --method POST --input - --jq '.sha')
+              jq -n --arg sha "$BRANCH_SHA" '{ref: "refs/heads/gh-pages", sha: $sha}' \
+                | gh api "repos/$REPO/git/refs" --method POST --input - > /dev/null
             fi
 
             if gh api graphql -f query='

--- a/.github/workflows/pr-review-reminder.yaml
+++ b/.github/workflows/pr-review-reminder.yaml
@@ -120,9 +120,6 @@ jobs:
 
       - name: Setup gh-pages branch
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
           # Fetch gh-pages if it exists, or create an orphan branch
           git fetch origin gh-pages:gh-pages 2>/dev/null || true
           if git rev-parse --verify gh-pages >/dev/null 2>&1; then
@@ -430,38 +427,68 @@ jobs:
           echo "$EXISTING" | jq . > "$DATA_FILE"
           cp "$DATA_FILE" /tmp/metrics_data.json
 
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.AUTOMERGE_APP_ID }}
+          private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
+
       - name: Push to gh-pages branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           TODAY=$(date -u +%Y-%m-%d)
 
-          # Switch to gh-pages branch (create orphan if first run)
-          if git rev-parse --verify gh-pages >/dev/null 2>&1; then
-            git checkout gh-pages
-          else
-            git checkout --orphan gh-pages
-            git rm -rf . 2>/dev/null || true
-          fi
-
-          # Move data and index into place
           if [ ! -f /tmp/metrics_data.json ]; then
             echo "Error: /tmp/metrics_data.json not found. Metrics step may have failed."
             exit 1
           fi
-          cp /tmp/metrics_data.json data.json
-          git checkout main -- docs/metrics/index.html 2>/dev/null || git checkout master -- docs/metrics/index.html 2>/dev/null || true
-          if [ -f docs/metrics/index.html ]; then
-            mv docs/metrics/index.html index.html
-            rm -rf docs
+
+          # Prepare index.html from the source branch
+          INDEX_HTML=""
+          if git show origin/master:docs/metrics/index.html > /tmp/index.html 2>/dev/null || \
+             git show origin/main:docs/metrics/index.html > /tmp/index.html 2>/dev/null; then
+            INDEX_HTML=$(base64 -w0 /tmp/index.html)
           fi
 
-          git add data.json index.html
-          git diff --cached --quiet || git commit -m "chore: update PR metrics for ${TODAY}"
+          DATA_JSON=$(base64 -w0 /tmp/metrics_data.json)
 
-          for attempt in 1 2 3; do
-            git push origin gh-pages && break
-            echo "Push attempt $attempt failed, retrying in 5s..."
-            git pull --rebase origin gh-pages
-            sleep 5
-            [ "$attempt" -eq 3 ] && exit 1
-          done
+          # Get current gh-pages HEAD (or empty if branch doesn't exist)
+          BRANCH_SHA=$(gh api "repos/$REPO/git/ref/heads/gh-pages" --jq '.object.sha' 2>/dev/null || echo "")
+
+          # Build file additions
+          ADDITIONS="[{\"path\":\"data.json\",\"contents\":\"$DATA_JSON\"}"
+          if [ -n "$INDEX_HTML" ]; then
+            ADDITIONS="$ADDITIONS,{\"path\":\"index.html\",\"contents\":\"$INDEX_HTML\"}"
+          fi
+          ADDITIONS="$ADDITIONS]"
+
+          if [ -z "$BRANCH_SHA" ]; then
+            # Create gh-pages branch from an empty tree via the API
+            EMPTY_TREE=$(gh api "repos/$REPO/git/trees" --method POST --field 'tree=[{"path":".gitkeep","mode":"100644","type":"blob","content":""}]' --jq '.sha')
+            BRANCH_SHA=$(gh api "repos/$REPO/git/commits" --method POST --field "message=init gh-pages" --field "tree=$EMPTY_TREE" --jq '.sha')
+            gh api "repos/$REPO/git/refs" --method POST --field "ref=refs/heads/gh-pages" --field "sha=$BRANCH_SHA" > /dev/null
+          fi
+
+          # Use createCommitOnBranch to produce a verified commit
+          gh api graphql -f query='
+            mutation($input: CreateCommitOnBranchInput!) {
+              createCommitOnBranch(input: $input) {
+                commit { oid }
+              }
+            }' -f "variables=$(jq -n \
+              --arg repo "$REPO" \
+              --arg oid "$BRANCH_SHA" \
+              --arg msg "chore: update PR metrics for $TODAY" \
+              --argjson additions "$ADDITIONS" \
+              '{input: {
+                branch: {repositoryNameWithOwner: $repo, branchName: "gh-pages"},
+                message: {headline: $msg},
+                fileChanges: {additions: $additions},
+                expectedHeadOid: $oid
+              }}')" > /dev/null
+
+          echo "Pushed verified commit to gh-pages"

--- a/.github/workflows/pr-review-reminder.yaml
+++ b/.github/workflows/pr-review-reminder.yaml
@@ -456,12 +456,11 @@ jobs:
 
           DATA_JSON=$(base64 -w0 /tmp/metrics_data.json)
 
-          # Build file additions
-          ADDITIONS="[{\"path\":\"data.json\",\"contents\":\"$DATA_JSON\"}"
+          # Build file additions via jq for correct JSON structure
+          ADDITIONS=$(jq -n --arg data "$DATA_JSON" '[{path: "data.json", contents: $data}]')
           if [ -n "$INDEX_HTML" ]; then
-            ADDITIONS="$ADDITIONS,{\"path\":\"index.html\",\"contents\":\"$INDEX_HTML\"}"
+            ADDITIONS=$(echo "$ADDITIONS" | jq --arg html "$INDEX_HTML" '. + [{path: "index.html", contents: $html}]')
           fi
-          ADDITIONS="$ADDITIONS]"
 
           # Use createCommitOnBranch to produce a verified commit (with retry for races)
           for attempt in 1 2 3; do


### PR DESCRIPTION
## Jira
[RHINENG-28345](https://issues.redhat.com/browse/RHINENG-28345)

## What
Rework GitHub actions that were failing due to the "Commits must have verified signatures" error.

## Why
A number of automations fail without these GH actions.

## How

- `konflux-rebase.yaml`: Replace the local git rebase/push with GitHub's REST API endpoint [PUT /repos/{owner}/{repo}/pulls/{number}/update-branch](https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request-branch) with `update_method=rebase`.
- `checkimage.yaml`: Moved token generation first; pass app token + sign-commits: true to peter-evans/create-pull-request, removing the manual commit step.
- `hermetic-updates.yaml`: Replaced manual commit/push with peter-evans/create-pull-request using sign-commits: true and branch: hermetic_updates.
- `pr-review-reminder.yaml`: Replaced with createCommitOnBranch GraphQL mutation (same approach as bugkiller-agent), using the app token for verified commits.

## Testing
None; we need to test after merging by re-running each of these workflows.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-28345]: https://redhat.atlassian.net/browse/RHINENG-28345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update GitHub Actions workflows to use GitHub App tokens and API-based, verified commits to avoid failures from signature restrictions.

CI:
- Switch pr-review-reminder metrics publishing to use createCommitOnBranch GraphQL commits on gh-pages with GitHub App tokens and verified signatures.
- Change hermetic-updates workflow to detect changes and use peter-evans/create-pull-request with signed commits on a dedicated hermetic_updates branch.
- Update konflux-rebase workflow to rebase outdated Konflux PRs via the GitHub REST update-branch endpoint instead of local git rebase and push.
- Adjust checkimage workflow to generate a GitHub App token up front and use peter-evans/create-pull-request with signed commits for base image updates.