### PR TITLE
ci: Install uv using COPY --from

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -23,8 +23,12 @@ jobs:
               echo "error: $f must declare ARG UV_VERSION=${PIN} to match uv-build-version" >&2
               exit 1
             fi
-            if ! grep -Fq 'ghcr.io/astral-sh/uv:${UV_VERSION}' "$f"; then
-              echo "error: $f must COPY uv from ghcr.io/astral-sh/uv:\${UV_VERSION}" >&2
+            if ! grep -Fq 'FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv' "$f"; then
+              echo "error: $f must declare FROM ghcr.io/astral-sh/uv:\${UV_VERSION} AS uv" >&2
+              exit 1
+            fi
+            if ! grep -q 'COPY --from=uv ' "$f"; then
+              echo "error: $f must COPY uv binaries from the uv stage" >&2
               exit 1
             fi
           done

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -15,6 +15,20 @@ jobs:
         with:
             fetch-depth: 0
 
+      - name: Verify Dockerfile uv pin matches uv-build-version
+        run: |
+          PIN=$(tr -d '[:space:]' < uv-build-version)
+          for f in Dockerfile Dockerfile.upstream dev.dockerfile; do
+            if ! grep -q "ARG UV_VERSION=${PIN}" "$f"; then
+              echo "error: $f must declare ARG UV_VERSION=${PIN} to match uv-build-version" >&2
+              exit 1
+            fi
+            if ! grep -Fq 'ghcr.io/astral-sh/uv:${UV_VERSION}' "$f"; then
+              echo "error: $f must COPY uv from ghcr.io/astral-sh/uv:\${UV_VERSION}" >&2
+              exit 1
+            fi
+          done
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Red Hat Insights Host Based Inventory (HBI) — Flask REST API managing system i
 - Main app: `uv sync --frozen` at repo root. IQE: `uv --project iqe-host-inventory-plugin sync --frozen` (see `docs/IQE.md`). Both use uv with separate venvs and lockfiles.
 - Set a minimum `uv` CLI version via `[tool.uv] required-version` in `pyproject.toml` (for Dependabot/MintMaker compatibility).
 - Pin the exact `uv` version used in hermetic builds via `uv-build-version` (must satisfy `required-version`).
-- Dockerfiles install uv via `COPY --from=ghcr.io/astral-sh/uv:<version>` — update the tag in all Dockerfiles when bumping `uv`.
+- Dockerfiles install uv via `COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION}` with `ARG UV_VERSION` defaulted to the same pin as `uv-build-version` (CI checks they match). Override with `--build-arg UV_VERSION=…` when needed. Runtime images do not include `pip`; use `uv`.
 - Auth uses `x-rh-identity` header (Base64-encoded JSON with org_id) — org_id isolates tenant data
 - DB schema is `hbi.*` with partitioned tables
 - The `hbi-web` container auto-reloads on code changes — no manual restart needed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@ Red Hat Insights Host Based Inventory (HBI) — Flask REST API managing system i
 
 - Main app: `uv sync --frozen` at repo root. IQE: `uv --project iqe-host-inventory-plugin sync --frozen` (see `docs/IQE.md`). Both use uv with separate venvs and lockfiles.
 - Set a minimum `uv` CLI version via `[tool.uv] required-version` in `pyproject.toml` (for Dependabot/MintMaker compatibility).
-- Pin the exact `uv` version used in container and hermetic builds via `uv-build-version` (`UV_VERSION=x.y.z`; must satisfy `required-version`). Container builds pass it as a Docker/buildah build-arg.
-- Dockerfiles install uv via `COPY --from=ghcr.io/astral-sh/uv:<version>` — update the tag in all Dockerfiles when bumping `uv-build-version`.
+- Pin the exact `uv` version used in hermetic builds via `uv-build-version` (must satisfy `required-version`).
+- Dockerfiles install uv via `COPY --from=ghcr.io/astral-sh/uv:<version>` — update the tag in all Dockerfiles when bumping `uv`.
 - Auth uses `x-rh-identity` header (Base64-encoded JSON with org_id) — org_id isolates tenant data
 - DB schema is `hbi.*` with partitioned tables
 - The `hbi-web` container auto-reloads on code changes — no manual restart needed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ Red Hat Insights Host Based Inventory (HBI) — Flask REST API managing system i
 
 - Main app: `uv sync --frozen` at repo root. IQE: `uv --project iqe-host-inventory-plugin sync --frozen` (see `docs/IQE.md`). Both use uv with separate venvs and lockfiles.
 - Set a minimum `uv` CLI version via `[tool.uv] required-version` in `pyproject.toml` (for Dependabot/MintMaker compatibility).
-- Pin the exact `uv` version used in container and hermetic builds via `uv-build-version` (must satisfy `required-version`).
+- Pin the exact `uv` version used in container and hermetic builds via `uv-build-version` (`UV_VERSION=x.y.z`; must satisfy `required-version`). Container builds pass it as a Docker/buildah build-arg.
+- Dockerfiles install uv via `COPY --from=ghcr.io/astral-sh/uv:<version>` — update the tag in all Dockerfiles when bumping `uv-build-version`.
 - Auth uses `x-rh-identity` header (Base64-encoded JSON with org_id) — org_id isolates tenant data
 - DB schema is `hbi.*` with partitioned tables
 - The `hbi-web` container auto-reloads on code changes — no manual restart needed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Red Hat Insights Host Based Inventory (HBI) — Flask REST API managing system i
 - Main app: `uv sync --frozen` at repo root. IQE: `uv --project iqe-host-inventory-plugin sync --frozen` (see `docs/IQE.md`). Both use uv with separate venvs and lockfiles.
 - Set a minimum `uv` CLI version via `[tool.uv] required-version` in `pyproject.toml` (for Dependabot/MintMaker compatibility).
 - Pin the exact `uv` version used in hermetic builds via `uv-build-version` (must satisfy `required-version`).
-- Dockerfiles install uv via `COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION}` with `ARG UV_VERSION` defaulted to the same pin as `uv-build-version` (CI checks they match). Override with `--build-arg UV_VERSION=…` when needed. Runtime images do not include `pip`; use `uv`.
+- Dockerfiles install uv via a `FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv` stage (global `ARG UV_VERSION` defaulted to the same pin as `uv-build-version`; CI checks they match). Override with `--build-arg UV_VERSION=…` when needed. Runtime images do not include `pip`; use `uv`.
 - Auth uses `x-rh-identity` header (Base64-encoded JSON with org_id) — org_id isolates tenant data
 - DB schema is `hbi.*` with partitioned tables
 - The `hbi-web` container auto-reloads on code changes — no manual restart needed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# Keep default in sync with uv-build-version (enforced in checks.yaml)
+ARG UV_VERSION=0.11.21
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
 FROM registry.access.redhat.com/ubi9/s2i-base:9.8-1784784059 AS kafka_build
 
 USER 0
@@ -53,9 +57,7 @@ COPY run.py run.py
 COPY wait_for_migrations.py wait_for_migrations.py
 COPY jobs/ jobs/
 
-# Keep default in sync with uv-build-version (enforced in checks.yaml)
-ARG UV_VERSION=0.11.21
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
+COPY --from=uv /uv /uvx /bin/
 
 ENV UV_COMPILE_BYTECODE=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,6 @@ COPY logconfig.yaml logconfig.yaml
 COPY manage.py manage.py
 COPY pyproject.toml pyproject.toml
 COPY uv.lock uv.lock
-COPY uv-build-version uv-build-version
-COPY scripts/get_uv_pip_specifier.py scripts/get_uv_pip_specifier.py
 COPY pytest.ini pytest.ini
 COPY run_gunicorn.py run_gunicorn.py
 COPY run_command.sh run_command.sh
@@ -55,12 +53,13 @@ COPY run.py run.py
 COPY wait_for_migrations.py wait_for_migrations.py
 COPY jobs/ jobs/
 
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
+
 ENV PIP_NO_CACHE_DIR=1
 ENV UV_COMPILE_BYTECODE=1
 
-RUN UV_SPEC=$(python3 scripts/get_uv_pip_specifier.py --build-pin) && \
-    python3 -m pip install --upgrade pip setuptools wheel && \
-    python3 -m pip install "uv${UV_SPEC}" dumb-init && \
+RUN python3 -m pip install --upgrade pip setuptools wheel && \
+    python3 -m pip install dumb-init && \
     uv sync --frozen --no-dev && \
     chown -R 1001:0 "$APP_ROOT/.venv"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ COPY run.py run.py
 COPY wait_for_migrations.py wait_for_migrations.py
 COPY jobs/ jobs/
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
+# Keep default in sync with uv-build-version (enforced in checks.yaml)
+ARG UV_VERSION=0.11.21
+COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
 
 ENV UV_COMPILE_BYTECODE=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV APP_ROOT=/opt/app-root/src
 WORKDIR $APP_ROOT
 
 RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $pgRepo) && \
-    microdnf install --setopt=tsflags=nodocs -y postgresql python3.12 python3.12-pip rsync tar procps-ng make git && \
+    microdnf install --setopt=tsflags=nodocs -y postgresql python3.12 rsync tar procps-ng make git && \
     microdnf update -y gnupg2 glib2 libcap && \
     rpm -qa | sort > packages-before-devel-install.txt && \
     microdnf install --setopt=tsflags=nodocs -y libpq-devel python3.12-devel gcc libatomic cargo rust glibc-devel krb5-libs krb5-devel libffi-devel gcc-c++ make zlib zlib-devel openssl-libs openssl-devel libzstd libzstd-devel unzip which diffutils && \
@@ -55,11 +55,9 @@ COPY jobs/ jobs/
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
 
-ENV PIP_NO_CACHE_DIR=1
 ENV UV_COMPILE_BYTECODE=1
 
-RUN python3 -m pip install --upgrade pip setuptools wheel && \
-    python3 -m pip install dumb-init && \
+RUN uv pip install --system dumb-init && \
     uv sync --frozen --no-dev && \
     chown -R 1001:0 "$APP_ROOT/.venv"
 

--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -39,7 +39,9 @@ COPY run_command.sh run_command.sh
 COPY run.py run.py
 COPY jobs/ jobs/
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
+# Keep default in sync with uv-build-version (enforced in checks.yaml)
+ARG UV_VERSION=0.11.21
+COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
 
 ENV UV_COMPILE_BYTECODE=1
 

--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -1,3 +1,7 @@
+# Keep default in sync with uv-build-version (enforced in checks.yaml)
+ARG UV_VERSION=0.11.21
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG pgRepo="https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo"
@@ -39,9 +43,7 @@ COPY run_command.sh run_command.sh
 COPY run.py run.py
 COPY jobs/ jobs/
 
-# Keep default in sync with uv-build-version (enforced in checks.yaml)
-ARG UV_VERSION=0.11.21
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
+COPY --from=uv /uv /uvx /bin/
 
 ENV UV_COMPILE_BYTECODE=1
 

--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -10,7 +10,7 @@ WORKDIR $APP_ROOT
 
 RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $pgRepo) && \
     microdnf upgrade -y && \
-    microdnf install --setopt=tsflags=nodocs -y postgresql python3.12 python3.12-pip rsync tar procps-ng make && \
+    microdnf install --setopt=tsflags=nodocs -y postgresql python3.12 rsync tar procps-ng make && \
     rpm -qa | sort > packages-before-devel-install.txt && \
     microdnf install --setopt=tsflags=nodocs -y libpq-devel python3.12-devel gcc libatomic cargo rust && \
     rpm -qa | sort > packages-after-devel-install.txt && \
@@ -41,11 +41,9 @@ COPY jobs/ jobs/
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
 
-ENV PIP_NO_CACHE_DIR=1
 ENV UV_COMPILE_BYTECODE=1
 
-RUN python3.12 -m pip install --upgrade pip setuptools wheel && \
-    python3.12 -m pip install dumb-init && \
+RUN uv pip install --system dumb-init && \
     uv sync --frozen && \
     chown -R 1001:0 "$APP_ROOT/.venv"
 

--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -33,20 +33,19 @@ COPY logconfig.yaml logconfig.yaml
 COPY manage.py manage.py
 COPY pyproject.toml pyproject.toml
 COPY uv.lock uv.lock
-COPY uv-build-version uv-build-version
-COPY scripts/get_uv_pip_specifier.py scripts/get_uv_pip_specifier.py
 COPY pytest.ini pytest.ini
 COPY run_gunicorn.py run_gunicorn.py
 COPY run_command.sh run_command.sh
 COPY run.py run.py
 COPY jobs/ jobs/
 
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
+
 ENV PIP_NO_CACHE_DIR=1
 ENV UV_COMPILE_BYTECODE=1
 
-RUN UV_SPEC=$(python3.12 scripts/get_uv_pip_specifier.py --build-pin) && \
-    python3.12 -m pip install --upgrade pip setuptools wheel && \
-    python3.12 -m pip install "uv${UV_SPEC}" dumb-init && \
+RUN python3.12 -m pip install --upgrade pip setuptools wheel && \
+    python3.12 -m pip install dumb-init && \
     uv sync --frozen && \
     chown -R 1001:0 "$APP_ROOT/.venv"
 

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -27,18 +27,18 @@ COPY logconfig.yaml logconfig.yaml
 COPY manage.py manage.py
 COPY pyproject.toml pyproject.toml
 COPY uv.lock uv.lock
-COPY uv-build-version uv-build-version
-COPY scripts/get_uv_pip_specifier.py scripts/get_uv_pip_specifier.py
 COPY pytest.ini pytest.ini
 COPY run_gunicorn.py run_gunicorn.py
 COPY run_command.sh run_command.sh
 COPY run.py run.py
+
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
+
 RUN chown -R 1001:0 ./
 USER 1001
 
 ENV PATH="$APP_ROOT/.venv/bin:$PATH"
 
-RUN UV_SPEC=$(python3 scripts/get_uv_pip_specifier.py --build-pin) && pip install "uv${UV_SPEC}" && \
-    uv sync --frozen
+RUN uv sync --frozen
 
 CMD bash -c 'make upgrade_db && make run_inv_mq_service'

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -1,3 +1,7 @@
+# Keep default in sync with uv-build-version (enforced in checks.yaml)
+ARG UV_VERSION=0.11.21
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
 FROM registry.access.redhat.com/ubi9/python-312
 
 ENV APP_ROOT=/opt/app-root/src
@@ -32,9 +36,7 @@ COPY run_gunicorn.py run_gunicorn.py
 COPY run_command.sh run_command.sh
 COPY run.py run.py
 
-# Keep default in sync with uv-build-version (enforced in checks.yaml)
-ARG UV_VERSION=0.11.21
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
+COPY --from=uv /uv /uvx /bin/
 
 RUN chown -R 1001:0 ./
 USER 1001

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -32,7 +32,9 @@ COPY run_gunicorn.py run_gunicorn.py
 COPY run_command.sh run_command.sh
 COPY run.py run.py
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /uvx /bin/
+# Keep default in sync with uv-build-version (enforced in checks.yaml)
+ARG UV_VERSION=0.11.21
+COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
 
 RUN chown -R 1001:0 ./
 USER 1001

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,4 +1,4 @@
-packages: [cargo, diffutils, gcc, gcc-c++, git, glibc-devel, krb5-devel, krb5-libs, libffi-devel, libpq-devel, libzstd, libzstd-devel, make, openssl-devel, openssl-libs, postgresql, procps-ng, python3.12, python3.12-devel, python3.12-pip, rsync, rust, tar, unzip, which, zlib, zlib-devel]
+packages: [cargo, diffutils, gcc, gcc-c++, git, glibc-devel, krb5-devel, krb5-libs, libffi-devel, libpq-devel, libzstd, libzstd-devel, make, openssl-devel, openssl-libs, postgresql, procps-ng, python3.12, python3.12-devel, rsync, rust, tar, unzip, which, zlib, zlib-devel]
 contentOrigin:
   repofiles: [".hermetic_builds/redhat.repo"]
 moduleEnable: ["postgresql:16"]

--- a/tools/simple-test/init.sh
+++ b/tools/simple-test/init.sh
@@ -2,6 +2,6 @@
 set -e
 
 cd tools/simple-test/
-python3 -m venv venv
+uv venv venv
 source venv/bin/activate
-pip install -r requirements.txt
+uv pip install -r requirements.txt


### PR DESCRIPTION
## Jira
None

## What
Update our container builds to install `uv` using `COPY --from` rather than `pip install`.

## Why
Should be faster, and removes reliance on pip as an intermediary for `uv` installation.

## How
Removed the `pip install` command for uv.

## Testing
`podman compose -f dev.yml up -d`

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Install the uv CLI in application containers via a multi-stage COPY rather than pip and update related configuration and docs accordingly.

Enhancements:
- Update Dockerfile and dev.dockerfile to obtain uv from the official uv container image using COPY --from instead of installing it via pip.
- Remove the python3.12-pip dependency from the base image and rely on the bundled uv binary to manage Python packages, including installing dumb-init.
- Adjust project documentation to describe the new Dockerfile-based uv installation method and limit uv-build-version pinning to hermetic builds.