### PR TITLE
feat(RHINENG-30669): Allow periods and apostrophes in view names

### DIFF
--- a/app/models/schemas/views.py
+++ b/app/models/schemas/views.py
@@ -6,12 +6,16 @@ from marshmallow import validate as marshmallow_validate
 
 from app.models.views import MAX_VIEW_NAME_LENGTH
 
-VIEW_NAME_PATTERN = r"^[a-zA-Z0-9 _-]+$"
-VIEW_NAME_VALIDATION_ERROR = "View name must contain only letters, numbers, spaces, hyphens, and underscores."
-
+VIEW_NAME_PATTERN = r"^[a-zA-Z0-9 _.'-]+$"
+VIEW_NAME_VALIDATION_ERROR = (
+    "View name must contain only letters, numbers, spaces, hyphens, underscores, periods, and apostrophes."
+)
+VIEW_NAME_ALPHANUMERIC_PATTERN = r".*[a-zA-Z0-9].*"
+VIEW_NAME_ALPHANUMERIC_ERROR = "View name must contain at least one letter or number."
 _VIEW_NAME_VALIDATION = marshmallow_validate.And(
     marshmallow_validate.Length(min=1, max=MAX_VIEW_NAME_LENGTH),
     marshmallow_validate.Regexp(VIEW_NAME_PATTERN, error=VIEW_NAME_VALIDATION_ERROR),
+    marshmallow_validate.Regexp(VIEW_NAME_ALPHANUMERIC_PATTERN, error=VIEW_NAME_ALPHANUMERIC_ERROR),
 )
 
 

--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -3037,11 +3037,12 @@ components:
         name:
           description: >-
             The display name for the view.
-            Must contain only letters, numbers, spaces, hyphens, and underscores.
+            Must contain only letters, numbers, spaces, hyphens, underscores, periods, and apostrophes,
+            and include at least one letter or number.
           type: string
           minLength: 1
           maxLength: 255
-          pattern: '^[a-zA-Z0-9 _-]+$'
+          pattern: "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 _.'-]+$"
         description:
           description: An optional description of the view.
           type: string
@@ -3063,11 +3064,12 @@ components:
         name:
           description: >-
             The display name for the view.
-            Must contain only letters, numbers, spaces, hyphens, and underscores.
+            Must contain only letters, numbers, spaces, hyphens, underscores, periods, and apostrophes,
+            and include at least one letter or number.
           type: string
           minLength: 1
           maxLength: 255
-          pattern: '^[a-zA-Z0-9 _-]+$'
+          pattern: "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 _.'-]+$"
         description:
           description: An optional description of the view.
           type: string

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -5728,11 +5728,11 @@
         ],
         "properties": {
           "name": {
-            "description": "The display name for the view. Must contain only letters, numbers, spaces, hyphens, and underscores.",
+            "description": "The display name for the view. Must contain only letters, numbers, spaces, hyphens, underscores, periods, and apostrophes, and include at least one letter or number.",
             "type": "string",
             "minLength": 1,
             "maxLength": 255,
-            "pattern": "^[a-zA-Z0-9 _-]+$"
+            "pattern": "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 _.'-]+$"
           },
           "description": {
             "description": "An optional description of the view.",
@@ -5756,11 +5756,11 @@
         "type": "object",
         "properties": {
           "name": {
-            "description": "The display name for the view. Must contain only letters, numbers, spaces, hyphens, and underscores.",
+            "description": "The display name for the view. Must contain only letters, numbers, spaces, hyphens, underscores, periods, and apostrophes, and include at least one letter or number.",
             "type": "string",
             "minLength": 1,
             "maxLength": 255,
-            "pattern": "^[a-zA-Z0-9 _-]+$"
+            "pattern": "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 _.'-]+$"
           },
           "description": {
             "description": "An optional description of the view.",

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -694,13 +694,22 @@ class TestCreateView:
         assert "name" in response_data["detail"]
 
     def test_400_for_punctuation_only_name(self, flask_client: TestClient) -> None:
-        data = {"name": "!!!", "configuration": VALID_CONFIG}
+        data = {"name": "...", "configuration": VALID_CONFIG}
 
         url = build_views_url()
         response_status, response_data = do_request(flask_client.post, url, USER_IDENTITY, data)
 
         assert_response_status(response_status, 400)
         assert "name" in response_data["detail"]
+
+    def test_creates_view_with_periods_and_apostrophes(self, flask_client: TestClient) -> None:
+        data = {"name": "Bob's RHEL 9.4", "configuration": VALID_CONFIG}
+
+        url = build_views_url()
+        response_status, response_data = do_request(flask_client.post, url, USER_IDENTITY, data)
+
+        assert_response_status(response_status, 201)
+        assert response_data["name"] == "Bob's RHEL 9.4"
 
     def test_creates_view_with_hyphens_and_underscores(self, flask_client: TestClient) -> None:
         data = {"name": "my-view_2024", "configuration": VALID_CONFIG}
@@ -887,10 +896,23 @@ class TestUpdateView:
         view = db_create_view(org_id=USER_IDENTITY["org_id"], created_by=USER_ID)
 
         url = build_views_url(view_id=str(view.id))
-        response_status, response_data = do_request(flask_client.patch, url, USER_IDENTITY, {"name": "!!!"})
+        response_status, response_data = do_request(flask_client.patch, url, USER_IDENTITY, {"name": "..."})
 
         assert_response_status(response_status, 400)
         assert "name" in response_data["detail"]
+
+    def test_updates_name_with_periods_and_apostrophes(
+        self, flask_client: TestClient, db_create_view: Callable
+    ) -> None:
+        view = db_create_view(org_id=USER_IDENTITY["org_id"], created_by=USER_ID)
+
+        url = build_views_url(view_id=str(view.id))
+        response_status, response_data = do_request(
+            flask_client.patch, url, USER_IDENTITY, {"name": "Q1'26 patch view"}
+        )
+
+        assert_response_status(response_status, 200)
+        assert response_data["name"] == "Q1'26 patch view"
 
     def test_updates_name_with_hyphens_and_underscores(
         self, flask_client: TestClient, db_create_view: Callable

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2522,6 +2522,27 @@ class TestInputViewSchema:
 
         assert "name" in exc_info.value.messages
 
+    def test_punctuation_only_name_raises_error(self):
+        with pytest.raises(MarshmallowValidationError) as exc_info:
+            InputViewSchema().load(
+                {
+                    "name": "...",
+                    "configuration": {"columns": [{"key": "id"}]},
+                }
+            )
+
+        assert "name" in exc_info.value.messages
+
+    def test_name_with_periods_and_apostrophes(self):
+        result = InputViewSchema().load(
+            {
+                "name": "Bob's RHEL 9.4",
+                "configuration": {"columns": [{"key": "display_name"}]},
+            }
+        )
+
+        assert result["name"] == "Bob's RHEL 9.4"
+
     def test_name_too_long_raises_error(self):
         with pytest.raises(MarshmallowValidationError) as exc_info:
             InputViewSchema().load(


### PR DESCRIPTION
## Jira
[RHINENG-30669](https://issues.redhat.com/browse/RHINENG-xxxx)

## What
Allow periods and apostrophes in view names 

## Why
 UX 

## How
Change the regex pattern 

## Testing
Added test cases

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-30669]: https://redhat.atlassian.net/browse/RHINENG-30669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Expand view-name validation to support periods and apostrophes without allowing names made solely of punctuation.

New Features:
- Allow view names to include periods and apostrophes while requiring at least one letter or number.

Enhancements:
- Update view-name validation errors and API schemas to document the expanded naming rules.

Tests:
- Add model and API coverage for creating and updating names with periods and apostrophes, while rejecting punctuation-only names.