### PR TITLE
tests: Revert user_provider migration in IQE conftest

### DIFF
--- a/iqe-host-inventory-plugin/iqe_host_inventory/tests/conftest.py
+++ b/iqe-host-inventory-plugin/iqe_host_inventory/tests/conftest.py
@@ -14,7 +14,7 @@ from _pytest.fixtures import FixtureRequest
 from _pytest.nodes import Item
 from dynaconf.utils.boxing import DynaBox
 from iqe.base.application import Application
-from iqe.users.user_provider_standalone import StandaloneUserProvider
+from iqe.users.user_provider import UserProvider
 
 from iqe_host_inventory import ApplicationHostInventory
 from iqe_host_inventory.fixtures.cleanup_fixtures import HBICleanupRegistry
@@ -875,7 +875,6 @@ def hbi_cleanup_identity_auth_service_account_function(
 @pytest.fixture(scope="session", autouse=True)
 def hbi_setup_ephemeral_accounts(
     application: Application,
-    user_provider: StandaloneUserProvider,
     host_inventory: ApplicationHostInventory,
     hbi_default_user_data: DynaBox,
     hbi_maybe_secondary_user_data: DynaBox | None,
@@ -890,9 +889,11 @@ def hbi_setup_ephemeral_accounts(
         logger.info("Some accounts are not available in the config, skipping accounts setup")
         return
 
-    # Create accounts in Keycloak
-    user_provider.ensure_user_from_config(hbi_maybe_secondary_user_data)
-    user_provider.ensure_user_from_config(hbi_maybe_non_org_admin_user_data)
+    user_provider = UserProvider(application)
+
+    # Create secondary and non-org-admin users
+    user_provider.get_user_from_config(hbi_maybe_secondary_user_data)
+    user_provider.get_user_from_config(hbi_maybe_non_org_admin_user_data)
 
     # Setup RBAC on non org admin user - remove all permissions
     # There are 2 RBAC groups assigned to non org admin user after the user is created


### PR DESCRIPTION
## What
Revert user_provider migration in IQE conftest: https://github.com/RedHatInsights/insights-host-inventory/pull/4497

## Why
The new way of using the user_provider uses the fixture before the keycloak existence checks happen, so it tries to initialize the user provider even in environments where we don't have access to keycloak (stage, prod). This breaks the tests: https://gitlab.cee.redhat.com/insights-qe/iqe-host-inventory-plugin/-/jobs/58112975

## How
Revert the user_provider part from https://github.com/RedHatInsights/insights-host-inventory/pull/4497

There is a followup task to find a better way to migrate to the new user provider: https://redhat.atlassian.net/browse/RHINENG-29660

## Testing
PR check + running the tests locally against stage

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Bug Fixes:
- Prevent test failures in environments without Keycloak by constructing the user provider inside the ephemeral accounts fixture instead of via a standalone fixture-based provider.