### PR TITLE
chore(RHINENG-28938) Replace `platform.rbac.workspaces` feature flag

### DIFF
--- a/.unleash/flags.json
+++ b/.unleash/flags.json
@@ -34,8 +34,8 @@
             "createdAt": "2025-02-14T16:29:19.146Z"
         },
         {
-            "name": "platform.rbac.workspaces",
-            "description": "Gates Kessel/RBAC v2 workspace-based authorization for HBI (consolidates kessel-phase-1 and kessel-groups).",
+            "name": "hbi.rbac-v2",
+            "description": "Gates Kessel/RBAC v2 workspace-based authorization for HBI.",
             "type": "release",
             "project": "default",
             "stale": false,
@@ -47,7 +47,7 @@
                 }
             ],
             "variants": [],
-            "createdAt": "2026-04-21T00:00:00.000Z"
+            "createdAt": "2026-07-21T00:00:00.000Z"
         },
         {
             "name": "hbi.api.kessel-force-single-checks-for-bulk",

--- a/api/host_group.py
+++ b/api/host_group.py
@@ -54,7 +54,7 @@ def get_host_list_by_group(
     """
     Get the list of hosts in a specific group.
 
-    Behind feature flag: platform.rbac.workspaces
+    Behind feature flag: hbi.rbac-v2
     - If enabled: Validates group via RBAC v2 workspace API
     - If disabled: Validates group via database
 

--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/unleash.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/unleash.py
@@ -67,7 +67,7 @@ class HBIUnleash(BaseEntity):
 
     @cached_property
     def rbac_workspaces_flag(self) -> str:
-        feature_flag = "platform.rbac.workspaces"
+        feature_flag = "hbi.rbac-v2"
 
         if isinstance(self._unleash, UnleashBackend) and not self._unleash.has_flag(feature_flag):
             flag_request = UnleashFlagRequest(

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
@@ -58,7 +58,7 @@ def permission_to_v2(permission: RBACInventoryPermission) -> RBACV2Permission:
 
 def wait_for_kessel_sync(host_inventory: ApplicationHostInventory) -> None:
     """
-    Wait for RBAC -> Kessel sync if the platform.rbac.workspaces feature flag is enabled.
+    Wait for RBAC -> Kessel sync if the hbi.rbac-v2 feature flag is enabled.
     """
     wait_seconds = 3 if host_inventory.application.config.current_env == "clowder_smoke" else 21
     if host_inventory.unleash.is_rbac_workspaces_enabled:

--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -10,7 +10,7 @@ UNLEASH = Unleash()
 logger = get_logger(__name__)
 
 FLAG_INVENTORY_API_READ_ONLY = "hbi.api.read-only"
-FLAG_RBAC_WORKSPACES = "platform.rbac.workspaces"
+FLAG_RBAC_WORKSPACES = "hbi.rbac-v2"
 FLAG_INVENTORY_USE_NEW_SYSTEM_PROFILE_TABLES = "hbi.use_new_system_profile_tables"
 FLAG_INVENTORY_REJECT_RHSM_PAYLOADS = "hbi.api.reject-rhsm-payloads"
 FLAG_INVENTORY_KESSEL_FORCE_SINGLE_CHECKS_FOR_BULK = "hbi.api.kessel-force-single-checks-for-bulk"

--- a/lib/middleware.py
+++ b/lib/middleware.py
@@ -697,7 +697,7 @@ def is_rbac_v2_enabled(org_id: str) -> bool:
     """
     Check if RBAC v2 (workspace-based) authorization is enabled.
 
-    Single source of truth for the platform.rbac.workspaces feature flag.
+    Single source of truth for the hbi.rbac-v2 feature flag.
     Used to gate both Kessel permission checks and RBAC v2 workspace API calls.
 
     When True: Kessel/RBAC v2 workspace API handles all authorization

--- a/tests/test_api_groups_create.py
+++ b/tests/test_api_groups_create.py
@@ -300,7 +300,7 @@ def test_create_group_RBAC_denied_attribute_filter(mocker, api_create_group):
 
 @pytest.mark.usefixtures("event_producer")
 def test_create_group_same_name_platform_rbac_workspaces_enabled(api_create_group, db_get_group_by_name):
-    """Test that groups with the same name can be created when platform.rbac.workspaces is True."""
+    """Test that groups with the same name can be created when hbi.rbac-v2 is True."""
     group_data = {"name": "duplicate_group_name", "host_ids": []}
 
     # Create the first group

--- a/tests/test_api_groups_update.py
+++ b/tests/test_api_groups_update.py
@@ -887,7 +887,7 @@ def test_patch_group_no_permission_checks_when_platform_rbac_workspaces_disabled
     db_get_group_by_id,
     event_producer,
 ):
-    """When platform.rbac.workspaces is disabled, renaming should succeed without any Kessel permission checks."""
+    """When hbi.rbac-v2 is disabled, renaming should succeed without any Kessel permission checks."""
     mocker.patch.object(event_producer, "write_event")
 
     group = db_create_group("old_name")


### PR DESCRIPTION
## Jira
[RHINENG-28938](https://issues.redhat.com/browse/RHINENG-28938)

## What
Replaces the `platform.rbac.workspaces` feature flag with the new `hbi.rbac-v2` feature flag.

## Why
The Kessel/RBAC team wants to roll out Kessel/RBAC v2 access checks for more and more orgs for HBI, but does not want to roll out the RBAC v2 experience for more orgs yet. So, we need to use a feature flag that uses a superset of the orgs that they're using. To that end, I made the `hbi.rbac-v2` feature flag, which uses a common Segment that's now also used by the `platform.rbac.workspaces` feature flag; we can also increase the gradual rollout to include additional orgs on top of that.
Design doc here: https://docs.google.com/document/d/1ihM0w4JZeA5AaLOho2dnvu6JXj3IOW6uMXtn7MZD_9I/edit?tab=t.0#heading=h.pfjzbznm9cbk 

## How
Simple find & replace.

## Testing
It's just a string swap, so the existing unit tests are enough for now. We'll test more thoroughly in Stage.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Replace all usages and references of the RBAC workspaces feature flag with the new hbi.rbac-v2 flag for RBAC v2 workspace-based authorization.

Enhancements:
- Align feature flag constants, middleware checks, and Unleash integration with the new hbi.rbac-v2 flag for RBAC v2 workspaces.
- Update host group API documentation strings and helper utilities to reflect the new RBAC v2 feature flag name.
- Adjust tests to reference the new hbi.rbac-v2 feature flag in their descriptions and behavior assumptions.

Tests:
- Update group creation and update tests to validate behavior when the hbi.rbac-v2 feature flag is enabled or disabled.

[RHINENG-28938]: https://redhat.atlassian.net/browse/RHINENG-28938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Replace the RBAC workspaces feature flag with the new hbi.rbac-v2 flag across host group APIs, feature flag utilities, middleware, and tests.

Enhancements:
- Align feature flag constants, middleware checks, and Unleash integration with the hbi.rbac-v2 flag for RBAC v2 workspace-based authorization.
- Update host group API docstrings and RBAC utility descriptions to reference the hbi.rbac-v2 feature flag instead of the legacy platform.rbac.workspaces flag.

Tests:
- Adjust group creation and update tests to validate behavior when the hbi.rbac-v2 feature flag is enabled or disabled and reflect the new flag name in test descriptions.