### PR TITLE
fix(RHINENG-30671): register Container as named schema in bundled OpenAPI

### DIFF
--- a/swagger/api.spec.yaml
+++ b/swagger/api.spec.yaml
@@ -2896,6 +2896,8 @@ components:
       $ref: 'system_profile.spec.yaml#/$defs/NetworkInterface'
     SystemProfileInterSystemsRunningInstance:
       $ref: 'system_profile.spec.yaml#/$defs/InterSystemsRunningInstance'
+    SystemProfileContainer:
+      $ref: 'system_profile.spec.yaml#/$defs/Container'
 
 
     # Inventory Views schemas

--- a/swagger/api_v2.spec.yaml
+++ b/swagger/api_v2.spec.yaml
@@ -617,6 +617,10 @@ components:
       $ref: 'system_profile.spec.yaml#/$defs/SystemProfile'
     SystemProfileNestedObject:
       $ref: 'system_profile.spec.yaml#/$defs/NestedObject'
+    SystemProfileContainer:
+      $ref: 'system_profile.spec.yaml#/$defs/Container'
+    SystemProfileInterSystemsRunningInstance:
+      $ref: 'system_profile.spec.yaml#/$defs/InterSystemsRunningInstance'
 
     # -- Phase 1 (Hosts & Host Views) — schemas to be added with Phase 1 endpoints:
     #    Status: pending

--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -4757,22 +4757,7 @@
               "containers": {
                 "type": "array",
                 "items": {
-                  "description": "A container on the system",
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "maxLength": 255
-                    },
-                    "image": {
-                      "type": "string",
-                      "maxLength": 255
-                    },
-                    "state": {
-                      "type": "string",
-                      "maxLength": 30
-                    }
-                  }
+                  "$ref": "#/components/schemas/SystemProfileContainer"
                 }
               }
             }
@@ -5121,7 +5106,7 @@
                   "containers": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/SystemProfile/properties/ansible/properties/containers/items"
+                      "$ref": "#/components/schemas/SystemProfileContainer"
                     }
                   }
                 }
@@ -5299,7 +5284,7 @@
                   "containers": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/SystemProfile/properties/ansible/properties/containers/items"
+                      "$ref": "#/components/schemas/SystemProfileContainer"
                     }
                   }
                 }
@@ -5566,6 +5551,24 @@
             "example": "2023.1, 2023.2",
             "maxLength": 7,
             "pattern": "^\\d+(\\.\\d+)+$"
+          }
+        }
+      },
+      "SystemProfileContainer": {
+        "description": "A container on the system",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "image": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "state": {
+            "type": "string",
+            "maxLength": 30
           }
         }
       },

--- a/swagger/openapi_v2.json
+++ b/swagger/openapi_v2.json
@@ -1633,22 +1633,7 @@
               "containers": {
                 "type": "array",
                 "items": {
-                  "description": "A container on the system",
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "maxLength": 255
-                    },
-                    "image": {
-                      "type": "string",
-                      "maxLength": 255
-                    },
-                    "state": {
-                      "type": "string",
-                      "maxLength": 30
-                    }
-                  }
+                  "$ref": "#/components/schemas/SystemProfileContainer"
                 }
               }
             }
@@ -1664,29 +1649,7 @@
               "running_instances": {
                 "type": "array",
                 "items": {
-                  "description": "The info for an InterSystems instance running on the system",
-                  "type": "object",
-                  "properties": {
-                    "instance_name": {
-                      "description": "The name of the instance",
-                      "type": "string",
-                      "example": "IRIS3, PROD",
-                      "maxLength": 255
-                    },
-                    "product": {
-                      "description": "The product of the instance",
-                      "type": "string",
-                      "example": "IRIS",
-                      "maxLength": 64
-                    },
-                    "version": {
-                      "description": "The version of the instance",
-                      "type": "string",
-                      "example": "2023.1, 2023.2",
-                      "maxLength": 7,
-                      "pattern": "^\\d+(\\.\\d+)+$"
-                    }
-                  }
+                  "$ref": "#/components/schemas/SystemProfileInterSystemsRunningInstance"
                 }
               }
             }
@@ -2019,7 +1982,7 @@
                   "containers": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/SystemProfile/properties/ansible/properties/containers/items"
+                      "$ref": "#/components/schemas/SystemProfileContainer"
                     }
                   }
                 }
@@ -2069,7 +2032,7 @@
                   "running_instances": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/SystemProfile/properties/intersystems/properties/running_instances/items"
+                      "$ref": "#/components/schemas/SystemProfileInterSystemsRunningInstance"
                     }
                   }
                 }
@@ -2197,7 +2160,7 @@
                   "containers": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/SystemProfile/properties/ansible/properties/containers/items"
+                      "$ref": "#/components/schemas/SystemProfileContainer"
                     }
                   }
                 }
@@ -2258,6 +2221,49 @@
               }
             }
           ]
+        }
+      },
+      "SystemProfileContainer": {
+        "description": "A container on the system",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "image": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "state": {
+            "type": "string",
+            "maxLength": 30
+          }
+        }
+      },
+      "SystemProfileInterSystemsRunningInstance": {
+        "description": "The info for an InterSystems instance running on the system",
+        "type": "object",
+        "properties": {
+          "instance_name": {
+            "description": "The name of the instance",
+            "type": "string",
+            "example": "IRIS3, PROD",
+            "maxLength": 255
+          },
+          "product": {
+            "description": "The product of the instance",
+            "type": "string",
+            "example": "IRIS",
+            "maxLength": 64
+          },
+          "version": {
+            "description": "The version of the instance",
+            "type": "string",
+            "example": "2023.1, 2023.2",
+            "maxLength": 7,
+            "pattern": "^\\d+(\\.\\d+)+$"
+          }
         }
       }
     },


### PR DESCRIPTION
## Jira
[RHINENG-30671](https://issues.redhat.com/browse/RHINENG-30671)

## What
Fix broken sp.workloads.satellite.containers referrence in json schemas

## Why
The bundled openapi.json/openapi_v2.json expanded the Container object inline at its first occurrence (ansible.containers) and pointed later occurrences (satellite.containers, workloads.*) at a deep JSON pointer into that inline location. Autogenerated frontend clients can't resolve refs that point into the middle of another schema's properties.

Root cause: shared $defs are promoted to named component schemas only when api.spec.yaml declares an explicit rename alias. Container (and, in v2, InterSystemsRunningInstance) had no alias, so swagger-cli bundle fell back to deep-pointer refs.

## How
Add the missing aliases and regenerate the bundles so all usages resolve to #/components/schemas/SystemProfileContainer (and SystemProfileInterSystemsRunningInstance in v2).

## Testing
No needed, schema change.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-30671]: https://redhat.atlassian.net/browse/RHINENG-30671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Register shared system profile schemas as named OpenAPI components and regenerate the bundled specifications to prevent unresolved deep references.

Bug Fixes:
- Fix bundled OpenAPI schema references for Container objects by registering Container as a named component schema.
- Ensure v2 bundled schemas resolve InterSystemsRunningInstance through a named component schema.