### PR TITLE
refactor: Change nginx image to a var

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -194,7 +194,7 @@ objects:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: registry.access.redhat.com/ubi9/nginx-124:latest
+        image: ${NGINX_IMAGE}:${NGINX_IMAGE_TAG}
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
@@ -2628,6 +2628,10 @@ parameters:
   value: 100Mi
 - name: NGINX_MEMORY_LIMIT
   value: 200Mi
+- name: NGINX_IMAGE
+  value: 'registry.access.redhat.com/ubi9/nginx-124'
+- name: NGINX_IMAGE_TAG
+  value: 'latest'
 
 # -- API Service Resources (service-reads/writes) --
 - name: CPU_REQUEST_SERVICE


### PR DESCRIPTION
In the govcloud environment, we need to be able modify the nginx image that we use. By making this change, it leaves the commercial deployment untouched, but allows us to make changes in app-interface to override the image more easily.

## Jira

## What
<!-- Short description of the change -->
Set the nginx image to be a variable that defaults to the latest nginx-124 image

## Why
<!-- Reason for change / linked ticket -->
If it's a variable, we can override it in the govcloud environment when necessary and more easily.

## How
<!-- Brief explanation of approach -->
Add the vars to the template, and set the default parameters to the current image as it stands today.

## Testing
<!-- How was this tested? -->

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Enhancements:
- Replace the hardcoded nginx image reference in the deployment template with parameterized NGINX_IMAGE and NGINX_IMAGE_TAG values.