### PR TITLE
perf(RHINENG-28746): Export-service performance improvements

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -878,20 +878,23 @@ def get_hosts_to_export(
     )
     columns = [
         Host.id,
-        Host.account,
-        Host.org_id,
         Host.display_name,
         Host.host_type,
         Host.modified_on,
-        Host.facts,
-        Host.reporter,
-        Host.created_on,
         Host.groups,
+        Host.tags,
+        Host.fqdn,
+        Host.subscription_manager_id,
+        Host.satellite_id,
+        Host.last_check_in,
     ]
 
     export_host_query = (
         _find_hosts_model_query(identity=identity, columns=columns)
-        .options(joinedload(Host.static_system_profile), joinedload(Host.dynamic_system_profile))
+        .options(
+            joinedload(Host.static_system_profile).load_only(HostStaticSystemProfile.os_release),
+            noload(Host.dynamic_system_profile),
+        )
         .filter(*q_filters)
     )
     export_host_query = export_host_query.execution_options(yield_per=batch_size)

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -909,7 +909,8 @@ def get_hosts_to_export(
     except SQLAlchemyError as e:  # Most likely ObjectDeletedError, but catching all DB errors
         raise InventoryException(title="DB Error", detail=str(e)) from e
 
-    db.session.close()
+    finally:
+        db.session.close()
 
 
 def _get_group_name_order_post_kessel(order_how):

--- a/app/queue/export_service.py
+++ b/app/queue/export_service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import itertools
 import json
+from collections.abc import Iterator
 from http import HTTPStatus
 from uuid import UUID
 
@@ -17,13 +19,41 @@ from app.auth.rbac import KesselResourceTypes
 from app.config import Config
 from app.exceptions import InventoryException
 from app.logging import get_logger
+from app.serialization import _EXPORT_SERVICE_FIELDS
 from lib import metrics
 from lib.middleware import resolve_permission
-from utils.json_to_csv import json_arr_to_csv
+from utils.json_to_csv import export_csv_header
+from utils.json_to_csv import export_host_to_csv_row
 
 logger = get_logger(__name__)
 
 HEADER_CONTENT_TYPE = {"json": "application/json; charset=utf-8", "csv": "text/csv; charset=utf-8"}
+
+
+class _StreamingExportBody:
+    def __init__(self, host_iter: Iterator[dict], export_format: str):
+        self._host_iter = host_iter
+        self._export_format = export_format.lower()
+        self.host_count = 0
+
+    def __iter__(self):
+        if self._export_format == "json":
+            yield b"["
+            first = True
+            for host in self._host_iter:
+                self.host_count += 1
+                if not first:
+                    yield b","
+                first = False
+                yield json.dumps(host).encode("utf-8")
+            yield b"]"
+        elif self._export_format == "csv":
+            yield export_csv_header(_EXPORT_SERVICE_FIELDS).encode("utf-8")
+            for host in self._host_iter:
+                self.host_count += 1
+                yield export_host_to_csv_row(host, _EXPORT_SERVICE_FIELDS).encode("utf-8")
+        else:
+            raise ValueError(f"Unsupported export format: {self._export_format}")
 
 
 def extract_export_svc_data(export_svc_data: dict) -> tuple[str, UUID, str, str, str]:
@@ -53,16 +83,12 @@ def build_headers(
     return rbac_request_headers, request_headers
 
 
-def get_host_list(identity: Identity, rbac_filter: dict | None, inventory_config: Config) -> list[dict]:
-    host_data = list(
-        get_hosts_to_export(
-            identity,
-            rbac_filter=rbac_filter,
-            batch_size=inventory_config.export_svc_batch_size,
-        )
+def _hosts_to_export_iter(identity: Identity, rbac_filter: dict | None, inventory_config: Config) -> Iterator[dict]:
+    return get_hosts_to_export(
+        identity,
+        rbac_filter=rbac_filter,
+        batch_size=inventory_config.export_svc_batch_size,
     )
-
-    return host_data
 
 
 @metrics.create_export_processing_time.time()
@@ -113,8 +139,8 @@ def create_export(
         return export_created
 
     try:
-        # create a generator with serialized host data
-        host_data = get_host_list(identity, rbac_filter, inventory_config)
+        host_iter = _hosts_to_export_iter(identity, rbac_filter, inventory_config)
+        first_host = next(host_iter, None)
 
         request_url = _build_export_request_url(
             export_service_endpoint, exportUUID, applicationName, resourceUUID, "upload"
@@ -124,15 +150,16 @@ def create_export(
 
         logger.info(f"Trying to get data for org_id: {identity.org_id}")
 
-        if host_data:
+        if first_host is not None:
             logger.debug(f"Trying to upload data using URL:{request_url}")
-            logger.info(
-                f"{len(host_data)} hosts will be exported (format: {exportFormat}) for org_id {identity.org_id}"
-            )
+            export_body = _StreamingExportBody(itertools.chain([first_host], host_iter), exportFormat)
             response = session.post(
                 url=request_url,
                 headers=request_headers,
-                data=_format_export_data(host_data, exportFormat).encode("utf-8"),
+                data=export_body,
+            )
+            logger.info(
+                f"{export_body.host_count} hosts exported (format: {exportFormat}) for org_id {identity.org_id}"
             )
             _handle_export_response(response, exportUUID, exportFormat)
             export_created = True
@@ -198,8 +225,6 @@ def _handle_export_response(response: Response, exportUUID: UUID, exportFormat: 
 
 
 def _format_export_data(data: list[dict], exportFormat: str) -> str:
-    if exportFormat == "json":
-        return json.dumps(data)
-    elif exportFormat == "csv":
-        return json_arr_to_csv(data)
-    raise ValueError(f"Unsupported export format: {exportFormat}")
+    """Materialize export payload for tests and small fixtures."""
+    body = _StreamingExportBody(iter(data), exportFormat)
+    return b"".join(body).decode("utf-8")

--- a/app/queue/export_service.py
+++ b/app/queue/export_service.py
@@ -83,12 +83,19 @@ def build_headers(
     return rbac_request_headers, request_headers
 
 
-def _hosts_to_export_iter(identity: Identity, rbac_filter: dict | None, inventory_config: Config) -> Iterator[dict]:
-    return get_hosts_to_export(
+def _non_empty_hosts_iter(
+    identity: Identity, rbac_filter: dict | None, inventory_config: Config
+) -> Iterator[dict] | None:
+    """Return a non-empty host iterator, or None if there are no hosts to export."""
+    host_iter = get_hosts_to_export(
         identity,
         rbac_filter=rbac_filter,
         batch_size=inventory_config.export_svc_batch_size,
     )
+    first_host = next(host_iter, None)
+    if first_host is None:
+        return None
+    return itertools.chain([first_host], host_iter)
 
 
 @metrics.create_export_processing_time.time()
@@ -139,8 +146,7 @@ def create_export(
         return export_created
 
     try:
-        host_iter = _hosts_to_export_iter(identity, rbac_filter, inventory_config)
-        first_host = next(host_iter, None)
+        hosts_iter = _non_empty_hosts_iter(identity, rbac_filter, inventory_config)
 
         request_url = _build_export_request_url(
             export_service_endpoint, exportUUID, applicationName, resourceUUID, "upload"
@@ -150,9 +156,9 @@ def create_export(
 
         logger.info(f"Trying to get data for org_id: {identity.org_id}")
 
-        if first_host is not None:
+        if hosts_iter is not None:
             logger.debug(f"Trying to upload data using URL:{request_url}")
-            export_body = _StreamingExportBody(itertools.chain([first_host], host_iter), exportFormat)
+            export_body = _StreamingExportBody(hosts_iter, exportFormat)
             response = session.post(
                 url=request_url,
                 headers=request_headers,
@@ -164,7 +170,7 @@ def create_export(
             _handle_export_response(response, exportUUID, exportFormat)
             export_created = True
         else:
-            logger.debug(f"No data found for org_id: {identity.org_id}")
+            logger.info(f"No hosts to export for org_id: {identity.org_id}")
             request_url = _build_export_request_url(
                 export_service_endpoint, exportUUID, applicationName, resourceUUID, "error"
             )

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -301,7 +301,7 @@ def serialize_host_for_export_svc(
     if host.static_system_profile is not None:
         os_release = host.static_system_profile.os_release
 
-    return {
+    field_values = {
         "display_name": host.display_name,
         "fqdn": host.fqdn,
         "host_id": serialize_uuid(host.id),
@@ -318,6 +318,7 @@ def serialize_host_for_export_svc(
         "tags": _serialize_tags(host.tags),
         "host_type": host.host_type or "conventional",
     }
+    return {field: field_values[field] for field in _EXPORT_SERVICE_FIELDS}
 
 
 def serialize_group_without_host_count(group: Group) -> dict:

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -289,24 +289,35 @@ def serialize_host_for_export_svc(
     host: Host | LimitedHost,
     staleness: AttrDict,
 ):
-    serialized_host = serialize_host(host, staleness, additional_fields=("os_release", "state"))
+    st_timestamps = get_staleness_timestamps(host, staleness)
 
-    serialized_host["host_id"] = serialize_uuid(host.id)
-    serialized_host["hostname"] = host.display_name
+    group_id = None
+    group_name = None
     if host.groups:
-        serialized_host["group_id"] = host.groups[0]["id"]  # Assuming just one group per host
-        serialized_host["group_name"] = host.groups[0]["name"]  # Assuming just one group per host
-    else:
-        serialized_host["group_id"] = None  # Assuming just one group per host
-        serialized_host["group_name"] = None  # Assuming just one group per host
-    serialized_host["host_type"] = host.host_type
-    if not host.host_type:
-        # For export service, host_type should be exported as conventional
-        # if the host is not an edge one instead of None.
-        serialized_host["host_type"] = "conventional"
+        group_id = host.groups[0]["id"]
+        group_name = host.groups[0]["name"]
 
-    serialized_host = {key: serialized_host[key] for key in _EXPORT_SERVICE_FIELDS}
-    return serialized_host
+    os_release = None
+    if host.static_system_profile is not None:
+        os_release = host.static_system_profile.os_release
+
+    return {
+        "display_name": host.display_name,
+        "fqdn": host.fqdn,
+        "host_id": serialize_uuid(host.id),
+        "subscription_manager_id": host.subscription_manager_id,
+        "satellite_id": host.satellite_id,
+        "group_id": group_id,
+        "group_name": group_name,
+        "os_release": os_release,
+        "updated": _serialize_datetime(host.modified_on),
+        "state": Conditions.find_host_state(
+            stale_timestamp=st_timestamps["stale_timestamp"],
+            stale_warning_timestamp=st_timestamps["stale_warning_timestamp"],
+        ),
+        "tags": _serialize_tags(host.tags),
+        "host_type": host.host_type or "conventional",
+    }
 
 
 def serialize_group_without_host_count(group: Group) -> dict:

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -737,9 +737,12 @@ def assert_resource_types_pagination(
     assert links["last"] == f"{expected_path_base}?per_page={expected_per_page}&page={expected_number_of_pages}"
 
 
-def mocked_export_post(_self: Any, url: str, *, data: bytes, **_: Any) -> Response:
-    # This will raise UnicodeDecodeError if not correctly encoded or AttributeError if data is str
-    data.decode("utf-8")
+def mocked_export_post(_self: Any, url: str, *, data: Any, **_: Any) -> Response:
+    # Verify payload is valid UTF-8 (bytes, or a streaming iterable of byte chunks).
+    if hasattr(data, "decode"):
+        data.decode("utf-8")
+    else:
+        b"".join(data).decode("utf-8")
     response = Response()
     response.url = url
     response.status_code = HTTPStatus.ACCEPTED

--- a/tests/helpers/api_utils.py
+++ b/tests/helpers/api_utils.py
@@ -739,6 +739,7 @@ def assert_resource_types_pagination(
 
 def mocked_export_post(_self: Any, url: str, *, data: Any, **_: Any) -> Response:
     # Verify payload is valid UTF-8 (bytes, or a streaming iterable of byte chunks).
+    assert not isinstance(data, str), "data must be bytes or a streaming iterable, not str"
     if hasattr(data, "decode"):
         data.decode("utf-8")
     else:

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -276,6 +276,24 @@ class TestStreamingExportBody:
         assert streamed == _format_export_data(hosts, "json")
         assert json.loads(streamed) == hosts
 
+    def test_json_stream_empty_iterator(self):
+        hosts = []
+        body = _StreamingExportBody(iter(hosts), "json")
+        streamed = b"".join(body).decode("utf-8")
+
+        assert streamed == "[]"
+        assert body.host_count == 0
+
+    def test_csv_stream_empty_iterator_emits_only_header(self):
+        hosts = []
+        body = _StreamingExportBody(iter(hosts), "csv")
+        streamed = b"".join(body).decode("utf-8")
+
+        assert streamed == _format_export_data(hosts, "csv")
+        lines = streamed.splitlines()
+        assert len(lines) == 1
+        assert body.host_count == 0
+
     def test_csv_stream_includes_header_and_rows(self):
         hosts = [
             {

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -341,6 +341,25 @@ class TestHandleExportError:
 
 
 @mock.patch("requests.Session.post", autospec=True)
+def test_create_export_posts_streaming_body(mock_post, db_create_host, flask_app, inventory_config):
+    """create_export must pass a _StreamingExportBody to session.post, not a pre-materialized str/bytes."""
+    with flask_app.app.app_context():
+        db_create_host()
+
+        mock_post.return_value.status_code = HTTPStatus.ACCEPTED
+        mock_post.return_value.text = ""
+
+        validated_msg = parse_export_service_message(es_utils.create_export_message_mock())
+        base64_x_rh_identity = validated_msg["data"]["resource_request"]["x_rh_identity"]
+
+        create_export(validated_msg, base64_x_rh_identity, inventory_config)
+
+        upload_call = mock_post.call_args_list[-1]
+        data_arg = upload_call.kwargs.get("data") or upload_call[1].get("data")
+        assert isinstance(data_arg, _StreamingExportBody), f"Expected _StreamingExportBody, got {type(data_arg)}"
+
+
+@mock.patch("requests.Session.post", autospec=True)
 def test_create_export_already_processed_returns_true(mock_post, db_create_host, flask_app, inventory_config):
     """When the upload gets 'already processed', create_export should return True (not raise)."""
     with flask_app.app.app_context():

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -11,13 +11,14 @@ import pytest
 from marshmallow.exceptions import ValidationError
 from sqlalchemy.orm.exc import ObjectDeletedError
 
+from api.host_query_db import get_hosts_to_export
 from app.auth.identity import Identity
 from app.exceptions import InventoryException
 from app.queue.export_service import _format_export_data
 from app.queue.export_service import _handle_export_error
 from app.queue.export_service import _handle_export_response
+from app.queue.export_service import _StreamingExportBody
 from app.queue.export_service import create_export
-from app.queue.export_service import get_host_list
 from app.queue.export_service_mq import parse_export_service_message
 from app.serialization import _EXPORT_SERVICE_FIELDS
 from app.serialization import serialize_host_for_export_svc
@@ -72,7 +73,7 @@ def test_handle_create_export_request_with_data_to_export(mock_post, flask_app, 
 def test_handle_create_export_request_with_no_data_to_export(mock_post, flask_app, export_service_consumer_mock):
     with (
         flask_app.app.app_context(),
-        mock.patch("app.queue.export_service.get_hosts_to_export", return_value=[]),
+        mock.patch("app.queue.export_service.get_hosts_to_export", return_value=iter([])),
         mock.patch("app.queue.export_service.create_export", return_value=False),
     ):
         export_message = es_utils.create_export_message_mock()
@@ -231,7 +232,9 @@ def test_do_not_export_culled_hosts(flask_app, db_create_host, db_create_stalene
             db_create_host()
 
         identity = Identity(USER_IDENTITY)
-        host_list = get_host_list(identity=identity, rbac_filter=None, inventory_config=inventory_config)
+        host_list = list(
+            get_hosts_to_export(identity, rbac_filter=None, batch_size=inventory_config.export_svc_batch_size)
+        )
 
         assert len(host_list) == 0
 
@@ -240,7 +243,9 @@ def test_export_one_host(flask_app, db_create_host, inventory_config):
     with flask_app.app.app_context():
         db_create_host()
         identity = Identity(USER_IDENTITY)
-        host_list = get_host_list(identity=identity, rbac_filter=None, inventory_config=inventory_config)
+        host_list = list(
+            get_hosts_to_export(identity, rbac_filter=None, batch_size=inventory_config.export_svc_batch_size)
+        )
 
         assert len(host_list) == 1
 
@@ -262,6 +267,37 @@ def _make_response(status_code, text=""):
     resp.status_code = status_code
     resp.text = text
     return resp
+
+
+class TestStreamingExportBody:
+    def test_json_stream_matches_materialized_format(self):
+        hosts = [{"host_id": "1", "display_name": "host-a"}, {"host_id": "2", "display_name": "host-b"}]
+        streamed = b"".join(_StreamingExportBody(iter(hosts), "json")).decode("utf-8")
+        assert streamed == _format_export_data(hosts, "json")
+        assert json.loads(streamed) == hosts
+
+    def test_csv_stream_includes_header_and_rows(self):
+        hosts = [
+            {
+                "display_name": "host-a",
+                "fqdn": "host-a.example.com",
+                "host_id": "1",
+                "subscription_manager_id": None,
+                "satellite_id": None,
+                "group_id": None,
+                "group_name": None,
+                "os_release": "8.10",
+                "updated": "2026-01-01T00:00:00+00:00",
+                "state": "fresh",
+                "tags": [{"namespace": "insights", "key": "env", "value": "prod"}],
+                "host_type": "conventional",
+            }
+        ]
+        body = _StreamingExportBody(iter(hosts), "csv")
+        csv_output = b"".join(body).decode("utf-8")
+        assert body.host_count == 1
+        assert csv_output == _format_export_data(hosts, "csv")
+        assert "host-a.example.com" in csv_output
 
 
 class TestHandleExportResponse:

--- a/utils/json_to_csv.py
+++ b/utils/json_to_csv.py
@@ -25,3 +25,18 @@ def json_arr_to_csv(json_arr_data):
     csv_string = output.getvalue()
 
     return csv_string
+
+
+def export_csv_header(fieldnames):
+    output = io.StringIO()
+    writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
+    writer.writerow(fieldnames)
+    return output.getvalue()
+
+
+def export_host_to_csv_row(host, fieldnames):
+    output = io.StringIO()
+    writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
+    row = {**host, "tags": _tags_to_string(host["tags"])}
+    writer.writerow([row[field] for field in fieldnames])
+    return output.getvalue()

--- a/utils/json_to_csv.py
+++ b/utils/json_to_csv.py
@@ -37,6 +37,6 @@ def export_csv_header(fieldnames):
 def export_host_to_csv_row(host, fieldnames):
     output = io.StringIO()
     writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
-    row = {**host, "tags": _tags_to_string(host["tags"])}
-    writer.writerow([row[field] for field in fieldnames])
+    row = {**host, "tags": _tags_to_string(host.get("tags", []))}
+    writer.writerow([row.get(field, "") for field in fieldnames])
     return output.getvalue()

--- a/utils/json_to_csv.py
+++ b/utils/json_to_csv.py
@@ -11,22 +11,6 @@ def _tags_to_string(tags_arr):
     return f"{tags_str}"
 
 
-def json_arr_to_csv(json_arr_data):
-    # Prepare a buffer to store the CSV data
-    output = io.StringIO()
-    writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
-    writer.writerow(json_arr_data[0].keys())
-    for host in json_arr_data:
-        host["tags"] = _tags_to_string(host["tags"])
-        # Write the data row
-        writer.writerow(host.values())
-
-    # Get the CSV string from the buffer
-    csv_string = output.getvalue()
-
-    return csv_string
-
-
 def export_csv_header(fieldnames):
     output = io.StringIO()
     writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)


### PR DESCRIPTION
## Jira
[RHINENG-28746](https://issues.redhat.com/browse/RHINENG-28746)

## What
Make a few improvements to export-service's performance.

## Why
The logs for the export-service failures indicate that large exports can take upwards of 5m, leading to what's effectively a timeout (5m TTL, most likely).

## How

- Slim down serialization for host exports so it only serializes the fields that are actually needed/used
- Remove a `joinedload()` that's not necessary for host exports
- Stream serialized hosts (using a generator) directly into the HTTP post body rather than evaluating them into a list first

## Testing
<!-- How was this tested? -->

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-28746]: https://redhat.atlassian.net/browse/RHINENG-28746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Improve export-service performance by streaming host export payloads and reducing exported data to only required fields.

New Features:
- Stream host export responses directly to the export service via a custom iterable request body for JSON and CSV formats.

Enhancements:
- Reduce host export serialization to a minimal set of fields tailored for the export service.
- Simplify and optimize the database query for exports by loading only necessary host and system profile attributes and avoiding unnecessary relationships.
- Adjust export logging to report the actual number of streamed hosts and clarify the no-hosts case.
- Provide CSV-specific helpers for emitting headers and host rows based on the export field list.

Tests:
- Add coverage to ensure the streaming export body produces correct JSON/CSV output and is used by create_export.
- Update tests and mocks to work with iterator-based host exports and streaming request bodies.