### PR TITLE
ci: Use squash merge type in github workflows

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -26,7 +26,7 @@ jobs:
         if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
         run: |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto --merge "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Enable auto-merge for the base image PR
         if: ${{ steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated' }}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/konflux-automerge.yaml
+++ b/.github/workflows/konflux-automerge.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Enable auto-merge for Konflux PRs
         run: |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto --merge "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Jira
None

## What
Use `--squash` instead of `--merge` or `--rebase`.

## Why
`--rebase` causes problems with the signed/verified commit rule, and basic `--merge` isn't allowed. `--squash` is our default for merges, so this param value should be allowed.

## How
Simple find & replace

## Testing
None - CI will test after merging

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

CI:
- Change all GitHub CLI auto-merge commands in workflows to use the --squash merge strategy.