### PR TITLE
Update the get username, org_id and account number util functions to …

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/__init__.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/__init__.py
@@ -11,9 +11,10 @@ from itertools import chain as _chain
 from random import randint
 from typing import TYPE_CHECKING
 
-from dynaconf.utils.boxing import DynaBox
+from box import BoxKeyError
 from iqe.base.application import Application
 from iqe.users.user import ExplicitUser
+from iqe.users.user import User
 
 if TYPE_CHECKING:
     from iqe_host_inventory.modeling.wrappers import HostWrapper
@@ -39,14 +40,20 @@ def get_account_number(application: Application, given_account_number: str | Non
         return given_account_number
 
     user = application.user
-    if isinstance(user, ExplicitUser):
+    if isinstance(user, (ExplicitUser, User)) or hasattr(user, "attributes"):
         account_number = user.attributes.account_number
+        if account_number is None:
+            raise InvalidConfigurationParameterError(
+                "Missing primary_user account_number in your settings.local.yaml file"
+            )
+        return str(account_number)
 
-    if account_number is None:
+    try:
+        return str(user["identity"].account_number)
+    except BoxKeyError:
         raise InvalidConfigurationParameterError(
-            "Missing user.attributes.account_number field in the config"
-        )
-    return str(account_number)
+            "Missing primary_user account_number in your settings.local.yaml file"
+        ) from None
 
 
 def get_org_id(application: Application, given_org_id: str | None = None) -> str:
@@ -54,21 +61,29 @@ def get_org_id(application: Application, given_org_id: str | None = None) -> str
         return given_org_id
 
     user = application.user
-    if isinstance(user, ExplicitUser):
-        org_id = user.attributes.org_id or user.attributes.internal.org_id
+    if isinstance(user, (ExplicitUser, User)) or hasattr(user, "attributes"):
+        org_id: str | None = user.attributes.org_id
+    else:
+        identity_data = user.get("identity", {})
+        org_id = identity_data.get("org_id") or identity_data.get("internal", {}).get("org_id")
 
     if org_id is None:
         raise InvalidConfigurationParameterError(
-            "Missing user.attributes.org_id or user.attributes.internal.org_id field in the config"
+            "Missing user.identity.org_id or user.identity.internal.org_id field in the config"
         )
+
     return str(org_id)
 
 
-def get_username(user_data: DynaBox) -> str:
-    username = user_data.attributes.username
+def get_username(user_data) -> str:
+    if hasattr(user_data, "auth") and hasattr(user_data.auth, "username"):
+        return user_data.auth.username
+    username = user_data.get("auth", {}).get("username") or user_data.get("identity", {}).get(
+        "user", {}
+    ).get("username")
     if username is None:
         raise ValueError(f"Given user doesn't have a defined username: {user_data}")
-    return str(username)
+    return username
 
 
 def rand_start_end(max_page: int, num_iterations: int) -> tuple[int, int]:

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/__init__.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/__init__.py
@@ -11,7 +11,6 @@ from itertools import chain as _chain
 from random import randint
 from typing import TYPE_CHECKING
 
-from box import BoxKeyError
 from dynaconf.utils.boxing import DynaBox
 from iqe.base.application import Application
 from iqe.users.user import ExplicitUser
@@ -38,18 +37,16 @@ def flatten[T](input: Sequence[Sequence[T]] | Iterator[Sequence[T]]) -> list[T]:
 def get_account_number(application: Application, given_account_number: str | None = None) -> str:
     if given_account_number is not None:
         return given_account_number
-    try:
-        user = application.user
-        if isinstance(user, ExplicitUser):
-            identity = user.identity
-            if identity is None:
-                raise BoxKeyError("identity")
-            return str(identity.account_number)
-        return str(user["identity"].account_number)
-    except BoxKeyError:
+
+    user = application.user
+    if isinstance(user, ExplicitUser):
+        account_number = user.attributes.account_number
+
+    if account_number is None:
         raise InvalidConfigurationParameterError(
-            "Missing primary_user account_number in your settings.local.yaml file"
-        ) from None
+            "Missing user.attributes.account_number field in the config"
+        )
+    return str(account_number)
 
 
 def get_org_id(application: Application, given_org_id: str | None = None) -> str:
@@ -58,27 +55,20 @@ def get_org_id(application: Application, given_org_id: str | None = None) -> str
 
     user = application.user
     if isinstance(user, ExplicitUser):
-        identity = user.identity
-        org_id: str | None = identity.org_id if identity is not None else None
-    else:
-        identity_data = user.get("identity", {})
-        org_id = identity_data.get("org_id") or identity_data.get("internal", {}).get("org_id")
+        org_id = user.attributes.org_id or user.attributes.internal.org_id
 
     if org_id is None:
         raise InvalidConfigurationParameterError(
-            "Missing user.identity.org_id or user.identity.internal.org_id field in the config"
+            "Missing user.attributes.org_id or user.attributes.internal.org_id field in the config"
         )
-
     return str(org_id)
 
 
 def get_username(user_data: DynaBox) -> str:
-    username = user_data.get("auth", {}).get("username") or user_data.get("identity", {}).get(
-        "user", {}
-    ).get("username")
+    username = user_data.attributes.username
     if username is None:
         raise ValueError(f"Given user doesn't have a defined username: {user_data}")
-    return username
+    return str(username)
 
 
 def rand_start_end(max_page: int, num_iterations: int) -> tuple[int, int]:


### PR DESCRIPTION
…use latest format with attributes

## Jira
[RHINENG-28747](https://issues.redhat.com/browse/RHINENG-28747)

There is another related MR that has similar (and more) changes: https://github.com/RedHatInsights/insights-host-inventory/pull/4497 . For [IQE-3958](https://issues.redhat.com/browse/IQE-3958)

## What
Update functions in iqe_host_inventory/utils/__init__.py to use the new user format with attribute sections instead of identity and also using object dot notation (user.attribute.org_id) instead of user.get('xxxx') 


## Why
A test in the iqe playbook dispatcher plugin (test_e2e.py::test_highlevel_status_list_limited_to_50) uses functions in iqe_host_inventory/utils/__init__.py.  These functions use the older format of user config that uses identity sections instead of attributes. This is causing an iqe.deprecations.IQEExpiredDeprecationWarning which is throwing an error. 

lib/python3.12/site-packages/iqe_playbook_dispatcher/tests/test_e2e.py:446: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
lib/python3.12/site-packages/iqe_host_inventory/modeling/uploads.py:286: in create_host
    host_ids = self._hosts_api.wait_for_host_exists([archive.insights_id])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/python3.12/site-packages/iqe_host_inventory/modeling/hosts_api.py:1110: in wait_for_host_exists
    response = self.get_host_exists(insights_id=insights_id)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/python3.12/site-packages/iqe_host_inventory/utils/api_utils.py:404: in _method_wrapper
    my_org_id = get_org_id(self.application)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/python3.12/site-packages/iqe_host_inventory/utils/__init__.py:64: in get_org_id
    identity_data = user.get("identity", {})
## How

Initially made updates that may have worked but were not the best pattern.  I was focused on fixing a test. I then was informed about PR 4497 and decided that the code in this was a better approach. The code was written by Ronny in an MR weeks ago. I am including the code here just to give us more options. This smaller MR may take less review, but also maybe it is not needed.

## Testing
I ran the playbook dispatcher plugin 'smoke' suite in ephemeral and it passed. It was failing before the updates. 

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Update user utility helpers to use the new attributes-based structure for retrieving identity fields.

Bug Fixes:
- Tighten configuration validation by raising clearer errors when required user attributes (account_number, org_id, username) are missing.

Enhancements:
- Refactor account number, org ID, and username retrieval to rely on the ExplicitUser.attributes format instead of legacy identity-based access.

[RHINENG-28747]: https://redhat.atlassian.net/browse/RHINENG-28747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update user utility helpers to use the new attributes-based user structure instead of legacy identity-based access.

Bug Fixes:
- Ensure missing account number raises a clear configuration error when not present in the user attributes.

Enhancements:
- Adjust account number and org ID retrieval to support ExplicitUser/User objects with attributes and fall back to legacy identity dicts.
- Relax get_username input type and add support for username resolution from auth.username on user-like objects.

[IQE-3958]: https://redhat.atlassian.net/browse/IQE-3958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ