### PR TITLE
feat(RHINENG-30197): Use sentence case for default "All Systems" title instead of title case and add tags column

### DIFF
--- a/migrations/versions/4124f5b6e6a4_update_all_systems_view_name_and_config.py
+++ b/migrations/versions/4124f5b6e6a4_update_all_systems_view_name_and_config.py
@@ -1,0 +1,63 @@
+"""Update 'All Systems' view name to sentence case and add tags column
+
+Revision ID: 4124f5b6e6a4
+Revises: 286f3c4f6e4f
+Create Date: 2026-08-24 17:55:00.000000
+
+"""
+
+import json
+
+from alembic import op
+
+from app.models.constants import INVENTORY_SCHEMA
+
+revision = "4124f5b6e6a4"
+down_revision = "286f3c4f6e4f"
+branch_labels = None
+depends_on = None
+
+UPDATED_CONFIG = json.dumps(
+    {
+        "columns": [
+            {"key": "display_name"},
+            {"key": "tags"},
+            {"key": "group_name"},
+            {"key": "operating_system"},
+            {"key": "last_check_in"},
+        ]
+    }
+)
+
+ORIGINAL_CONFIG = json.dumps(
+    {
+        "columns": [
+            {"key": "display_name"},
+            {"key": "group_name"},
+            {"key": "operating_system"},
+            {"key": "last_check_in"},
+        ]
+    }
+)
+
+
+def upgrade():
+    op.execute(
+        f"""
+        UPDATE {INVENTORY_SCHEMA}.inventory_views
+        SET name = 'All systems',
+            configuration = '{UPDATED_CONFIG}'::jsonb
+        WHERE name = 'All Systems' AND org_id IS NULL
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        f"""
+        UPDATE {INVENTORY_SCHEMA}.inventory_views
+        SET name = 'All Systems',
+            configuration = '{ORIGINAL_CONFIG}'::jsonb
+        WHERE name = 'All systems' AND org_id IS NULL
+        """
+    )


### PR DESCRIPTION
## Jira
[RHINENG-30197](https://issues.redhat.com/browse/RHINENG-30197)

## What
New data migration to update the seeded "All Systems" view: fixes name casing to sentence case ("All systems") and adds the `tags` column to the default configuration.

## Why
The original seed migration (`286f3c4f6e4f`) was already merged and deployed with title case naming and without the `tags` column. Since Alembic won't re-run an applied migration, a new migration is needed to update the existing row.

## How
A new Alembic data migration (`4124f5b6e6a4`) that runs an `UPDATE` on the seeded row, targeting it via `WHERE name = 'All Systems' AND org_id IS NULL`. The downgrade reverses both changes.

## Testing
- All 84 `test_api_views.py` tests pass
- Ruff lint and format checks pass
- Migration chain verified (`down_revision` points to `286f3c4f6e4f`)

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

[RHINENG-30197]: https://redhat.atlassian.net/browse/RHINENG-30197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update the existing default inventory view through a reversible data migration to use sentence-case naming and include system tags.

Bug Fixes:
- Update the seeded default view name from “All Systems” to sentence case, “All systems”.
- Add the tags column to the default “All systems” view configuration.