### PR TITLE
fix(RHINENG-28746): Fix DB session close so it works with generators

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -878,6 +878,7 @@ def get_hosts_to_export(
     )
     columns = [
         Host.id,
+        Host.org_id,
         Host.display_name,
         Host.host_type,
         Host.modified_on,

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -878,7 +878,6 @@ def get_hosts_to_export(
     )
     columns = [
         Host.id,
-        Host.org_id,
         Host.display_name,
         Host.host_type,
         Host.modified_on,
@@ -907,11 +906,13 @@ def get_hosts_to_export(
             exported += 1
         logger.debug(f"Number of hosts exported: {exported}")
 
+    except GeneratorExit:
+        return
+
     except SQLAlchemyError as e:  # Most likely ObjectDeletedError, but catching all DB errors
         raise InventoryException(title="DB Error", detail=str(e)) from e
 
-    finally:
-        db.session.close()
+    db.session.close()
 
 
 def _get_group_name_order_post_kessel(order_how):


### PR DESCRIPTION
## Jira
[RHINENG-28746](https://issues.redhat.com/browse/RHINENG-28746)

## What
Fix closing the DB session so it works with our Generator usage.

## Why
When a generator isn't fully consumed (e.g., the empty-export peek path calls next() then drops the iterator), Python eventually GC's it by throwing GeneratorExit into it. The finally block then fires db.session.close(), but this can happen during a completely different test's db.session.commit(), corrupting the transaction state.

## How
Extracted `db.session.close()` outside of the `finally` clause; added a GeneratorExit return condition

## Testing
Ran the unit tests; wait until the full IQE test suite finishes before merging, just in case there's another failure.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-28746]: https://redhat.atlassian.net/browse/RHINENG-28746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Fix incorrect table joins during host export by loading org_id for each host record.