### PR TITLE
fix host culling variables data type on foreman-3.18

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -296,23 +296,25 @@ class Config:
             os.environ.get("CONVENTIONAL_TIME_TO_STALE_SECONDS", 104400)
         )  # 29 hours
 
-        self.conventional_time_to_stale_warning_seconds = os.environ.get(
+        self.conventional_time_to_stale_warning_seconds = int(os.environ.get(
             "CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS", days_to_seconds(7)
-        )
+        ))
 
-        self.conventional_time_to_delete_seconds = os.environ.get(
+        self.conventional_time_to_delete_seconds = int(os.environ.get(
             "CONVENTIONAL_TIME_TO_DELETE_SECONDS", days_to_seconds(14)
-        )
+        ))
 
-        self.immutable_time_to_stale_seconds = os.environ.get("IMMUTABLE_TIME_TO_STALE_SECONDS", days_to_seconds(2))
+        self.immutable_time_to_stale_seconds = int(os.environ.get(
+            "IMMUTABLE_TIME_TO_STALE_SECONDS", days_to_seconds(2)
+        ))
 
-        self.immutable_time_to_stale_warning_seconds = os.environ.get(
+        self.immutable_time_to_stale_warning_seconds = int(os.environ.get(
             "IMMUTABLE_TIME_TO_STALE_WARNING_SECONDS", days_to_seconds(180)
-        )
+        ))
 
-        self.immutable_time_to_delete_seconds = os.environ.get(
+        self.immutable_time_to_delete_seconds = int(os.environ.get(
             "IMMUTABLE_TIME_TO_DELETE_SECONDS", days_to_seconds(730)
-        )
+        ))
 
         self.use_sub_man_id_for_host_id = os.environ.get("USE_SUBMAN_ID", "false").lower() == "true"
         self.host_delete_chunk_size = int(os.getenv("HOST_DELETE_CHUNK_SIZE", "1000"))


### PR DESCRIPTION
## Jira
[RHINENG-29233](https://redhat.atlassian.net/browse/RHINENG-29233)

## What
<!-- Short description of the change -->

## Why
<!-- Reason for change / linked ticket -->

## How
<!-- Brief explanation of approach -->

## Testing
<!-- How was this tested? -->

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Bug Fixes:
- Fix incorrect data types for host culling timing configuration by casting environment variables to integers.

[RHINENG-29233]: https://redhat.atlassian.net/browse/RHINENG-29233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Cast host culling-related environment variables to integers to fix incorrect data types in configuration.