### PR TITLE
ci: Add pyproject and uv.lock paths to konflux-automerge GitHub Action

### DIFF
--- a/.github/workflows/konflux-automerge.yaml
+++ b/.github/workflows/konflux-automerge.yaml
@@ -2,6 +2,8 @@ name: Konflux Auto-merge
 on:
   pull_request_target:
     paths:
+      - 'pyproject.toml'
+      - 'uv.lock'
       - 'Dockerfile'
       - '.pre-commit-config.yaml'
       - 'iqe-host-inventory-plugin/.pre-commit-config.yaml'


### PR DESCRIPTION
## Jira
None

## What
Add `pyproject.toml` and `uv.lock` paths to the konflux-automerge GitHub Action

## Why
Automate more dependency-update PRs

## How
Add those files to the `on.pull_request_target.paths` list

## Testing
N/A

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

CI:
- Trigger the konflux-automerge workflow when changes are made to pyproject.toml or uv.lock.