### PR TITLE
ci(RHINENG-28345): GitHub Actions fixes

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -39,11 +39,16 @@ jobs:
           title: 'chore(image): update base image'
           committer: 'Update-a-Bot <insights@redhat.com>'
 
-      - name: Approve and enable auto-merge for the base image PR
+      - name: Approve the base image PR
         if: ${{ steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated' }}
-        run: |
-          gh pr review --approve "$PR_URL"
-          gh pr merge --auto --rebase "$PR_URL"
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Enable auto-merge for the base image PR
+        if: ${{ steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated' }}
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/hermetic-updates.yaml
+++ b/.github/workflows/hermetic-updates.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install prerequisites
         run: |
           sed -i 's/include-system-site-packages = false/include-system-site-packages = true/' $APP_ROOT/pyvenv.cfg
-          dnf install -y skopeo
+          dnf install -y skopeo python3-dnf
           UV_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['tool']['uv']['required-version'])") && \
             python3 -m pip install "uv==${UV_VERSION}"
           python3 -m pip install https://github.com/konflux-ci/rpm-lockfile-prototype/archive/refs/heads/main.zip

--- a/.github/workflows/konflux-rebase.yaml
+++ b/.github/workflows/konflux-rebase.yaml
@@ -16,7 +16,7 @@ jobs:
           app-id: ${{ secrets.AUTOMERGE_APP_ID }}
           private-key: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}
 
-      - name: Rebase Konflux PRs that are behind
+      - name: Update Konflux PRs that are behind
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
@@ -26,14 +26,14 @@ jobs:
               behind_count=$(gh api "repos/$REPO/compare/master...$head_sha" --jq '.behind_by' 2>/dev/null || echo "0")
 
               if [ "$behind_count" -gt 0 ]; then
-                echo "PR #$pr_number ($branch_name) is $behind_count commits behind, rebasing via API..."
+                echo "PR #$pr_number ($branch_name) is $behind_count commits behind, updating via API..."
 
-                # Use the GitHub API to rebase — produces verified (signed) commits
+                # Use merge to update — GitHub signs the merge commit, satisfying verified-signature rules
                 response=$(gh api "repos/$REPO/pulls/$pr_number/update-branch" \
                   --method PUT \
-                  --field update_method=rebase 2>&1) && \
-                  echo "Successfully rebased PR #$pr_number" || \
-                  echo "Failed to rebase PR #$pr_number: $response"
+                  --field update_method=merge 2>&1) && \
+                  echo "Successfully updated PR #$pr_number" || \
+                  echo "Failed to update PR #$pr_number: $response"
               else
                 echo "PR #$pr_number is up to date"
               fi

--- a/.github/workflows/pr-review-reminder.yaml
+++ b/.github/workflows/pr-review-reminder.yaml
@@ -474,12 +474,7 @@ jobs:
                 | gh api "repos/$REPO/git/refs" --method POST --input - > /dev/null
             fi
 
-            if gh api graphql -f query='
-              mutation($input: CreateCommitOnBranchInput!) {
-                createCommitOnBranch(input: $input) {
-                  commit { oid }
-                }
-              }' -f "variables=$(jq -n \
+            VARIABLES=$(jq -n \
                 --arg repo "$REPO" \
                 --arg oid "$BRANCH_SHA" \
                 --arg msg "chore: update PR metrics for $TODAY" \
@@ -489,15 +484,19 @@ jobs:
                   message: {headline: $msg},
                   fileChanges: {additions: $additions},
                   expectedHeadOid: $oid
-                }}')" > /dev/null 2>&1; then
+                }}')
+
+            if output=$(gh api graphql \
+                -f query='mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }' \
+                -f "variables=$VARIABLES" 2>&1); then
               echo "Pushed verified commit to gh-pages"
               break
             fi
 
-            echo "Attempt $attempt failed (likely stale expectedHeadOid), retrying..."
+            echo "Attempt $attempt failed: $output"
             sleep 3
             if [ "$attempt" -eq 3 ]; then
-              echo "::error::Failed to push to gh-pages after 3 attempts"
+              echo "::error::Failed to push to gh-pages after 3 attempts. Last error: $output"
               exit 1
             fi
           done


### PR DESCRIPTION
## Jira
[RHINENG-28345](https://issues.redhat.com/browse/RHINENG-28345)

## What
Another attempt to address CI failures in these 4 GitHub Actions. Follows up on #4541.

## Why
The workflows are still failing (differently).

## How

- Change `update_method` from `rebase` to `merge`.
- Split approve & merge into 2 different steps, since the same account cannot both create the PR and also merge.
- Update pr-review-reminder to capture error output instead of suppressing it, so we can debug more easily if it fails again.
- Add python3-dnf to the `dnf install` command in hermetic-updates.

## Testing
None - need to test after merge by re-running the GH actions.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-28345]: https://redhat.atlassian.net/browse/RHINENG-28345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Adjust GitHub Actions workflows to stabilize automated PR maintenance and improve CI debuggability.

CI:
- Capture and surface error output in the pr-review-reminder workflow when updating gh-pages metrics to aid debugging.
- Split base image PR approval and auto-merge in checkimage into separate steps using distinct tokens for review and merge operations.
- Change Konflux PR update workflow to use the GitHub update-branch API with merge instead of rebase while updating related log messages.
- Install python3-dnf alongside skopeo in the hermetic-updates workflow to satisfy dependencies during hermetic update runs.