### PR TITLE
perf(RHINENG-29090): eliminate N+1 queries in export service

### DIFF
--- a/api/host_query_db.py
+++ b/api/host_query_db.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Iterator
 from itertools import islice
 from typing import Any
+from typing import NamedTuple
 
 from sqlalchemy import Boolean
 from sqlalchemy import Integer
@@ -49,7 +50,7 @@ from app.models.system_profile_transformer import DYNAMIC_FIELDS
 from app.models.system_profile_transformer import STATIC_FIELDS
 from app.serialization import SP_FIELD_SERIALIZERS
 from app.serialization import _sanitize_workloads_none_values
-from app.serialization import serialize_host_for_export_svc
+from app.serialization import serialize_host_row_for_export
 
 __all__ = (
     "get_all_hosts",
@@ -884,6 +885,25 @@ def get_host_ids_list(
     return host_list
 
 
+class _ExportHostRow(NamedTuple):
+    id: Any
+    display_name: str | None
+    host_type: str | None
+    modified_on: Any
+    groups: Any
+    tags: Any
+    fqdn: str | None
+    subscription_manager_id: str | None
+    satellite_id: str | None
+    last_check_in: Any
+    bios_uuid: str | None
+    ip_addresses: Any
+    os_release: str | None
+    satellite_managed: bool | None
+    cloud_provider: str | None
+    is_marketplace: bool | None
+
+
 def get_hosts_to_export(
     identity: Identity,
     filters: dict | None = None,
@@ -900,6 +920,7 @@ def get_hosts_to_export(
     q_filters, _ = query_filters(
         filter=filters, rbac_filter=rbac_filter, staleness=ALL_STALENESS_STATES, identity=identity
     )
+
     columns = [
         Host.id,
         Host.display_name,
@@ -913,34 +934,37 @@ def get_hosts_to_export(
         Host.last_check_in,
         Host.bios_uuid,
         Host.ip_addresses,
+        HostStaticSystemProfile.os_release,
+        HostStaticSystemProfile.satellite_managed,
+        HostStaticSystemProfile.cloud_provider,
+        HostStaticSystemProfile.is_marketplace,
     ]
 
-    export_host_query = (
-        _find_hosts_model_query(identity=identity, columns=columns)
-        .options(
-            joinedload(Host.static_system_profile).load_only(
-                HostStaticSystemProfile.os_release,
-                HostStaticSystemProfile.satellite_managed,
-                HostStaticSystemProfile.cloud_provider,
-                HostStaticSystemProfile.is_marketplace,
+    base_query = (
+        _find_hosts_entities_query(identity=identity, columns=columns)
+        .outerjoin(
+            HostStaticSystemProfile,
+            and_(
+                Host.id == HostStaticSystemProfile.host_id,
+                Host.org_id == HostStaticSystemProfile.org_id,
             ),
-            noload(Host.dynamic_system_profile),
         )
         .filter(*q_filters)
     )
-    export_host_query = export_host_query.execution_options(yield_per=batch_size)
+    base_query = base_query.yield_per(batch_size)
 
     try:
         exported = 0
-        for host in db.session.scalars(export_host_query):
-            yield serialize_host_for_export_svc(host, staleness=staleness)
+        for row in base_query:
+            host_row = _ExportHostRow(*row)
+            yield serialize_host_row_for_export(host_row, staleness=staleness)
             exported += 1
         logger.debug(f"Number of hosts exported: {exported}")
 
     except GeneratorExit:
         return
 
-    except SQLAlchemyError as e:  # Most likely ObjectDeletedError, but catching all DB errors
+    except SQLAlchemyError as e:
         raise InventoryException(title="DB Error", detail=str(e)) from e
 
     db.session.close()

--- a/app/serialization.py
+++ b/app/serialization.py
@@ -283,42 +283,37 @@ def serialize_host(
     return serialized_host
 
 
-def serialize_host_for_export_svc(
-    host: Host | LimitedHost,
-    staleness: AttrDict,
-):
-    st_timestamps = get_staleness_timestamps(host, staleness)
-
+def serialize_host_row_for_export(row, *, staleness):
+    """Serialize a flat query row (no ORM relationship access) for the export service."""
     group_id = None
     group_name = None
-    if host.groups:
-        group_id = host.groups[0]["id"]
-        group_name = host.groups[0]["name"]
+    if row.groups:
+        group_id = row.groups[0]["id"]
+        group_name = row.groups[0]["name"]
 
-    static_profile = host.static_system_profile
-    os_release = static_profile.os_release if static_profile is not None else None
+    st_timestamps = get_staleness_timestamps(row, staleness, last_check_in=row.last_check_in)
 
     field_values = {
-        "display_name": host.display_name,
-        "fqdn": host.fqdn,
-        "host_id": serialize_uuid(host.id),
-        "subscription_manager_id": host.subscription_manager_id,
-        "satellite_id": host.satellite_id,
+        "display_name": row.display_name,
+        "fqdn": row.fqdn,
+        "host_id": serialize_uuid(row.id),
+        "subscription_manager_id": row.subscription_manager_id,
+        "satellite_id": row.satellite_id,
         "group_id": group_id,
         "group_name": group_name,
-        "os_release": os_release,
-        "updated": _serialize_datetime(host.modified_on),
+        "os_release": row.os_release,
+        "updated": _serialize_datetime(row.modified_on),
         "state": Conditions.find_host_state(
             stale_timestamp=st_timestamps["stale_timestamp"],
             stale_warning_timestamp=st_timestamps["stale_warning_timestamp"],
         ),
-        "tags": _serialize_tags(host.tags),
-        "host_type": host.host_type or "conventional",
-        "bios_uuid": host.bios_uuid,
-        "satellite_managed": static_profile.satellite_managed if static_profile is not None else None,
-        "cloud_provider": static_profile.cloud_provider if static_profile is not None else None,
-        "is_marketplace": static_profile.is_marketplace if static_profile is not None else None,
-        "ip_addresses": host.ip_addresses,
+        "tags": _serialize_tags(row.tags),
+        "host_type": row.host_type or "conventional",
+        "bios_uuid": row.bios_uuid,
+        "satellite_managed": row.satellite_managed,
+        "cloud_provider": row.cloud_provider,
+        "is_marketplace": row.is_marketplace,
+        "ip_addresses": row.ip_addresses,
     }
     return {field: field_values[field] for field in _EXPORT_SERVICE_FIELDS}
 

--- a/dev.yml
+++ b/dev.yml
@@ -154,10 +154,12 @@ services:
       image: grafana/tempo:2.7.1
       command: ["-config.file=/etc/tempo.yaml"]
       volumes:
-        - ./.otel/tempo.yaml:/etc/tempo.yaml
+        - ./.otel/tempo.yaml:/etc/tempo.yaml:Z
       ports:
         - "${HBI_TEMPO_OTLP_PORT:-4318}:4318"
         - "${HBI_TEMPO_INTERNAL_PORT:-3250}:3200"
+      security_opt:
+        - label=disable
 
     grafana:
       image: grafana/grafana:11.5.2
@@ -167,9 +169,11 @@ services:
         - GF_AUTH_ANONYMOUS_ENABLED=true
         - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       volumes:
-        - ./.otel/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+        - ./.otel/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:Z
       depends_on:
         - tempo
+      security_opt:
+        - label=disable
 
     hbi-web:
       build: .
@@ -253,5 +257,42 @@ services:
         - .:/opt/app-root/src
         - /opt/app-root/src/.venv
       command: python3 inv_mq_service.py
+      security_opt:
+        - label=disable
+
+    hbi-export:
+      build: .
+      environment:
+        - INVENTORY_LOG_LEVEL=${INVENTORY_LOG_LEVEL:-DEBUG}
+        - INVENTORY_DB_HOST=db
+        - INVENTORY_DB_NAME=${INVENTORY_DB_NAME:-insights}
+        - INVENTORY_DB_USER=${INVENTORY_DB_USER:-insights}
+        - INVENTORY_DB_PASS=${INVENTORY_DB_PASS:-insights}
+        - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+        - KAFKA_EVENT_TOPIC=platform.inventory.events
+        - KAFKA_EXPORT_SERVICE_TOPIC=${KAFKA_EXPORT_SERVICE_TOPIC:-platform.export.requests}
+        - EXPORT_SERVICE_ENDPOINT=http://export-service:10010
+        - EXPORT_SERVICE_TOKEN=testing-a-psk
+        - BYPASS_RBAC=${BYPASS_RBAC:-true}
+        - BYPASS_KESSEL=${BYPASS_KESSEL:-true}
+        - INVENTORY_API_CACHE_TYPE=${INVENTORY_API_CACHE_TYPE:-RedisCache}
+        - INVENTORY_API_CACHE_TIMEOUT_SECONDS=${INVENTORY_API_CACHE_TIMEOUT_SECONDS:-300}
+        - INVENTORY_API_STALENESS_CACHE_ENABLED=${INVENTORY_API_STALENESS_CACHE_ENABLED:-true}
+        - CACHE_HOST=redis
+        - CACHE_PORT=6379
+        - OTEL_ENABLED=${OTEL_ENABLED:-true}
+        - OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318
+        - PROMETHEUS_PUSHGATEWAY=prometheus-gateway:9091
+      depends_on:
+        db:
+          condition: service_healthy
+        kafka:
+          condition: service_healthy
+        redis:
+          condition: service_healthy
+      volumes:
+        - .:/opt/app-root/src
+        - /opt/app-root/src/.venv
+      command: python3 inv_export_service.py
       security_opt:
         - label=disable

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -22,8 +22,6 @@ from app.queue.export_service import create_export
 from app.queue.export_service_mq import parse_export_service_message
 from app.queue.host_mq import OperationResult
 from app.serialization import _EXPORT_SERVICE_FIELDS
-from app.serialization import serialize_host_for_export_svc
-from app.staleness_serialization import get_sys_default_staleness
 from tests.helpers import export_service_utils as es_utils
 from tests.helpers.api_utils import HOST_READ_ALLOWED_RBAC_RESPONSE_FILES
 from tests.helpers.api_utils import HOST_READ_PROHIBITED_RBAC_RESPONSE_FILES
@@ -114,21 +112,27 @@ def test_handle_create_export_empty_message(flask_app, export_service_consumer_m
             export_service_consumer_mock.handle_message(export_message)
 
 
-def test_host_serialization(flask_app, db_create_host):
+def test_host_serialization(flask_app, db_create_host, inventory_config):
     with flask_app.app.app_context():
         expected_fields = _EXPORT_SERVICE_FIELDS
-        host = db_create_host(host=db_host())
-        staleness = get_sys_default_staleness()
-        serialized_host = serialize_host_for_export_svc(host, staleness=staleness)
+        db_create_host(host=db_host())
+        identity = Identity(USER_IDENTITY)
+        host_list = list(
+            get_hosts_to_export(identity, rbac_filter=None, batch_size=inventory_config.export_svc_batch_size)
+        )
 
-        assert expected_fields == list(serialized_host.keys())
+        assert len(host_list) == 1
+        assert expected_fields == list(host_list[0].keys())
 
 
-def test_handle_csv_format(flask_app, db_create_host, mocker):
+def test_handle_csv_format(flask_app, db_create_host, mocker, inventory_config):
     with flask_app.app.app_context():
-        host = db_create_host(host=db_host())
-        staleness = get_sys_default_staleness()
-        serialized_host = serialize_host_for_export_svc(host, staleness=staleness)
+        db_create_host(host=db_host())
+        identity = Identity(USER_IDENTITY)
+        host_list = list(
+            get_hosts_to_export(identity, rbac_filter=None, batch_size=inventory_config.export_svc_batch_size)
+        )
+        serialized_host = host_list[0]
         export_host = _format_export_data([serialized_host], "csv")
 
         csv_file = io.StringIO(export_host)
@@ -139,11 +143,14 @@ def test_handle_csv_format(flask_app, db_create_host, mocker):
         assert mocked_csv == export_host
 
 
-def test_handle_json_format(flask_app, db_create_host, mocker):
+def test_handle_json_format(flask_app, db_create_host, mocker, inventory_config):
     with flask_app.app.app_context():
-        host = db_create_host(host=db_host())
-        staleness = get_sys_default_staleness()
-        serialized_host = serialize_host_for_export_svc(host, staleness=staleness)
+        db_create_host(host=db_host())
+        identity = Identity(USER_IDENTITY)
+        host_list = list(
+            get_hosts_to_export(identity, rbac_filter=None, batch_size=inventory_config.export_svc_batch_size)
+        )
+        serialized_host = host_list[0]
 
         export_host = json.loads(_format_export_data([serialized_host], "json"))
         mocked_json = es_utils.create_export_json_mock(mocker)
@@ -251,10 +258,18 @@ def test_export_one_host(flask_app, db_create_host, inventory_config):
         assert len(host_list) == 1
 
 
-@mock.patch("api.host_query_db.db.session.scalars", side_effect=ObjectDeletedError(None))
-def test_export_catches_db_error(flask_app, inventory_config, mocker):
+def test_export_catches_db_error(flask_app, inventory_config, mocker, db_create_host):
     with flask_app.app.app_context():
+        db_create_host()
         handle_export_error_mock = mocker.patch("app.queue.export_service._handle_export_error")
+
+        real_entities_query = mocker.patch("api.host_query_db._find_hosts_entities_query")
+        broken_query = mock.MagicMock()
+        broken_query.outerjoin.return_value = broken_query
+        broken_query.filter.return_value = broken_query
+        broken_query.yield_per.return_value = broken_query
+        broken_query.__iter__ = mock.Mock(side_effect=ObjectDeletedError(None))
+        real_entities_query.return_value = broken_query
 
         validated_msg = parse_export_service_message(es_utils.create_export_message_mock())
         base64_x_rh_identity = validated_msg["data"]["resource_request"]["x_rh_identity"]


### PR DESCRIPTION
## Jira
[RHINENG-29090](https://issues.redhat.com/browse/RHINENG-29090)

## What
Eliminate the N+1 query problem in the export service that was generating thousands of individual SELECT queries against `system_profiles_static` — one per host.

## Why
With ~42,000 hosts in our prod test account, the export service was issuing 6,000+ SELECT queries per export request, causing timeouts. The root cause was that `joinedload` on the `static_system_profile` relationship is silently downgraded to lazy loading when combined with `yield_per` batching, resulting in one query per host.

## How
- Replaced ORM relationship-based eager loading (`joinedload`/`selectinload`) with an explicit `LEFT JOIN` to `system_profiles_static` in `get_hosts_to_export`, selecting only the 4 needed columns (`os_release`, `satellite_managed`, `cloud_provider`, `is_marketplace`) via `with_entities`.
- Switched from `_find_hosts_model_query` (returns ORM objects) to `_find_hosts_entities_query` (returns flat column tuples), avoiding all ORM relationship loading overhead.
- Replaced `serialize_host_for_export_svc` (which accessed `host.static_system_profile` triggering lazy loads) with `serialize_host_row_for_export` that reads directly from the flat row tuple.
- Removed the now-unused `serialize_host_for_export_svc` function.
- Added `hbi-export` container and fixed Tempo/Grafana volume permissions in `dev.yml`.

## Testing
- All 41 existing export service tests pass (field output, CSV/JSON format, RBAC, Kessel, streaming body, error handling).
- Verified locally with Tempo traces using 100 seeded hosts via `podman compose`:
  - **Before**: 102 SELECT queries, 108 spans, 159 ms total.
  - **After**: 1 SELECT query, 7 spans, 38 ms total.
- `make style` passes (ruff, ruff-format, mypy).

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.

Assisted-by: Cursor:claude-4.6-opus


[RHINENG-29090]: https://redhat.atlassian.net/browse/RHINENG-29090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Eliminate N+1 database queries from host exports to improve export performance and reliability at scale.

Bug Fixes:
- Eliminate per-host database queries during host exports by loading static profile fields in the export query.

Enhancements:
- Refactor export serialization to consume flat query results and reduce ORM relationship-loading overhead.

Tests:
- Update export service tests to validate serialization through the host export query and cover database error handling with the new query flow.

Chores:
- Add a local export service container and adjust Tempo/Grafana volume and security settings for development observability.