### PR TITLE
fix(RHINENG-30093): Adjust return type for export-service's handle_message

### DIFF
--- a/app/queue/export_service_mq.py
+++ b/app/queue/export_service_mq.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from marshmallow import Schema
 from marshmallow import ValidationError
 from marshmallow import fields
@@ -7,6 +9,7 @@ from app.logging import get_logger
 from app.queue import metrics
 from app.queue.export_service import create_export
 from app.queue.host_mq import HBIMessageConsumerBase
+from app.queue.host_mq import OperationResult
 from app.queue.mq_common import common_message_parser
 
 logger = get_logger(__name__)
@@ -45,9 +48,12 @@ class ExportEventSchema(Schema):
 
 class ExportServiceConsumer(HBIMessageConsumerBase):
     @metrics.export_service_message_handler_time.time()
-    def handle_message(self, message: str | bytes, headers: list[tuple[str, bytes]] | None = None):  # noqa: ARG002
+    def handle_message(
+        self,
+        message: str | bytes,
+        headers: list[tuple[str, bytes]] | None = None,  # noqa: ARG002
+    ) -> OperationResult | None:
         validated_msg = parse_export_service_message(message)
-        message_handled = False
         try:
             if (
                 validated_msg["source"] == EXPORT_EVENT_SOURCE
@@ -59,19 +65,19 @@ class ExportServiceConsumer(HBIMessageConsumerBase):
 
                 if create_export(validated_msg, base64_x_rh_identity, inventory_config()):
                     metrics.export_service_message_handler_success.inc()
-                    message_handled = True
+                    return OperationResult(
+                        None, None, None, None, partial(logger.info, "Export message processed successfully")
+                    )
                 else:
                     metrics.export_service_message_handler_failure.inc()
-                    message_handled = False
+                    return None
             else:
                 logger.debug("Found export message not related to host-inventory")
-                message_handled = False
+                return None
         except Exception as e:
             logger.error(e)
             metrics.export_service_message_handler_failure.inc()
-            message_handled = False
-
-        return message_handled
+            return None
 
 
 @metrics.export_service_message_parsing_time.time()

--- a/app/queue/export_service_mq.py
+++ b/app/queue/export_service_mq.py
@@ -1,4 +1,5 @@
 from functools import partial
+from typing import override
 
 from marshmallow import Schema
 from marshmallow import ValidationError
@@ -48,6 +49,7 @@ class ExportEventSchema(Schema):
 
 class ExportServiceConsumer(HBIMessageConsumerBase):
     @metrics.export_service_message_handler_time.time()
+    @override
     def handle_message(
         self,
         message: str | bytes,

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from functools import partial
 from typing import Any
 from typing import ClassVar
+from typing import override
 from uuid import UUID
 
 from confluent_kafka import Consumer
@@ -221,7 +222,7 @@ class HBIMessageConsumerBase:
         self.flask_app = flask_app
         self.event_producer = event_producer
         self.notification_event_producer = notification_event_producer
-        self.processed_rows: list[OperationResult] = []
+        self.processed_rows: list[OperationResult | None] = []
         self._is_retry = False
         self._messages_pending_retry: list | None = None
         self._producer_ctx: OtelContext | None = None
@@ -245,12 +246,17 @@ class HBIMessageConsumerBase:
     def process_message(self, *args, **kwargs):
         raise NotImplementedError("Not implemented in the HBIMessageConsumerBase class")
 
-    def handle_message(self, message: str | bytes, headers: list[tuple[str, bytes]] | None = None) -> OperationResult:
+    def handle_message(
+        self, message: str | bytes, headers: list[tuple[str, bytes]] | None = None
+    ) -> OperationResult | None:
         """
         Process a message from Kafka.
 
         Subclasses must override this method and should apply their own
         timing metric decorator (e.g., @metrics.ingress_message_handler_time.time())
+
+        Returns an OperationResult on success, or None if the message was
+        consumed but no action was needed (e.g. idempotent duplicate, stale update).
         """
         raise NotImplementedError("Not implemented in the HBIMessageConsumerBase class")
 
@@ -619,7 +625,10 @@ class HBIMessageConsumerBase:
 
 class WorkspaceMessageConsumer(HBIMessageConsumerBase):
     @metrics.ingress_message_handler_time.time()
-    def handle_message(self, message: str | bytes, headers: list[tuple[str, bytes]] | None = None):
+    @override
+    def handle_message(
+        self, message: str | bytes, headers: list[tuple[str, bytes]] | None = None
+    ) -> OperationResult | None:
         payload_schema = parse_operation_message(message, DebeziumEnvelopeSchema)
         validated_operation_msg = parse_operation_message(payload_schema["payload"], WorkspaceOperationSchema)
         org_id = validated_operation_msg["org_id"]
@@ -652,6 +661,7 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
 
             except (IntegrityError, UniqueViolation):
                 logger.warning(f"Group with ID {workspace['id']} already exists; skipping creation")
+                return None
 
         elif operation == "update":
             group_to_update = group_repository.get_group_by_id_from_db(str(workspace["id"]), org_id)
@@ -691,15 +701,16 @@ class WorkspaceMessageConsumer(HBIMessageConsumerBase):
         else:
             raise ValidationError("Operation must be 'create', 'update', or 'delete'.")
 
+    @override
     def post_process_rows(self) -> None:
         # Note: Commit happens in event_loop before this is called
         for processed_row in self.processed_rows:
             # Invoke OperationResult success logger for each processed row
-            if hasattr(processed_row, "success_logger") and callable(processed_row.success_logger):
+            if isinstance(processed_row, OperationResult) and callable(processed_row.success_logger):
                 processed_row.success_logger()
 
             # PG Notify for each processed workspace
-            if processed_row and processed_row.event_type and processed_row.row:
+            if isinstance(processed_row, OperationResult) and processed_row.event_type and processed_row.row:
                 _pg_notify_workspace(processed_row.event_type.name, str(processed_row.row.id))
 
 
@@ -707,6 +718,7 @@ class HostMessageConsumer(HBIMessageConsumerBase):
     _has_upstream_trace = True
 
     @metrics.ingress_message_handler_time.time()
+    @override
     def handle_message(self, message: str | bytes, headers: list[tuple[str, bytes]] | None = None) -> OperationResult:
         validated_operation_msg = parse_operation_message(message, HostOperationSchema)
         platform_metadata = validated_operation_msg.get("platform_metadata", {})
@@ -766,6 +778,7 @@ class HostMessageConsumer(HBIMessageConsumerBase):
                 )
                 raise
 
+    @override
     def post_process_rows(self) -> None:
         # Note: Commit happens in event_loop before this is called
         if len(self.processed_rows) > 0:
@@ -773,6 +786,7 @@ class HostMessageConsumer(HBIMessageConsumerBase):
 
 
 class IngressMessageConsumer(HostMessageConsumer):
+    @override
     def process_message(
         self,
         host_data: dict[str, Any],
@@ -802,7 +816,7 @@ class IngressMessageConsumer(HostMessageConsumer):
                 _validate_payload_owner_id(input_host, identity)
 
             log_add_host_attempt(logger, input_host, sp_fields_to_log, identity)
-            processed_hosts = [result.row for result in self.processed_rows]
+            processed_hosts = [result.row for result in self.processed_rows if result is not None]
             host_row, add_result = host_repository.add_host(
                 input_host, identity, operation_args=operation_args, existing_hosts=processed_hosts
             )
@@ -843,6 +857,7 @@ class SystemProfileMessageConsumer(HostMessageConsumer):
     # Overrides parent: system-profile updates come from rhsm-conduit directly, not from ingress
     _has_upstream_trace = False
 
+    @override
     def process_message(
         self,
         host_data: dict[str, Any],
@@ -908,6 +923,7 @@ class HostAppMessageConsumer(HBIMessageConsumerBase):
     }
 
     @metrics.host_app_message_handler_time.time()
+    @override
     def handle_message(self, message: str | bytes, headers: list[tuple[str, bytes]] | None = None) -> OperationResult:
         application_str, request_id = self._extract_headers(headers)
 
@@ -935,6 +951,7 @@ class HostAppMessageConsumer(HBIMessageConsumerBase):
         initialize_thread_local_storage(request_id, org_id=validated_msg.get("org_id"))
         return self.process_message(application, validated_msg)
 
+    @override
     def process_message(self, application: ConsumerApplication, validated_msg: dict[str, Any]) -> OperationResult:
         org_id = validated_msg["org_id"]
         timestamp = validated_msg["timestamp"]
@@ -1079,10 +1096,11 @@ class HostAppMessageConsumer(HBIMessageConsumerBase):
             metrics.host_app_data_failure.labels(application=application, reason="unexpected_error").inc()
             raise
 
+    @override
     def post_process_rows(self) -> None:
         """Process the results after batch commit - call success loggers."""
         for processed_row in self.processed_rows:
-            if processed_row and hasattr(processed_row, "success_logger") and callable(processed_row.success_logger):
+            if isinstance(processed_row, OperationResult) and callable(processed_row.success_logger):
                 processed_row.success_logger()
 
 
@@ -1388,7 +1406,7 @@ def write_add_update_event_message(
 def write_message_batch(
     event_producer: EventProducer,
     notification_event_producer: EventProducer,
-    processed_rows: list[OperationResult],
+    processed_rows: list[OperationResult | None],
 ):
     for result in processed_rows:
         if result is not None:

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -265,7 +265,7 @@ class HBIMessageConsumerBase:
         error status before ending them.
         """
         for result in self.processed_rows:
-            if result is not None and result.otel_span is not None:
+            if isinstance(result, OperationResult) and result.otel_span is not None:
                 if error:
                     self._mark_span_error(result.otel_span, error)
                 self._enrich_span_from_threadctx(result.otel_span)
@@ -407,7 +407,7 @@ class HBIMessageConsumerBase:
         start_ns = None if span else time.time_ns()
         try:
             result = self.handle_message(msg.value(), headers=msg.headers())
-            if result is not None:
+            if isinstance(result, OperationResult):
                 result.otel_context = otel_context_api.get_current()
                 result.otel_span = span
             self.processed_rows.append(result)

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -20,6 +20,7 @@ from app.queue.export_service import _handle_export_response
 from app.queue.export_service import _StreamingExportBody
 from app.queue.export_service import create_export
 from app.queue.export_service_mq import parse_export_service_message
+from app.queue.host_mq import OperationResult
 from app.serialization import _EXPORT_SERVICE_FIELDS
 from app.serialization import serialize_host_for_export_svc
 from app.staleness_serialization import get_sys_default_staleness
@@ -39,7 +40,7 @@ def test_handle_create_export_happy_path(mock_post, db_create_host, flask_app, e
         export_message = es_utils.create_export_message_mock()
         mock_post.return_value.status_code = 202
         resp = export_service_consumer_mock.handle_message(export_message)
-        assert resp is True
+        assert isinstance(resp, OperationResult)
 
 
 @pytest.mark.parametrize("format", ("json", "csv"))
@@ -66,7 +67,7 @@ def test_handle_create_export_request_with_data_to_export(mock_post, flask_app, 
         export_message = es_utils.create_export_message_mock()
         mock_post.return_value.status_code = 202
         resp = export_service_consumer_mock.handle_message(export_message)
-        assert resp is True
+        assert isinstance(resp, OperationResult)
 
 
 @mock.patch("requests.Session.post", autospec=True)
@@ -79,7 +80,7 @@ def test_handle_create_export_request_with_no_data_to_export(mock_post, flask_ap
         export_message = es_utils.create_export_message_mock()
         mock_post.return_value.status_code = 202
         resp = export_service_consumer_mock.handle_message(export_message)
-        assert resp is False
+        assert resp is None
 
 
 @pytest.mark.parametrize(
@@ -101,7 +102,7 @@ def test_handle_create_export_wrong_application(flask_app, export_service_consum
 
         resp = export_service_consumer_mock.handle_message(export_message)
 
-        assert resp is False
+        assert resp is None
 
 
 def test_handle_create_export_empty_message(flask_app, export_service_consumer_mock):
@@ -164,7 +165,7 @@ def test_handle_rbac_allowed(mock_post, subtests, flask_app, db_create_host, moc
                 export_message = es_utils.create_export_message_mock()
                 mock_post.return_value.status_code = 202
                 resp = export_service_consumer_mock.handle_message(export_message)
-                assert resp is True
+                assert isinstance(resp, OperationResult)
 
 
 @pytest.mark.usefixtures("enable_rbac")
@@ -182,7 +183,7 @@ def test_handle_rbac_prohibited(mock_post, subtests, flask_app, db_create_host, 
                 export_message = es_utils.create_export_message_mock()
                 mock_post.return_value.status_code = 202
                 resp = export_service_consumer_mock.handle_message(export_message)
-                assert resp is False
+                assert resp is None
 
 
 @mock.patch("requests.Session.post", autospec=True)
@@ -195,7 +196,7 @@ def test_handle_kessel_allowed(mock_resolve, mock_post, flask_app, db_create_hos
 
         resp = export_service_consumer_mock.handle_message(export_message)
 
-        assert resp is True
+        assert isinstance(resp, OperationResult)
         mock_resolve.assert_called_once()
 
         args, kwargs = mock_resolve.call_args
@@ -214,7 +215,7 @@ def test_handle_kessel_prohibited(mock_resolve, mock_post, flask_app, db_create_
         export_message = es_utils.create_export_message_mock()
         mock_post.return_value.status_code = 202
         resp = export_service_consumer_mock.handle_message(export_message)
-        assert resp is False
+        assert resp is None
         mock_resolve.assert_called_once()
 
 

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -2691,8 +2691,16 @@ def test_workspace_bulk_mq_duplicate_does_not_rollback_prior_creates(
     "processed_rows,event_type,should_notify",
     [
         ([], EventType.created, False),
-        ([mock.Mock()], EventType.created, True),
-        ([mock.Mock()], None, False),
+        (
+            [OperationResult(mock.Mock(id="workspace-id"), None, None, EventType.created, lambda: None)],
+            EventType.created,
+            True,
+        ),
+        (
+            [OperationResult(mock.Mock(id="workspace-id"), None, None, None, lambda: None)],
+            None,
+            False,
+        ),
     ],
 )
 def test_post_process_rows_commit_and_notify(


### PR DESCRIPTION
## Jira
[RHINENG-30093](https://redhat.atlassian.net/browse/RHINENG-30093)

## What
- Adjust the return type for export-service's `handle_message` function
- Add type guard before checking `otel_context`
- Adjust unit tests

## Why
export-service's handle_message function returns a boolean, which leads to an exception when `result.otel_span` is called.

## How
Updated the return calls, and added an isinstance type-guard

## Testing
Adjusted `test_export_service.py` tests

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

## Summary by Sourcery

Align export-service message handling with the consumer's OperationResult contract and safely process optional results.

Bug Fixes:
- Return an OperationResult for successfully processed export messages and None for unsuccessful or unrelated messages, preventing downstream telemetry handling errors.

Enhancements:
- Guard OperationResult-specific context and span handling in the message consumer.
- Update export-service unit tests to validate the revised result contract.

[RHINENG-30093]: https://redhat.atlassian.net/browse/RHINENG-30093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Align message consumer result handling with the OperationResult contract to prevent downstream telemetry errors.

Bug Fixes:
- Align export-service message handling with the consumer contract by returning OperationResult for successful processing and None when no action is taken or processing fails.
- Prevent telemetry and post-processing logic from treating non-OperationResult values as operation results.

Enhancements:
- Update message consumer return type annotations and result handling to support optional processing results.
- Add override annotations across consumer implementations.

Tests:
- Update export-service and workspace consumer tests to validate OperationResult and None outcomes.