### PR TITLE
fix host culling variables data type on foreman-3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/s2i-base:9.8-1784819222 AS kafka_build
+FROM registry.access.redhat.com/ubi9/s2i-base:9.8-1785114049 AS kafka_build
 
 USER 0
 ADD librdkafka .

--- a/app/config.py
+++ b/app/config.py
@@ -296,23 +296,25 @@ class Config:
             os.environ.get("CONVENTIONAL_TIME_TO_STALE_SECONDS", 104400)
         )  # 29 hours
 
-        self.conventional_time_to_stale_warning_seconds = os.environ.get(
+        self.conventional_time_to_stale_warning_seconds = int(os.environ.get(
             "CONVENTIONAL_TIME_TO_STALE_WARNING_SECONDS", days_to_seconds(7)
-        )
+        ))
 
-        self.conventional_time_to_delete_seconds = os.environ.get(
+        self.conventional_time_to_delete_seconds = int(os.environ.get(
             "CONVENTIONAL_TIME_TO_DELETE_SECONDS", days_to_seconds(14)
-        )
+        ))
 
-        self.immutable_time_to_stale_seconds = os.environ.get("IMMUTABLE_TIME_TO_STALE_SECONDS", days_to_seconds(2))
+        self.immutable_time_to_stale_seconds = int(os.environ.get(
+            "IMMUTABLE_TIME_TO_STALE_SECONDS", days_to_seconds(2)
+        ))
 
-        self.immutable_time_to_stale_warning_seconds = os.environ.get(
+        self.immutable_time_to_stale_warning_seconds = int(os.environ.get(
             "IMMUTABLE_TIME_TO_STALE_WARNING_SECONDS", days_to_seconds(180)
-        )
+        ))
 
-        self.immutable_time_to_delete_seconds = os.environ.get(
+        self.immutable_time_to_delete_seconds = int(os.environ.get(
             "IMMUTABLE_TIME_TO_DELETE_SECONDS", days_to_seconds(730)
-        )
+        ))
 
         self.use_sub_man_id_for_host_id = os.environ.get("USE_SUBMAN_ID", "false").lower() == "true"
         self.host_delete_chunk_size = int(os.getenv("HOST_DELETE_CHUNK_SIZE", "1000"))

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -67,13 +67,13 @@ arches:
     name: glibc-headers
     evr: 2.34-274.el9_8
     sourcerpm: glibc-2.34-274.el9_8.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.29.1.el9_8.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-687.30.1.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 2897201
-    checksum: sha256:023287346c8cfd9ca6faf762ac386074d75fc00c682c18a557ce231926106b04
+    size: 2898657
+    checksum: sha256:070047e3c5c86402a72e56e2cf71b77407f2f56c4a4cc55d321ceeb3059a3cda
     name: kernel-headers
-    evr: 5.14.0-687.29.1.el9_8
-    sourcerpm: kernel-5.14.0-687.29.1.el9_8.src.rpm
+    evr: 5.14.0-687.30.1.el9_8
+    sourcerpm: kernel-5.14.0-687.30.1.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/k/keyutils-libs-devel-1.6.3-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 66082
@@ -1443,12 +1443,12 @@ arches:
     checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
     name: gzip
     evr: 1.12-1.el9
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kernel-5.14.0-687.29.1.el9_8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/kernel-5.14.0-687.30.1.el9_8.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
-    size: 152360105
-    checksum: sha256:eb49c7d77925c7b0d189064a153e9902c33852f814664eca25a9f5c5f7e71c11
+    size: 152368772
+    checksum: sha256:84c47952729f3ec970baed4aa2164473a102b3f3d334b03d01e178ca3714e872
     name: kernel
-    evr: 5.14.0-687.29.1.el9_8
+    evr: 5.14.0-687.30.1.el9_8
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/k/keyutils-1.6.3-1.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 150790
@@ -1654,7 +1654,7 @@ arches:
     name: zstd
     evr: 1.5.5-1.el9
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/repodata/feb749649ad1b093794ef875bc9f277ef51963e2e9bd37479fd569acf1851303-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/repodata/f193ca70d87661e8485d85b798a6318bda16b634b8abf289efb1f90a021cc0be-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 63492
-    checksum: sha256:feb749649ad1b093794ef875bc9f277ef51963e2e9bd37479fd569acf1851303
+    checksum: sha256:f193ca70d87661e8485d85b798a6318bda16b634b8abf289efb1f90a021cc0be


### PR DESCRIPTION
## Jira
[RHINENG-29233](https://redhat.atlassian.net/browse/RHINENG-29233)

## What
<!-- Short description of the change -->

## Why
<!-- Reason for change / linked ticket -->

## How
<!-- Brief explanation of approach -->

## Testing
<!-- How was this tested? -->

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-29233]: https://redhat.atlassian.net/browse/RHINENG-29233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Correct host culling timeout configuration to parse environment variable values as integers for all relevant stale and delete intervals.