### PR TITLE
perf(RHINENG-28940): move tag aggregation from Python to SQL

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -496,6 +496,44 @@ def _convert_null_string(input: str | list):
     return input
 
 
+def _build_tags_aggregation_query(filtered_hosts, search: str | None, order_by: str, order_how: str | None):
+    """Build the SQL aggregation query for tag listing using jsonb_array_elements."""
+    tag_lateral = (
+        func.jsonb_array_elements(func.coalesce(filtered_hosts.c.tags_alt, literal("[]").cast(JSONB)))
+        .table_valued(column("value", JSONB))
+        .lateral("t")
+    )
+
+    namespace_expr = tag_lateral.c.value["namespace"].astext
+    key_expr = tag_lateral.c.value["key"].astext
+    value_expr = tag_lateral.c.value["value"].astext
+    # count(*) is safe because tags_alt write paths deduplicate (ns, key, value) entries per host
+    host_count_expr = func.count()
+    tag_string_expr = func.concat(
+        func.coalesce(namespace_expr, "None"), "/", func.coalesce(key_expr, "None"), "=", func.coalesce(value_expr, "")
+    )
+
+    agg_stmt = (
+        select(
+            namespace_expr.label("namespace"),
+            key_expr.label("key"),
+            value_expr.label("value"),
+            host_count_expr.label("host_count"),
+        )
+        .select_from(filtered_hosts)
+        .join(tag_lateral, literal(True))
+        .group_by(namespace_expr, key_expr, value_expr)
+    )
+
+    if search:
+        agg_stmt = agg_stmt.where(tag_string_expr.op("~*")(search))
+
+    order_col = tag_string_expr if order_by == "tag" else host_count_expr
+    agg_stmt = agg_stmt.order_by(order_col.desc()) if order_how == "DESC" else agg_stmt.order_by(order_col.asc())
+
+    return agg_stmt
+
+
 def get_tag_list(
     display_name: str | None,
     fqdn: str | None,
@@ -557,36 +595,7 @@ def get_tag_list(
     host_query = _find_hosts_entities_query(query=query_base, columns=[Host.id, Host.tags_alt])
     filtered_hosts = host_query.filter(*all_filters).subquery("filtered_hosts")
 
-    # Unnest tags_alt using jsonb_array_elements and aggregate via GROUP BY
-    tag_lateral = (
-        func.jsonb_array_elements(filtered_hosts.c.tags_alt).table_valued(column("value", JSONB)).lateral("t")
-    )
-    namespace_expr = tag_lateral.c.value["namespace"].astext
-    key_expr = tag_lateral.c.value["key"].astext
-    value_expr = tag_lateral.c.value["value"].astext
-    # count(*) is safe here because tags_alt never contains duplicate (ns, key, value)
-    host_count_expr = func.count()
-    tag_string_expr = func.concat(
-        func.coalesce(namespace_expr, "None"), "/", func.coalesce(key_expr, "None"), "=", func.coalesce(value_expr, "")
-    )
-
-    agg_stmt = (
-        select(
-            namespace_expr.label("namespace"),
-            key_expr.label("key"),
-            value_expr.label("value"),
-            host_count_expr.label("host_count"),
-        )
-        .select_from(filtered_hosts)
-        .join(tag_lateral, literal(True))
-        .group_by(namespace_expr, key_expr, value_expr)
-    )
-
-    if search:
-        agg_stmt = agg_stmt.where(tag_string_expr.op("~*")(search))
-
-    order_col = tag_string_expr if order_by == "tag" else host_count_expr
-    agg_stmt = agg_stmt.order_by(order_col.desc()) if order_how == "DESC" else agg_stmt.order_by(order_col.asc())
+    agg_stmt = _build_tags_aggregation_query(filtered_hosts, search, order_by, order_how)
 
     total = db.session.execute(select(func.count()).select_from(agg_stmt.subquery())).scalar()
     results = db.session.execute(agg_stmt.limit(limit).offset(offset)).all()

--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -9,7 +9,11 @@ from sqlalchemy import Boolean
 from sqlalchemy import Integer
 from sqlalchemy import and_
 from sqlalchemy import case
+from sqlalchemy import column
 from sqlalchemy import func
+from sqlalchemy import literal
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Query
@@ -525,7 +529,6 @@ def get_tag_list(
             "Providing ordering direction without a column is not supported. Provide order_by={tag,count}."
         )
 
-    columns = [Host.id, Host.tags]
     all_filters, query_base = query_filters(
         fqdn,
         display_name,
@@ -549,38 +552,50 @@ def get_tag_list(
         order_by,
         get_current_identity(),
     )
-    query = _find_hosts_entities_query(query=query_base, columns=columns)
 
-    query_results = query.filter(*all_filters).all()
-    db.session.close()
-    _, host_tags_dict = _expand_host_tags(query_results)
-    host_tags = host_tags_dict
+    # Build a subquery of filtered host IDs with their tags_alt JSONB array
+    host_query = _find_hosts_entities_query(query=query_base, columns=[Host.id, Host.tags_alt])
+    filtered_hosts = host_query.filter(*all_filters).subquery("filtered_hosts")
+
+    # Unnest tags_alt using jsonb_array_elements and aggregate via GROUP BY
+    tag_lateral = (
+        func.jsonb_array_elements(filtered_hosts.c.tags_alt).table_valued(column("value", JSONB)).lateral("t")
+    )
+    namespace_expr = tag_lateral.c.value["namespace"].astext
+    key_expr = tag_lateral.c.value["key"].astext
+    value_expr = tag_lateral.c.value["value"].astext
+    # count(*) is safe here because tags_alt never contains duplicate (ns, key, value)
+    host_count_expr = func.count()
+    tag_string_expr = func.concat(
+        func.coalesce(namespace_expr, "None"), "/", func.coalesce(key_expr, "None"), "=", func.coalesce(value_expr, "")
+    )
+
+    agg_stmt = (
+        select(
+            namespace_expr.label("namespace"),
+            key_expr.label("key"),
+            value_expr.label("value"),
+            host_count_expr.label("host_count"),
+        )
+        .select_from(filtered_hosts)
+        .join(tag_lateral, literal(True))
+        .group_by(namespace_expr, key_expr, value_expr)
+    )
+
     if search:
-        regex = re.compile(search, re.IGNORECASE)
-        host_tags = {}
-        for key in host_tags_dict.keys():
-            if regex.search(key):
-                host_tags[key] = host_tags_dict[key]
+        agg_stmt = agg_stmt.where(tag_string_expr.op("~*")(search))
 
-    tag_list = []
-    query_count = 0
-    tag_count_list = []
-    for stored_key, tag_contents in host_tags.items():
-        tag_count_item = {"tag": stored_key, "count": len(tag_contents.get("hosts"))}
-        tag_count_list.append(tag_count_item)
-    if order_by == "tag":
-        sorted_tag_count_list = sorted(tag_count_list, reverse=order_how == "DESC", key=lambda item: item["tag"])
-    if order_by == "count":
-        sorted_tag_count_list = sorted(tag_count_list, reverse=order_how == "DESC", key=lambda item: item["count"])
-    for tag_item in sorted_tag_count_list:
-        tag_key = tag_item.get("tag")
-        tag_dict = host_tags[tag_key]
-        output = {"tag": tag_dict.get("output", {}), "count": len(tag_dict.get("hosts", []))}
-        tag_list.append(output)
+    order_col = tag_string_expr if order_by == "tag" else host_count_expr
+    agg_stmt = agg_stmt.order_by(order_col.desc()) if order_how == "DESC" else agg_stmt.order_by(order_col.asc())
 
-    query_count = len(tag_list)
-    tag_list = list(islice(islice(tag_list, offset, None), limit))
-    return tag_list, query_count
+    total = db.session.execute(select(func.count()).select_from(agg_stmt.subquery())).scalar()
+    results = db.session.execute(agg_stmt.limit(limit).offset(offset)).all()
+    db.session.close()
+
+    return [
+        {"tag": {"namespace": row.namespace, "key": row.key, "value": row.value}, "count": row.host_count}
+        for row in results
+    ], total
 
 
 def get_os_info(

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -121,7 +121,14 @@ class LimitedHost(db.Model, HostTypeDeriver):
         else:
             raise TypeError("Tags must be dict or list")
 
-        return transformed_tags
+        # Deduplicate to ensure no duplicate (namespace, key, value) entries exist.
+        seen = set()
+        return [
+            t
+            for t in transformed_tags
+            if (t["namespace"], t["key"], t.get("value")) not in seen
+            and not seen.add((t["namespace"], t["key"], t.get("value")))
+        ]
 
     @hybrid_property
     def operating_system(self):
@@ -499,7 +506,15 @@ class Host(LimitedHost):
             for key, values in ns_items.items():
                 final_tags_alt.extend({"namespace": ns, "key": key, "value": value} for value in values)
 
-        self.tags_alt = final_tags_alt
+        # Deduplicate to ensure no duplicate (namespace, key, value) entries exist.
+        # This guarantees count(*) == count(DISTINCT id) in tag aggregation queries.
+        seen = set()
+        self.tags_alt = [
+            t
+            for t in final_tags_alt
+            if (t["namespace"], t["key"], t.get("value")) not in seen
+            and not seen.add((t["namespace"], t["key"], t.get("value")))
+        ]
 
         orm.attributes.flag_modified(self, "tags_alt")
 

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -122,13 +122,10 @@ class LimitedHost(db.Model, HostTypeDeriver):
             raise TypeError("Tags must be dict or list")
 
         # Deduplicate to ensure no duplicate (namespace, key, value) entries exist.
-        seen = set()
-        return [
-            t
-            for t in transformed_tags
-            if (t["namespace"], t["key"], t.get("value")) not in seen
-            and not seen.add((t["namespace"], t["key"], t.get("value")))
-        ]
+        seen = {}
+        for t in transformed_tags:
+            seen.setdefault((t["namespace"], t["key"], t.get("value")), t)
+        return list(seen.values())
 
     @hybrid_property
     def operating_system(self):
@@ -507,14 +504,10 @@ class Host(LimitedHost):
                 final_tags_alt.extend({"namespace": ns, "key": key, "value": value} for value in values)
 
         # Deduplicate to ensure no duplicate (namespace, key, value) entries exist.
-        # This guarantees count(*) == count(DISTINCT id) in tag aggregation queries.
-        seen = set()
-        self.tags_alt = [
-            t
-            for t in final_tags_alt
-            if (t["namespace"], t["key"], t.get("value")) not in seen
-            and not seen.add((t["namespace"], t["key"], t.get("value")))
-        ]
+        seen = {}
+        for t in final_tags_alt:
+            seen.setdefault((t["namespace"], t["key"], t.get("value")), t)
+        self.tags_alt = list(seen.values())
 
         orm.attributes.flag_modified(self, "tags_alt")
 

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -80,6 +80,8 @@ class LimitedHost(db.Model, HostTypeDeriver):
             tags = {}
             tags_alt = []
         else:
+            if isinstance(tags, dict):
+                tags = self._deduplicate_tags_dict(tags)
             tags_alt = self._populate_tags_alt_from_tags(tags)
         if groups is None:
             groups = []
@@ -112,20 +114,22 @@ class LimitedHost(db.Model, HostTypeDeriver):
         if ansible_host is not None:
             self.ansible_host = ansible_host
 
+    @staticmethod
+    def _deduplicate_tags_dict(tags_dict: dict) -> dict:
+        """Deduplicate values per key in a nested tags dict."""
+        return {
+            ns: {k: list(dict.fromkeys(v)) if isinstance(v, list) else v for k, v in keys.items()} if keys else keys
+            for ns, keys in tags_dict.items()
+        }
+
     def _populate_tags_alt_from_tags(self, tags):
         if isinstance(tags, dict):
             transformed_tags_obj = Tag.create_tags_from_nested(tags)
-            transformed_tags = [tag.data() for tag in transformed_tags_obj]
+            return [tag.data() for tag in transformed_tags_obj]
         elif isinstance(tags, list):
-            transformed_tags = tags
+            return tags
         else:
             raise TypeError("Tags must be dict or list")
-
-        # Deduplicate to ensure no duplicate (namespace, key, value) entries exist.
-        seen = {}
-        for t in transformed_tags:
-            seen.setdefault((t["namespace"], t["key"], t.get("value")), t)
-        return list(seen.values())
 
     @hybrid_property
     def operating_system(self):
@@ -475,6 +479,8 @@ class Host(LimitedHost):
                 title="Invalid request", detail="Tags must be either an object or an array, and cannot be null."
             )
 
+        tags_dict = self._deduplicate_tags_dict(tags_dict)
+
         for namespace, ns_tags in tags_dict.items():
             if ns_tags:
                 self._replace_tags_in_namespace(namespace, ns_tags)
@@ -503,11 +509,7 @@ class Host(LimitedHost):
             for key, values in ns_items.items():
                 final_tags_alt.extend({"namespace": ns, "key": key, "value": value} for value in values)
 
-        # Deduplicate to ensure no duplicate (namespace, key, value) entries exist.
-        seen = {}
-        for t in final_tags_alt:
-            seen.setdefault((t["namespace"], t["key"], t.get("value")), t)
-        self.tags_alt = list(seen.values())
+        self.tags_alt = final_tags_alt
 
         orm.attributes.flag_modified(self, "tags_alt")
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -414,10 +414,13 @@ class Tag:
         tags = []
         for namespace in nested_tags:
             for key in nested_tags[namespace]:
-                if nested_tags[namespace][key] is None or len(nested_tags[namespace][key]) == 0:
+                values = nested_tags[namespace][key]
+                if values is None or (isinstance(values, list) and len(values) == 0):
                     tags.append(Tag(Tag.serialize_namespace(namespace), key, None))
+                elif isinstance(values, str):
+                    tags.append(Tag(Tag.serialize_namespace(namespace), key, values))
                 else:
-                    for value in nested_tags[namespace][key]:
+                    for value in values:
                         tags.append(Tag(Tag.serialize_namespace(namespace), key, value))
         return tags
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -269,6 +269,37 @@ def test_host_models_missing_reporter_field():
         Host(**values)
 
 
+def test_tags_alt_deduplication_on_create():
+    """tags_alt must never contain duplicate (namespace, key, value) entries."""
+    # Simulate a reporter sending duplicate values in the tags list
+    tags_with_dupes = {"ns1": {"key1": ["val1", "val1", "val2"], "key2": ["val3"]}}
+    host = LimitedHost(
+        account=USER_IDENTITY["account_number"],
+        fqdn="dedup-test.example.com",
+        tags=tags_with_dupes,
+    )
+
+    # Verify no duplicates in tags_alt
+    tag_tuples = [(t["namespace"], t["key"], t.get("value")) for t in host.tags_alt]
+    assert len(tag_tuples) == len(set(tag_tuples))
+    assert ("ns1", "key1", "val1") in tag_tuples
+    assert ("ns1", "key1", "val2") in tag_tuples
+    assert ("ns1", "key2", "val3") in tag_tuples
+    assert len(tag_tuples) == 3
+
+
+def test_tags_alt_deduplication_on_update(db_create_host):
+    """Updating tags must not introduce duplicates in tags_alt."""
+    host = db_create_host(extra_data={"tags": {"ns1": {"key1": ["val1"]}}})
+
+    # Update with duplicates in the incoming data
+    host._replace_tags_alt_in_namespace({"ns1": {"key1": ["val1", "val1", "val2"]}})
+
+    tag_tuples = [(t["namespace"], t["key"], t.get("value")) for t in host.tags_alt]
+    assert len(tag_tuples) == len(set(tag_tuples))
+    assert len(tag_tuples) == 2  # val1 + val2, no duplicate val1
+
+
 @pytest.mark.parametrize(
     "tags",
     [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -289,15 +289,19 @@ def test_tags_alt_deduplication_on_create():
 
 
 def test_tags_alt_deduplication_on_update(db_create_host):
-    """Updating tags must not introduce duplicates in tags_alt."""
+    """Updating tags must not introduce duplicates in tags or tags_alt."""
     host = db_create_host(extra_data={"tags": {"ns1": {"key1": ["val1"]}}})
 
-    # Update with duplicates in the incoming data
-    host._replace_tags_alt_in_namespace({"ns1": {"key1": ["val1", "val1", "val2"]}})
+    # Update with duplicates in the incoming data (via _update_tags, the public entry point)
+    host._update_tags({"ns1": {"key1": ["val1", "val1", "val2"]}})
 
+    # Verify tags_alt has no duplicates
     tag_tuples = [(t["namespace"], t["key"], t.get("value")) for t in host.tags_alt]
     assert len(tag_tuples) == len(set(tag_tuples))
     assert len(tag_tuples) == 2  # val1 + val2, no duplicate val1
+
+    # Verify tags column also has no duplicate values
+    assert host.tags["ns1"]["key1"] == ["val1", "val2"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -543,3 +543,72 @@ def test_query_tags_by_conflicting_ids(api_get, query):
         "Only one of [fqdn, display_name, hostname_or_id, insights_id] may be provided at a time."
         in response_data["detail"]
     )
+
+
+def test_get_tags_aggregation_with_multi_value_tags(db_create_multiple_hosts, api_get):
+    """
+    Validate correct aggregation for hosts with multi-value tags.
+    When multiple hosts share the same tag, the count should reflect the number
+    of distinct hosts. Multi-value tags on a single host should produce separate
+    entries in the results.
+    """
+    shared_namespace = "app"
+    shared_key = "env"
+    shared_value = "production"
+    unique_value = "staging"
+
+    # Host 1: has "app/env=production" and "app/env=staging"
+    # Host 2: has "app/env=production" only
+    # Host 3: has a completely different tag
+    db_create_multiple_hosts(
+        how_many=1,
+        extra_data={
+            "tags": _deserialize_tags_dict({shared_namespace: {shared_key: [shared_value, unique_value]}}),
+        },
+    )
+    db_create_multiple_hosts(
+        how_many=1,
+        extra_data={
+            "tags": _deserialize_tags_dict({shared_namespace: {shared_key: [shared_value]}}),
+        },
+    )
+    db_create_multiple_hosts(
+        how_many=1,
+        extra_data={
+            "tags": _deserialize_tags_dict({"other-ns": {"other-key": ["other-value"]}}),
+        },
+    )
+
+    url = build_tags_url(query="?order_by=count&order_how=DESC")
+    response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert response_data["total"] == 3  # 3 distinct tag combinations
+
+    # The shared tag "app/env=production" should have count=2 (two hosts)
+    production_tag = next(
+        r
+        for r in response_data["results"]
+        if r["tag"]["namespace"] == shared_namespace
+        and r["tag"]["key"] == shared_key
+        and r["tag"]["value"] == shared_value
+    )
+    assert production_tag["count"] == 2
+
+    # The unique tag "app/env=staging" should have count=1
+    staging_tag = next(
+        r
+        for r in response_data["results"]
+        if r["tag"]["namespace"] == shared_namespace
+        and r["tag"]["key"] == shared_key
+        and r["tag"]["value"] == unique_value
+    )
+    assert staging_tag["count"] == 1
+
+    # The other tag should have count=1
+    other_tag = next(r for r in response_data["results"] if r["tag"]["namespace"] == "other-ns")
+    assert other_tag["count"] == 1
+
+    # Verify ordering: count DESC means production (2) comes first
+    assert response_data["results"][0]["count"] >= response_data["results"][1]["count"]
+    assert response_data["results"][1]["count"] >= response_data["results"][2]["count"]


### PR DESCRIPTION
## Jira
[RHINENG-28940](https://issues.redhat.com/browse/RHINENG-28940)

## What
Move tag aggregation from Python to SQL for the `GET /api/inventory/v1/tags` endpoint, reducing response time by 70% and eliminating the memory-heavy `.all()` fetch pattern.

## Why
The old implementation fetched ALL hosts into Python memory and aggregated tags in a loop — O(hosts × tags_per_host). For large orgs, this caused high memory usage and ~3.7s response times. 

## How
- Replace Python-side iteration with a PostgreSQL lateral join using `jsonb_array_elements` on `tags_alt`, performing aggregation, search filtering, sorting, and pagination entirely in SQL.
- Use `count(*)` instead of `count(DISTINCT id)` — verified via production `EXPLAIN ANALYZE` that this enables HashAggregate with parallel workers (215ms vs 3705ms for 152k hosts, avoids 154MB disk spill).
- Add deduplication safeguard in both `tags_alt` write paths (`_populate_tags_alt_from_tags` and `_replace_tags_alt_in_namespace`) to structurally guarantee `count(*) == count(DISTINCT id)`. Confirmed zero duplicates exist across all production data via GABI.
- Fix `Tag.create_tags_from_nested` to correctly handle string tag values (was iterating characters).

## Testing
- All 46 existing tag tests pass with no behavioral changes.
- Added unit test for multi-value tag aggregation correctness.
- Added unit tests for `tags_alt` deduplication on create and update paths.
- Local Docker benchmark (10k hosts, 950 unique tags): OLD 320ms → NEW 95ms (70% faster).
- Production `EXPLAIN ANALYZE` via GABI (152k hosts): 3705ms → 215ms (17× faster).

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-28940]: https://redhat.atlassian.net/browse/RHINENG-28940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Move tag aggregation for the inventory tags endpoint from in-memory Python processing to SQL-based aggregation over tags_alt, improving performance and scalability while preserving behavior.

Bug Fixes:
- Correct handling of string tag values when creating tags from nested structures so they are treated as single values rather than iterated characters.

Enhancements:
- Aggregate tags directly in PostgreSQL using tags_alt JSONB, including search, sorting, and pagination, eliminating full host fetches and reducing response time.
- Guarantee uniqueness of (namespace, key, value) entries in tags_alt on both create and update paths to support efficient SQL aggregation.

Tests:
- Add tests covering multi-value tag aggregation behavior and verifying tags_alt deduplication on host creation and update.