### PR TITLE
fix(RHINENG-29751): flush event messages synchronously

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -1351,7 +1351,7 @@ def write_add_update_event_message(
             tracker_ctx._success_status_msg = "skipped – host deleted before event production"
             return
 
-        event_producer.write_event(event, str(result.row.id), headers, wait=False)
+        event_producer.write_event(event, str(result.row.id), headers, wait=True)
 
         if result.event_type.name == HOST_EVENT_TYPE_CREATED:
             # Notifications are expected to omit null canonical facts
@@ -1379,21 +1379,6 @@ def write_add_update_event_message(
             logger.error("Error during set cache", ex)
 
 
-def _end_deferred_span(result: OperationResult) -> None:
-    """Enrich and end the deferred mq.process span after post-processing completes."""
-    if result.otel_span is not None:
-        span = result.otel_span
-        if span.is_recording():
-            org_id = getattr(threadctx, "org_id", None)
-            if org_id:
-                span.set_attribute("rh.org_id", org_id)
-            request_id = getattr(threadctx, "request_id", None)
-            if request_id:
-                span.set_attribute("rh.request_id", request_id)
-        span.end()
-        result.otel_span = None
-
-
 def write_message_batch(
     event_producer: EventProducer,
     notification_event_producer: EventProducer,
@@ -1407,10 +1392,6 @@ def write_message_batch(
             except Exception as exc:
                 metrics.ingress_message_handler_failure.inc()
                 logger.exception("Error while producing message", exc_info=exc)
-            finally:
-                _end_deferred_span(result)
-
-    event_producer.flush()
 
 
 def initialize_thread_local_storage(

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -2817,6 +2817,9 @@ def test_write_add_update_event_message(mocker):
     assert cached_group == serialized_group
     mock_host_exists.assert_called_once_with("host-id", org_id="org-id", session=db.session)
 
+    # Assert synchronous flush per ADR-0002
+    assert mock_event_producer.write_event.call_args.kwargs["wait"] is True
+
 
 @pytest.mark.usefixtures("flask_app")
 def test_write_add_update_event_message_skips_deleted_host(mocker):
@@ -3082,8 +3085,8 @@ def test_batch_50_messages_no_system_profile_accumulation(mocker, event_producer
     )
 
 
-def test_write_message_batch_flushes_once(mocker):
-    """Kafka events should be produced with wait=False and flushed once at the end of the batch."""
+def test_write_message_batch_produces_all_messages(mocker):
+    """Each event in the batch should be produced via write_add_update_event_message (flushed per-message)."""
     from uuid import uuid4
 
     from app.queue.host_mq import write_message_batch
@@ -3104,4 +3107,6 @@ def test_write_message_batch_flushes_once(mocker):
     write_message_batch(mock_event_producer, notification_producer, mock_results)
 
     assert mock_write.call_count == 5
-    assert mock_event_producer.flush.call_count == 1, "flush() should be called exactly once at the end of the batch"
+    assert mock_event_producer.flush.call_count == 0, (
+        "flush() should not be called; each event is flushed via wait=True"
+    )

--- a/tests/test_mq_message_spans.py
+++ b/tests/test_mq_message_spans.py
@@ -342,10 +342,9 @@ def test_process_message_without_span_captures_otel_context(otel_spans, consumer
     assert result.otel_context is not None
 
 
-def test_end_deferred_span_enriches_with_threadctx(otel_spans, consumer, monkeypatch):
-    """Verify that _end_deferred_span enriches spans with rh.org_id and rh.request_id."""
+def test_end_all_deferred_spans_enriches_with_threadctx(otel_spans, consumer, monkeypatch):
+    """Verify that _end_all_deferred_spans enriches spans with rh.org_id and rh.request_id."""
     from app.logging import threadctx
-    from app.queue.host_mq import _end_deferred_span
 
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_ENABLED", True)
     monkeypatch.setattr("app.queue.host_mq.OTEL_MQ_MESSAGE_SPANS_ENABLED", True)
@@ -358,7 +357,7 @@ def test_end_deferred_span_enriches_with_threadctx(otel_spans, consumer, monkeyp
     threadctx.org_id = "enrichment_org"
     threadctx.request_id = "enrichment_req"
 
-    _end_deferred_span(result)
+    consumer._end_all_deferred_spans()
 
     assert result.otel_span is None
     spans = otel_spans.get_finished_spans()


### PR DESCRIPTION
## Jira
[RHINENG-29751](https://issues.redhat.com/browse/RHINENG-29751)

## What
Switch create/update event production to synchronous flush (`wait=True`) and remove the now-redundant batch flush and deferred span handling from `write_message_batch`.

## Why
ADR-0002 (event-based system attributes replication) requires the producer to use synchronous sends to the broker for all events on `platform.inventory.events`. Delete events already complied (`wait=True`), but create/update events were produced with `wait=False` and only flushed once at the end of the batch. This created a window where a delete event could reach the broker before a buffered update for the same host, breaking the ordering guarantee that downstream consumers (Compliance, Vulnerability, Advisor) depend on after the Cyndi migration.

## How
- Changed `wait=False` to `wait=True` in `write_add_update_event_message()` so each create/update event is individually flushed to the broker before proceeding.
- Removed the trailing `event_producer.flush()` call in `write_message_batch()` since each event is now flushed per-message.
- Removed the `_end_deferred_span()` helper function, which was only needed for the batched post-processing path. Span lifecycle is now handled by `_end_all_deferred_spans()` in `_run_batch()`.

## Testing
- All 290 MQ-related unit tests pass (`test_host_mq_service.py`, `test_mq_message_spans.py`, `test_notifications.py`, `test_outbox_end_to_end_cases.py`).
- Updated `test_write_message_batch_flushes_once` → `test_write_message_batch_produces_all_messages` to assert flush is no longer called at the batch level.
- Updated `test_end_deferred_span_enriches_with_threadctx` → `test_end_all_deferred_spans_enriches_with_threadctx` to test enrichment through the remaining code path.
- End-to-end trace verified locally via Tempo/Grafana: uploaded an archive through ingress → puptoo → hbi-mq → events topic → insights-engine/vulnerability. Confirmed `traceparent` propagation and span parenting are intact.
- `make style` passes (ruff, mypy, pre-commit hooks).

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


Assisted-by: Cursor:claude-4.6-opus


[RHINENG-29751]: https://redhat.atlassian.net/browse/RHINENG-29751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Flush create and update host events synchronously and streamline MQ span handling, updating tests to align with the new event production behavior.

Bug Fixes:
- Ensure create and update host events are flushed synchronously to the broker to maintain ordering guarantees with delete events.

Enhancements:
- Simplify MQ span lifecycle handling by removing per-message deferred span ending in batch processing.

Tests:
- Adjust MQ tests to reflect per-message flushing and validate span enrichment via the remaining _end_all_deferred_spans path.