### PR TITLE
fix(RHINENG-29084): add missing span kind and messaging attributes

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -276,6 +276,7 @@ class HBIMessageConsumerBase:
     def _message_span_attrs(self, msg, **extra) -> dict:
         """Build common span attributes for a Kafka message."""
         attrs = {
+            "messaging.system": "kafka",
             "messaging.operation": "process",
             "messaging.destination.name": msg.topic() or "",
             "messaging.kafka.partition": msg.partition() or 0,
@@ -303,6 +304,14 @@ class HBIMessageConsumerBase:
 
         return otel_extract(carrier=carrier)
 
+    def _consumer_span_kwargs(self, msg, **extra_attrs) -> dict:
+        """Build common kwargs for consumer spans (shared by _message_span and _retroactive_span)."""
+        producer_ctx = self._producer_ctx or self._extract_producer_context(msg)
+        kwargs = {"attributes": self._message_span_attrs(msg, **extra_attrs)}
+        if producer_ctx is not None:
+            kwargs["context"] = producer_ctx
+        return kwargs
+
     @contextmanager
     def _message_span(self, msg, **extra_attrs):
         """Create a per-message span that automatically enriches from threadctx on exit.
@@ -314,12 +323,9 @@ class HBIMessageConsumerBase:
         Uses self._producer_ctx if set (by _process_single_message_in_batch);
         otherwise extracts the producer context from message headers directly.
         """
-        producer_ctx = self._producer_ctx or self._extract_producer_context(msg)
-        span_kwargs = {"attributes": self._message_span_attrs(msg, **extra_attrs)}
-        if producer_ctx is not None:
-            span_kwargs["context"] = producer_ctx
+        span_kwargs = self._consumer_span_kwargs(msg, **extra_attrs)
 
-        with tracer.start_as_current_span(f"mq.process {msg.topic()}", **span_kwargs) as span:
+        with tracer.start_as_current_span(f"mq.process {msg.topic()}", kind=SpanKind.CONSUMER, **span_kwargs) as span:
             try:
                 yield span
             finally:
@@ -333,15 +339,10 @@ class HBIMessageConsumerBase:
         handle_message() has already run (or raised), so threadctx is
         already populated and enrichment can happen eagerly.
         """
-        producer_ctx = self._extract_producer_context(msg)
-        span_kwargs = {
-            "attributes": self._message_span_attrs(msg, **extra_attrs),
-            "start_time": start_ns,
-        }
-        if producer_ctx is not None:
-            span_kwargs["context"] = producer_ctx
+        span_kwargs = self._consumer_span_kwargs(msg, **extra_attrs)
+        span_kwargs["start_time"] = start_ns
 
-        span = tracer.start_span(f"mq.process {msg.topic()}", **span_kwargs)
+        span = tracer.start_span(f"mq.process {msg.topic()}", kind=SpanKind.CONSUMER, **span_kwargs)
         self._enrich_span_from_threadctx(span)
         yield span
 
@@ -383,7 +384,7 @@ class HBIMessageConsumerBase:
 
         self._producer_ctx, upstream_sc = self._get_upstream_span_context(msg)
         links = [Link(upstream_sc)] if upstream_sc else []
-        attrs = {"messaging.batch.message_index": index}
+        attrs = self._message_span_attrs(msg, **{"messaging.batch.message_index": index})
 
         with tracer.start_as_current_span(f"msg {index}", links=links, attributes=attrs):
             self._process_single_message(msg)


### PR DESCRIPTION
## Jira
[RHINENG-29084](https://issues.redhat.com/browse/RHINENG-29084)

## What
Add `SpanKind.CONSUMER` and `messaging.system` attribute to HBI MQ processing spans so Tempo's metrics-generator can correctly identify them as messaging consumer spans.

## Why
Tempo's metrics-generator uses `SpanKind` + `messaging.system` to build service graph edges and calculate inter-service messaging latency. Without these, the Puptoo→HBI edge doesn't appear in the service graph and queue wait time cannot be measured for dashboards.

## How
- Added `kind=SpanKind.CONSUMER` to `_message_span` and `_retroactive_span` (the two batch-level consumer spans).
- Added `"messaging.system": "kafka"` to `_message_span_attrs` (shared by both span types).
- Added `messaging.system` and `messaging.destination.name` to individual `msg {index}` spans to improve filtering in Grafana (their kind remains INTERNAL since they're children of the batch CONSUMER span).

## Testing
- Verified locally with full Ingress→Puptoo→HBI pipeline using Docker Compose + Tempo + Prometheus + Grafana.
- Confirmed traces in Tempo show correct `SpanKind=CONSUMER` and `messaging.system=kafka` on HBI MQ spans.
- Confirmed Tempo's metrics-generator produces service graph metrics with the Puptoo→HBI edge including messaging latency.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-29084]: https://redhat.atlassian.net/browse/RHINENG-29084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add messaging consumer span metadata to HBI Kafka processing to enable correct identification and metrics generation in Tempo.

Enhancements:
- Set HBI Kafka batch processing spans to SpanKind.CONSUMER and centralize shared consumer span kwargs construction.
- Add messaging.system and messaging.destination.name attributes to batch and per-message spans for improved tracing and Grafana filtering.