### PR TITLE
tests: Use both RBAC v2 feature flags

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/modeling/unleash.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/modeling/unleash.py
@@ -67,7 +67,7 @@ class HBIUnleash(BaseEntity):
 
     @cached_property
     def rbac_workspaces_flag(self) -> str:
-        feature_flag = "hbi.rbac-v2"
+        feature_flag = "platform.rbac.workspaces"
 
         if isinstance(self._unleash, UnleashBackend) and not self._unleash.has_flag(feature_flag):
             flag_request = UnleashFlagRequest(
@@ -95,9 +95,28 @@ class HBIUnleash(BaseEntity):
 
         return feature_flag
 
+    @cached_property
+    def hbi_rbac_v2_flag(self) -> str:
+        feature_flag = "hbi.rbac-v2"
+
+        if isinstance(self._unleash, UnleashBackend) and not self._unleash.has_flag(feature_flag):
+            flag_request = UnleashFlagRequest(
+                name=feature_flag,
+                description="HBI RBAC v2 authz checks toggle",
+                type=_RequestType.RELEASE,
+                impressionData=False,
+            )
+            self._unleash.admin.create_flag(flag_request=flag_request)
+
+        return feature_flag
+
     def is_flag_enabled(self, flag: str) -> bool:
         return self._unleash.is_enabled(flag, context={"orgId": get_org_id(self.application)})
 
     @cached_property
     def is_rbac_workspaces_enabled(self) -> bool:
         return self.is_flag_enabled(self.rbac_workspaces_flag)
+
+    @cached_property
+    def is_hbi_rbac_v2_enabled(self) -> bool:
+        return self.is_flag_enabled(self.hbi_rbac_v2_flag)

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/conftest.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/conftest.py
@@ -194,6 +194,9 @@ def enable_kessel_backend_flags(
         host_inventory.unleash.toggle_feature_flag(
             host_inventory.unleash.rbac_workspace_access_check_v2_flag, enable=True
         )
+        host_inventory.unleash.toggle_feature_flag(
+            host_inventory.unleash.hbi_rbac_v2_flag, enable=True
+        )
         _ensure_ungrouped_group_exists(host_inventory)
         _ensure_ungrouped_group_exists(host_inventory_secondary)
 

--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_get_list.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/groups/test_groups_get_list.py
@@ -182,7 +182,6 @@ def test_groups_get_list_pagination_only_my_groups(
 def test_groups_get_list_ordering(
     host_inventory,
     setup_groups_for_ordering,
-    is_rbac_workspaces_enabled_session,
     order_by,
     order_how,
 ):
@@ -214,7 +213,6 @@ def test_groups_get_list_ordering(
 def test_groups_get_list_ordering_and_pagination(
     host_inventory,
     setup_groups_for_ordering,
-    is_rbac_workspaces_enabled_session,
     order_by,
     order_how,
 ):
@@ -252,7 +250,6 @@ def test_groups_get_list_ordering_and_pagination(
 def test_groups_get_list_order_how_default(
     host_inventory,
     setup_groups_for_ordering,
-    is_rbac_workspaces_enabled_session,
     order_by,
 ):
     """

--- a/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/utils/rbac_utils.py
@@ -61,6 +61,6 @@ def wait_for_kessel_sync(host_inventory: ApplicationHostInventory) -> None:
     Wait for RBAC -> Kessel sync if the hbi.rbac-v2 feature flag is enabled.
     """
     wait_seconds = 3 if host_inventory.application.config.current_env == "clowder_smoke" else 21
-    if host_inventory.unleash.is_rbac_workspaces_enabled:
+    if host_inventory.unleash.is_hbi_rbac_v2_enabled:
         logger.info(f"Waiting {wait_seconds} seconds for RBAC -> Kessel sync...")
         sleep(wait_seconds)


### PR DESCRIPTION
## What
Use both `platform.rbac.workspaces` and `hbi.rbac-v2` feature flags at the places where they should be used.

## Why
Before this PR, the IQE would check `hbi.rbac-v2` to know if it should use RBAC v2 write endpoints for setting up RBAC permissions. If that happens, we can't go back to using v1, even if we decide to lower the gradual rollout of the flag. Then, we wouldn't have a testing account for v1.

## How
- Use `platform.rbac.workspaces` in `rbac_workspaces_flag` method
- Add new methods for `hbi.rbac-v2`
- Start referencing the correct flags in other places in the IQE plugin

## Testing
This was tested against Prod, Stage, and ephemeral as part of this PR: https://github.com/RedHatInsights/insights-host-inventory/pull/4685

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Align RBAC-related feature flag usage so workspace behavior and RBAC v2 authorization checks are controlled by their respective flags.

Enhancements:
- Use the platform.rbac.workspaces flag for workspace-related behavior instead of hbi.rbac-v2.
- Expose dedicated helpers for the hbi.rbac-v2 flag and its enabled state for RBAC v2 authorization checks.
- Update RBAC sync utilities to rely on the hbi.rbac-v2 flag when deciding whether to wait for Kessel synchronization.

Tests:
- Toggle the new hbi.rbac-v2 flag in test setup and remove an obsolete RBAC workspaces-enabled session fixture from group listing tests.