### PR TITLE
feat(RHINENG-29632): per-message OTel spans with full lifecycle coverage

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -6,15 +6,16 @@ import sys
 import time
 import uuid
 from collections.abc import Callable
-from contextlib import contextmanager
 from contextlib import suppress
 from copy import deepcopy
 from datetime import datetime
 from functools import partial
 from typing import Any
+from typing import ClassVar
 from uuid import UUID
 
 from confluent_kafka import Consumer
+from confluent_kafka import Message
 from connexion import FlaskApp
 from flask_sqlalchemy.model import Model
 from marshmallow import Schema
@@ -22,12 +23,11 @@ from marshmallow import ValidationError
 from marshmallow import fields
 from marshmallow import validate
 from opentelemetry import context as otel_context_api
-from opentelemetry import trace
+from opentelemetry import trace as trace_api
+from opentelemetry.context import Context as OtelContext
 from opentelemetry.propagate import extract as otel_extract
-from opentelemetry.trace import Link
 from opentelemetry.trace import SpanKind
 from opentelemetry.trace import StatusCode
-from psycopg2.errors import DeadlockDetected
 from psycopg2.errors import UniqueViolation
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from sqlalchemy.exc import IntegrityError
@@ -78,6 +78,7 @@ from app.queue.events import extract_system_profile_fields_for_headers
 from app.queue.events import message_headers
 from app.queue.events import operation_results_to_event_type
 from app.queue.mq_common import common_message_parser
+from app.queue.mq_common import decode_kafka_headers
 from app.queue.notifications import NotificationType
 from app.queue.notifications import send_notification
 from app.serialization import deserialize_host
@@ -89,12 +90,13 @@ from app.telemetry import OTEL_MQ_ENABLED
 from app.telemetry import OTEL_MQ_MESSAGE_SPANS_ENABLED
 from app.telemetry import OTEL_MQ_SLOW_MESSAGE_MS
 from app.telemetry import get_tracer
+from app.telemetry import use_otel_context
 from lib import group_repository
 from lib import host_app_repository
 from lib import host_repository
+from lib.db import is_deadlock_error
 from lib.db import no_expire_on_commit
 from lib.db import raw_db_connection
-from lib.db import session_guard
 from lib.feature_flags import FLAG_INVENTORY_REJECT_RHSM_PAYLOADS
 from lib.feature_flags import get_flag_value
 from lib.group_repository import UngroupedGroupCache
@@ -106,14 +108,6 @@ tracer = get_tracer(__name__)
 
 CONSUMER_POLL_TIMEOUT_SECONDS = 0.5
 MAX_RETRIES = 5
-
-
-def _is_deadlock_error(error: Exception) -> bool:
-    """Return True when the exception (or its DBAPI cause) is a PostgreSQL deadlock."""
-    if isinstance(error, DeadlockDetected):
-        return True
-    orig = getattr(error, "orig", None)
-    return isinstance(orig, DeadlockDetected)
 
 
 SYSTEM_IDENTITY = {"auth_type": "cert-auth", "system": {"cert_type": "system"}, "type": "System"}
@@ -192,17 +186,6 @@ class HostAppOperationSchema(Schema):
     hosts = fields.List(fields.Nested(HostAppDataSchema), required=True)
 
 
-@contextmanager
-def _use_otel_context(ctx):
-    """Temporarily activate an OTel context (or no-op if None)."""
-    token = otel_context_api.attach(ctx) if ctx is not None else None
-    try:
-        yield
-    finally:
-        if token is not None:
-            otel_context_api.detach(token)
-
-
 # Helper class to facilitate batch operations
 class OperationResult:
     def __init__(
@@ -218,10 +201,13 @@ class OperationResult:
         self.staleness_object = so
         self.event_type = et
         self.success_logger = sl
-        self.otel_context = None
+        self.otel_context: OtelContext | None = None
+        self.otel_span = None
 
 
 class HBIMessageConsumerBase:
+    _has_upstream_trace: ClassVar[bool] = False
+
     def __init__(
         self,
         consumer: Consumer,
@@ -236,7 +222,7 @@ class HBIMessageConsumerBase:
         self.processed_rows: list[OperationResult] = []
         self._is_retry = False
         self._messages_pending_retry: list | None = None
-        self._producer_ctx = None
+        self._producer_ctx: OtelContext | None = None
 
     @property
     def success_metric(self):
@@ -269,22 +255,43 @@ class HBIMessageConsumerBase:
     def post_process_rows(self) -> None:
         pass  # No action is taken by default
 
+    def _end_all_deferred_spans(self, error: Exception | None = None) -> None:
+        """Enrich and end any deferred mq.process spans still open on processed_rows.
+
+        Used as a safety net on error paths (flush/commit failure) and after
+        post_process_rows. If an error is provided, marks all open spans with
+        error status before ending them.
+        """
+        for result in self.processed_rows:
+            if result is not None and result.otel_span is not None:
+                if error:
+                    self._mark_span_error(result.otel_span, error)
+                self._enrich_span_from_threadctx(result.otel_span)
+                result.otel_span.end()
+                result.otel_span = None
+
     def _should_emit_message_span(self) -> bool:
         """Whether a per-message child span should be started eagerly."""
         return OTEL_MQ_ENABLED and (OTEL_MQ_MESSAGE_SPANS_ENABLED or self._is_retry)
 
-    def _message_span_attrs(self, msg, **extra) -> dict:
+    def _message_span_attrs(self, msg: Message, **extra) -> dict:
         """Build common span attributes for a Kafka message."""
         attrs = {
             "messaging.system": "kafka",
-            "messaging.operation": "process",
+            "messaging.operation.name": "process",
             "messaging.destination.name": msg.topic() or "",
             "messaging.kafka.partition": msg.partition() or 0,
         }
         attrs.update(extra)
         return attrs
 
-    def _extract_producer_context(self, msg):
+    def _mark_span_error(self, span, exc: Exception) -> None:
+        """Record an error on a span if it's recording."""
+        if span and span.is_recording():
+            span.set_status(StatusCode.ERROR, str(exc))
+            span.record_exception(exc)
+
+    def _extract_producer_context(self, msg: Message) -> OtelContext | None:
         """Extract W3C trace context from Kafka message headers.
 
         The returned context is used as the parent for per-message spans, making
@@ -293,11 +300,8 @@ class HBIMessageConsumerBase:
 
         Returns None if no valid context is found in the message headers.
         """
-        headers = msg.headers() or []
-        carrier = {}
-        for key, value in headers:
-            if key in ("traceparent", "tracestate"):
-                carrier[key] = value.decode("utf-8") if isinstance(value, bytes) else value
+        decoded = decode_kafka_headers(msg.headers())
+        carrier = {k: v for k, v in decoded.items() if k in ("traceparent", "tracestate")}
 
         if not carrier:
             return None
@@ -305,46 +309,26 @@ class HBIMessageConsumerBase:
         return otel_extract(carrier=carrier)
 
     def _consumer_span_kwargs(self, msg, **extra_attrs) -> dict:
-        """Build common kwargs for consumer spans (shared by _message_span and _retroactive_span)."""
+        """Build common kwargs for consumer spans."""
         producer_ctx = self._producer_ctx or self._extract_producer_context(msg)
         kwargs = {"attributes": self._message_span_attrs(msg, **extra_attrs)}
         if producer_ctx is not None:
             kwargs["context"] = producer_ctx
         return kwargs
 
-    @contextmanager
-    def _message_span(self, msg, **extra_attrs):
-        """Create a per-message span that automatically enriches from threadctx on exit.
-
-        Enrichment is deferred to span exit because handle_message() populates
-        threadctx during processing. Using this context manager means callers
-        never need to call _enrich_span_from_threadctx manually.
-
-        Uses self._producer_ctx if set (by _process_single_message_in_batch);
-        otherwise extracts the producer context from message headers directly.
-        """
-        span_kwargs = self._consumer_span_kwargs(msg, **extra_attrs)
-
-        with tracer.start_as_current_span(f"mq.process {msg.topic()}", kind=SpanKind.CONSUMER, **span_kwargs) as span:
-            try:
-                yield span
-            finally:
-                self._enrich_span_from_threadctx(span)
-
-    @contextmanager
-    def _retroactive_span(self, msg, start_ns: int, **extra_attrs):
+    def _create_retroactive_span(self, msg, start_ns: int, **extra_attrs):
         """Create a retroactive span that automatically enriches from threadctx.
 
-        Unlike _message_span, retroactive spans are always created after
-        handle_message() has already run (or raised), so threadctx is
-        already populated and enrichment can happen eagerly.
+        Unlike _message_span, retroactive spans are created after handle_message()
+        has already run (or raised), so threadctx is already populated.
+        Callers are responsible for calling span.end(end_time=...).
         """
         span_kwargs = self._consumer_span_kwargs(msg, **extra_attrs)
         span_kwargs["start_time"] = start_ns
 
         span = tracer.start_span(f"mq.process {msg.topic()}", kind=SpanKind.CONSUMER, **span_kwargs)
         self._enrich_span_from_threadctx(span)
-        yield span
+        return span
 
     def _emit_slow_message_span(self, msg, start_ns: int, end_ns: int) -> None:
         """Emit a retroactive span for a message that exceeded the slow threshold."""
@@ -355,61 +339,36 @@ class HBIMessageConsumerBase:
             return
 
         extra = {"hbi.slow_message": True, "hbi.duration_ms": duration_ms}
-        with self._retroactive_span(msg, start_ns, **extra) as span:
-            span.end(end_time=end_ns)
+        span = self._create_retroactive_span(msg, start_ns, **extra)
+        span.end(end_time=end_ns)
 
-    def _get_upstream_span_context(self, msg):
-        """Get the upstream producer's SpanContext from message headers (for links).
+    def _process_single_message_in_batch(self, msg: Message) -> None:
+        """Process a single message within a batch, extracting upstream trace context.
 
-        Returns (producer_ctx, span_context) tuple. Either or both may be None.
+        Extracts the producer's span context from message headers so that
+        per-message spans are parented under the upstream trace (e.g. ingress).
+        Flushes the session per-message so SQL operations appear under the message span.
         """
-        producer_ctx = self._extract_producer_context(msg)
-        if producer_ctx is None:
-            return None, None
-        span = trace.get_current_span(producer_ctx)
-        sc = span.get_span_context()
-        if sc and sc.is_valid:
-            return producer_ctx, sc
-        return producer_ctx, None
+        if OTEL_MQ_ENABLED:
+            self._producer_ctx = self._extract_producer_context(msg)
 
-    def _process_single_message_in_batch(self, index: int, msg) -> None:
-        """Wrap message processing with a batch-child span that links to the upstream trace.
+        token = self._process_message_core(msg)
+        try:
+            db.session.flush()
+        finally:
+            if token:
+                otel_context_api.detach(token)
+            self._producer_ctx = None
 
-        Creates a lightweight span under the batch `process` span so operators
-        can navigate from the batch view to each message's end-to-end trace.
-        """
-        if not OTEL_MQ_ENABLED:
-            self._process_single_message(msg)
-            return
-
-        self._producer_ctx, upstream_sc = self._get_upstream_span_context(msg)
-        links = [Link(upstream_sc)] if upstream_sc else []
-        attrs = self._message_span_attrs(msg, **{"messaging.batch.message_index": index})
-
-        with tracer.start_as_current_span(f"msg {index}", links=links, attributes=attrs):
-            self._process_single_message(msg)
-        self._producer_ctx = None
-
-    def _process_single_message(self, msg) -> None:
-        """Process a single Kafka message, conditionally emitting a child span.
-
-        Span emission rules:
-        - Always emit when OTEL_MQ_MESSAGE_SPANS_ENABLED is True (default for stage).
-        - Always emit during retry attempts or on error.
-        - When disabled, emit retroactively for messages exceeding OTEL_MQ_SLOW_MESSAGE_MS.
-        """
+    def _process_single_message(self, msg: Message) -> None:
+        """Process a single Kafka message, conditionally emitting a child span."""
         logger.debug("Message received")
-
-        if self._should_emit_message_span():
-            self._process_message_with_span(msg)
-        else:
-            self._process_message_without_span(msg)
+        token = self._process_message_core(msg)
+        if token:
+            otel_context_api.detach(token)
 
     def _enrich_span_from_threadctx(self, span) -> None:
-        """Add rh.org_id and rh.request_id to a span from thread-local storage.
-
-        Called automatically by _message_span and _retroactive_span context managers.
-        """
+        """Add rh.org_id and rh.request_id to a span from thread-local storage."""
         if not span or not span.is_recording():
             return
         org_id = getattr(threadctx, "org_id", None)
@@ -419,62 +378,81 @@ class HBIMessageConsumerBase:
         if request_id:
             span.set_attribute("rh.request_id", request_id)
 
-    def _process_message_with_span(self, msg) -> None:
-        """Process a message with a full tracing span (used when spans are enabled or on retry)."""
-        with self._message_span(msg, **{"hbi.retry": self._is_retry}) as span:
-            try:
-                result = self.handle_message(msg.value(), headers=msg.headers())
-                if result is not None:
-                    result.otel_context = otel_context_api.get_current()
-                self.processed_rows.append(result)
-                metrics.consumed_message_size.observe(len(str(msg).encode("utf-8")))
-                self.success_metric.inc()
-            except OperationalError as oe:
-                span.set_status(StatusCode.ERROR, str(oe))
-                span.record_exception(oe)
-                # Deadlocks are retriable; let event_loop handle retry instead of exiting.
-                if _is_deadlock_error(oe):
-                    raise
-                logger.error(f"Could not access DB {str(oe)}")
-                sys.exit(3)
-            except Exception as exc:
-                span.set_status(StatusCode.ERROR, str(exc))
-                span.record_exception(exc)
-                self.failure_metric.inc()
-                logger.exception("Unable to process message", extra={"incoming_message": msg.value()})
+    def _start_deferred_message_span(self, msg: Message):
+        """Start a per-message span that will be ended later (after post_process).
 
-    def _process_message_without_span(self, msg) -> None:
-        """Process a message without an eager span; emit retroactively on error or slow threshold."""
-        start_ns = time.time_ns()
+        Returns (span, token) where token is used to detach the context later.
+        If spans are disabled, returns (None, None) and records start_ns instead.
+        """
+        if not self._should_emit_message_span():
+            return None, None
+        span_kwargs = self._consumer_span_kwargs(msg, **{"hbi.retry": self._is_retry})
+        span = tracer.start_span(f"mq.process {msg.topic()}", kind=SpanKind.CONSUMER, **span_kwargs)
+        ctx = trace_api.set_span_in_context(span)
+        token = otel_context_api.attach(ctx)
+        return span, token
+
+    def _process_message_core(self, msg: Message) -> object | None:
+        """Unified message processing with deferred span lifecycle.
+
+        The span is started here but NOT ended — it stays open through flush/commit
+        and post_process, and is ended in post_process_rows() so that its duration
+        reflects the full message lifecycle for accurate metrics.
+
+        Returns the context token so callers can detach after flushing.
+        """
+        span, token = self._start_deferred_message_span(msg)
+        start_ns = None if span else time.time_ns()
         try:
-            self.processed_rows.append(self.handle_message(msg.value(), headers=msg.headers()))
+            result = self.handle_message(msg.value(), headers=msg.headers())
+            if result is not None:
+                result.otel_context = otel_context_api.get_current()
+                result.otel_span = span
+            self.processed_rows.append(result)
             metrics.consumed_message_size.observe(len(str(msg).encode("utf-8")))
             self.success_metric.inc()
         except OperationalError as oe:
-            self._emit_error_span(msg, start_ns, oe)
+            self._record_processing_error(span, msg, start_ns or 0, oe)
+            if span:
+                self._enrich_span_from_threadctx(span)
+                span.end()
+            if token:
+                otel_context_api.detach(token)
             # Deadlocks are retriable; let event_loop handle retry instead of exiting.
-            if _is_deadlock_error(oe):
+            if is_deadlock_error(oe):
                 raise
             logger.error(f"Could not access DB {str(oe)}")
             sys.exit(3)
         except Exception as exc:
-            self._emit_error_span(msg, start_ns, exc)
+            self._record_processing_error(span, msg, start_ns or 0, exc)
+            if span:
+                self._enrich_span_from_threadctx(span)
+                span.end()
+            if token:
+                otel_context_api.detach(token)
             self.failure_metric.inc()
             logger.exception("Unable to process message", extra={"incoming_message": msg.value()})
         else:
-            if OTEL_MQ_SLOW_MESSAGE_MS > 0:
-                end_ns = time.time_ns()
-                self._emit_slow_message_span(msg, start_ns, end_ns)
+            if span is None and OTEL_MQ_SLOW_MESSAGE_MS > 0:
+                self._emit_slow_message_span(msg, start_ns or 0, time.time_ns())
+            return token
+        return None
 
-    def _emit_error_span(self, msg, start_ns: int, exc: Exception) -> None:
+    def _record_processing_error(self, span, msg: Message, start_ns: int, exc: Exception) -> None:
+        """Record error on live span or emit retroactive error span."""
+        if span is not None:
+            self._mark_span_error(span, exc)
+        else:
+            self._emit_error_span(msg, start_ns, exc)
+
+    def _emit_error_span(self, msg: Message, start_ns: int, exc: Exception) -> None:
         """Emit a span for a failed message when routine per-message spans are disabled."""
         if not OTEL_MQ_ENABLED:
             return
         end_ns = time.time_ns()
-        with self._retroactive_span(msg, start_ns, **{"hbi.error": True}) as span:
-            span.set_status(StatusCode.ERROR, str(exc))
-            span.record_exception(exc)
-            span.end(end_time=end_ns)
+        span = self._create_retroactive_span(msg, start_ns, **{"hbi.error": True})
+        self._mark_span_error(span, exc)
+        span.end(end_time=end_ns)
 
     def _consume_valid_messages(self) -> list:
         messages = self.consumer.consume(
@@ -497,9 +475,10 @@ class HBIMessageConsumerBase:
     def _process_batch(self, replay_messages: list | None = None) -> None:
         """Process a single batch of messages from Kafka.
 
-        Creates a manual batch-level span for operational monitoring (batch size,
-        duration, DB queries). Per-message spans are created separately as children
-        of the upstream producer's trace for end-to-end visibility.
+        For host ingestion topics, no batch-level span is created because
+        per-message spans (linked to the upstream producer trace) already
+        capture full end-to-end latency. For non-ingestion topics, a batch
+        span is emitted for operational monitoring.
 
         Args:
             replay_messages: Messages from a failed batch to retry without re-consuming.
@@ -523,41 +502,62 @@ class HBIMessageConsumerBase:
         self._messages_pending_retry = valid_messages
 
         topic = valid_messages[0].topic() or "unknown"
-        span_attrs = {
-            "messaging.system": "kafka",
-            "messaging.destination.name": topic,
-            "messaging.operation.type": "process",
-            "messaging.batch.message_count": len(valid_messages),
-        }
 
-        with tracer.start_as_current_span(
-            f"{topic} process", kind=SpanKind.CONSUMER, attributes=span_attrs
-        ) as batch_span:
+        if self._has_upstream_trace:
+            self._run_batch(valid_messages)
+        else:
+            span_attrs = {
+                "messaging.system": "kafka",
+                "messaging.destination.name": topic,
+                "messaging.operation.type": "process",
+                "messaging.batch.message_count": len(valid_messages),
+            }
+            with tracer.start_as_current_span(
+                f"{topic} process", kind=SpanKind.CONSUMER, attributes=span_attrs
+            ) as batch_span:
+                try:
+                    self._run_batch(valid_messages)
+                except Exception as exc:
+                    self._mark_span_error(batch_span, exc)
+                    raise
+
+    def _run_batch(self, valid_messages: list) -> None:
+        """Execute the batch processing logic (message handling, DB commit, post-processing).
+
+        Each message is flushed individually inside _process_single_message_in_batch
+        so its SQL operations appear as children of its mq.process span.
+        """
+        with no_expire_on_commit(db.session):
             try:
-                with no_expire_on_commit(db.session):
-                    with (
-                        session_guard(db.session, close=False),
-                        db.session.no_autoflush,
-                        StalenessCache(),
-                        UngroupedGroupCache(),
-                    ):
-                        for i, msg in enumerate(valid_messages):
-                            self._process_single_message_in_batch(i, msg)
+                with (
+                    db.session.no_autoflush,
+                    StalenessCache(),
+                    UngroupedGroupCache(),
+                ):
+                    for msg in valid_messages:
+                        self._process_single_message_in_batch(msg)
 
-                    self.post_process_rows()
-                    # Commit Kafka offsets after successful batch processing
-                    if len(self.processed_rows) > 0:
-                        try:
-                            self.consumer.commit(asynchronous=False)
-                            logger.debug(f"Successfully committed offsets for {len(self.processed_rows)} messages")
-                        except Exception as e:
-                            logger.exception(f"Failed to commit Kafka offsets: {e}")
+                db.session.commit()
             except Exception as exc:
-                batch_span.set_status(StatusCode.ERROR, str(exc))
-                batch_span.record_exception(exc)
+                db.session.rollback()
+                self._end_all_deferred_spans(error=exc)
                 raise
-            else:
-                self._messages_pending_retry = None
+
+            try:
+                self.post_process_rows()
+            finally:
+                self._end_all_deferred_spans()
+
+            # Commit Kafka offsets after successful batch processing
+            if len(self.processed_rows) > 0:
+                try:
+                    self.consumer.commit(asynchronous=False)
+                    logger.debug(f"Successfully committed offsets for {len(self.processed_rows)} messages")
+                except Exception as e:
+                    logger.exception(f"Failed to commit Kafka offsets: {e}")
+
+        # Only cleared on success; on exception, event_loop reads _messages_pending_retry for retry
+        self._messages_pending_retry = None
 
     def event_loop(self, interrupt):
         with self.flask_app.app.app_context():
@@ -584,9 +584,9 @@ class HBIMessageConsumerBase:
                             occur when a unique constraint is violated. OperationalError is only retried when
                             it wraps a PostgreSQL deadlock (DeadlockDetected); other operational errors are
                             re-raised so the process can restart.
-                            Note: session_guard already calls rollback() when an exception occurs.
+                            Note: _process_batch already calls rollback() when an exception occurs.
                             """
-                            if isinstance(e, OperationalError) and not _is_deadlock_error(e):
+                            if isinstance(e, OperationalError) and not is_deadlock_error(e):
                                 raise
 
                             retry_messages = self._messages_pending_retry
@@ -691,6 +691,8 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
 
 
 class HostMessageConsumer(HBIMessageConsumerBase):
+    _has_upstream_trace = True
+
     @metrics.ingress_message_handler_time.time()
     def handle_message(self, message: str | bytes, headers: list[tuple[str, bytes]] | None = None) -> OperationResult:
         validated_operation_msg = parse_operation_message(message, HostOperationSchema)
@@ -825,6 +827,9 @@ class IngressMessageConsumer(HostMessageConsumer):
 
 
 class SystemProfileMessageConsumer(HostMessageConsumer):
+    # Overrides parent: system-profile updates come from rhsm-conduit directly, not from ingress
+    _has_upstream_trace = False
+
     def process_message(
         self,
         host_data: dict[str, Any],
@@ -870,6 +875,8 @@ class SystemProfileMessageConsumer(HostMessageConsumer):
 
 class HostAppMessageConsumer(HBIMessageConsumerBase):
     """Consumer for host application data from downstream services (Advisor, Vulnerability, Patch, etc.)."""
+
+    _has_upstream_trace = True
 
     # Mapping of application names to their corresponding model and schema classes
     APPLICATION_MAP = {
@@ -950,17 +957,8 @@ class HostAppMessageConsumer(HBIMessageConsumerBase):
         )
 
     def _extract_headers(self, headers: list[tuple[str, bytes]] | None = None) -> tuple[str | None, str | None]:
-        application = None
-        request_id = None
-
-        if headers:
-            for key, value in headers:
-                if key == "application":
-                    application = value.decode("utf-8") if isinstance(value, bytes) else value
-                elif key == "request_id":
-                    request_id = value.decode("utf-8") if isinstance(value, bytes) else value
-
-        return application, request_id
+        decoded = decode_kafka_headers(headers)
+        return decoded.get("application"), decoded.get("request_id")
 
     def _get_app_classes(self, application: ConsumerApplication) -> tuple[type, type]:
         """Get the model and schema classes for a given application.
@@ -1346,19 +1344,16 @@ def write_add_update_event_message(
             tracker_ctx._success_status_msg = "skipped – host deleted before event production"
             return
 
-        # Re-attach the per-message OTel context so outbound Kafka events carry
-        # the upstream trace
-        with _use_otel_context(result.otel_context):
-            event_producer.write_event(event, str(result.row.id), headers, wait=False)
+        event_producer.write_event(event, str(result.row.id), headers, wait=False)
 
-            if result.event_type.name == HOST_EVENT_TYPE_CREATED:
-                # Notifications are expected to omit null canonical facts
-                remove_null_canonical_facts(output_host)
-                send_notification(
-                    notification_event_producer,
-                    notification_type=NotificationType.new_system_registered,
-                    host=output_host,
-                )
+        if result.event_type.name == HOST_EVENT_TYPE_CREATED:
+            # Notifications are expected to omit null canonical facts
+            remove_null_canonical_facts(output_host)
+            send_notification(
+                notification_event_producer,
+                notification_type=NotificationType.new_system_registered,
+                host=output_host,
+            )
         result.success_logger(output_host)
 
         org_id = output_host.get("org_id")
@@ -1377,6 +1372,21 @@ def write_add_update_event_message(
             logger.error("Error during set cache", ex)
 
 
+def _end_deferred_span(result: OperationResult) -> None:
+    """Enrich and end the deferred mq.process span after post-processing completes."""
+    if result.otel_span is not None:
+        span = result.otel_span
+        if span.is_recording():
+            org_id = getattr(threadctx, "org_id", None)
+            if org_id:
+                span.set_attribute("rh.org_id", org_id)
+            request_id = getattr(threadctx, "request_id", None)
+            if request_id:
+                span.set_attribute("rh.request_id", request_id)
+        span.end()
+        result.otel_span = None
+
+
 def write_message_batch(
     event_producer: EventProducer,
     notification_event_producer: EventProducer,
@@ -1385,10 +1395,13 @@ def write_message_batch(
     for result in processed_rows:
         if result is not None:
             try:
-                write_add_update_event_message(event_producer, notification_event_producer, result)
+                with use_otel_context(result.otel_context):
+                    write_add_update_event_message(event_producer, notification_event_producer, result)
             except Exception as exc:
                 metrics.ingress_message_handler_failure.inc()
                 logger.exception("Error while producing message", exc_info=exc)
+            finally:
+                _end_deferred_span(result)
 
     event_producer.flush()
 

--- a/app/queue/mq_common.py
+++ b/app/queue/mq_common.py
@@ -22,3 +22,11 @@ def common_message_parser(message: str | bytes):
         logger.exception("Unable to parse json message from message queue", extra={"incoming_message": message})
         metrics.common_message_parsing_failure.labels("invalid").inc()
         raise
+
+
+def decode_kafka_headers(headers: list[tuple[str, bytes]] | None) -> dict[str, str]:
+    """Decode Kafka message headers into a plain dict of strings."""
+    result = {}
+    for key, value in headers or []:
+        result[key] = value.decode("utf-8") if isinstance(value, bytes) else value
+    return result

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -22,7 +22,10 @@ Usage:
 
 import contextlib
 import os
+from contextlib import contextmanager
 from urllib.parse import urlparse
+
+from opentelemetry import context as otel_context_api
 
 from app.logging import get_logger
 
@@ -131,6 +134,17 @@ def get_tracer(name: str):
     from opentelemetry import trace
 
     return trace.get_tracer(name)
+
+
+@contextmanager
+def use_otel_context(ctx):
+    """Temporarily activate an OTel context (or no-op if None)."""
+    token = otel_context_api.attach(ctx) if ctx is not None else None
+    try:
+        yield
+    finally:
+        if token is not None:
+            otel_context_api.detach(token)
 
 
 def init_otel(

--- a/lib/db.py
+++ b/lib/db.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 import psycopg2
+from psycopg2.errors import DeadlockDetected
 
 from app.models import db
 
@@ -74,3 +75,11 @@ def raw_db_connection():
         user=url.username,
         password=url.password,
     )
+
+
+def is_deadlock_error(error: Exception) -> bool:
+    """Return True when the exception (or its DBAPI cause) is a PostgreSQL deadlock."""
+    if isinstance(error, DeadlockDetected):
+        return True
+    orig = getattr(error, "orig", None)
+    return isinstance(orig, DeadlockDetected)

--- a/tests/test_mq_message_spans.py
+++ b/tests/test_mq_message_spans.py
@@ -77,6 +77,7 @@ def test_span_emitted_when_enabled(otel_spans, consumer, monkeypatch):
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
 
     consumer._process_single_message(FakeMessage())
+    consumer._end_all_deferred_spans()
 
     spans = otel_spans.get_finished_spans()
     assert len(spans) == 1
@@ -92,6 +93,8 @@ def test_message_span_is_child_of_current_consume_context(otel_spans, consumer, 
 
     with host_mq.tracer.start_as_current_span("inventory process") as consume_span:
         consumer._process_single_message(FakeMessage())
+
+    consumer._end_all_deferred_spans()
 
     process_spans = [span for span in otel_spans.get_finished_spans() if span.name.startswith("mq.process ")]
     assert len(process_spans) == 1
@@ -130,6 +133,7 @@ def test_retry_emits_span_when_disabled(otel_spans, consumer, monkeypatch):
     consumer._is_retry = True
 
     consumer._process_single_message(FakeMessage())
+    consumer._end_all_deferred_spans()
 
     spans = otel_spans.get_finished_spans()
     assert len(spans) == 1
@@ -195,6 +199,7 @@ def test_span_includes_org_id_and_request_id_from_threadctx(otel_spans, consumer
     consumer._handler.side_effect = populate_threadctx
 
     consumer._process_single_message(FakeMessage())
+    consumer._end_all_deferred_spans()
 
     spans = otel_spans.get_finished_spans()
     assert len(spans) == 1
@@ -270,6 +275,7 @@ def test_span_without_threadctx_has_no_rh_attributes(otel_spans, consumer, monke
             delattr(threadctx, attr)
 
     consumer._process_single_message(FakeMessage())
+    consumer._end_all_deferred_spans()
 
     spans = otel_spans.get_finished_spans()
     assert len(spans) == 1
@@ -320,3 +326,59 @@ def test_non_deadlock_operational_error_still_exits(consumer, monkeypatch, spans
         consumer._process_single_message(FakeMessage())
 
     exit_mock.assert_called_once_with(3)
+
+
+def test_process_message_without_span_captures_otel_context(otel_spans, consumer, monkeypatch):
+    """Verify that _process_message_core stores otel_context on the result when spans are disabled."""
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", False)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
+
+    consumer._process_single_message(FakeMessage())
+
+    assert len(otel_spans.get_finished_spans()) == 0
+    assert len(consumer.processed_rows) == 1
+    result = consumer.processed_rows[0]
+    assert result.otel_context is not None
+
+
+def test_end_deferred_span_enriches_with_threadctx(otel_spans, consumer, monkeypatch):
+    """Verify that _end_deferred_span enriches spans with rh.org_id and rh.request_id."""
+    from app.logging import threadctx
+    from app.queue.host_mq import _end_deferred_span
+
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
+
+    consumer._process_single_message(FakeMessage())
+    result = consumer.processed_rows[0]
+    assert result.otel_span is not None
+
+    threadctx.org_id = "enrichment_org"
+    threadctx.request_id = "enrichment_req"
+
+    _end_deferred_span(result)
+
+    assert result.otel_span is None
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes["rh.org_id"] == "enrichment_org"
+    assert spans[0].attributes["rh.request_id"] == "enrichment_req"
+
+
+def test_end_all_deferred_spans_marks_error(otel_spans, consumer, monkeypatch):
+    """Verify that _end_all_deferred_spans records error status on spans when an error is provided."""
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", True)
+    monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_SLOW_MESSAGE_MS", 0)
+
+    consumer._process_single_message(FakeMessage())
+    assert consumer.processed_rows[0].otel_span is not None
+
+    error = RuntimeError("flush failed")
+    consumer._end_all_deferred_spans(error=error)
+
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code.name == "ERROR"


### PR DESCRIPTION
## Jira
[RHINENG-29632](https://issues.redhat.com/browse/RHINENG-29632)

## What
Restructure HBI MQ consumer's OpenTelemetry tracing so that `mq.process` spans cover the full message lifecycle (handle_message + flush + post_process) and all SQL operations appear as children of their respective message span.

## Why
The existing tracing produced misleading results: batch-level spans created separate traces disconnected from the upstream ingress root trace, and individual SQL operations (INSERT/UPDATE/SELECT) from the batch flush appeared as orphaned root traces in Tempo. This made it impossible to see true end-to-end latency for a single host message or attribute DB time to specific messages.

## How
- **Deferred span lifecycle**: `mq.process` spans start in `_process_message_core` and are ended after `post_process_rows()` completes, so their duration reflects the full message lifecycle
- **Per-message flush**: Each message flushes individually while its span context is active, so INSERT/UPDATE operations appear as children of the correct `mq.process` span (~47ms/min overhead per pod at peak, negligible)
- **Context re-attachment during post-process**: `use_otel_context` wraps the entire `write_message_batch` per result, attributing `host_exists` checks and event production to the correct message span
- **Removed `session_guard`**: Replaced with functionally equivalent manual flush/commit/rollback (required to separate per-message flush from batch-level commit)
- **Extracted utilities**: `decode_kafka_headers` → `mq_common.py`, `is_deadlock_error` → `lib/db.py`, `use_otel_context` → `app/telemetry.py`

## Testing
- All 18 tests in `test_mq_message_spans.py` pass
- Manual end-to-end verification with Docker Compose stack: uploaded 10 archives per topic (host-ingress, host-apps, system-profile, workspaces) and confirmed in Grafana/Tempo that:
  - Host-ingestion traces show all SQL and event spans nested under `mq.process`, parented under the ingress root trace
  - No orphaned SQL traces appear as separate root traces
  - System-profile/workspaces retain their own batch-level root span
- Pre-commit hooks pass (ruff, ruff-format, mypy)

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

Assisted-by: Cursor:claude-4.6-opus

[RHINENG-29632]: https://redhat.atlassian.net/browse/RHINENG-29632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Restructure host MQ consumer tracing so per-message OpenTelemetry spans cover the full message lifecycle and SQL operations are correctly associated with their originating messages.

Enhancements:
- Introduce deferred per-message mq.process spans that remain active through DB flush/commit and post-processing, with per-message flushes so SQL operations appear under the correct span.
- Adjust batch processing to create batch-level spans only for topics without upstream traces while host-ingress topics rely solely on per-message spans, and replace session_guard with explicit transaction management.
- Generalize Kafka header decoding and deadlock detection into shared utilities, and centralize an OTel context helper in the telemetry module for reuse across consumers and event production.

Tests:
- Extend mq_message_spans tests to cover deferred span lifecycle handling and OTel context capture when per-message spans are disabled.

## Summary by Sourcery

Restructure MQ consumer tracing so per-message OpenTelemetry spans cover the full message lifecycle and batch processing/DB transactions align with those spans.

New Features:
- Add per-message mq.process spans that stay active through DB flush/commit and post-processing to capture full message lifecycle latency.

Enhancements:
- Refactor host MQ batch processing to flush and commit per-message under its span while using batch-level spans only for topics without upstream traces.
- Centralize Kafka header decoding, deadlock detection, and OTel context helpers into shared utility modules for reuse across consumers and event production.
- Replace the session_guard helper with explicit transaction management that rolls back on error and ensures deferred spans are properly closed or marked failed.
- Update event production to reattach stored OTel context so outbound events and notifications are correctly linked to the originating message trace.

Tests:
- Extend MQ span tests to cover deferred span lifecycle handling, error marking, OTel context capture when spans are disabled, and span enrichment at end-of-lifecycle.