### PR TITLE
disable host filtering by staleness

### DIFF
--- a/lib/host_repository.py
+++ b/lib/host_repository.py
@@ -202,7 +202,9 @@ def multiple_canonical_facts_host_query(
     )
     if restrict_to_owner_id:
         query = update_query_for_owner_id(identity, query)
-    return find_non_culled_hosts(query, identity.org_id)
+    # NOTE: Culled hosts are intentionally not filtered out here to prevent 
+    # service failures caused by attempts to re-insert existing primary keys.
+    return query
 
 
 def multiple_canonical_facts_host_query_in_memory(


### PR DESCRIPTION
## Jira
[RHINENG-28769](https://redhat.atlassian.net/browse/RHINENG-28769)

## What
The host-inventory is filtering hosts on Satellite by staleness but these hosts aren't deleted there because there is no such job. These filtered and not deleted hosts can cause failing INSERT on re-inserting existing primary key.

## Why
On the Satellite there is no inventory reaper job running. So when the host gets into culled state it is not deleted from the database but the SELECT is ignoring these host. When there is run `insights-client --register` on the host the inventory-host service fails because of the attempt to reinsert primary key.

## How
Removed the filtering of culled hosts from `multiple_canonical_facts_host_query`.

## Testing
I provisioned Satellite 6.19 instance and registered RHEL host. I manually changed all staleness timestamps of the host in database two months back. Then I tried reregister the host using `insights-client --register` and the inventory-host service failed.

After that I replaced the iop-core-host-inventory.service's image with the new image built from this PR. After this reregistering was successful. Without failing iop-core-host-inventory service.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-28769]: https://redhat.atlassian.net/browse/RHINENG-28769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ