### PR TITLE
chore(deps): Add container-publish.yaml to allowed dependabot automerge targets

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -7,6 +7,7 @@ on:
       - 'iqe-host-inventory-plugin/pyproject.toml'
       - 'iqe-host-inventory-plugin/uv.lock'
       - '.hermetic_builds/requirements.txt'
+      - '.github/workflows/container-publish.yaml'
 
 jobs:
   dependabot-automerge:


### PR DESCRIPTION
## Jira
None

## What
Add `.github/workflows/container-publish.yaml` to list of target files for allowed Dependabot automerges

## Why
More automation

## How
Added the file to the list of paths in `pull_request_target`.

## Testing
None (must test after merge)

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

CI:
- Expand Dependabot automerge workflow paths to include .github/workflows/container-publish.yaml.