### PR TITLE
Cherry-picks of fixes for foreman-3.18

### DIFF
--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -12,6 +12,7 @@ from api.filtering.filtering_common import FIELD_FILTER_TO_PYTHON_CAST
 from api.filtering.filtering_common import POSTGRES_COMPARATOR_LOOKUP
 from api.filtering.filtering_common import POSTGRES_COMPARATOR_NO_EQ_LOOKUP
 from api.filtering.filtering_common import POSTGRES_DEFAULT_COMPARATOR
+from api.filtering.filtering_common import escape_ilike_value
 from api.filtering.filtering_common import get_valid_os_names
 from app import system_profile_spec
 from app.config import HOST_TYPES
@@ -302,8 +303,8 @@ def build_single_filter(filter_param: dict) -> ColumnElement:
             pg_op = POSTGRES_DEFAULT_COMPARATOR.get(field_filter)
 
         # Handle wildcard fields (use ILIKE, replace * with %)
-        if pg_op == ColumnOperators.ilike:
-            value = value.replace("*", "%")
+        if pg_op == ColumnOperators.ilike and value not in ("nil", "not_nil"):
+            value = escape_ilike_value(value)
 
         if value in ["nil", "not_nil"]:
             pg_op = POSTGRES_COMPARATOR_LOOKUP[value]

--- a/api/filtering/db_custom_filters.py
+++ b/api/filtering/db_custom_filters.py
@@ -45,7 +45,7 @@ class OsFilter:
         except ValidationException:
             raise
 
-        self.name = name
+        self.name = name.lower()
         self.comparator = comparator
         self.major = major
         self.minor = minor
@@ -151,6 +151,11 @@ def separate_operating_system_filters(filter_url_params) -> list[OsFilter]:
     return os_filter_list
 
 
+def _operating_system_name_lower(os_field: ColumnElement) -> ColumnElement:
+    """Lowercase `operating_system.name` text for case-insensitive comparisons."""
+    return func.lower(os_field["name"].astext)
+
+
 # Takes an OS filter param and converts it into a tuple containing the DB filter
 def build_operating_system_filter(filter_param: dict) -> tuple:
     os_filter_list = []  # Top-level filter
@@ -168,7 +173,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
 
         elif os_filter.comparator in ["eq", "neq"]:
             os_filters = [
-                func.lower(os_field["name"].astext).operate(comparator, os_filter.name.lower()),
+                _operating_system_name_lower(os_field).operate(comparator, os_filter.name),
             ]
 
             if os_filter.major is not None:
@@ -185,7 +190,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
                 # output: (major < 9) OR (major = 9 AND minor <= 5)
                 comparator_no_eq = POSTGRES_COMPARATOR_NO_EQ_LOOKUP.get(os_filter.comparator)
                 os_filter = and_(
-                    os_field["name"].astext == os_filter.name,
+                    _operating_system_name_lower(os_field) == os_filter.name,
                     or_(
                         os_field["major"].astext.cast(Integer).operate(comparator_no_eq, os_filter.major),
                         and_(
@@ -197,7 +202,7 @@ def build_operating_system_filter(filter_param: dict) -> tuple:
 
             else:
                 os_filter = and_(
-                    os_field["name"].astext == os_filter.name,
+                    _operating_system_name_lower(os_field) == os_filter.name,
                     os_field["major"].astext.cast(Integer).operate(comparator, os_filter.major),
                 )
 

--- a/api/filtering/db_filters.py
+++ b/api/filtering/db_filters.py
@@ -19,6 +19,7 @@ from sqlalchemy.dialects.postgresql import JSON
 
 from api.filtering.db_custom_filters import build_system_profile_filter
 from api.filtering.db_custom_filters import get_host_types_from_filter
+from api.filtering.filtering_common import escape_ilike_value
 from api.staleness_query import get_staleness_obj
 from app.auth.identity import Identity
 from app.auth.identity import IdentityType
@@ -60,7 +61,7 @@ def canonical_fact_filter(canonical_fact: str, value, case_insensitive: bool = F
 
 
 def _display_name_filter(display_name: str) -> list:
-    return [Host.display_name.ilike(f"%{display_name.replace('*', '%')}%")]
+    return [Host.display_name.ilike(f"%{escape_ilike_value(display_name)}%")]
 
 
 def _tags_filter(string_tags: list[str]) -> list:
@@ -292,7 +293,7 @@ def _system_profile_filter(filter: dict) -> tuple[list, set[str | None]]:
 
 
 def _hostname_or_id_filter(hostname_or_id: str) -> tuple:
-    wildcard_id = f"%{hostname_or_id.replace('*', '%')}%"
+    wildcard_id = f"%{escape_ilike_value(hostname_or_id)}%"
     filter_list = [
         Host.display_name.ilike(wildcard_id),
         Host.canonical_facts["fqdn"].astext.ilike(wildcard_id),

--- a/api/filtering/filtering_common.py
+++ b/api/filtering/filtering_common.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Any
 
 from sqlalchemy import BigInteger
 from sqlalchemy import Boolean
@@ -49,3 +50,25 @@ FIELD_FILTER_TO_PYTHON_CAST: dict[str, Callable] = {
 
 def get_valid_os_names() -> list:
     return system_profile_spec()["operating_system"]["children"]["name"]["enum"]
+
+
+def escape_ilike_value(value: Any) -> Any:
+    """
+    Escapes special characters for SQL ILIKE queries (backslash, percent, underscore)
+    and converts asterisks to percent signs.
+
+    This relies on Postgres' default backslash escape behavior for ILIKE.
+    It MUST be called before adding any outer '%' wildcards (e.g. f'%{value}%')
+    so that the outer wildcards are not accidentally escaped.
+    """
+    if not isinstance(value, str):
+        return value
+    # 1. backslash to double backslash
+    value = value.replace("\\", "\\\\")
+    # 2. percent to escaped percent
+    value = value.replace("%", "\\%")
+    # 3. underscore to escaped underscore
+    value = value.replace("_", "\\_")
+    # 4. asterisk to percent
+    value = value.replace("*", "%")
+    return value

--- a/api/staleness_query.py
+++ b/api/staleness_query.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 def get_staleness_obj(org_id: str) -> AttrDict:
     try:
         staleness = db.session.query(Staleness).filter(Staleness.org_id == org_id).one()
-        logger.info(f"Using custom staleness for org {org_id}.")
+        logger.debug(f"Using custom staleness for org {org_id}.")
         staleness = build_serialized_acc_staleness_obj(staleness)
     except NoResultFound:
         logger.debug(f"No custom staleness data found for org {org_id}, using system default values instead.")

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -264,6 +264,7 @@ class Host(LimitedHost):
             self._update_per_reporter_staleness(reporter)
 
         self.update_canonical_facts(canonical_facts)
+        self.update_canonical_facts_columns(canonical_facts)
 
     def save(self):
         self._cleanup_tags()

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -274,6 +274,8 @@ class Host(LimitedHost):
 
         self.update_canonical_facts(input_host.canonical_facts)
 
+        self.update_canonical_facts_columns(input_host.canonical_facts)
+
         self._update_ansible_host(input_host.ansible_host)
 
         self.update_facts(input_host.facts)
@@ -321,6 +323,16 @@ class Host(LimitedHost):
         self.canonical_facts.update(canonical_facts)  # Field being removed in the future
         logger.debug("Host (id=%s) has updated canonical_facts (%s)", self.id, self.canonical_facts)
         orm.attributes.flag_modified(self, "canonical_facts")  # Field being removed in the future
+
+    def update_canonical_facts_columns(self, canonical_facts):
+        try:
+            for key, value in canonical_facts.items():
+                if getattr(self, key) != value:
+                    setattr(self, key, value)
+                    orm.attributes.flag_modified(self, key)
+        except AttributeError as e:
+            logger.warning("Error updating canonical facts column %s: %s", key, str(e))
+            raise e
 
     def update_facts(self, facts_dict):
         if facts_dict:

--- a/jobs/host_reaper.py
+++ b/jobs/host_reaper.py
@@ -98,20 +98,22 @@ def run(config, logger, session, event_producer, notification_event_producer, sh
         while hosts_processed == config.host_delete_chunk_size:
             logger.info(f"Reaper starting batch; {deletions_remaining} remaining.")
             try:
-                events = delete_hosts(
-                    query,
-                    event_producer,
-                    notification_event_producer,
-                    config.host_delete_chunk_size,
-                    shutdown_handler.shut_down,
-                    control_rule="REAPER",
+                hosts_processed = sum(
+                    1
+                    for _ in delete_hosts(
+                        query,
+                        event_producer,
+                        notification_event_producer,
+                        config.host_delete_chunk_size,
+                        shutdown_handler.shut_down,
+                        control_rule="REAPER",
+                    )
                 )
-                hosts_processed = len(list(events))
             except InterruptedError:
-                events = []
                 hosts_processed = 0
 
             deletions_remaining -= hosts_processed
+            session.expunge_all()
 
 
 if __name__ == "__main__":

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -1411,6 +1411,12 @@ def test_query_all_sp_filters_not_found(db_create_host, api_get, sp_filter_param
         "[RHEL][version][eq][]=8",
         "[RHEL][version]=8",  # Minor version should be ignored
         "[RHEL][version][gte]=8&filter[system_profile][operating_system][RHEL][version][lte]=8",
+        # RHINENG-15763: range comparators must match stored OS name case-insensitively
+        "[Rhel][version][gt][]=7",
+        "[rHeL][version][gte]=8",
+        "[rhel][version][gt][]=7&filter[system_profile][operating_system][rhel][version][lt][]=9",
+        "[rhel][version][gt][]=7&filter[system_profile][operating_system][rhel][version][lte][]=8",
+        "[rhel][version][gte]=8&filter[system_profile][operating_system][rhel][version][lte]=8",
     ),
 )
 def test_query_all_sp_filters_operating_system(db_create_host, api_get, sp_filter_param):

--- a/tests/test_api_hosts_get.py
+++ b/tests/test_api_hosts_get.py
@@ -4,12 +4,14 @@ from collections.abc import Callable
 from datetime import timedelta
 from itertools import chain
 from itertools import combinations
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 from pytest_mock import MockerFixture
 from pytest_subtests import SubTests
 
+from api.filtering.filtering_common import escape_ilike_value
 from app.models.host import Host
 from lib.host_repository import find_hosts_by_staleness
 from tests.helpers.api_utils import HOST_READ_ALLOWED_RBAC_RESPONSE_FILES
@@ -2330,6 +2332,322 @@ def test_fresh_staleness_with_only_rhsm_system_profile_bridge(api_get, db_create
     response_status, response_data = api_get(url=url)
 
     assert response_status == 200
-    # The host should be present in the results
-    result_ids = [result["id"] for result in response_data["results"]]
-    assert host_id in result_ids
+    response_ids = [result["id"] for result in response_data["results"]]
+
+    assert len(response_ids) == 2
+
+    if "sap" in sp_filter_param:
+        assert sap_host_id in response_ids
+    if "ansible" in sp_filter_param:
+        assert ansible_host_id in response_ids
+    if "mssql" in sp_filter_param:
+        assert mssql_host_id in response_ids
+    if "rhel_ai" in sp_filter_param:
+        assert no_rhel_host_id in response_ids
+
+
+def test_query_operating_system_and_sap_workload_presence_not_nil(db_create_host, api_get):
+    """OS filter AND SAP workload presence (not_nil) narrow results; both must match."""
+    rhel_86_os = {"name": "RHEL", "major": 8, "minor": 6}
+    match_id = str(
+        db_create_host(
+            extra_data={
+                "system_profile_facts": {
+                    "operating_system": rhel_86_os,
+                    "workloads": {"sap": {"sap_system": True}},
+                }
+            }
+        ).id
+    )
+    same_os_no_sap = str(
+        db_create_host(
+            extra_data={
+                "system_profile_facts": {
+                    "operating_system": rhel_86_os,
+                    "workloads": {},
+                }
+            }
+        ).id
+    )
+    sap_wrong_os = str(
+        db_create_host(
+            extra_data={
+                "system_profile_facts": {
+                    "operating_system": {"name": "RHEL", "major": 7, "minor": 7},
+                    "workloads": {"sap": {"sap_system": True}},
+                }
+            }
+        ).id
+    )
+
+    url = build_hosts_url(
+        query="?filter[system_profile][operating_system][RHEL][version][eq][]=8.6"
+        "&filter[system_profile][workloads][sap][is]=not_nil"
+    )
+    response_status, response_data = api_get(url)
+    assert response_status == 200
+    response_ids = {r["id"] for r in response_data["results"]}
+    assert response_ids == {match_id}
+    assert same_os_no_sap not in response_ids
+    assert sap_wrong_os not in response_ids
+
+
+def test_query_workload_presence_or_logic_combined_with_operating_system_filter(db_create_host, api_get):
+    """Top-level workload existence filters use OR among themselves; OS remains AND (narrowing)."""
+    rhel_86_os = {"name": "RHEL", "major": 8, "minor": 6}
+    sap_on_rhel86 = str(
+        db_create_host(
+            extra_data={
+                "system_profile_facts": {
+                    "operating_system": rhel_86_os,
+                    "workloads": {"sap": {"sap_system": True}},
+                }
+            }
+        ).id
+    )
+    ansible_on_rhel86 = str(
+        db_create_host(
+            extra_data={
+                "system_profile_facts": {
+                    "operating_system": rhel_86_os,
+                    "workloads": {"ansible": {"controller_version": "1.2"}},
+                }
+            }
+        ).id
+    )
+    sap_on_rhel77 = str(
+        db_create_host(
+            extra_data={
+                "system_profile_facts": {
+                    "operating_system": {"name": "RHEL", "major": 7, "minor": 7},
+                    "workloads": {"sap": {"sap_system": True}},
+                }
+            }
+        ).id
+    )
+    neither_on_rhel86 = str(
+        db_create_host(
+            extra_data={
+                "system_profile_facts": {
+                    "operating_system": rhel_86_os,
+                    "workloads": {},
+                }
+            }
+        ).id
+    )
+
+    url = build_hosts_url(
+        query="?filter[system_profile][workloads][sap][is]=not_nil"
+        "&filter[system_profile][workloads][ansible][is]=not_nil"
+        "&filter[system_profile][operating_system][RHEL][version][eq][]=8.6"
+    )
+    response_status, response_data = api_get(url)
+    assert response_status == 200
+    response_ids = {r["id"] for r in response_data["results"]}
+    assert response_ids == {sap_on_rhel86, ansible_on_rhel86}
+    assert sap_on_rhel77 not in response_ids
+    assert neither_on_rhel86 not in response_ids
+
+
+def test_query_workload_specific_properties_across_workloads_still_use_and_logic(db_create_host, api_get):
+    """Drill-down filters on different workloads remain AND (Case 2)."""
+    sap_ver = "1.00.122.04.1478575636"
+    mssql_ver = "15.2.0"
+
+    both = {
+        "system_profile_facts": {
+            "workloads": {
+                "sap": {"sap_system": True, "version": sap_ver},
+                "mssql": {"version": mssql_ver},
+            }
+        }
+    }
+    sap_only = {
+        "system_profile_facts": {
+            "workloads": {"sap": {"sap_system": True, "version": sap_ver}},
+        }
+    }
+    mssql_only = {
+        "system_profile_facts": {
+            "workloads": {"mssql": {"version": mssql_ver}},
+        }
+    }
+
+    both_id = str(db_create_host(extra_data=both).id)
+    sap_only_id = str(db_create_host(extra_data=sap_only).id)
+    mssql_only_id = str(db_create_host(extra_data=mssql_only).id)
+
+    url = build_hosts_url(
+        query=f"?filter[system_profile][workloads][sap][version]={sap_ver}"
+        f"&filter[system_profile][workloads][mssql][version]={mssql_ver}"
+    )
+    response_status, response_data = api_get(url)
+    assert response_status == 200
+    response_ids = {r["id"] for r in response_data["results"]}
+    assert both_id in response_ids
+    assert sap_only_id not in response_ids
+    assert mssql_only_id not in response_ids
+
+
+def test_mixed_workload_property_and_type_no_matches(db_create_host, api_get):
+    db_create_host(extra_data={"system_profile_facts": {"workloads": {"sap": {"sids": ["H2O"]}}}})
+    db_create_host(extra_data={"system_profile_facts": {"workloads": {"rhel_ai": {"variant": "RHEL AI"}}}})
+
+    query = "?filter[system_profile][sap_sids][contains][]=H2O&filter[system_profile][rhel_ai][is][]=not_nil"
+
+    url = build_hosts_url(query)
+    response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert response_data["results"] == []
+
+
+def test_get_hosts_sp_workload_filters_no_matches(db_create_host, api_get):
+    db_create_host(extra_data={"system_profile_facts": {"workloads": {"sap": {"sap_system": False}}}})
+    db_create_host(extra_data={"system_profile_facts": {"workloads": {"sap": {"sids": ["ABC", "DEF"]}}}})
+    db_create_host(extra_data={"system_profile_facts": {"workloads": {"ansible": {}}}})
+
+    url = build_hosts_url(
+        query="?filter[system_profile][workloads][sap][sids][contains][]=NONEXISTENT_SID"
+        "&filter[system_profile][workloads][sap][sap_system][]=true"
+        "&filter[system_profile][workloads][ansible][controller_version][is]=not_nil"
+    )
+    response_status, response_data = api_get(url)
+
+    assert response_status == 200
+    assert response_data["results"] == []
+
+
+def test_no_hosts_in_org(api_get):
+    """Test no hosts are returned if for empty organization."""
+
+    url = build_hosts_url()
+    response_status, response_data = api_get(url, identity=IDENTITY_WITHOUT_HOSTS)
+    assert response_status == 200
+    assert response_data["results"] == []
+    assert response_data["count"] == response_data["total"] == 0
+
+
+@pytest.mark.parametrize(
+    "input_val,expected",
+    [
+        ("hello", "hello"),
+        ("hello%world", "hello\\%world"),
+        ("hello_world", "hello\\_world"),
+        ("hello\\world", "hello\\\\world"),
+        ("hello*world", "hello%world"),
+        ("hello\\%_*world", "hello\\\\\\%\\_%world"),
+        (123, 123),
+        (None, None),
+    ],
+)
+def test_escape_ilike_value(input_val: Any, expected: Any) -> None:
+    assert escape_ilike_value(input_val) == expected
+
+
+@pytest.mark.parametrize(
+    "filter_field,data_key,is_system_profile",
+    [
+        ("display_name", "display_name", False),
+        ("hostname_or_id", "fqdn", False),
+        ("insights_client_version", "insights_client_version", True),
+    ],
+)
+def test_wildcard_escaping(
+    filter_field: str,
+    data_key: str,
+    is_system_profile: bool,
+    db_create_host: Callable[..., Host],
+    api_get: Callable[..., tuple[int, dict]],
+) -> None:
+    # Create hosts with special characters
+    if is_system_profile:
+        host_percent = db_create_host(extra_data={"system_profile_facts": {data_key: "Version%1"}})
+        host_underscore = db_create_host(extra_data={"system_profile_facts": {data_key: "Version_1"}})
+        host_backslash = db_create_host(extra_data={"system_profile_facts": {data_key: "Version\\1"}})
+        host_asterisk = db_create_host(extra_data={"system_profile_facts": {data_key: "VersionX1"}})
+        prefix = "Version"
+    else:
+        host_percent = db_create_host(extra_data={data_key: "Host%1"})
+        host_underscore = db_create_host(extra_data={data_key: "Host_1"})
+        host_backslash = db_create_host(extra_data={data_key: "Host\\1"})
+        host_asterisk = db_create_host(extra_data={data_key: "HostX1"})
+        prefix = "Host"
+
+    # 1. Query for percent: should only match host_percent, not host_underscore or host_backslash or host_asterisk
+    if is_system_profile:
+        url = build_hosts_url(query=f"?filter[system_profile][{filter_field}]={prefix}%251")
+    else:
+        url = build_hosts_url(query=f"?{filter_field}={prefix}%251")
+    status, response = api_get(url)
+    assert status == 200
+    ids = [r["id"] for r in response["results"]]
+    assert str(host_percent.id) in ids
+    assert str(host_underscore.id) not in ids
+    assert str(host_backslash.id) not in ids
+    assert str(host_asterisk.id) not in ids
+
+    # 2. Query for underscore: should only match host_underscore
+    if is_system_profile:
+        url = build_hosts_url(query=f"?filter[system_profile][{filter_field}]={prefix}_1")
+    else:
+        url = build_hosts_url(query=f"?{filter_field}={prefix}_1")
+    status, response = api_get(url)
+    assert status == 200
+    ids = [r["id"] for r in response["results"]]
+    assert str(host_underscore.id) in ids
+    assert str(host_percent.id) not in ids
+    assert str(host_backslash.id) not in ids
+    assert str(host_asterisk.id) not in ids
+
+    # 3. Query for backslash: should only match host_backslash
+    if is_system_profile:
+        url = build_hosts_url(query=f"?filter[system_profile][{filter_field}]={prefix}%5C1")
+    else:
+        url = build_hosts_url(query=f"?{filter_field}={prefix}%5C1")
+    status, response = api_get(url)
+    assert status == 200
+    ids = [r["id"] for r in response["results"]]
+    assert str(host_backslash.id) in ids
+    assert str(host_percent.id) not in ids
+    assert str(host_underscore.id) not in ids
+    assert str(host_asterisk.id) not in ids
+
+    # 4. Query for asterisk: should match host_asterisk, host_percent, host_underscore, host_backslash
+    if is_system_profile:
+        url = build_hosts_url(query=f"?filter[system_profile][{filter_field}]={prefix}*1")
+    else:
+        url = build_hosts_url(query=f"?{filter_field}={prefix}*1")
+    status, response = api_get(url)
+    assert status == 200
+    ids = [r["id"] for r in response["results"]]
+    assert str(host_asterisk.id) in ids
+    assert str(host_percent.id) in ids
+    assert str(host_underscore.id) in ids
+    assert str(host_backslash.id) in ids
+
+
+def test_system_profile_nil_not_nil_not_escaped(
+    db_create_host: Callable[..., Host],
+    api_get: Callable[..., tuple[int, dict]],
+) -> None:
+    # Create a host with insights_client_version key
+    host_with_val = db_create_host(extra_data={"system_profile_facts": {"insights_client_version": "Version1"}})
+    # Create a host without insights_client_version key
+    host_without_val = db_create_host(extra_data={"system_profile_facts": {}})
+
+    # 1. Query with nil: should return host_without_val, but not host_with_val
+    url = build_hosts_url(query="?filter[system_profile][insights_client_version]=nil")
+    status, response = api_get(url)
+    assert status == 200
+    ids = [r["id"] for r in response["results"]]
+    assert str(host_without_val.id) in ids
+    assert str(host_with_val.id) not in ids
+
+    # 2. Query with not_nil: should return host_with_val, but not host_without_val
+    url = build_hosts_url(query="?filter[system_profile][insights_client_version]=not_nil")
+    status, response = api_get(url)
+    assert status == 200
+    ids = [r["id"] for r in response["results"]]
+    assert str(host_with_val.id) in ids
+    assert str(host_without_val.id) not in ids


### PR DESCRIPTION
## Jira
[RHINENG-30314](https://issues.redhat.com/browse/RHINENG-30314)

## What

Cherry-picks of various fixes:

* 370f2e09 fix(RHINENG-28743): Reduce log level for recurring "Using custom staleness for o (#4598)
* 7a2f6d92 fix(RHINENG-4809): System Profile filtering treats URL-decoded '*' (from '%2A') (#4543)
* 3fd9d227 fix(RHINENG-15763): case-insensitive OS name for version range filters (#4147)
* 6fecbbdc fix: populate canonical facts columns on host creation (#2974)
* ed369986 fix(RHINENG-20395): Fix canonical facts updates (#2949)
* 32e1c186 fix: Clean host reaper's DB session memory between batches (#4467)

## Why
<!-- Reason for change / linked ticket -->

Fixes for Foreman.

## How
<!-- Brief explanation of approach -->

## Testing
<!-- How was this tested? -->

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-30314]: https://redhat.atlassian.net/browse/RHINENG-30314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Apply Foreman fixes for reliable host filtering, canonical fact synchronization, quieter logging, and host cleanup.

Bug Fixes:
- Correct system profile filtering for URL-encoded wildcards and make operating-system version range matching case-insensitive.
- Populate and maintain canonical fact columns when hosts are created or updated.
- Reduce recurring custom-staleness log messages from info to debug.
- Improve host reaper processing and session cleanup.

Enhancements:
- Centralize escaping of SQL ILIKE special characters while preserving asterisk wildcard behavior.

Tests:
- Add coverage for case-insensitive operating-system filters, workload filter combinations, wildcard escaping, nil/not-nil predicates, and canonical fact updates through messaging.