### PR TITLE
feat(deploy): add puptoo to clowdapp hard dependencies

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -175,6 +175,7 @@ objects:
       - rbac
       - ingress
       - export-service
+      - puptoo
     optionalDependencies:
       - kessel-inventory
       - kessel-relations


### PR DESCRIPTION
## Jira
[RHINENG-28781](https://issues.redhat.com/browse/RHINENG-28781)

## What
Since insights-ingress-go removed puptoo from their list of deps, puptoo is not deployed anymore in ephemeral tests. HBI team decided to add it as hard dependency in the immediate term, and it will be revisit with a platform-wide approach later.

## Why
<!-- Reason for change / linked ticket -->

## How
<!-- Brief explanation of approach -->

## Testing
<!-- How was this tested? -->

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-28781]: https://redhat.atlassian.net/browse/RHINENG-28781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Deployment:
- Declare puptoo as a required dependency in deploy/clowdapp.yml so it is included in ephemeral and standard deployments.