### PR TITLE
chore(RHINENG-26247): Add ansible playbook that creates users for RBAC testing

### DIFF
--- a/scripts/rbac-setup/README.md
+++ b/scripts/rbac-setup/README.md
@@ -1,0 +1,135 @@
+# RBAC Setup for HBI Tests
+
+Ansible playbooks that provision dedicated Red Hat users with specific RBAC
+permissions for HBI testing. Each user gets exactly one role (or zero
+for the no-permissions user), eliminating the need to reconfigure RBAC
+between test classes.
+
+## Prerequisites
+
+1. **Ansible** — `pip install ansible` or your system's package manager
+2. **VPN** — connected (required for stage environment)
+3. **Offline token** — generate from the API tokens page:
+   - Prod: https://access.redhat.com/management/api
+   - Stage: https://access.stage.redhat.com/management/api
+4. **User accounts** — created via `create_users.yml` (uses Red Hat Account API)
+
+## Quick Start
+
+```bash
+cd scripts/rbac-setup
+
+# 1. Create any missing users (auto-discovers username, email, and account ID)
+ansible-playbook create_users.yml \
+  -e "offline_token=YOUR_TOKEN" \
+  -e "target_env=prod"
+
+# 2. Configure RBAC permissions (choose v1 OR v2 — never both on same org)
+ansible-playbook setup_rbac_v1.yml \
+  -e "offline_token=YOUR_TOKEN" \
+  -e "target_env=prod"
+
+# Or for v2:
+ansible-playbook setup_rbac_v2.yml \
+  -e "offline_token=YOUR_TOKEN" \
+  -e "target_env=prod"
+
+# 3. To clean up (remove test groups and custom roles)
+ansible-playbook teardown_rbac.yml \
+  -e "offline_token=YOUR_TOKEN" \
+  -e "target_env=prod" \
+  -e "rbac_version=v1"
+```
+
+### Stage Environment
+
+Stage requires VPN access and an HTTP proxy:
+
+```bash
+ansible-playbook setup_rbac_v1.yml \
+  -e "offline_token=YOUR_TOKEN" \
+  -e "target_env=stage" \
+  -e "stage_proxy=http://YOUR_PROXY_HOST:PORT"
+```
+
+## CRITICAL: V1 vs V2 Isolation
+
+**Never run `setup_rbac_v2.yml` on an org that needs v1 testing.**
+Making any RBAC v2 API call permanently disables v1 for that org.
+The playbooks are separate files to ensure a playbook doesn't trigger
+v2 APIs unintentionally, but you must make sure to always run the
+correct playbook for your org.
+
+As of June 2026, the only account where v2 should be used is
+**insights-inventory-qe** on stage.
+
+## Playbooks
+
+| Playbook | Purpose |
+|---|---|
+| `create_users.yml` | Create missing users via Red Hat Account API |
+| `setup_rbac_v1.yml` | Configure RBAC using v1 API only |
+| `setup_rbac_v2.yml` | Configure RBAC using v2 API (with workspaces) |
+| `teardown_rbac.yml` | Remove all test groups and custom roles |
+
+## Users Created
+
+See `vars/users.yml` for the full list. Username format:
+`<org_admin_username>-<suffix>`.
+
+### What the Setup Playbooks Do
+
+1. **Strip the "Default access" group** — removes all roles so test users
+   don't inherit unwanted permissions
+2. **Clean up each user** — removes from any non-designated groups
+3. **Assign the correct role** — via a dedicated `test-<suffix>` group
+4. **Result** — each user has exactly the specified permissions, no more
+
+All playbooks are idempotent and safe to re-run.
+
+### How User Creation Works
+
+All playbooks auto-discover the org admin's username and email from
+the SSO token via `GET /account/v1/user`. `create_users.yml` additionally
+discovers:
+
+1. **Account ID** — fetched via `GET /account/v1/accounts`
+2. **Existing users** — listed via `GET /account/v1/accounts/{id}/users`
+3. **Missing users** — created via `POST /account/v1/accounts/{id}/users`
+
+Each test user's email is derived from the org admin's email using `+` aliasing:
+- Prod: `admin+myaccount-hosts-viewer@example.com`
+- Stage: `admin+myaccount-hosts-viewer+stage@example.com`
+
+This means all test user emails route to the org admin's inbox.
+
+### After User Creation
+
+The Account API creates the user accounts, but each user still needs manual
+setup before it can be used in automated tests:
+
+1. **Confirm email address** — each new user receives a confirmation email.
+   Open it (most of our test users use Google Groups) and click the confirmation link.
+2. **Set password** — go to the Red Hat SSO login page, click
+   "Forgot your password?", and follow the email link to set a password.
+   For simplicity, set the same password as the main org admin.
+3. **Generate offline token** — log in as the new user and generate an
+   offline token from the API tokens page:
+   - Prod: https://access.redhat.com/management/api
+   - Stage: https://access.stage.redhat.com/management/api
+4. **Store credentials in Vault** — save the offline token for each user
+   so automated tests can retrieve them at runtime. Open the vault entry
+   for the org admin and add <username>-refresh_token fields.
+
+Repeat for each user. Since all confirmation and password-reset
+emails are `+` aliases, they all arrive in the org admin's inbox (or the
+corresponding Google Group).
+
+## Required Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `offline_token` | Always | SSO offline token for authentication |
+| `target_env` | Always | `prod` or `stage` |
+| `stage_proxy` | Stage only | HTTP proxy URL (e.g., `http://squid:3128`) |
+| `rbac_version` | Teardown only | `v1` or `v2` |

--- a/scripts/rbac-setup/create_users.yml
+++ b/scripts/rbac-setup/create_users.yml
@@ -1,0 +1,116 @@
+---
+- name: "Create Red Hat user accounts for HBI tests"
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - vars/users.yml
+
+  pre_tasks:
+    - name: "Validate required variables"
+      ansible.builtin.assert:
+        that:
+          - offline_token is defined and offline_token | length > 0
+          - target_env is defined and target_env in ['prod', 'stage']
+          - target_env != 'stage' or (stage_proxy is defined and stage_proxy | length > 0)
+        fail_msg: >-
+          Missing required variables. Usage:
+          ansible-playbook create_users.yml
+          -e "offline_token=<token>"
+          -e "target_env=prod|stage"
+          [-e "stage_proxy=http://host:port"]
+
+    - name: "Authenticate via SSO"
+      ansible.builtin.include_tasks:
+        file: "tasks_auth.yml"
+
+  tasks:
+    # ================================================================
+    # PHASE 1: Auto-discover account ID
+    # (org_admin_username and org_admin_email already set by tasks_auth.yml)
+    # ================================================================
+
+    - name: "Look up account ID"
+      ansible.builtin.uri:
+        url: "{{ account_api_base }}/accounts"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: accounts_info
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: accounts_info is not failed
+
+    - name: "Fail if no accounts found"
+      ansible.builtin.fail:
+        msg: "No accounts found for the authenticated user."
+      when: accounts_info.json.body | length == 0
+
+    - name: "Set account ID"
+      ansible.builtin.set_fact:
+        account_id: "{{ accounts_info.json.body[0].id }}"
+
+    - name: "Display discovered settings"
+      ansible.builtin.debug:
+        msg: "Account ID: {{ account_id }}, Admin email: {{ org_admin_email }}"
+
+    # ================================================================
+    # PHASE 2: List existing users and identify missing ones
+    # ================================================================
+
+    - name: "Build list of expected usernames"
+      ansible.builtin.set_fact:
+        expected_usernames: "{{ users | map(attribute='suffix') | map('regex_replace', '^(.*)$', org_admin_username + '-\\1') | list }}"
+
+    - name: "List existing account users"
+      ansible.builtin.uri:
+        url: "{{ account_api_base }}/accounts/{{ account_id }}/users?status=enabled&maxResults=500"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: existing_account_users
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: existing_account_users is not failed
+
+    - name: "Extract existing usernames"
+      ansible.builtin.set_fact:
+        existing_usernames: "{{ existing_account_users.json.body | map(attribute='user') | map(attribute='username') | list }}"
+
+    - name: "Identify missing users"
+      ansible.builtin.set_fact:
+        missing_users: "{{ expected_usernames | difference(existing_usernames) }}"
+        found_users: "{{ expected_usernames | intersect(existing_usernames) }}"
+
+    - name: "Report existing users"
+      ansible.builtin.debug:
+        msg: "Found {{ found_users | length }}/{{ expected_usernames | length }} users already exist."
+
+    # ================================================================
+    # PHASE 3: Create missing users
+    # ================================================================
+
+    - name: "Initialize failed users list"
+      ansible.builtin.set_fact:
+        failed_users: []
+      when: missing_users | length > 0
+
+    - name: "Create missing users"
+      ansible.builtin.include_tasks:
+        file: "tasks_create_user.yml"
+      loop: "{{ missing_users }}"
+      loop_control:
+        loop_var: "new_username"
+        label: "{{ new_username }}"
+      when: missing_users | length > 0
+
+    - name: "Fail if any users could not be created"
+      ansible.builtin.fail:
+        msg: "Failed to create {{ failed_users | length }} user(s): {{ failed_users | join(', ') }}"
+      when: failed_users | default([]) | length > 0
+
+    - name: "All users exist"
+      ansible.builtin.debug:
+        msg: "All {{ expected_usernames | length }} users exist. Ready to run setup_rbac_v1.yml or setup_rbac_v2.yml."
+      when: failed_users | default([]) | length == 0

--- a/scripts/rbac-setup/group_vars/all.yml
+++ b/scripts/rbac-setup/group_vars/all.yml
@@ -1,0 +1,33 @@
+# Environment configuration — selected via -e "target_env=prod|stage"
+env_configs:
+  prod:
+    console_url: "https://console.redhat.com"
+    sso_url: "https://sso.redhat.com"
+    account_api_url: "https://api.access.redhat.com"
+  stage:
+    console_url: "https://console.stage.redhat.com"
+    sso_url: "https://sso.stage.redhat.com"
+    account_api_url: "https://api.access.stage.redhat.com"
+
+# Resolved at runtime
+env_config: "{{ env_configs[target_env] }}"
+
+# Proxy environment — applied to all uri tasks
+# When target_env=stage, stage_proxy must be provided via -e
+proxy_env: "{{ {'https_proxy': stage_proxy} if target_env == 'stage' else {} }}"
+
+# Common API settings
+rbac_v1_base: "{{ env_config.console_url }}/api/rbac/v1"
+rbac_v2_base: "{{ env_config.console_url }}/api/rbac/v2"
+sso_token_url: "{{ env_config.sso_url }}/auth/realms/redhat-external/protocol/openid-connect/token"
+account_api_base: "{{ env_config.account_api_url }}/account/v1"
+
+# Retry settings for all API calls
+api_retries: 3
+api_delay: 5
+
+# Platform-default group names (users cannot be removed from these)
+platform_default_groups:
+  - "Default access"
+  - "Custom default access"
+  - "Default admin access"

--- a/scripts/rbac-setup/inventory.yml
+++ b/scripts/rbac-setup/inventory.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    localhost:
+      ansible_connection: local
+      ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/scripts/rbac-setup/setup_rbac_v1.yml
+++ b/scripts/rbac-setup/setup_rbac_v1.yml
@@ -1,0 +1,107 @@
+---
+- name: "Setup RBAC V1 permissions for HBI test users"
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - vars/users.yml
+
+  pre_tasks:
+    - name: "Validate required variables"
+      ansible.builtin.assert:
+        that:
+          - offline_token is defined and offline_token | length > 0
+          - target_env is defined and target_env in ['prod', 'stage']
+          - target_env != 'stage' or (stage_proxy is defined and stage_proxy | length > 0)
+        fail_msg: >-
+          Missing required variables. Usage:
+          ansible-playbook setup_rbac_v1.yml
+          -e "offline_token=<token>"
+          -e "target_env=prod|stage"
+          [-e "stage_proxy=http://host:port"]  (required for stage)
+
+    - name: "Authenticate via SSO"
+      ansible.builtin.include_tasks:
+        file: "tasks_auth.yml"
+
+  tasks:
+    # ================================================================
+    # PHASE 1: Strip "Default access" group (org-wide, run once)
+    # ================================================================
+
+    - name: "Look up 'Default access' group"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/groups/?name=Default%20access"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: default_access_lookup
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: default_access_lookup is not failed
+
+    - name: "Look up 'Custom default access' group (fallback)"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/groups/?name=Custom%20default%20access"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: custom_default_access_lookup
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: custom_default_access_lookup is not failed
+      when: default_access_lookup.json.meta.count == 0
+
+    - name: "Set default access group UUID"
+      ansible.builtin.set_fact:
+        default_access_group_uuid: >-
+          {{
+            default_access_lookup.json.data[0].uuid
+            if default_access_lookup.json.meta.count > 0
+            else (
+              custom_default_access_lookup.json.data[0].uuid
+              if (custom_default_access_lookup is not skipped and custom_default_access_lookup.json.meta.count > 0)
+              else ''
+            )
+          }}
+
+    - name: "List roles in Default access group"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/groups/{{ default_access_group_uuid }}/roles/"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: default_access_roles
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: default_access_roles is not failed
+      when: default_access_group_uuid | length > 0
+
+    - name: "Remove all roles from Default access group"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/groups/{{ default_access_group_uuid }}/roles/?roles={{ default_access_roles.json.data | map(attribute='uuid') | join(',') }}"
+        method: DELETE
+        headers: "{{ auth_header }}"
+        status_code: [200, 204]
+      environment: "{{ proxy_env }}"
+      register: roles_removed
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: roles_removed is not failed
+      when:
+        - default_access_group_uuid | length > 0
+        - default_access_roles.json.data | length > 0
+
+    # ================================================================
+    # PHASE 2: Per-user setup
+    # ================================================================
+
+    - name: "Configure RBAC for each user"
+      ansible.builtin.include_tasks:
+        file: "tasks_v1_per_user.yml"
+      loop: "{{ users }}"
+      loop_control:
+        loop_var: "user"
+        label: "{{ org_admin_username }}-{{ user.suffix }}"

--- a/scripts/rbac-setup/setup_rbac_v1.yml
+++ b/scripts/rbac-setup/setup_rbac_v1.yml
@@ -66,6 +66,13 @@
             )
           }}
 
+    - name: "Fail if no default access group found"
+      ansible.builtin.fail:
+        msg: >-
+          Neither 'Default access' nor 'Custom default access' group found.
+          Users may retain unwanted default permissions.
+      when: default_access_group_uuid | length == 0
+
     - name: "List roles in Default access group"
       ansible.builtin.uri:
         url: "{{ rbac_v1_base }}/groups/{{ default_access_group_uuid }}/roles/"
@@ -77,7 +84,6 @@
       retries: "{{ api_retries }}"
       delay: "{{ api_delay }}"
       until: default_access_roles is not failed
-      when: default_access_group_uuid | length > 0
 
     - name: "Remove all roles from Default access group"
       ansible.builtin.uri:
@@ -90,9 +96,7 @@
       retries: "{{ api_retries }}"
       delay: "{{ api_delay }}"
       until: roles_removed is not failed
-      when:
-        - default_access_group_uuid | length > 0
-        - default_access_roles.json.data | length > 0
+      when: default_access_roles.json.data | length > 0
 
     # ================================================================
     # PHASE 2: Per-user setup

--- a/scripts/rbac-setup/setup_rbac_v2.yml
+++ b/scripts/rbac-setup/setup_rbac_v2.yml
@@ -1,0 +1,164 @@
+---
+- name: "Setup RBAC V2 permissions for HBI test users"
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - vars/users.yml
+
+  pre_tasks:
+    - name: "Validate required variables"
+      ansible.builtin.assert:
+        that:
+          - offline_token is defined and offline_token | length > 0
+          - target_env is defined and target_env in ['prod', 'stage']
+          - target_env != 'stage' or (stage_proxy is defined and stage_proxy | length > 0)
+        fail_msg: >-
+          Missing required variables. Usage:
+          ansible-playbook setup_rbac_v2.yml
+          -e "offline_token=<token>"
+          -e "target_env=prod|stage"
+          [-e "stage_proxy=http://host:port"]  (required for stage)
+
+    - name: "Authenticate via SSO"
+      ansible.builtin.include_tasks:
+        file: "tasks_auth.yml"
+
+  tasks:
+    # ================================================================
+    # PHASE 1: Strip "Default access" group role bindings (v2 API)
+    # ================================================================
+
+    - name: "Look up 'Default access' group"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/groups/?name=Default%20access"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: default_access_lookup
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: default_access_lookup is not failed
+
+    - name: "Look up 'Custom default access' group (fallback)"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/groups/?name=Custom%20default%20access"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: custom_default_access_lookup
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: custom_default_access_lookup is not failed
+      when: default_access_lookup.json.meta.count == 0
+
+    - name: "Set default access group UUID"
+      ansible.builtin.set_fact:
+        default_access_group_uuid: >-
+          {{
+            default_access_lookup.json.data[0].uuid
+            if default_access_lookup.json.meta.count > 0
+            else (
+              custom_default_access_lookup.json.data[0].uuid
+              if (custom_default_access_lookup is not skipped and custom_default_access_lookup.json.meta.count > 0)
+              else ''
+            )
+          }}
+
+    - name: "List role bindings for Default access group"
+      ansible.builtin.uri:
+        url: "{{ rbac_v2_base }}/role-bindings/?subject_type=group&subject_id={{ default_access_group_uuid }}&limit=10000&fields=resource(id,type),role(id),subject(id,type)"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: default_access_bindings
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: default_access_bindings is not failed
+      when: default_access_group_uuid | length > 0
+
+    - name: "Collect unique workspace resources from role bindings"
+      ansible.builtin.set_fact:
+        binding_resources: >-
+          {{
+            default_access_bindings.json.data
+            | map(attribute='resource')
+            | selectattr('type', 'equalto', 'workspace')
+            | unique
+            | list
+          }}
+      when:
+        - default_access_group_uuid | length > 0
+        - default_access_bindings.json.data | length > 0
+
+    - name: "Clear role bindings for each workspace"
+      ansible.builtin.uri:
+        url: "{{ rbac_v2_base }}/role-bindings/by-subject/?resource_id={{ item.id }}&resource_type=workspace&subject_id={{ default_access_group_uuid }}&subject_type=group"
+        method: PUT
+        headers: "{{ auth_header }}"
+        body_format: json
+        body:
+          roles: []
+        status_code: [200, 204]
+      environment: "{{ proxy_env }}"
+      loop: "{{ binding_resources }}"
+      loop_control:
+        label: "workspace:{{ item.id }}"
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      when: binding_resources | default([]) | length > 0
+
+    # ================================================================
+    # PHASE 1.5: Look up workspaces (run once, used by all users)
+    # ================================================================
+
+    - name: "Look up default workspace"
+      ansible.builtin.uri:
+        url: "{{ rbac_v2_base }}/workspaces/?type=default&limit=1"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: default_workspace_lookup
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: default_workspace_lookup is not failed
+
+    - name: "Look up root workspace"
+      ansible.builtin.uri:
+        url: "{{ rbac_v2_base }}/workspaces/?type=root&limit=1"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: root_workspace_lookup
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: root_workspace_lookup is not failed
+
+    - name: "Verify workspaces found"
+      ansible.builtin.assert:
+        that:
+          - default_workspace_lookup.json.data | length > 0
+          - root_workspace_lookup.json.data | length > 0
+        fail_msg: "Failed to find required workspaces (default and/or root). Is the org enabled for v2?"
+
+    - name: "Set workspace IDs"
+      ansible.builtin.set_fact:
+        workspace_ids:
+          default: "{{ default_workspace_lookup.json.data[0].id }}"
+          root: "{{ root_workspace_lookup.json.data[0].id }}"
+
+    # ================================================================
+    # PHASE 2: Per-user setup
+    # ================================================================
+
+    - name: "Configure RBAC for each user"
+      ansible.builtin.include_tasks:
+        file: "tasks_v2_per_user.yml"
+      loop: "{{ users }}"
+      loop_control:
+        loop_var: "user"
+        label: "{{ org_admin_username }}-{{ user.suffix }}"

--- a/scripts/rbac-setup/setup_rbac_v2.yml
+++ b/scripts/rbac-setup/setup_rbac_v2.yml
@@ -66,6 +66,13 @@
             )
           }}
 
+    - name: "Fail if no default access group found"
+      ansible.builtin.fail:
+        msg: >-
+          Neither 'Default access' nor 'Custom default access' group found.
+          Users may retain unwanted default permissions.
+      when: default_access_group_uuid | length == 0
+
     - name: "List role bindings for Default access group"
       ansible.builtin.uri:
         url: "{{ rbac_v2_base }}/role-bindings/?subject_type=group&subject_id={{ default_access_group_uuid }}&limit=10000&fields=resource(id,type),role(id),subject(id,type)"
@@ -77,7 +84,6 @@
       retries: "{{ api_retries }}"
       delay: "{{ api_delay }}"
       until: default_access_bindings is not failed
-      when: default_access_group_uuid | length > 0
 
     - name: "Collect unique workspace resources from role bindings"
       ansible.builtin.set_fact:
@@ -89,9 +95,7 @@
             | unique
             | list
           }}
-      when:
-        - default_access_group_uuid | length > 0
-        - default_access_bindings.json.data | length > 0
+      when: default_access_bindings.json.data | length > 0
 
     - name: "Clear role bindings for each workspace"
       ansible.builtin.uri:
@@ -103,12 +107,13 @@
           roles: []
         status_code: [200, 204]
       environment: "{{ proxy_env }}"
-      loop: "{{ binding_resources }}"
+      loop: "{{ binding_resources | default([]) }}"
       loop_control:
         label: "workspace:{{ item.id }}"
+      register: binding_cleared
       retries: "{{ api_retries }}"
       delay: "{{ api_delay }}"
-      when: binding_resources | default([]) | length > 0
+      until: binding_cleared is not failed
 
     # ================================================================
     # PHASE 1.5: Look up workspaces (run once, used by all users)

--- a/scripts/rbac-setup/tasks_auth.yml
+++ b/scripts/rbac-setup/tasks_auth.yml
@@ -19,7 +19,7 @@
   retries: "{{ api_retries }}"
   delay: "{{ api_delay }}"
   until: sso_response is not failed
-  failed_when: false
+  ignore_errors: true
 
 - name: "Fail if token exchange failed"
   ansible.builtin.fail:

--- a/scripts/rbac-setup/tasks_auth.yml
+++ b/scripts/rbac-setup/tasks_auth.yml
@@ -1,0 +1,51 @@
+---
+# Shared authentication and identity discovery tasks
+# Required variables: offline_token, sso_token_url, account_api_base,
+#                     proxy_env, api_retries, api_delay
+# Sets: auth_header, org_admin_username, org_admin_email
+
+- name: "Exchange offline token for access token"
+  ansible.builtin.uri:
+    url: "{{ sso_token_url }}"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      grant_type: "refresh_token"
+      client_id: "rhsm-api"
+      refresh_token: "{{ offline_token }}"
+    status_code: 200
+  environment: "{{ proxy_env }}"
+  register: sso_response
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: sso_response is not failed
+  failed_when: false
+
+- name: "Fail if token exchange failed"
+  ansible.builtin.fail:
+    msg: >-
+      Failed to authenticate with SSO. Is your offline token valid/expired?
+      HTTP {{ sso_response.status }}: {{ sso_response.json | default(sso_response.msg) }}
+  when: sso_response is failed or sso_response.status != 200
+
+- name: "Set auth header"
+  ansible.builtin.set_fact:
+    auth_header:
+      Authorization: "Bearer {{ sso_response.json.access_token }}"
+
+- name: "Discover org admin identity"
+  ansible.builtin.uri:
+    url: "{{ account_api_base }}/user"
+    method: GET
+    headers: "{{ auth_header }}"
+    status_code: 200
+  environment: "{{ proxy_env }}"
+  register: admin_identity
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: admin_identity is not failed
+
+- name: "Set org admin username and email"
+  ansible.builtin.set_fact:
+    org_admin_username: "{{ admin_identity.json.body.username }}"
+    org_admin_email: "{{ admin_identity.json.body.email }}"

--- a/scripts/rbac-setup/tasks_auth.yml
+++ b/scripts/rbac-setup/tasks_auth.yml
@@ -20,6 +20,7 @@
   delay: "{{ api_delay }}"
   until: sso_response is not failed
   ignore_errors: true
+  no_log: true
 
 - name: "Fail if token exchange failed"
   ansible.builtin.fail:
@@ -32,6 +33,7 @@
   ansible.builtin.set_fact:
     auth_header:
       Authorization: "Bearer {{ sso_response.json.access_token }}"
+  no_log: true
 
 - name: "Discover org admin identity"
   ansible.builtin.uri:

--- a/scripts/rbac-setup/tasks_create_user.yml
+++ b/scripts/rbac-setup/tasks_create_user.yml
@@ -1,0 +1,55 @@
+---
+# Per-user creation via Red Hat Account API
+# Required variables: new_username, org_admin_email, account_id,
+#                     account_api_base, auth_header, proxy_env,
+#                     target_env, api_retries, api_delay
+
+- name: "Derive email for {{ new_username }}"
+  ansible.builtin.set_fact:
+    user_email: >-
+      {%- set local = org_admin_email.split('@')[0].split('+')[0] -%}
+      {%- set domain = org_admin_email.split('@')[1] -%}
+      {%- if target_env == 'stage' -%}
+        {{ local }}+{{ new_username }}+stage@{{ domain }}
+      {%- else -%}
+        {{ local }}+{{ new_username }}@{{ domain }}
+      {%- endif -%}
+    user_suffix: "{{ new_username.split('-', 1)[1] | default(new_username) }}"
+
+- name: "Create user {{ new_username }}"
+  ansible.builtin.uri:
+    url: "{{ account_api_base }}/accounts/{{ account_id }}/users"
+    method: POST
+    headers: "{{ auth_header }}"
+    body_format: json
+    body:
+      username: "{{ new_username }}"
+      firstName: "{{ new_username }}"
+      lastName: "{{ user_suffix }}"
+      email: "{{ user_email }}"
+      phone: "0123456789"
+      address:
+        streets:
+          - "100 East Davie Street"
+        city: "Raleigh"
+        state: "NC"
+        county: "Wake"
+        zipCode: "27601"
+        country: "US"
+    status_code: [200, 201]
+  environment: "{{ proxy_env }}"
+  register: user_creation_result
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: user_creation_result is not failed
+  ignore_errors: true
+
+- name: "Report success for {{ new_username }}"
+  ansible.builtin.debug:
+    msg: "CREATED: {{ new_username }} (email: {{ user_email }})"
+  when: user_creation_result is not failed
+
+- name: "Track failed user {{ new_username }}"
+  ansible.builtin.set_fact:
+    failed_users: "{{ failed_users + [new_username] }}"
+  when: user_creation_result is failed

--- a/scripts/rbac-setup/tasks_group_setup.yml
+++ b/scripts/rbac-setup/tasks_group_setup.yml
@@ -44,7 +44,7 @@
 
 - name: "List principals in group '{{ group_name }}'"
   ansible.builtin.uri:
-    url: "{{ rbac_v1_base }}/groups/{{ group_uuid }}/principals/"
+    url: "{{ rbac_v1_base }}/groups/{{ group_uuid }}/principals/?limit=1000"
     method: GET
     headers: "{{ auth_header }}"
     status_code: 200

--- a/scripts/rbac-setup/tasks_group_setup.yml
+++ b/scripts/rbac-setup/tasks_group_setup.yml
@@ -1,0 +1,72 @@
+---
+# Shared group setup and membership tasks (common to both v1 and v2)
+# Required variables: username, group_name, auth_header, rbac_v1_base,
+#                     proxy_env, api_retries, api_delay
+# Sets: group_uuid
+
+- name: "Check if group '{{ group_name }}' exists"
+  ansible.builtin.uri:
+    url: "{{ rbac_v1_base }}/groups/?name={{ group_name | urlencode }}"
+    method: GET
+    headers: "{{ auth_header }}"
+    status_code: 200
+  environment: "{{ proxy_env }}"
+  register: group_lookup
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: group_lookup is not failed
+
+- name: "Create group '{{ group_name }}'"
+  ansible.builtin.uri:
+    url: "{{ rbac_v1_base }}/groups/"
+    method: POST
+    headers: "{{ auth_header }}"
+    body_format: json
+    body:
+      name: "{{ group_name }}"
+      description: "Test group for {{ username }}"
+    status_code: [200, 201]
+  environment: "{{ proxy_env }}"
+  register: group_created
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: group_created is not failed
+  when: group_lookup.json.meta.count == 0
+
+- name: "Set group UUID"
+  ansible.builtin.set_fact:
+    group_uuid: >-
+      {{ group_lookup.json.data[0].uuid
+         if group_lookup.json.meta.count > 0
+         else group_created.json.uuid }}
+
+# --- Add user to group ---
+
+- name: "List principals in group '{{ group_name }}'"
+  ansible.builtin.uri:
+    url: "{{ rbac_v1_base }}/groups/{{ group_uuid }}/principals/"
+    method: GET
+    headers: "{{ auth_header }}"
+    status_code: 200
+  environment: "{{ proxy_env }}"
+  register: group_principals
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: group_principals is not failed
+
+- name: "Add {{ username }} to group '{{ group_name }}'"
+  ansible.builtin.uri:
+    url: "{{ rbac_v1_base }}/groups/{{ group_uuid }}/principals/"
+    method: POST
+    headers: "{{ auth_header }}"
+    body_format: json
+    body:
+      principals:
+        - username: "{{ username }}"
+    status_code: [200, 201]
+  environment: "{{ proxy_env }}"
+  register: user_added
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: user_added is not failed
+  when: username not in (group_principals.json.data | map(attribute='username') | list)

--- a/scripts/rbac-setup/tasks_teardown_group.yml
+++ b/scripts/rbac-setup/tasks_teardown_group.yml
@@ -48,8 +48,9 @@
                 | selectattr('type', 'equalto', 'workspace')
                 | unique
                 | list
+                if group_bindings.json.data | length > 0
+                else []
               }}
-          when: group_bindings.json.data | length > 0
 
         - name: "Clear role bindings for each workspace"
           ansible.builtin.uri:
@@ -64,9 +65,10 @@
           loop: "{{ group_binding_resources }}"
           loop_control:
             label: "workspace:{{ item.id }}"
+          register: binding_cleared
           retries: "{{ api_retries }}"
           delay: "{{ api_delay }}"
-          when: group_binding_resources | default([]) | length > 0
+          until: binding_cleared is not failed
 
     - name: "Delete group '{{ group_name }}'"
       ansible.builtin.uri:

--- a/scripts/rbac-setup/tasks_teardown_group.yml
+++ b/scripts/rbac-setup/tasks_teardown_group.yml
@@ -1,0 +1,81 @@
+---
+- name: "Set group name"
+  ansible.builtin.set_fact:
+    group_name: "test-{{ user.suffix }}"
+
+- name: "Look up group '{{ group_name }}'"
+  ansible.builtin.uri:
+    url: "{{ rbac_v1_base }}/groups/?name={{ group_name | urlencode }}"
+    method: GET
+    headers: "{{ auth_header }}"
+    status_code: 200
+  environment: "{{ proxy_env }}"
+  register: group_lookup
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: group_lookup is not failed
+
+- name: "Handle group deletion for '{{ group_name }}'"
+  when: group_lookup.json.meta.count > 0
+  block:
+    - name: "Set group UUID"
+      ansible.builtin.set_fact:
+        group_uuid: "{{ group_lookup.json.data[0].uuid }}"
+
+    # In v2, role bindings must be removed before group deletion
+    - name: "Clear role bindings for group (v2 only)"
+      when: rbac_version == 'v2'
+      block:
+        - name: "List role bindings for group"
+          ansible.builtin.uri:
+            url: "{{ rbac_v2_base }}/role-bindings/?subject_type=group&subject_id={{ group_uuid }}&limit=1000&fields=resource(id,type),role(id),subject(id,type)"
+            method: GET
+            headers: "{{ auth_header }}"
+            status_code: 200
+          environment: "{{ proxy_env }}"
+          register: group_bindings
+          retries: "{{ api_retries }}"
+          delay: "{{ api_delay }}"
+          until: group_bindings is not failed
+
+        - name: "Collect unique workspace resources"
+          ansible.builtin.set_fact:
+            group_binding_resources: >-
+              {{
+                group_bindings.json.data
+                | map(attribute='resource')
+                | selectattr('type', 'defined')
+                | selectattr('type', 'equalto', 'workspace')
+                | unique
+                | list
+              }}
+          when: group_bindings.json.data | length > 0
+
+        - name: "Clear role bindings for each workspace"
+          ansible.builtin.uri:
+            url: "{{ rbac_v2_base }}/role-bindings/by-subject/?resource_id={{ item.id }}&resource_type=workspace&subject_id={{ group_uuid }}&subject_type=group"
+            method: PUT
+            headers: "{{ auth_header }}"
+            body_format: json
+            body:
+              roles: []
+            status_code: [200, 204]
+          environment: "{{ proxy_env }}"
+          loop: "{{ group_binding_resources }}"
+          loop_control:
+            label: "workspace:{{ item.id }}"
+          retries: "{{ api_retries }}"
+          delay: "{{ api_delay }}"
+          when: group_binding_resources | default([]) | length > 0
+
+    - name: "Delete group '{{ group_name }}'"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/groups/{{ group_uuid }}/"
+        method: DELETE
+        headers: "{{ auth_header }}"
+        status_code: [200, 204, 404]
+      environment: "{{ proxy_env }}"
+      register: group_deleted
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: group_deleted is not failed

--- a/scripts/rbac-setup/tasks_teardown_role.yml
+++ b/scripts/rbac-setup/tasks_teardown_role.yml
@@ -1,0 +1,64 @@
+---
+- name: "Set role name"
+  ansible.builtin.set_fact:
+    role_name_custom: "test-role-{{ user.suffix }}"
+
+- name: "Look up custom role (v1)"
+  ansible.builtin.uri:
+    url: "{{ rbac_v1_base }}/roles/?name={{ role_name_custom | urlencode }}"
+    method: GET
+    headers: "{{ auth_header }}"
+    status_code: 200
+  environment: "{{ proxy_env }}"
+  register: role_lookup_v1
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: role_lookup_v1 is not failed
+  when: rbac_version == 'v1'
+
+- name: "Delete custom role (v1)"
+  ansible.builtin.uri:
+    url: "{{ rbac_v1_base }}/roles/{{ role_lookup_v1.json.data[0].uuid }}/"
+    method: DELETE
+    headers: "{{ auth_header }}"
+    status_code: [200, 204, 404]
+  environment: "{{ proxy_env }}"
+  register: role_deleted_v1
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: role_deleted_v1 is not failed
+  when:
+    - rbac_version == 'v1'
+    - role_lookup_v1.json.meta.count > 0
+
+- name: "Look up custom role (v2)"
+  ansible.builtin.uri:
+    url: "{{ rbac_v2_base }}/roles/?name={{ role_name_custom | urlencode }}&limit=10"
+    method: GET
+    headers: "{{ auth_header }}"
+    status_code: 200
+  environment: "{{ proxy_env }}"
+  register: role_lookup_v2
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: role_lookup_v2 is not failed
+  when: rbac_version == 'v2'
+
+- name: "Delete custom role (v2)"
+  ansible.builtin.uri:
+    url: "{{ rbac_v2_base }}/roles:batchDelete/"
+    method: POST
+    headers: "{{ auth_header }}"
+    body_format: json
+    body:
+      ids:
+        - "{{ role_lookup_v2.json.data[0].id }}"
+    status_code: [200, 204, 404]
+  environment: "{{ proxy_env }}"
+  register: role_deleted_v2
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: role_deleted_v2 is not failed
+  when:
+    - rbac_version == 'v2'
+    - role_lookup_v2.json.data | length > 0

--- a/scripts/rbac-setup/tasks_user_cleanup.yml
+++ b/scripts/rbac-setup/tasks_user_cleanup.yml
@@ -1,0 +1,73 @@
+---
+# Shared user cleanup tasks (common to both v1 and v2)
+# Required variables: user (from loop), org_admin_username, auth_header,
+#                     rbac_v1_base, proxy_env, platform_default_groups,
+#                     api_retries, api_delay
+# Sets: username, group_name, role_name_custom
+
+- name: "Set username for {{ user.suffix }}"
+  ansible.builtin.set_fact:
+    username: "{{ org_admin_username }}-{{ user.suffix }}"
+    group_name: "test-{{ user.suffix }}"
+    role_name_custom: "test-role-{{ user.suffix }}"
+
+# --- Verify user exists ---
+
+- name: "Verify user {{ username }} exists"
+  ansible.builtin.uri:
+    url: "{{ rbac_v1_base }}/principals/?usernames={{ username }}"
+    method: GET
+    headers: "{{ auth_header }}"
+    status_code: 200
+  environment: "{{ proxy_env }}"
+  register: principal_check
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: principal_check is not failed
+
+- name: "Fail if user {{ username }} does not exist"
+  ansible.builtin.fail:
+    msg: >-
+      User '{{ username }}' does not exist.
+      Create it at https://www.redhat.com/wapps/ugc/protected/usermgt/userList.html
+      or run create_users.yml first.
+  when: principal_check.json.meta.count == 0
+
+# --- Permission cleanup: remove user from non-designated groups ---
+
+- name: "List groups for {{ username }}"
+  ansible.builtin.uri:
+    url: "{{ rbac_v1_base }}/groups/?username={{ username }}&limit=100"
+    method: GET
+    headers: "{{ auth_header }}"
+    status_code: 200
+  environment: "{{ proxy_env }}"
+  register: user_groups
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: user_groups is not failed
+
+- name: "Remove {{ username }} from unwanted groups"
+  ansible.builtin.uri:
+    url: "{{ rbac_v1_base }}/groups/{{ item.uuid }}/principals/?usernames={{ username }}"
+    method: DELETE
+    headers: "{{ auth_header }}"
+    status_code: [200, 204, 404]
+  environment: "{{ proxy_env }}"
+  loop: "{{ user_groups.json.data }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when:
+    - item.name not in platform_default_groups
+    - item.name != group_name or user.type == 'none'
+  register: group_removal
+  retries: "{{ api_retries }}"
+  delay: "{{ api_delay }}"
+  until: group_removal is not failed
+
+# --- Stop here for no-perms user ---
+
+- name: "Skip role/group setup for no-perms user"
+  ansible.builtin.debug:
+    msg: "User {{ username }} is the no-perms user — cleanup complete, skipping role assignment."
+  when: user.type == 'none'

--- a/scripts/rbac-setup/tasks_v1_per_user.yml
+++ b/scripts/rbac-setup/tasks_v1_per_user.yml
@@ -1,0 +1,119 @@
+---
+# Included once per user from setup_rbac_v1.yml
+# Variables available: user (from loop), org_admin_username, auth_header,
+#                      rbac_v1_base, proxy_env, platform_default_groups,
+#                      api_retries, api_delay
+
+- name: "User cleanup for {{ user.suffix }}"
+  ansible.builtin.include_tasks:
+    file: "tasks_user_cleanup.yml"
+
+- name: "Setup role and group for {{ username }}"
+  when: user.type != 'none'
+  block:
+    # --- Look up or create role ---
+
+    - name: "Look up pre-configured role '{{ user.role_name | default('N/A') }}'"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/roles/?name={{ user.role_name | urlencode }}"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: preconfigured_role_lookup
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: preconfigured_role_lookup is not failed
+      when: user.type == 'preconfigured'
+
+    - name: "Fail if pre-configured role '{{ user.role_name | default('N/A') }}' not found"
+      ansible.builtin.fail:
+        msg: "Pre-configured role '{{ user.role_name }}' not found in RBAC. Available roles may differ by environment."
+      when:
+        - user.type == 'preconfigured'
+        - preconfigured_role_lookup.json.meta.count == 0
+
+    - name: "Check if custom role '{{ role_name_custom }}' exists"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/roles/?name={{ role_name_custom | urlencode }}"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: custom_role_lookup
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: custom_role_lookup is not failed
+      when: user.type == 'custom'
+
+    - name: "Create custom role '{{ role_name_custom }}'"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/roles/"
+        method: POST
+        headers: "{{ auth_header }}"
+        body_format: json
+        body:
+          name: "{{ role_name_custom }}"
+          description: "Test role for {{ user.permission }} permission"
+          access:
+            - permission: "{{ user.permission }}"
+              resourceDefinitions: []
+          applications:
+            - "{{ user.permission.split(':')[0] }}"
+        status_code: [200, 201]
+      environment: "{{ proxy_env }}"
+      register: custom_role_created
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: custom_role_created is not failed
+      when:
+        - user.type == 'custom'
+        - custom_role_lookup.json.meta.count == 0
+
+    - name: "Set role UUID"
+      ansible.builtin.set_fact:
+        role_uuid: >-
+          {%- if user.type == 'preconfigured' -%}
+            {{ preconfigured_role_lookup.json.data[0].uuid }}
+          {%- elif user.type == 'custom' and custom_role_lookup.json.meta.count > 0 -%}
+            {{ custom_role_lookup.json.data[0].uuid }}
+          {%- else -%}
+            {{ custom_role_created.json.uuid }}
+          {%- endif -%}
+
+    # --- Check / create RBAC group ---
+
+    - name: "Setup group and membership"
+      ansible.builtin.include_tasks:
+        file: "tasks_group_setup.yml"
+
+    # --- Add role to group ---
+
+    - name: "List roles in group '{{ group_name }}'"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/groups/{{ group_uuid }}/roles/"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: group_roles
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: group_roles is not failed
+
+    - name: "Add role to group '{{ group_name }}'"
+      ansible.builtin.uri:
+        url: "{{ rbac_v1_base }}/groups/{{ group_uuid }}/roles/"
+        method: POST
+        headers: "{{ auth_header }}"
+        body_format: json
+        body:
+          roles:
+            - "{{ role_uuid }}"
+        status_code: [200, 201]
+      environment: "{{ proxy_env }}"
+      register: role_added
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: role_added is not failed
+      when: role_uuid not in (group_roles.json.data | map(attribute='uuid') | list)

--- a/scripts/rbac-setup/tasks_v2_per_user.yml
+++ b/scripts/rbac-setup/tasks_v2_per_user.yml
@@ -1,0 +1,141 @@
+---
+# Included once per user from setup_rbac_v2.yml
+# Variables available: user (from loop), org_admin_username, auth_header,
+#                      rbac_v1_base, rbac_v2_base, proxy_env,
+#                      platform_default_groups, workspace_ids,
+#                      api_retries, api_delay
+
+- name: "User cleanup for {{ user.suffix }}"
+  ansible.builtin.include_tasks:
+    file: "tasks_user_cleanup.yml"
+
+- name: "Setup role, group, and binding for {{ username }}"
+  when: user.type != 'none'
+  block:
+    # --- Look up or create role (via v2 API) ---
+
+    - name: "Set v2 role name"
+      ansible.builtin.set_fact:
+        v2_role_name: "{{ user.role_name_v2 | default(user.role_name) }}"
+      when: user.type == 'preconfigured'
+
+    - name: "Look up pre-configured role '{{ v2_role_name | default('N/A') }}' via v2"
+      ansible.builtin.uri:
+        url: "{{ rbac_v2_base }}/roles/?name={{ v2_role_name | urlencode }}&limit=100"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: preconfigured_role_lookup_v2
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: preconfigured_role_lookup_v2 is not failed
+      when: user.type == 'preconfigured'
+
+    - name: "Fail if pre-configured role '{{ v2_role_name | default('N/A') }}' not found"
+      ansible.builtin.fail:
+        msg: "Pre-configured role '{{ v2_role_name }}' not found in RBAC v2."
+      when:
+        - user.type == 'preconfigured'
+        - preconfigured_role_lookup_v2.json.data | length == 0
+
+    - name: "Check if custom role '{{ role_name_custom }}' exists in v2"
+      ansible.builtin.uri:
+        url: "{{ rbac_v2_base }}/roles/?name={{ role_name_custom | urlencode }}&limit=10"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: custom_role_lookup_v2
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: custom_role_lookup_v2 is not failed
+      when: user.type == 'custom'
+
+    - name: "Create custom role '{{ role_name_custom }}' via v2"
+      ansible.builtin.uri:
+        url: "{{ rbac_v2_base }}/roles/"
+        method: POST
+        headers: "{{ auth_header }}"
+        body_format: json
+        body:
+          name: "{{ role_name_custom }}"
+          description: "Test role for {{ user.permission }} permission"
+          permissions:
+            - application: "{{ user.permission.split(':')[0] }}"
+              resource_type: "{{ user.permission.split(':')[1] }}"
+              operation: "{{ user.permission.split(':')[2] }}"
+        status_code: [200, 201]
+      environment: "{{ proxy_env }}"
+      register: custom_role_created_v2
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: custom_role_created_v2 is not failed
+      when:
+        - user.type == 'custom'
+        - custom_role_lookup_v2.json.data | length == 0
+
+    - name: "Set role ID (v2 uses 'id' not 'uuid')"
+      ansible.builtin.set_fact:
+        role_id: >-
+          {%- if user.type == 'preconfigured' -%}
+            {{ preconfigured_role_lookup_v2.json.data[0].id }}
+          {%- elif user.type == 'custom' and custom_role_lookup_v2.json.data | length > 0 -%}
+            {{ custom_role_lookup_v2.json.data[0].id }}
+          {%- else -%}
+            {{ custom_role_created_v2.json.id }}
+          {%- endif -%}
+
+    # --- Check / create RBAC group (via v1 — groups are v1 entities) ---
+
+    - name: "Setup group and membership"
+      ansible.builtin.include_tasks:
+        file: "tasks_group_setup.yml"
+
+    # --- Create role binding (v2) ---
+
+    - name: "Set target workspace ID"
+      ansible.builtin.set_fact:
+        target_workspace_id: "{{ workspace_ids[user.workspace_type] }}"
+
+    - name: "Check existing role bindings for group"
+      ansible.builtin.uri:
+        url: "{{ rbac_v2_base }}/role-bindings/?subject_type=group&subject_id={{ group_uuid }}&limit=100"
+        method: GET
+        headers: "{{ auth_header }}"
+        status_code: 200
+      environment: "{{ proxy_env }}"
+      register: existing_bindings
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: existing_bindings is not failed
+
+    - name: "Check if correct binding already exists"
+      ansible.builtin.set_fact:
+        binding_exists: >-
+          {{ existing_bindings.json.data | selectattr('role.id', 'equalto', role_id)
+             | selectattr('resource.id', 'equalto', target_workspace_id) | list | length > 0 }}
+
+    - name: "Create role binding for {{ username }}"
+      ansible.builtin.uri:
+        url: "{{ rbac_v2_base }}/role-bindings:batchCreate/"
+        method: POST
+        headers: "{{ auth_header }}"
+        body_format: json
+        body:
+          requests:
+            - role:
+                id: "{{ role_id }}"
+              resource:
+                id: "{{ target_workspace_id }}"
+                type: "workspace"
+              subject:
+                id: "{{ group_uuid }}"
+                type: "group"
+        status_code: [200, 201]
+      environment: "{{ proxy_env }}"
+      retries: "{{ api_retries }}"
+      delay: "{{ api_delay }}"
+      until: role_binding_created is not failed
+      register: role_binding_created
+      when: not binding_exists

--- a/scripts/rbac-setup/teardown_rbac.yml
+++ b/scripts/rbac-setup/teardown_rbac.yml
@@ -1,0 +1,47 @@
+---
+- name: "Teardown RBAC configuration for HBI test users"
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - vars/users.yml
+
+  pre_tasks:
+    - name: "Validate required variables"
+      ansible.builtin.assert:
+        that:
+          - offline_token is defined and offline_token | length > 0
+          - target_env is defined and target_env in ['prod', 'stage']
+          - rbac_version is defined and rbac_version in ['v1', 'v2']
+          - target_env != 'stage' or (stage_proxy is defined and stage_proxy | length > 0)
+        fail_msg: >-
+          Missing required variables. Usage:
+          ansible-playbook teardown_rbac.yml
+          -e "offline_token=<token>"
+          -e "target_env=prod|stage"
+          -e "rbac_version=v1|v2"
+          [-e "stage_proxy=http://host:port"]
+
+    - name: "Authenticate via SSO"
+      ansible.builtin.include_tasks:
+        file: "tasks_auth.yml"
+
+  tasks:
+    # --- Delete test groups (and their role bindings in v2) ---
+
+    - name: "Delete test groups"
+      ansible.builtin.include_tasks:
+        file: "tasks_teardown_group.yml"
+      loop: "{{ users | selectattr('type', 'ne', 'none') | list }}"
+      loop_control:
+        loop_var: "user"
+        label: "test-{{ user.suffix }}"
+
+    # --- Delete custom roles ---
+
+    - name: "Delete custom roles"
+      ansible.builtin.include_tasks:
+        file: "tasks_teardown_role.yml"
+      loop: "{{ users | selectattr('type', 'equalto', 'custom') | list }}"
+      loop_control:
+        loop_var: "user"
+        label: "test-role-{{ user.suffix }}"

--- a/scripts/rbac-setup/vars/users.yml
+++ b/scripts/rbac-setup/vars/users.yml
@@ -1,0 +1,78 @@
+users:
+  # --- Pre-configured role users (assign existing RBAC role) ---
+  - suffix: "inv-admin"
+    type: "preconfigured"
+    role_name: "Inventory administrator"
+    workspace_type: "default"
+
+  - suffix: "hosts-admin"
+    type: "preconfigured"
+    role_name: "Inventory Hosts administrator"
+    workspace_type: "default"
+
+  - suffix: "hosts-viewer"
+    type: "preconfigured"
+    role_name: "Inventory Hosts viewer"
+    workspace_type: "default"
+
+  - suffix: "groups-admin"
+    type: "preconfigured"
+    role_name: "Inventory Groups administrator"
+    role_name_v2: "Workspace administrator"
+    workspace_type: "default"
+
+  - suffix: "groups-viewer"
+    type: "preconfigured"
+    role_name: "Inventory Groups viewer"
+    role_name_v2: "Workspace viewer"
+    workspace_type: "default"
+
+  - suffix: "staleness-admin"
+    type: "preconfigured"
+    role_name: "Organization Staleness and Deletion Administrator"
+    workspace_type: "root"
+
+  - suffix: "staleness-viewer"
+    type: "preconfigured"
+    role_name: "Organization Staleness and Deletion Viewer"
+    workspace_type: "root"
+
+  # --- Custom permission users (playbook creates the role) ---
+  - suffix: "staleness-write"
+    type: "custom"
+    permission: "staleness:staleness:write"
+    workspace_type: "root"
+
+  - suffix: "hosts-write"
+    type: "custom"
+    permission: "inventory:hosts:write"
+    workspace_type: "default"
+
+  - suffix: "groups-write"
+    type: "custom"
+    permission: "inventory:groups:write"
+    workspace_type: "default"
+
+  - suffix: "hosts-all"
+    type: "custom"
+    permission: "inventory:hosts:*"
+    workspace_type: "default"
+
+  - suffix: "groups-all"
+    type: "custom"
+    permission: "inventory:groups:*"
+    workspace_type: "default"
+
+  - suffix: "all-read"
+    type: "custom"
+    permission: "inventory:*:read"
+    workspace_type: "default"
+
+  - suffix: "staleness-all"
+    type: "custom"
+    permission: "staleness:staleness:*"
+    workspace_type: "root"
+
+  # --- Special users ---
+  - suffix: "no-perms"
+    type: "none"


### PR DESCRIPTION
## Jira
[RHINENG-26247](https://issues.redhat.com/browse/RHINENG-26247)

## What
Add Ansible playbooks that create users for RBAC testing

## Why
We want to start using pre-configured users for our RBAC tests to avoid having to change permissions during the tests. Changing the permissions is time-consuming when Kessel is enabled (due to caching), so this will save time on Kessel-enabled accounts.

## How
Create 4 playbooks:
- create_users.yml — auto-discovers the org admin's username, email, and account ID from the SSO token, then creates any missing test users via the Red Hat Account API. Each user's email is derived from the admin's email using + aliasing so all confirmation emails land in one inbox.
- setup_rbac_v1.yml — strips the "Default access" group of all roles (so test users don't inherit unwanted permissions), then for each user: verifies the user exists, removes them from non-designated groups, creates a dedicated test-<suffix> group with the correct role assigned.
- setup_rbac_v2.yml — same as v1 but uses the RBAC v2 API (role bindings on workspaces instead of roles on groups). Kept as a separate playbook because making any v2 API call permanently disables v1 for that org.
- teardown_rbac.yml — deletes all test groups (clearing role bindings first in v2) and custom roles.

All playbooks share common task files (tasks_auth.yml, tasks_user_cleanup.yml, tasks_group_setup.yml) and are idempotent. User definitions live in vars/users.yml — 15 users covering preconfigured roles, custom single-permission roles, and a no-permissions user.

## Testing
I ran the playbooks on both Kessel-enabled and Kessel-disabled accounts in Stage and Prod, and they worked fine.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-26247]: https://redhat.atlassian.net/browse/RHINENG-26247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add Ansible-based tooling to create and manage dedicated RBAC test users and their permissions for HBI across RBAC v1 and v2.

New Features:
- Introduce Ansible playbook to create Red Hat user accounts for HBI RBAC testing via the Red Hat Account API.
- Add RBAC v1 and RBAC v2 setup playbooks that configure per-user roles, groups, and workspace bindings for deterministic permissions.
- Provide a teardown playbook to remove test groups and custom roles for both RBAC v1 and v2 configurations.

Enhancements:
- Share common Ansible tasks for authentication, user cleanup, group setup, and per-user configuration between RBAC v1 and v2 workflows.
- Define a reusable users roster and environment-specific configuration for prod and stage, including proxy and API endpoints.

Documentation:
- Document how to run the RBAC setup, teardown, and user-creation playbooks, including prerequisites, v1 vs v2 guidance, and required variables.