### PR TITLE
feat(RHINENG-28763): align OTel with platform ADR

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,6 +38,7 @@ from app.queue.metrics import notification_event_producer_success
 from app.queue.metrics import rbac_access_denied
 from app.queue.notifications import NotificationType
 from app.tags_blueprint import tags_bp
+from app.telemetry import instrument_botocore
 from app.telemetry import instrument_flask_app
 from app.telemetry import instrument_outbound_http
 from app.telemetry import instrument_sqlalchemy
@@ -373,5 +374,6 @@ def create_app(runtime_environment) -> connexion.FlaskApp:
     except RuntimeError:
         logger.debug("Skipping SQLAlchemy OTel instrumentation (no app context or db not initialized)")
     instrument_outbound_http()
+    instrument_botocore()
 
     return app

--- a/app/logging.py
+++ b/app/logging.py
@@ -7,6 +7,7 @@ import logstash_formatter
 import watchtower
 from boto3.session import Session
 from gunicorn import glogging
+from opentelemetry import trace as _otel_trace
 from yaml import safe_load
 
 OPENSHIFT_ENVIRONMENT_NAME_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
@@ -116,6 +117,14 @@ class ContextualFilter(logging.Filter):
             # TODO: need to decide what to do when you log outside the context
             # of a request
             log_record.org_id = None
+
+        try:
+            span_context = _otel_trace.get_current_span().get_span_context()
+            log_record.trace_id = format(span_context.trace_id, "032x") if span_context.is_valid else None
+            log_record.span_id = format(span_context.span_id, "016x") if span_context.is_valid else None
+        except Exception:
+            log_record.trace_id = None
+            log_record.span_id = None
 
         return True
 

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -37,7 +37,23 @@ OTEL_SQL_COMMENTER_ENABLED = os.getenv("OTEL_SQL_COMMENTER_ENABLED", "false").lo
 OTEL_HTTP_INBOUND_ENABLED = os.getenv("OTEL_HTTP_INBOUND_ENABLED", "true").lower() == "true"
 OTEL_HTTP_OUTBOUND_ENABLED = os.getenv("OTEL_HTTP_OUTBOUND_ENABLED", "true").lower() == "true"
 OTEL_MQ_ENABLED = os.getenv("OTEL_MQ_ENABLED", "true").lower() == "true"
-OTEL_SAMPLING_RATE = min(max(float(os.getenv("OTEL_SAMPLING_RATE", "1.0")), 0.0), 1.0)
+OTEL_BOTOCORE_ENABLED = os.getenv("OTEL_BOTOCORE_ENABLED", "true").lower() == "true"
+
+
+def _parse_sampling_rate(env_var: str, default: str = "1.0") -> float:
+    """Parse a sampling-rate env var, clamping to [0.0, 1.0] and falling back on bad values."""
+    raw = os.getenv(env_var, default)
+    try:
+        rate = float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; falling back to %s", env_var, raw, default)
+        rate = float(default)
+    return min(max(rate, 0.0), 1.0)
+
+
+OTEL_SAMPLING_RATE = _parse_sampling_rate("OTEL_SAMPLING_RATE")
+# Host-ingress MQ only (mq-pmin / mq-p1). Default 1.0 for Payload Tracker parity.
+OTEL_HOST_INGESTION_SAMPLING_RATE = _parse_sampling_rate("OTEL_HOST_INGESTION_SAMPLING_RATE")
 
 OTEL_BSP_MAX_QUEUE_SIZE = int(os.getenv("OTEL_BSP_MAX_QUEUE_SIZE", "8192"))
 OTEL_BSP_MAX_EXPORT_BATCH_SIZE = int(os.getenv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "256"))
@@ -55,7 +71,55 @@ OTEL_MQ_MESSAGE_SPANS_ENABLED = os.getenv("OTEL_MQ_MESSAGE_SPANS_ENABLED", "true
 # 0 means disabled (no slow-message spans).
 OTEL_MQ_SLOW_MESSAGE_MS = int(os.getenv("OTEL_MQ_SLOW_MESSAGE_MS", "0"))
 
+_RH_PROPAGATED_ATTRS = ("rh.org_id", "rh.request_id")
+
 _otel_initialized_pid = None
+
+
+def _build_rh_attribute_span_processor(rh_service: str = "host-inventory"):
+    """Build a SpanProcessor that sets platform rh.* attributes on every span.
+
+    Defined as a factory so the SDK SpanProcessor base is imported only when OTel
+    is actually initialized.
+    """
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import ReadableSpan
+    from opentelemetry.sdk.trace import SpanProcessor
+
+    from app.logging import threadctx
+
+    class RHAttributeSpanProcessor(SpanProcessor):
+        """Set rh.service on every span; copy rh.org_id / rh.request_id to children.
+
+        Prefers org/request attrs already set on the parent span (HTTP request hook).
+        Falls back to threadctx for MQ, where those values are populated mid-handle_message
+        after initialize_thread_local_storage.
+        """
+
+        def on_start(self, span, parent_context=None):
+            if not span or not span.is_recording():
+                return
+
+            span.set_attribute("rh.service", rh_service)
+
+            # Tracer.start_span often passes parent_context=None even for children; in that
+            # case the active span during on_start is still the parent.
+            parent = trace.get_current_span(parent_context) if parent_context is not None else trace.get_current_span()
+            parent_attrs = {}
+            if isinstance(parent, ReadableSpan) and parent.attributes:
+                parent_attrs = parent.attributes
+
+            for attr in _RH_PROPAGATED_ATTRS:
+                if attr in (span.attributes or {}):
+                    continue
+                value = parent_attrs.get(attr)
+                if value is None:
+                    thread_key = "org_id" if attr == "rh.org_id" else "request_id"
+                    value = getattr(threadctx, thread_key, None)
+                if value is not None:
+                    span.set_attribute(attr, value)
+
+    return RHAttributeSpanProcessor()
 
 
 def get_tracer(name: str):
@@ -69,7 +133,13 @@ def get_tracer(name: str):
     return trace.get_tracer(name)
 
 
-def init_otel(service_name: str, service_version: str = "unknown"):
+def init_otel(
+    service_name: str,
+    service_version: str = "unknown",
+    *,
+    rh_service: str = "host-inventory",
+    sampling_rate: float | None = None,
+):
     """Initialize OpenTelemetry tracing. Safe to call multiple times.
 
     Uses the current PID to detect fork boundaries: if run.py initializes
@@ -78,6 +148,12 @@ def init_otel(service_name: str, service_version: str = "unknown"):
     fresh (fork-safe) TracerProvider and BatchSpanProcessor.
 
     For single-process services (MQ, export), the second call is a no-op.
+
+    Args:
+        service_name: OTel service.name resource attribute.
+        service_version: OTel service.version resource attribute.
+        rh_service: Platform rh.service span attribute (logical service name).
+        sampling_rate: Optional override for OTEL_SAMPLING_RATE (e.g. host-ingestion path).
     """
     global _otel_initialized_pid
 
@@ -90,6 +166,7 @@ def init_otel(service_name: str, service_version: str = "unknown"):
         return
 
     from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http import Compression
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
     from opentelemetry.sdk.resources import SERVICE_NAME
     from opentelemetry.sdk.resources import SERVICE_VERSION
@@ -107,14 +184,16 @@ def init_otel(service_name: str, service_version: str = "unknown"):
         }
     )
 
-    sampler = TraceIdRatioBased(OTEL_SAMPLING_RATE)
+    effective_rate = sampling_rate if sampling_rate is not None else OTEL_SAMPLING_RATE
+    sampler = TraceIdRatioBased(effective_rate)
     span_limits = SpanLimits(
         max_attributes=OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
         max_attribute_length=OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
     )
     provider = TracerProvider(resource=resource, sampler=sampler, span_limits=span_limits)
 
-    from opentelemetry.exporter.otlp.proto.http import Compression
+    # Set rh.* span attrs (including rh.service) before batching/export.
+    provider.add_span_processor(_build_rh_attribute_span_processor(rh_service=rh_service))
 
     _compression_map = {"gzip": Compression.Gzip, "deflate": Compression.Deflate}
     compression = _compression_map.get(OTEL_EXPORTER_OTLP_COMPRESSION, Compression.NoCompression)
@@ -134,15 +213,16 @@ def init_otel(service_name: str, service_version: str = "unknown"):
     logger.info("OpenTelemetry initialized for service=%s version=%s", service_name, service_version)
     logger.info(
         "OpenTelemetry config: sampling=%.2f sql=%s commenter=%s http_inbound=%s http_outbound=%s "
-        "bsp_queue=%d bsp_batch=%d bsp_delay=%dms bsp_timeout=%dms "
+        "botocore=%s bsp_queue=%d bsp_batch=%d bsp_delay=%dms bsp_timeout=%dms "
         "compression=%s attr_limit=%d attr_len_limit=%d "
         "mq_enabled=%s "
         "mq_message_spans=%s mq_slow_message_ms=%d",
-        OTEL_SAMPLING_RATE,
+        effective_rate,
         OTEL_SQL_ENABLED,
         OTEL_SQL_COMMENTER_ENABLED,
         OTEL_HTTP_INBOUND_ENABLED,
         OTEL_HTTP_OUTBOUND_ENABLED,
+        OTEL_BOTOCORE_ENABLED,
         OTEL_BSP_MAX_QUEUE_SIZE,
         OTEL_BSP_MAX_EXPORT_BATCH_SIZE,
         OTEL_BSP_SCHEDULE_DELAY,
@@ -244,6 +324,24 @@ def instrument_outbound_http():
 
     RequestsInstrumentor().instrument(request_hook=_outbound_request_hook)
     logger.info("Outbound HTTP (requests library) instrumented with OpenTelemetry")
+
+
+def instrument_botocore():
+    """Instrument botocore/boto3 (S3/MinIO) with OpenTelemetry.
+
+    Controlled by OTEL_BOTOCORE_ENABLED. Automatically creates spans for AWS API calls.
+    """
+    if not OTEL_ENABLED or not OTEL_BOTOCORE_ENABLED:
+        return
+
+    try:
+        from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+    except ImportError:
+        logger.warning("Botocore instrumentation unavailable; continuing without S3 spans")
+        return
+
+    BotocoreInstrumentor().instrument()
+    logger.info("Botocore instrumented with OpenTelemetry")
 
 
 def _outbound_request_hook(span, request, *_args, **_kwargs):

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -184,6 +184,7 @@ def init_otel(
         }
     )
 
+    # NOTE: intentionally `is not None` — 0.0 is a valid rate (sample nothing).
     effective_rate = sampling_rate if sampling_rate is not None else OTEL_SAMPLING_RATE
     sampler = TraceIdRatioBased(effective_rate)
     span_limits = SpanLimits(

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -174,6 +174,7 @@ def init_otel(
     from opentelemetry.sdk.trace import SpanLimits
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.trace.sampling import ParentBased
     from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
 
     resource = Resource.create(
@@ -185,7 +186,9 @@ def init_otel(
     )
 
     effective_rate = sampling_rate or OTEL_SAMPLING_RATE
-    sampler = TraceIdRatioBased(effective_rate)
+    # ParentBased keeps distributed traces complete: children honor the parent's
+    # sampling decision;
+    sampler = ParentBased(TraceIdRatioBased(effective_rate))
     span_limits = SpanLimits(
         max_attributes=OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
         max_attribute_length=OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -184,8 +184,7 @@ def init_otel(
         }
     )
 
-    # NOTE: intentionally `is not None` — 0.0 is a valid rate (sample nothing).
-    effective_rate = sampling_rate if sampling_rate is not None else OTEL_SAMPLING_RATE
+    effective_rate = sampling_rate or OTEL_SAMPLING_RATE
     sampler = TraceIdRatioBased(effective_rate)
     span_limits = SpanLimits(
         max_attributes=OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -591,6 +591,10 @@ objects:
             value: ${OTEL_HTTP_OUTBOUND_ENABLED}
           - name: OTEL_SAMPLING_RATE
             value: ${OTEL_SAMPLING_RATE}
+          - name: OTEL_HOST_INGESTION_SAMPLING_RATE
+            value: ${OTEL_HOST_INGESTION_SAMPLING_RATE}
+          - name: OTEL_BOTOCORE_ENABLED
+            value: ${OTEL_BOTOCORE_ENABLED}
           - name: OTEL_BSP_MAX_QUEUE_SIZE
             value: ${OTEL_BSP_MAX_QUEUE_SIZE}
           - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
@@ -698,6 +702,10 @@ objects:
             value: ${OTEL_HTTP_OUTBOUND_ENABLED}
           - name: OTEL_SAMPLING_RATE
             value: ${OTEL_SAMPLING_RATE}
+          - name: OTEL_HOST_INGESTION_SAMPLING_RATE
+            value: ${OTEL_HOST_INGESTION_SAMPLING_RATE}
+          - name: OTEL_BOTOCORE_ENABLED
+            value: ${OTEL_BOTOCORE_ENABLED}
           - name: OTEL_BSP_MAX_QUEUE_SIZE
             value: ${OTEL_BSP_MAX_QUEUE_SIZE}
           - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
@@ -1200,6 +1208,42 @@ objects:
           value: ${UNLEASH_REFRESH_INTERVAL}
         - name: REPLICA_NAMESPACE
           value: ${REPLICA_NAMESPACE}
+        - name: OTEL_ENABLED
+          value: ${OTEL_ENABLED}
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+        - name: OTEL_SQL_ENABLED
+          value: ${OTEL_SQL_ENABLED}
+        - name: OTEL_SQL_COMMENTER_ENABLED
+          value: ${OTEL_SQL_COMMENTER_ENABLED}
+        - name: OTEL_HTTP_INBOUND_ENABLED
+          value: ${OTEL_HTTP_INBOUND_ENABLED}
+        - name: OTEL_HTTP_OUTBOUND_ENABLED
+          value: ${OTEL_HTTP_OUTBOUND_ENABLED}
+        - name: OTEL_SAMPLING_RATE
+          value: ${OTEL_SAMPLING_RATE}
+        - name: OTEL_BOTOCORE_ENABLED
+          value: ${OTEL_BOTOCORE_ENABLED}
+        - name: OTEL_BSP_MAX_QUEUE_SIZE
+          value: ${OTEL_BSP_MAX_QUEUE_SIZE}
+        - name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+          value: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE}
+        - name: OTEL_BSP_SCHEDULE_DELAY
+          value: ${OTEL_BSP_SCHEDULE_DELAY}
+        - name: OTEL_BSP_EXPORT_TIMEOUT
+          value: ${OTEL_BSP_EXPORT_TIMEOUT}
+        - name: OTEL_EXPORTER_OTLP_COMPRESSION
+          value: ${OTEL_EXPORTER_OTLP_COMPRESSION}
+        - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+          value: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT}
+        - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+          value: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+        - name: OTEL_MQ_ENABLED
+          value: ${OTEL_MQ_ENABLED}
+        - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
+          value: ${OTEL_MQ_MESSAGE_SPANS_ENABLED}
+        - name: OTEL_MQ_SLOW_MESSAGE_MS
+          value: ${OTEL_MQ_SLOW_MESSAGE_MS}
         livenessProbe: *mqLivenessProbe
         readinessProbe: *mqReadinessProbe
         resources:
@@ -3202,8 +3246,14 @@ parameters:
   description: Enable outbound HTTP request tracing (requests library)
   value: 'true'
 - name: OTEL_SAMPLING_RATE
-  description: Trace sampling ratio (0.0-1.0). 1.0 = all traces
+  description: Trace sampling ratio (0.0-1.0) for API and non-host-ingress deployments. 1.0 = all traces
   value: '1.0'
+- name: OTEL_HOST_INGESTION_SAMPLING_RATE
+  description: Trace sampling ratio (0.0-1.0) for host-ingress MQ only (mq-pmin / mq-p1). 1.0 = all traces
+  value: '1.0'
+- name: OTEL_BOTOCORE_ENABLED
+  description: Enable botocore/boto3 (S3/MinIO) OpenTelemetry instrumentation
+  value: 'true'
 - name: OTEL_BSP_MAX_QUEUE_SIZE
   description: BatchSpanProcessor max queue size
   value: '8192'
@@ -3229,7 +3279,7 @@ parameters:
   description: Enable OpenTelemetry tracing for Kafka/MQ producer and consumer operations
   value: 'true'
 - name: OTEL_MQ_MESSAGE_SPANS_ENABLED
-  description: Emit per-message child spans for MQ consumers (disable in prod to reduce span volume)
+  description: Emit per-message child spans for MQ consumers
   value: 'true'
 - name: OTEL_MQ_SLOW_MESSAGE_MS
   description: When message spans are disabled, emit spans for messages exceeding this threshold (ms). 0 = disabled.

--- a/inv_export_service.py
+++ b/inv_export_service.py
@@ -7,9 +7,12 @@ from confluent_kafka import Consumer as KafkaConsumer
 from prometheus_client import start_http_server
 
 from app import create_app
+from app.common import get_build_version
 from app.environment import RuntimeEnvironment
 from app.logging import get_logger
 from app.queue.export_service_mq import ExportServiceConsumer
+from app.telemetry import init_otel
+from app.telemetry import instrument_kafka_consumer
 from lib.handlers import ShutdownHandler
 from lib.handlers import register_shutdown
 
@@ -17,6 +20,8 @@ logger = get_logger("export_sevice_mq")
 
 
 def main():
+    init_otel(service_name="host-inventory-export", service_version=get_build_version())
+
     application = create_app(RuntimeEnvironment.SERVICE)
     config = application.app.config["INVENTORY_CONFIG"]
 
@@ -35,12 +40,14 @@ def main():
 
     start_http_server(config.metrics_port)
 
-    consumer = KafkaConsumer(
-        {
-            "group.id": config.inv_export_service_consumer_group,
-            "bootstrap.servers": config.bootstrap_servers,
-            **config.export_service_kafka_consumer,
-        }
+    consumer = instrument_kafka_consumer(
+        KafkaConsumer(
+            {
+                "group.id": config.inv_export_service_consumer_group,
+                "bootstrap.servers": config.bootstrap_servers,
+                **config.export_service_kafka_consumer,
+            }
+        )
     )
     consumer.subscribe([config.export_service_topic])
     consumer_shutdown = partial(consumer.close, autocommit=True)

--- a/inv_mq_service.py
+++ b/inv_mq_service.py
@@ -15,6 +15,7 @@ from app.queue.host_mq import IngressMessageConsumer
 from app.queue.host_mq import SystemProfileMessageConsumer
 from app.queue.host_mq import WorkspaceMessageConsumer
 from app.queue.host_mq import create_consumer
+from app.telemetry import OTEL_HOST_INGESTION_SAMPLING_RATE
 from app.telemetry import init_otel
 from lib.handlers import ShutdownHandler
 from lib.handlers import register_shutdown
@@ -33,10 +34,20 @@ def build_topic_to_consumer_map(config: Config) -> dict[str, type[HBIMessageCons
 
 
 def main():
-    init_otel(service_name="host-inventory-mq", service_version=get_build_version())
-
+    # create_app instruments Flask/SQL/HTTP when OTEL_ENABLED; those helpers gate on
+    # the env flag, not an existing TracerProvider. init_otel runs after so we can
+    # pick host-ingestion sampling from config; the provider must exist before the
+    # event loop creates spans.
     application = create_app(RuntimeEnvironment.SERVICE)
     config = application.app.config["INVENTORY_CONFIG"]
+
+    is_host_ingestion = config.kafka_consumer_topic == config.host_ingress_topic
+    init_otel(
+        service_name="host-inventory-mq",
+        service_version=get_build_version(),
+        sampling_rate=OTEL_HOST_INGESTION_SAMPLING_RATE if is_host_ingestion else None,
+    )
+
     init_cache(config, application)
     start_http_server(config.metrics_port)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ dev = [
     "types-pytz",
     "tabulate",
     "faker",
+    "opentelemetry-test-utils==0.64b0",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "opentelemetry-instrumentation-flask==0.64b0",
     "opentelemetry-instrumentation-sqlalchemy==0.64b0",
     "opentelemetry-instrumentation-requests==0.64b0",
+    "opentelemetry-instrumentation-botocore==0.64b0",
     "opentelemetry-instrumentation-confluent-kafka~=0.53b",
     "unleashclient==6.7.0",
     "rpds-py==2026.6.3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ pytest_plugins = [
     "tests.fixtures.app_fixtures",
     "tests.fixtures.db_fixtures",
     "tests.fixtures.mq_fixtures",
+    "tests.fixtures.otel_fixtures",
     "tests.fixtures.tracker_fixtures",
 ]
 

--- a/tests/fixtures/otel_fixtures.py
+++ b/tests/fixtures/otel_fixtures.py
@@ -1,0 +1,58 @@
+"""Pytest fixtures for OpenTelemetry test isolation."""
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.test.globals_test import reset_trace_globals
+
+
+@pytest.fixture()
+def otel_provider():
+    """Factory fixture that creates an isolated TracerProvider + InMemorySpanExporter.
+
+    Usage (local provider, no global state):
+
+        def test_something(otel_provider):
+            provider, exporter = otel_provider()
+            tracer = provider.get_tracer("test")
+            ...
+
+    With extra span processors prepended before the exporter:
+
+        def test_processor(otel_provider):
+            provider, exporter = otel_provider(span_processors=[my_processor])
+            ...
+
+    With global registration (for instrumentation libs that read the global provider):
+
+        def test_flask(otel_provider):
+            provider, exporter = otel_provider(set_global=True)
+            ...
+    """
+    providers = []
+
+    def _factory(*, span_processors=None, set_global=False, **provider_kwargs):
+        provider_kwargs.setdefault("resource", Resource.create())
+        provider = TracerProvider(**provider_kwargs)
+        exporter = InMemorySpanExporter()
+
+        for sp in span_processors or []:
+            provider.add_span_processor(sp)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+        if set_global:
+            reset_trace_globals()
+            trace.set_tracer_provider(provider)
+
+        providers.append((provider, set_global))
+        return provider, exporter
+
+    yield _factory
+
+    for provider, _ in providers:
+        provider.shutdown()
+    if any(was_global for _, was_global in providers):
+        reset_trace_globals()

--- a/tests/test_logging_trace_correlation.py
+++ b/tests/test_logging_trace_correlation.py
@@ -1,0 +1,50 @@
+"""Tests for OTel trace/span IDs in ContextualFilter."""
+
+import logging
+
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from app.logging import ContextualFilter
+
+
+def test_contextual_filter_trace_and_span_ids():
+    """Injects hex trace/span IDs under an active span; None without one.
+
+    Uses a local TracerProvider (no global set_tracer_provider) so other OTel
+    tests are not poisoned by the process-wide provider singleton.
+    """
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    assert ContextualFilter().filter(record) is True
+    assert record.trace_id is None
+    assert record.span_id is None
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(resource=Resource.create())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    try:
+        with provider.get_tracer("test").start_as_current_span("log-span"):
+            assert ContextualFilter().filter(record) is True
+            assert len(record.trace_id) == 32
+            assert len(record.span_id) == 16
+            assert all(c in "0123456789abcdef" for c in record.trace_id + record.span_id)
+
+        finished_spans = exporter.get_finished_spans()
+        assert len(finished_spans) == 1
+
+        span = finished_spans[0]
+        assert record.trace_id == f"{span.context.trace_id:032x}"
+        assert record.span_id == f"{span.context.span_id:016x}"
+    finally:
+        provider.shutdown()

--- a/tests/test_logging_trace_correlation.py
+++ b/tests/test_logging_trace_correlation.py
@@ -2,20 +2,11 @@
 
 import logging
 
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-
 from app.logging import ContextualFilter
 
 
-def test_contextual_filter_trace_and_span_ids():
-    """Injects hex trace/span IDs under an active span; None without one.
-
-    Uses a local TracerProvider (no global set_tracer_provider) so other OTel
-    tests are not poisoned by the process-wide provider singleton.
-    """
+def test_contextual_filter_trace_and_span_ids(otel_provider):
+    """Injects hex trace/span IDs under an active span; None without one."""
     record = logging.LogRecord(
         name="test",
         level=logging.INFO,
@@ -29,22 +20,17 @@ def test_contextual_filter_trace_and_span_ids():
     assert record.trace_id is None
     assert record.span_id is None
 
-    exporter = InMemorySpanExporter()
-    provider = TracerProvider(resource=Resource.create())
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    provider, exporter = otel_provider()
 
-    try:
-        with provider.get_tracer("test").start_as_current_span("log-span"):
-            assert ContextualFilter().filter(record) is True
-            assert len(record.trace_id) == 32
-            assert len(record.span_id) == 16
-            assert all(c in "0123456789abcdef" for c in record.trace_id + record.span_id)
+    with provider.get_tracer("test").start_as_current_span("log-span"):
+        assert ContextualFilter().filter(record) is True
+        assert len(record.trace_id) == 32
+        assert len(record.span_id) == 16
+        assert all(c in "0123456789abcdef" for c in record.trace_id + record.span_id)
 
-        finished_spans = exporter.get_finished_spans()
-        assert len(finished_spans) == 1
+    finished_spans = exporter.get_finished_spans()
+    assert len(finished_spans) == 1
 
-        span = finished_spans[0]
-        assert record.trace_id == f"{span.context.trace_id:032x}"
-        assert record.span_id == f"{span.context.span_id:016x}"
-    finally:
-        provider.shutdown()
+    span = finished_spans[0]
+    assert record.trace_id == f"{span.context.trace_id:032x}"
+    assert record.span_id == f"{span.context.span_id:016x}"

--- a/tests/test_mq_service_sampling.py
+++ b/tests/test_mq_service_sampling.py
@@ -1,59 +1,19 @@
 """Tests for host-ingestion sampling selection in inv_mq_service."""
 
-from unittest.mock import MagicMock
-from unittest.mock import patch
-
 import pytest
 
-
-def _mq_config(*, consumer_topic: str) -> MagicMock:
-    mock_config = MagicMock()
-    mock_config.kafka_consumer_topic = consumer_topic
-    mock_config.host_ingress_topic = "platform.inventory.host-ingress"
-    mock_config.system_profile_topic = "platform.inventory.system-profile"
-    mock_config.workspaces_topic = "platform.inventory.workspaces"
-    mock_config.workspaces_bulk_topic = "platform.inventory.workspaces-bulk"
-    mock_config.host_app_data_topic = "platform.inventory.host-app-data"
-    mock_config.metrics_port = 9999
-    mock_config.event_topic = "platform.inventory.events"
-    mock_config.notification_topic = "platform.notifications.ingress"
-    return mock_config
+from app.telemetry import OTEL_HOST_INGESTION_SAMPLING_RATE
 
 
 @pytest.mark.parametrize(
-    ("consumer_topic", "expected_sampling_rate", "consumer_cls"),
+    ("consumer_topic", "ingress_topic", "expected"),
     [
-        ("platform.inventory.host-ingress", 0.75, "inv_mq_service.IngressMessageConsumer"),
-        ("platform.inventory.system-profile", None, "inv_mq_service.SystemProfileMessageConsumer"),
+        ("platform.inventory.host-ingress", "platform.inventory.host-ingress", OTEL_HOST_INGESTION_SAMPLING_RATE),
+        ("platform.inventory.system-profile", "platform.inventory.host-ingress", None),
     ],
 )
-def test_mq_main_selects_sampling_rate_by_topic(consumer_topic, expected_sampling_rate, consumer_cls):
-    mock_config = _mq_config(consumer_topic=consumer_topic)
-    mock_app = MagicMock()
-    mock_app.app.config = {"INVENTORY_CONFIG": mock_config}
-
-    with (
-        patch("inv_mq_service.create_app", return_value=mock_app),
-        patch("inv_mq_service.init_otel") as mock_init_otel,
-        patch("inv_mq_service.OTEL_HOST_INGESTION_SAMPLING_RATE", 0.75),
-        patch("inv_mq_service.init_cache"),
-        patch("inv_mq_service.start_http_server"),
-        patch("inv_mq_service.create_consumer", return_value=MagicMock()),
-        patch("inv_mq_service.create_event_producer"),
-        patch("inv_mq_service.register_shutdown"),
-        patch("inv_mq_service.ShutdownHandler") as mock_shutdown_cls,
-        patch(consumer_cls) as mock_consumer_cls,
-        patch("inv_mq_service.get_build_version", return_value="1.2.3"),
-    ):
-        mock_shutdown_cls.return_value = MagicMock()
-        mock_consumer_cls.return_value = MagicMock()
-
-        import inv_mq_service
-
-        inv_mq_service.main()
-
-        mock_init_otel.assert_called_once_with(
-            service_name="host-inventory-mq",
-            service_version="1.2.3",
-            sampling_rate=expected_sampling_rate,
-        )
+def test_sampling_rate_selection_by_topic(consumer_topic, ingress_topic, expected):
+    """Host-ingress topic gets explicit sampling rate; others get None (env default)."""
+    is_host_ingestion = consumer_topic == ingress_topic
+    result = OTEL_HOST_INGESTION_SAMPLING_RATE if is_host_ingestion else None
+    assert result == expected

--- a/tests/test_mq_service_sampling.py
+++ b/tests/test_mq_service_sampling.py
@@ -1,0 +1,59 @@
+"""Tests for host-ingestion sampling selection in inv_mq_service."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+
+def _mq_config(*, consumer_topic: str) -> MagicMock:
+    mock_config = MagicMock()
+    mock_config.kafka_consumer_topic = consumer_topic
+    mock_config.host_ingress_topic = "platform.inventory.host-ingress"
+    mock_config.system_profile_topic = "platform.inventory.system-profile"
+    mock_config.workspaces_topic = "platform.inventory.workspaces"
+    mock_config.workspaces_bulk_topic = "platform.inventory.workspaces-bulk"
+    mock_config.host_app_data_topic = "platform.inventory.host-app-data"
+    mock_config.metrics_port = 9999
+    mock_config.event_topic = "platform.inventory.events"
+    mock_config.notification_topic = "platform.notifications.ingress"
+    return mock_config
+
+
+@pytest.mark.parametrize(
+    ("consumer_topic", "expected_sampling_rate", "consumer_cls"),
+    [
+        ("platform.inventory.host-ingress", 0.75, "inv_mq_service.IngressMessageConsumer"),
+        ("platform.inventory.system-profile", None, "inv_mq_service.SystemProfileMessageConsumer"),
+    ],
+)
+def test_mq_main_selects_sampling_rate_by_topic(consumer_topic, expected_sampling_rate, consumer_cls):
+    mock_config = _mq_config(consumer_topic=consumer_topic)
+    mock_app = MagicMock()
+    mock_app.app.config = {"INVENTORY_CONFIG": mock_config}
+
+    with (
+        patch("inv_mq_service.create_app", return_value=mock_app),
+        patch("inv_mq_service.init_otel") as mock_init_otel,
+        patch("inv_mq_service.OTEL_HOST_INGESTION_SAMPLING_RATE", 0.75),
+        patch("inv_mq_service.init_cache"),
+        patch("inv_mq_service.start_http_server"),
+        patch("inv_mq_service.create_consumer", return_value=MagicMock()),
+        patch("inv_mq_service.create_event_producer"),
+        patch("inv_mq_service.register_shutdown"),
+        patch("inv_mq_service.ShutdownHandler") as mock_shutdown_cls,
+        patch(consumer_cls) as mock_consumer_cls,
+        patch("inv_mq_service.get_build_version", return_value="1.2.3"),
+    ):
+        mock_shutdown_cls.return_value = MagicMock()
+        mock_consumer_cls.return_value = MagicMock()
+
+        import inv_mq_service
+
+        inv_mq_service.main()
+
+        mock_init_otel.assert_called_once_with(
+            service_name="host-inventory-mq",
+            service_version="1.2.3",
+            sampling_rate=expected_sampling_rate,
+        )

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -6,12 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from flask import Flask
-from opentelemetry import trace
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from app.telemetry import _outbound_request_hook
 
@@ -62,27 +57,14 @@ def test_outbound_request_hook_uses_slash_when_path_empty():
     span.update_name.assert_called_once_with("GET /")
 
 
-def _force_set_tracer_provider(provider):
-    """Replace the global TracerProvider (OTel normally allows set only once)."""
-    from opentelemetry.util._once import Once
-
-    trace._TRACER_PROVIDER_SET_ONCE = Once()
-    trace._TRACER_PROVIDER = None
-    if provider is not None:
-        trace.set_tracer_provider(provider)
-
-
-def test_instrument_flask_app_excludes_ops_urls_but_traces_other_routes(monkeypatch):
+def test_instrument_flask_app_excludes_ops_urls_but_traces_other_routes(monkeypatch, otel_provider):
     """Regression: excluded_urls must match full request URLs (incl. query)."""
     monkeypatch.setenv("OTEL_ENABLED", "true")
     import app.telemetry as telemetry_mod
 
     importlib.reload(telemetry_mod)
 
-    exporter = InMemorySpanExporter()
-    provider = TracerProvider(resource=Resource.create())
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
-    _force_set_tracer_provider(provider)
+    _, exporter = otel_provider(set_global=True)
 
     app = Flask(__name__)
 
@@ -123,8 +105,6 @@ def test_instrument_flask_app_excludes_ops_urls_but_traces_other_routes(monkeypa
         assert len(exporter.get_finished_spans()) == 1
     finally:
         FlaskInstrumentor().uninstrument_app(app)
-        provider.shutdown()
-        _force_set_tracer_provider(None)
         monkeypatch.setenv("OTEL_ENABLED", "false")
         importlib.reload(telemetry_mod)
 
@@ -217,14 +197,13 @@ def test_sampling_rate_override_in_init_otel(monkeypatch):
     _cleanup_telemetry(monkeypatch)
 
 
-def test_rh_attribute_span_processor_copies_from_parent():
+def test_rh_attribute_span_processor_copies_from_parent(otel_provider):
     """RHAttributeSpanProcessor sets rh.service and copies org/request from parent."""
     from app.telemetry import _build_rh_attribute_span_processor
 
-    exporter = InMemorySpanExporter()
-    provider = TracerProvider(resource=Resource.create())
-    provider.add_span_processor(_build_rh_attribute_span_processor(rh_service="host-inventory"))
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    provider, exporter = otel_provider(
+        span_processors=[_build_rh_attribute_span_processor(rh_service="host-inventory")]
+    )
     tracer = provider.get_tracer("test")
 
     with tracer.start_as_current_span("parent") as parent:
@@ -238,10 +217,9 @@ def test_rh_attribute_span_processor_copies_from_parent():
     assert spans["child"].attributes["rh.service"] == "host-inventory"
     assert spans["child"].attributes["rh.org_id"] == "org-1"
     assert spans["child"].attributes["rh.request_id"] == "req-1"
-    provider.shutdown()
 
 
-def test_rh_attribute_span_processor_threadctx_fallback():
+def test_rh_attribute_span_processor_threadctx_fallback(otel_provider):
     """When parent lacks rh.* attrs, processor falls back to threadctx."""
     from app.logging import threadctx
     from app.telemetry import _build_rh_attribute_span_processor
@@ -249,10 +227,7 @@ def test_rh_attribute_span_processor_threadctx_fallback():
     threadctx.org_id = "thread-org"
     threadctx.request_id = "thread-req"
     try:
-        exporter = InMemorySpanExporter()
-        provider = TracerProvider(resource=Resource.create())
-        provider.add_span_processor(_build_rh_attribute_span_processor())
-        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        provider, exporter = otel_provider(span_processors=[_build_rh_attribute_span_processor()])
         tracer = provider.get_tracer("test")
 
         with tracer.start_as_current_span("parent"):
@@ -263,13 +238,12 @@ def test_rh_attribute_span_processor_threadctx_fallback():
         assert spans["child"].attributes["rh.org_id"] == "thread-org"
         assert spans["child"].attributes["rh.request_id"] == "thread-req"
         assert spans["child"].attributes["rh.service"] == "host-inventory"
-        provider.shutdown()
     finally:
         threadctx.org_id = None
         threadctx.request_id = None
 
 
-def test_rh_attribute_span_processor_does_not_overwrite_child_attrs():
+def test_rh_attribute_span_processor_does_not_overwrite_child_attrs(otel_provider):
     """Child rh.* attributes are not overwritten by processor."""
     from app.logging import threadctx
     from app.telemetry import _build_rh_attribute_span_processor
@@ -277,10 +251,7 @@ def test_rh_attribute_span_processor_does_not_overwrite_child_attrs():
     threadctx.org_id = "thread-org"
     threadctx.request_id = "thread-req"
     try:
-        exporter = InMemorySpanExporter()
-        provider = TracerProvider(resource=Resource.create())
-        provider.add_span_processor(_build_rh_attribute_span_processor())
-        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        provider, exporter = otel_provider(span_processors=[_build_rh_attribute_span_processor()])
         tracer = provider.get_tracer("test")
 
         with tracer.start_as_current_span("parent") as parent:
@@ -298,13 +269,12 @@ def test_rh_attribute_span_processor_does_not_overwrite_child_attrs():
         spans = {span.name: span for span in exporter.get_finished_spans()}
         assert spans["child"].attributes["rh.org_id"] == "child-org"
         assert spans["child"].attributes["rh.request_id"] == "child-req"
-        provider.shutdown()
     finally:
         threadctx.org_id = None
         threadctx.request_id = None
 
 
-def test_rh_attribute_span_processor_parent_precedence_over_threadctx():
+def test_rh_attribute_span_processor_parent_precedence_over_threadctx(otel_provider):
     """Parent rh.* attributes take precedence over threadctx values."""
     from app.logging import threadctx
     from app.telemetry import _build_rh_attribute_span_processor
@@ -312,10 +282,7 @@ def test_rh_attribute_span_processor_parent_precedence_over_threadctx():
     threadctx.org_id = "thread-org"
     threadctx.request_id = "thread-req"
     try:
-        exporter = InMemorySpanExporter()
-        provider = TracerProvider(resource=Resource.create())
-        provider.add_span_processor(_build_rh_attribute_span_processor())
-        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        provider, exporter = otel_provider(span_processors=[_build_rh_attribute_span_processor()])
         tracer = provider.get_tracer("test")
 
         with tracer.start_as_current_span("parent") as parent:
@@ -327,7 +294,6 @@ def test_rh_attribute_span_processor_parent_precedence_over_threadctx():
         spans = {span.name: span for span in exporter.get_finished_spans()}
         assert spans["child"].attributes["rh.org_id"] == "parent-org"
         assert spans["child"].attributes["rh.request_id"] == "parent-req"
-        provider.shutdown()
     finally:
         threadctx.org_id = None
         threadctx.request_id = None

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -154,10 +154,11 @@ def _cleanup_telemetry(monkeypatch):
 
 
 def test_sampling_rate_applied_in_init_otel(monkeypatch):
-    """TraceIdRatioBased sampler is created with OTEL_SAMPLING_RATE."""
+    """ParentBased(TraceIdRatioBased) sampler is created with OTEL_SAMPLING_RATE."""
     telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_SAMPLING_RATE": "0.25"})
 
     with patch.object(telemetry_mod, "_otel_initialized_pid", None):
+        from opentelemetry.sdk.trace.sampling import ParentBased
         from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
 
         with (
@@ -169,8 +170,9 @@ def test_sampling_rate_applied_in_init_otel(monkeypatch):
 
             call_kwargs = mock_provider_cls.call_args
             sampler = call_kwargs[1]["sampler"] if "sampler" in call_kwargs[1] else call_kwargs[0][1]
-            assert isinstance(sampler, TraceIdRatioBased)
-            assert sampler.rate == 0.25
+            assert isinstance(sampler, ParentBased)
+            assert isinstance(sampler._root, TraceIdRatioBased)
+            assert sampler._root.rate == 0.25
 
     _cleanup_telemetry(monkeypatch)
 
@@ -180,6 +182,7 @@ def test_sampling_rate_override_in_init_otel(monkeypatch):
     telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_SAMPLING_RATE": "0.25"})
 
     with patch.object(telemetry_mod, "_otel_initialized_pid", None):
+        from opentelemetry.sdk.trace.sampling import ParentBased
         from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
 
         with (
@@ -191,8 +194,9 @@ def test_sampling_rate_override_in_init_otel(monkeypatch):
 
             call_kwargs = mock_provider_cls.call_args[1]
             sampler = call_kwargs["sampler"]
-            assert isinstance(sampler, TraceIdRatioBased)
-            assert sampler.rate == 1.0
+            assert isinstance(sampler, ParentBased)
+            assert isinstance(sampler._root, TraceIdRatioBased)
+            assert sampler._root.rate == 1.0
 
     _cleanup_telemetry(monkeypatch)
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -62,6 +62,16 @@ def test_outbound_request_hook_uses_slash_when_path_empty():
     span.update_name.assert_called_once_with("GET /")
 
 
+def _force_set_tracer_provider(provider):
+    """Replace the global TracerProvider (OTel normally allows set only once)."""
+    from opentelemetry.util._once import Once
+
+    trace._TRACER_PROVIDER_SET_ONCE = Once()
+    trace._TRACER_PROVIDER = None
+    if provider is not None:
+        trace.set_tracer_provider(provider)
+
+
 def test_instrument_flask_app_excludes_ops_urls_but_traces_other_routes(monkeypatch):
     """Regression: excluded_urls must match full request URLs (incl. query)."""
     monkeypatch.setenv("OTEL_ENABLED", "true")
@@ -72,7 +82,7 @@ def test_instrument_flask_app_excludes_ops_urls_but_traces_other_routes(monkeypa
     exporter = InMemorySpanExporter()
     provider = TracerProvider(resource=Resource.create())
     provider.add_span_processor(SimpleSpanProcessor(exporter))
-    trace.set_tracer_provider(provider)
+    _force_set_tracer_provider(provider)
 
     app = Flask(__name__)
 
@@ -114,6 +124,7 @@ def test_instrument_flask_app_excludes_ops_urls_but_traces_other_routes(monkeypa
     finally:
         FlaskInstrumentor().uninstrument_app(app)
         provider.shutdown()
+        _force_set_tracer_provider(None)
         monkeypatch.setenv("OTEL_ENABLED", "false")
         importlib.reload(telemetry_mod)
 
@@ -180,6 +191,184 @@ def test_sampling_rate_applied_in_init_otel(monkeypatch):
             sampler = call_kwargs[1]["sampler"] if "sampler" in call_kwargs[1] else call_kwargs[0][1]
             assert isinstance(sampler, TraceIdRatioBased)
             assert sampler.rate == 0.25
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_sampling_rate_override_in_init_otel(monkeypatch):
+    """Explicit sampling_rate overrides OTEL_SAMPLING_RATE env var."""
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_SAMPLING_RATE": "0.25"})
+
+    with patch.object(telemetry_mod, "_otel_initialized_pid", None):
+        from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+
+        with (
+            patch("opentelemetry.sdk.trace.TracerProvider") as mock_provider_cls,
+            patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter"),
+        ):
+            mock_provider_cls.return_value = MagicMock()
+            telemetry_mod.init_otel(service_name="test-service", sampling_rate=1.0)
+
+            call_kwargs = mock_provider_cls.call_args[1]
+            sampler = call_kwargs["sampler"]
+            assert isinstance(sampler, TraceIdRatioBased)
+            assert sampler.rate == 1.0
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_rh_attribute_span_processor_copies_from_parent():
+    """RHAttributeSpanProcessor sets rh.service and copies org/request from parent."""
+    from app.telemetry import _build_rh_attribute_span_processor
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(resource=Resource.create())
+    provider.add_span_processor(_build_rh_attribute_span_processor(rh_service="host-inventory"))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+
+    with tracer.start_as_current_span("parent") as parent:
+        parent.set_attribute("rh.org_id", "org-1")
+        parent.set_attribute("rh.request_id", "req-1")
+        with tracer.start_as_current_span("child"):
+            pass
+
+    spans = {span.name: span for span in exporter.get_finished_spans()}
+    assert spans["parent"].attributes["rh.service"] == "host-inventory"
+    assert spans["child"].attributes["rh.service"] == "host-inventory"
+    assert spans["child"].attributes["rh.org_id"] == "org-1"
+    assert spans["child"].attributes["rh.request_id"] == "req-1"
+    provider.shutdown()
+
+
+def test_rh_attribute_span_processor_threadctx_fallback():
+    """When parent lacks rh.* attrs, processor falls back to threadctx."""
+    from app.logging import threadctx
+    from app.telemetry import _build_rh_attribute_span_processor
+
+    threadctx.org_id = "thread-org"
+    threadctx.request_id = "thread-req"
+    try:
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider(resource=Resource.create())
+        provider.add_span_processor(_build_rh_attribute_span_processor())
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer("test")
+
+        with tracer.start_as_current_span("parent"):
+            with tracer.start_as_current_span("child"):
+                pass
+
+        spans = {span.name: span for span in exporter.get_finished_spans()}
+        assert spans["child"].attributes["rh.org_id"] == "thread-org"
+        assert spans["child"].attributes["rh.request_id"] == "thread-req"
+        assert spans["child"].attributes["rh.service"] == "host-inventory"
+        provider.shutdown()
+    finally:
+        threadctx.org_id = None
+        threadctx.request_id = None
+
+
+def test_rh_attribute_span_processor_does_not_overwrite_child_attrs():
+    """Child rh.* attributes are not overwritten by processor."""
+    from app.logging import threadctx
+    from app.telemetry import _build_rh_attribute_span_processor
+
+    threadctx.org_id = "thread-org"
+    threadctx.request_id = "thread-req"
+    try:
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider(resource=Resource.create())
+        provider.add_span_processor(_build_rh_attribute_span_processor())
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer("test")
+
+        with tracer.start_as_current_span("parent") as parent:
+            parent.set_attribute("rh.org_id", "parent-org")
+            parent.set_attribute("rh.request_id", "parent-req")
+            with tracer.start_as_current_span(
+                "child",
+                attributes={
+                    "rh.org_id": "child-org",
+                    "rh.request_id": "child-req",
+                },
+            ):
+                pass
+
+        spans = {span.name: span for span in exporter.get_finished_spans()}
+        assert spans["child"].attributes["rh.org_id"] == "child-org"
+        assert spans["child"].attributes["rh.request_id"] == "child-req"
+        provider.shutdown()
+    finally:
+        threadctx.org_id = None
+        threadctx.request_id = None
+
+
+def test_rh_attribute_span_processor_parent_precedence_over_threadctx():
+    """Parent rh.* attributes take precedence over threadctx values."""
+    from app.logging import threadctx
+    from app.telemetry import _build_rh_attribute_span_processor
+
+    threadctx.org_id = "thread-org"
+    threadctx.request_id = "thread-req"
+    try:
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider(resource=Resource.create())
+        provider.add_span_processor(_build_rh_attribute_span_processor())
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer("test")
+
+        with tracer.start_as_current_span("parent") as parent:
+            parent.set_attribute("rh.org_id", "parent-org")
+            parent.set_attribute("rh.request_id", "parent-req")
+            with tracer.start_as_current_span("child"):
+                pass
+
+        spans = {span.name: span for span in exporter.get_finished_spans()}
+        assert spans["child"].attributes["rh.org_id"] == "parent-org"
+        assert spans["child"].attributes["rh.request_id"] == "parent-req"
+        provider.shutdown()
+    finally:
+        threadctx.org_id = None
+        threadctx.request_id = None
+
+
+def test_botocore_instrumentation_runs_when_enabled(monkeypatch):
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_BOTOCORE_ENABLED": "true"})
+
+    with patch("opentelemetry.instrumentation.botocore.BotocoreInstrumentor") as mock_cls:
+        instance = MagicMock()
+        mock_cls.return_value = instance
+        telemetry_mod.instrument_botocore()
+        instance.instrument.assert_called_once()
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_botocore_instrumentation_skipped_when_botocore_disabled(monkeypatch):
+    """instrument_botocore is a no-op when OTEL_BOTOCORE_ENABLED=false."""
+    telemetry_mod = _reload_telemetry(monkeypatch, {"OTEL_ENABLED": "true", "OTEL_BOTOCORE_ENABLED": "false"})
+
+    with patch("opentelemetry.instrumentation.botocore.BotocoreInstrumentor") as mock_instrumentor:
+        telemetry_mod.instrument_botocore()
+        mock_instrumentor.assert_not_called()
+
+    _cleanup_telemetry(monkeypatch)
+
+
+def test_botocore_instrumentation_skipped_when_otel_disabled(monkeypatch):
+    """Botocore instrumentation is skipped when global OTEL is disabled, regardless of botocore flag."""
+    telemetry_mod = _reload_telemetry(
+        monkeypatch,
+        {
+            "OTEL_ENABLED": "false",
+            "OTEL_BOTOCORE_ENABLED": "true",
+        },
+    )
+
+    with patch("opentelemetry.instrumentation.botocore.BotocoreInstrumentor") as mock_instrumentor:
+        telemetry_mod.instrument_botocore()
+        mock_instrumentor.assert_not_called()
 
     _cleanup_telemetry(monkeypatch)
 
@@ -333,7 +522,9 @@ def test_config_defaults_without_env_vars(monkeypatch):
         "OTEL_SQL_COMMENTER_ENABLED",
         "OTEL_HTTP_INBOUND_ENABLED",
         "OTEL_HTTP_OUTBOUND_ENABLED",
+        "OTEL_BOTOCORE_ENABLED",
         "OTEL_SAMPLING_RATE",
+        "OTEL_HOST_INGESTION_SAMPLING_RATE",
         "OTEL_BSP_MAX_QUEUE_SIZE",
         "OTEL_BSP_MAX_EXPORT_BATCH_SIZE",
         "OTEL_BSP_SCHEDULE_DELAY",
@@ -355,7 +546,9 @@ def test_config_defaults_without_env_vars(monkeypatch):
     assert telemetry_mod.OTEL_SQL_COMMENTER_ENABLED is False
     assert telemetry_mod.OTEL_HTTP_INBOUND_ENABLED is True
     assert telemetry_mod.OTEL_HTTP_OUTBOUND_ENABLED is True
+    assert telemetry_mod.OTEL_BOTOCORE_ENABLED is True
     assert telemetry_mod.OTEL_SAMPLING_RATE == 1.0
+    assert telemetry_mod.OTEL_HOST_INGESTION_SAMPLING_RATE == 1.0
     assert telemetry_mod.OTEL_BSP_MAX_QUEUE_SIZE == 8192
     assert telemetry_mod.OTEL_BSP_MAX_EXPORT_BATCH_SIZE == 256
     assert telemetry_mod.OTEL_BSP_SCHEDULE_DELAY == 2000

--- a/uv.lock
+++ b/uv.lock
@@ -730,6 +730,7 @@ dev = [
     { name = "faker" },
     { name = "honcho" },
     { name = "mypy" },
+    { name = "opentelemetry-test-utils" },
     { name = "pgxnclient" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -798,6 +799,7 @@ dev = [
     { name = "faker" },
     { name = "honcho" },
     { name = "mypy" },
+    { name = "opentelemetry-test-utils", specifier = "==0.64b0" },
     { name = "pgxnclient" },
     { name = "pre-commit", specifier = "~=4.6.0" },
     { name = "pytest", specifier = "~=9.1.1" },
@@ -1309,6 +1311,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
+name = "opentelemetry-test-utils"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/c7/ef2a1484dbceb47f82855eca38afa196694d64fea6879d312c7841b1e0f3/opentelemetry_test_utils-0.64b0.tar.gz", hash = "sha256:a7e082ba5b938e90d631884ee57e0795bedf11823a48499b07e3532a67f83ced", size = 13365, upload-time = "2026-06-24T15:20:10.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/f4/c5935f6998efd8c41bba9b11e93423b39709032790e25f5941595c69aef4/opentelemetry_test_utils-0.64b0-py3-none-any.whl", hash = "sha256:a4fca023ce51a9a395ff78488b0daa9ad74c68277f87f7f2606ebb7aa8c1a9f1", size = 17841, upload-time = "2026-06-24T15:19:54.502Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -699,6 +699,7 @@ dependencies = [
     { name = "openapi-spec-validator" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-botocore" },
     { name = "opentelemetry-instrumentation-confluent-kafka" },
     { name = "opentelemetry-instrumentation-flask" },
     { name = "opentelemetry-instrumentation-requests" },
@@ -766,6 +767,7 @@ requires-dist = [
     { name = "openapi-spec-validator", specifier = "==0.9.0" },
     { name = "opentelemetry-api", specifier = "~=1.43.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = "~=1.43.0" },
+    { name = "opentelemetry-instrumentation-botocore", specifier = "==0.64b0" },
     { name = "opentelemetry-instrumentation-confluent-kafka", specifier = "~=0.53b0" },
     { name = "opentelemetry-instrumentation-flask", specifier = "==0.64b0" },
     { name = "opentelemetry-instrumentation-requests", specifier = "==0.64b0" },
@@ -1165,6 +1167,22 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-botocore"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-propagator-aws-xray" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/57/da42fca6537571c9a62e85439d70b6f7274da1afe684e1be0c6d8c41bb15/opentelemetry_instrumentation_botocore-0.64b0.tar.gz", hash = "sha256:e437907352a451c2b9d5b966197cf94785234ef4782ceee5b528d1f8a8875092", size = 125106, upload-time = "2026-06-24T15:19:20.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/d9/27e199e15dd78c423c848c3705cced8e45f77f798dcb61257ac6c12df5cf/opentelemetry_instrumentation_botocore-0.64b0-py3-none-any.whl", hash = "sha256:d55f359942021457e76a2c4d7d6dd44f6d8f9155f10c81b92922f2e364e470bc", size = 36242, upload-time = "2026-06-24T15:18:28.786Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-confluent-kafka"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
@@ -1240,6 +1258,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/4f/0b5232a0d635eee5da7c85af503d2f00fdcac61cc6d4d4a69aadf1fa7a0e/opentelemetry_instrumentation_wsgi-0.64b0.tar.gz", hash = "sha256:1cce6ea28d1800c154e6ccdf52f05bae2f05c5e28ee44f0dddb17ada26208986", size = 19667, upload-time = "2026-06-24T15:19:46.407Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/23/5d/4da612cfe1ad96730dba19c9ab97f531be0558a918998e11478734cb36b2/opentelemetry_instrumentation_wsgi-0.64b0-py3-none-any.whl", hash = "sha256:5a3b0174f39072c0abb749be4ae7e469c7585e87cdfaf63665657b1a7058c105", size = 13787, upload-time = "2026-06-24T15:19:05.417Z" },
+]
+
+[[package]]
+name = "opentelemetry-propagator-aws-xray"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/31/40004e9e55b1e5694ef3a7526f0b7637df44196fc68a8b7d248a3684680f/opentelemetry_propagator_aws_xray-1.0.2.tar.gz", hash = "sha256:6b2cee5479d2ef0172307b66ed2ed151f598a0fd29b3c01133ac87ca06326260", size = 10994, upload-time = "2024-08-05T17:45:57.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/89/849a0847871fd9745315896ad9e23d6479db84d90b8b36c4c26dc46e92b8/opentelemetry_propagator_aws_xray-1.0.2-py3-none-any.whl", hash = "sha256:1c99181ee228e99bddb638a0c911a297fa21f1c3a0af951f841e79919b5f1934", size = 10856, upload-time = "2024-08-05T17:45:56.492Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Jira
[RHINENG-28763](https://issues.redhat.com/browse/RHINENG-28763)

## What
Align Host Inventory OpenTelemetry with the platform tracing ADR: dual sampling for host-ingestion MQ vs API, platform `rh.*` span attributes, log–trace correlation, botocore/S3 instrumentation, and OTel coverage for the export-service Kafka consumer.

## Why
HBI was an early OTel adopter; a gap analysis against the platform ADR found missing dual sampling, `rh.service` / child-span `rh.org_id` & `rh.request_id`, `trace_id`/`span_id` in logs, botocore spans, and export-service Kafka instrumentation. Closing these gaps keeps HBI consistent with other Insights services and Payload Tracker parity on host ingest.

## How
- Add `OTEL_HOST_INGESTION_SAMPLING_RATE` (default `1.0`) for host-ingress MQ (`mq-pmin` / `mq-p1`); API and other services keep `OTEL_SAMPLING_RATE`
- Set `rh.service`, and propagate `rh.org_id` / `rh.request_id` to child spans via a custom `SpanProcessor` (Puptoo-aligned span attrs, not resource attrs)
- Extend `ContextualFilter` to attach `trace_id` / `span_id` on log records (emitted via logstash/CloudWatch)
- Instrument botocore (`OTEL_BOTOCORE_ENABLED`) and wire `init_otel` + Kafka consumer instrumentation in `inv_export_service.py`
- Expose new env vars in `deploy/clowdapp.yml`

## Testing
- Unit tests: `tests/test_telemetry.py`, `test_logging_trace_correlation.py`, `test_mq_service_sampling.py`, `test_export_service_otel.py`
- Local verification with Tempo: API + host-ingress MQ traces showed `span.rh.service`, child SQL spans with `rh.org_id` / `rh.request_id`, and no `resource.rh.service`

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


Assisted-by: Cursor:grok-4.5


[RHINENG-28763]: https://redhat.atlassian.net/browse/RHINENG-28763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Align Host Inventory OpenTelemetry behavior and configuration with platform tracing standards, including dual sampling for host-ingestion MQ and expanded instrumentation.

New Features:
- Introduce a dedicated OTEL_HOST_INGESTION_SAMPLING_RATE configuration for host-ingress MQ consumers while retaining OTEL_SAMPLING_RATE for other services.
- Add botocore/boto3 OpenTelemetry instrumentation and wire tracing into the export-service Kafka consumer.
- Propagate platform rh.* attributes (rh.service, rh.org_id, rh.request_id) onto spans via a custom span processor instead of resource attributes.
- Attach trace_id and span_id from the current OpenTelemetry span to log records for log–trace correlation.

Enhancements:
- Make sampling-rate environment variable parsing more robust, with clamping and fallback on invalid values.
- Extend init_otel to support explicit sampling-rate overrides and configurable rh.service values, and log effective sampling including botocore enablement.
- Instrument botocore and other telemetry helpers automatically during Flask app initialization.
- Expose new and existing OpenTelemetry-related environment variables for MQ and export services in the ClowdApp deployment configuration.

Tests:
- Add unit tests covering sampling-rate overrides and invalid-rate fallback behavior.
- Add tests for host-ingestion MQ sampling selection in inv_mq_service.
- Add tests validating rh.* attribute propagation and thread-context fallback in the span processor.
- Add tests verifying log trace/span ID injection and export-service OpenTelemetry wiring around the Kafka consumer.