### PR TITLE
fix(RHINENG-30049): Add error handling for workspace delete-update race condition

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -655,6 +655,12 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
 
         elif operation == "update":
             group_to_update = group_repository.get_group_by_id_from_db(str(workspace["id"]), org_id)
+            if group_to_update is None:
+                logger.warning(
+                    f"Group with ID {workspace['id']} not found for update; "
+                    "it may have been deleted by a concurrent operation. Skipping update."
+                )
+                return None
             group_repository.patch_group(
                 group=group_to_update,
                 patch_data=workspace,

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -2488,6 +2488,21 @@ def test_workspace_mq_update(
         assert call_arg["host"]["groups"][0]["id"] == workspace_id
 
 
+def test_workspace_mq_update_after_delete(mocker, flask_app, caplog):
+    """An update message for a workspace that was already deleted is logged as a warning and skipped."""
+    import logging
+
+    workspace_id = str(generate_uuid())
+    message = generate_kessel_workspace_message("update", workspace_id, "deleted-workspace")
+    consumer = WorkspaceMessageConsumer(mocker.Mock(), flask_app, mocker.Mock(), mocker.Mock())
+
+    with caplog.at_level(logging.WARNING):
+        result = consumer.handle_message(json.dumps(message))
+
+    assert result is None
+    assert f"Group with ID {workspace_id} not found for update" in caplog.text
+
+
 @pytest.mark.parametrize("num_hosts", (0, 3))
 def test_workspace_mq_delete(
     db_create_group_with_hosts, db_get_group_by_id, db_get_hosts_for_group, num_hosts, flask_app, mocker

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -2492,6 +2492,9 @@ def test_workspace_mq_update_after_delete(mocker, flask_app, caplog):
     """An update message for a workspace that was already deleted is logged as a warning and skipped."""
     import logging
 
+    mocker.patch("app.queue.host_mq.group_repository.get_group_by_id_from_db", return_value=None)
+    mock_patch_group = mocker.patch("app.queue.host_mq.group_repository.patch_group")
+
     workspace_id = str(generate_uuid())
     message = generate_kessel_workspace_message("update", workspace_id, "deleted-workspace")
     consumer = WorkspaceMessageConsumer(mocker.Mock(), flask_app, mocker.Mock(), mocker.Mock())
@@ -2501,6 +2504,7 @@ def test_workspace_mq_update_after_delete(mocker, flask_app, caplog):
 
     assert result is None
     assert f"Group with ID {workspace_id} not found for update" in caplog.text
+    mock_patch_group.assert_not_called()
 
 
 @pytest.mark.parametrize("num_hosts", (0, 3))


### PR DESCRIPTION
## Jira
[RHINENG-30049](https://issues.redhat.com/browse/RHINENG-30049)

## What
Adds pessimistic error handling to the "update" path of workspace-mq, so it does not try to update a group that does not exist. Adds a warning-level log with a more useful message.

## Why
Without this change, it just logs "Unable to process message" with a traceback.

## How
Checks for the group's existence before attempting update; returns early if the group doesn't exist.

## Testing
Added `test_workspace_mq_update_after_delete`.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-30049]: https://redhat.atlassian.net/browse/RHINENG-30049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Prevent workspace update processing from failing when a concurrent deletion removes the target group.

Bug Fixes:
- Handle workspace update messages safely when the workspace group was deleted concurrently by logging a warning and skipping the update.

Tests:
- Add coverage for skipping updates after workspace deletion and verifying the warning log.