### PR TITLE
tests(RHINENG-29334): Fix test_filter_hosts_by_system_profile_bootc_status

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_filter_hosts.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/rest/test_filter_hosts.py
@@ -1330,8 +1330,8 @@ def test_filter_hosts_by_system_profile_object_nil(
         (
             [
                 (
-                    "[booted][image_digest][]=sha256:",
-                    "abcdefABCDEF01234567890000000000000000000000000000000000000000a7",
+                    "[booted][image_digest][]=sha256:"
+                    "abcdefABCDEF01234567890000000000000000000000000000000000000000a7"
                 )
             ],
             [7],


### PR DESCRIPTION
## Jira
[RHINENG-29334](https://issues.redhat.com/browse/RHINENG-29334)

## What
Fix test_filter_hosts_by_system_profile_bootc_status

## Why
It is failing on all PRs. It got broken here: https://github.com/RedHatInsights/insights-host-inventory/commit/278f22fc3ae892ea9ba51e510e4130544de4cfd6

## How
Remove the commas that blocked the multi-line string concatenation.

## Testing
I ran the test in ephemeral and it passed

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-29334]: https://redhat.atlassian.net/browse/RHINENG-29334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Tests:
- Update test_filter_hosts_by_system_profile_bootc_status to use a properly concatenated image_digest filter string, restoring test pass status.