### PR TITLE
fix(RHINENG-29632): suppress orphaned SQL traces during commit

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -6,6 +6,7 @@ import sys
 import time
 import uuid
 from collections.abc import Callable
+from contextlib import nullcontext
 from contextlib import suppress
 from copy import deepcopy
 from datetime import datetime
@@ -25,6 +26,7 @@ from marshmallow import validate
 from opentelemetry import context as otel_context_api
 from opentelemetry import trace as trace_api
 from opentelemetry.context import Context as OtelContext
+from opentelemetry.instrumentation.utils import suppress_instrumentation
 from opentelemetry.propagate import extract as otel_extract
 from opentelemetry.trace import SpanKind
 from opentelemetry.trace import StatusCode
@@ -537,7 +539,12 @@ class HBIMessageConsumerBase:
                     for msg in valid_messages:
                         self._process_single_message_in_batch(msg)
 
-                db.session.commit()
+                # Suppress instrumentation during commit for host-ingestion topics.
+                # The before_commit event listener (outbox processing) runs SQL queries
+                # (SELECT/INSERT/DELETE) that would otherwise appear as orphaned root
+                # traces since per-message span contexts have already been detached.
+                with suppress_instrumentation() if self._has_upstream_trace else nullcontext():
+                    db.session.commit()
             except Exception as exc:
                 db.session.rollback()
                 self._end_all_deferred_spans(error=exc)


### PR DESCRIPTION
## Jira
[RHINENG-29632](https://issues.redhat.com/browse/RHINENG-29632)

## What
Suppress OpenTelemetry auto-instrumentation during `db.session.commit()` for host-ingestion topics to prevent orphaned SQL traces appearing as separate root spans in Tempo.

## Why
The `before_commit` event listener (outbox processing) runs SQL queries (SELECT/INSERT/DELETE) after per-message span contexts have already been detached. These queries were showing up as orphaned root traces in Tempo, making it harder to diagnose real issues and polluting the trace view.

## How
- Wrap `db.session.commit()` with `suppress_instrumentation()` from OpenTelemetry, but only for consumers that have an upstream trace (`_has_upstream_trace = True`), i.e. `host-ingress` and `host-apps` topics.
- Non-ingestion topics (`system-profile`, `workspaces`) continue to commit without suppression, as their batch-level root span provides the correct parent context.

## Testing
- Uploaded archives via the dev upload script and verified in Grafana/Tempo that no orphaned SQL traces appear for host-ingestion messages.
- Confirmed that system-profile and workspaces topics still show full SQL instrumentation under their batch span.
- Existing unit tests pass (`tests/test_mq_message_spans.py`).

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-29632]: https://redhat.atlassian.net/browse/RHINENG-29632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Suppress OpenTelemetry SQL instrumentation during message batch commits for host-ingestion consumers to avoid orphaned traces.

Bug Fixes:
- Prevent orphaned root SQL spans from being created in Tempo when committing host-ingestion message batches with upstream traces.

Enhancements:
- Conditionally wrap db.session.commit() in OpenTelemetry suppression only when an upstream trace is present, preserving full instrumentation for non-ingestion topics.