### PR TITLE
fix(RHINENG-30218): Register subman cache keys, and delete specific cached system keys

### DIFF
--- a/api/cache.py
+++ b/api/cache.py
@@ -6,7 +6,8 @@ import connexion
 from flask_caching import Cache
 from redis import Redis
 
-from api.system_cache_key import SUBMAN_CACHE_KEY_DELIMITER
+from api.system_cache_key import subman_cache_index_key
+from api.system_cache_key import subman_cache_key
 from api.system_cache_key import system_cache_key_base
 from app.logging import get_logger
 
@@ -114,11 +115,69 @@ def delete_keys(cache_key, wildcard=True, spawn=False):
             logger.info(f"Not deleting cache: CACHE_TYPE '{cache_type}' != '{CACHE_TYPE_REDIS_CACHE}'")
 
 
+def register_subman_cache_key(base_key: str, forwarded_identity: str, timeout: int) -> None:
+    """Track a forwarded-identity cache key so invalidation can delete it without SCAN."""
+    if not (
+        CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == CACHE_TYPE_REDIS_CACHE and base_key and forwarded_identity
+    ):
+        return
+    try:
+        client = _get_redis_client()
+        index_key = f"{CACHE_PREFIX}{subman_cache_index_key(base_key)}"
+        client.sadd(index_key, forwarded_identity)
+        client.expire(index_key, timeout)
+    except Exception as exec:
+        logger.exception("Failed to register subman cache key", exc_info=exec)
+
+
+def _redis_member_str(value) -> str:
+    return value.decode() if isinstance(value, bytes) else value
+
+
+def _delete_cached_system_keys_redis(base_key: str) -> None:
+    try:
+        client = _get_redis_client()
+        keys_to_delete = [f"{CACHE_PREFIX}{base_key}"]
+
+        index_key = f"{CACHE_PREFIX}{subman_cache_index_key(base_key)}"
+        forwarded_ids = client.smembers(index_key)
+        if forwarded_ids:
+            keys_to_delete.extend(
+                f"{CACHE_PREFIX}{subman_cache_key(base_key, _redis_member_str(forwarded_id))}"
+                for forwarded_id in forwarded_ids
+            )
+            logger.info(f"Deleted subman cache keys count: {len(forwarded_ids)}")
+        keys_to_delete.append(index_key)
+        client.delete(*keys_to_delete)
+        logger.info(f"Deleted single cache key: {keys_to_delete[0]}")
+    except Exception as exec:
+        logger.exception("Cache deletion failed", exc_info=exec)
+
+
+def _delete_cached_system_keys(base_key: str, spawn: bool = False) -> None:
+    global CACHE_EXECUTOR
+
+    if not (CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == CACHE_TYPE_REDIS_CACHE and base_key):
+        if not CACHE_CONFIG:
+            logger.info("Not deleting cache: CACHE_CONFIG is falsy")
+        elif not base_key:
+            logger.info("Not deleting cache: base_key is falsy")
+        else:
+            cache_type = CACHE_CONFIG.get("CACHE_TYPE")
+            logger.info(f"Not deleting cache: CACHE_TYPE '{cache_type}' != '{CACHE_TYPE_REDIS_CACHE}'")
+        return
+
+    if spawn and CACHE_EXECUTOR:
+        logger.info("Submitted cache-deletion callable to executor")
+        CACHE_EXECUTOR.submit(_delete_cached_system_keys_redis, base_key)
+    else:
+        _delete_cached_system_keys_redis(base_key)
+
+
 def delete_cached_system_keys(insights_id=None, org_id=None, owner_id=None, spawn=False):
     if insights_id and org_id and owner_id:
         base_key = system_cache_key_base(insights_id, org_id, owner_id)
-        delete_keys(base_key, wildcard=False, spawn=spawn)
-        delete_keys(f"{base_key}{SUBMAN_CACHE_KEY_DELIMITER}", wildcard=True, spawn=spawn)
+        _delete_cached_system_keys(base_key, spawn=spawn)
     elif insights_id and org_id and not owner_id:
         delete_keys(f"insights_id={insights_id}_org={org_id}", wildcard=True, spawn=spawn)
     elif not insights_id and org_id:

--- a/api/cache.py
+++ b/api/cache.py
@@ -10,7 +10,7 @@ from api.system_cache_invalidation import INVALIDATE_SYSTEM_CACHE_KEYS_LUA
 from api.system_cache_invalidation import REGISTER_SUBMAN_CACHE_KEY_LUA
 from api.system_cache_invalidation import legacy_subman_scan_pattern
 from api.system_cache_invalidation import prefixed_base_cache_key
-from api.system_cache_invalidation import prefixed_invalidation_lock_key
+from api.system_cache_invalidation import prefixed_cache_generation_key
 from api.system_cache_invalidation import prefixed_subman_index_key
 from api.system_cache_invalidation import prefixed_subman_key_prefix
 from api.system_cache_key import system_cache_key_base
@@ -96,15 +96,16 @@ def _get_register_subman_cache_key_script(client):
     return _REGISTER_SUBMAN_CACHE_KEY_SCRIPT
 
 
-def subman_cache_invalidation_in_progress(base_key: str) -> bool:
+def get_system_cache_generation(base_key: str) -> int:
     if not (CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == CACHE_TYPE_REDIS_CACHE and base_key):
-        return False
+        return 0
     try:
         client = _get_redis_client()
-        return bool(client.exists(prefixed_invalidation_lock_key(base_key)))
+        value = client.get(prefixed_cache_generation_key(base_key))
+        return int(value) if value is not None else 0
     except Exception as exec:
-        logger.exception("Failed to check subman cache invalidation lock", exc_info=exec)
-        return False
+        logger.exception("Failed to read system cache generation", exc_info=exec)
+        return 0
 
 
 def _delete_keys_redis(cache_key, wildcard=True):
@@ -148,11 +149,11 @@ def delete_keys(cache_key, wildcard=True, spawn=False):
             logger.info(f"Not deleting cache: CACHE_TYPE '{cache_type}' != '{CACHE_TYPE_REDIS_CACHE}'")
 
 
-def register_subman_cache_key(base_key: str, forwarded_identity: str, timeout: int) -> bool:
+def register_subman_cache_key(base_key: str, forwarded_identity: str, timeout: int, cache_generation: int) -> bool:
     """Track a forwarded-identity cache key so invalidation can delete it without SCAN.
 
     Returns True when the forwarded identity was registered, False when registration was skipped
-    because invalidation is in progress for this base key.
+    because invalidation occurred after the caller observed the cache generation.
     """
     if not (
         CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == CACHE_TYPE_REDIS_CACHE and base_key and forwarded_identity
@@ -161,8 +162,8 @@ def register_subman_cache_key(base_key: str, forwarded_identity: str, timeout: i
     try:
         client = _get_redis_client()
         registered = _get_register_subman_cache_key_script(client)(
-            keys=[prefixed_subman_index_key(base_key), prefixed_invalidation_lock_key(base_key)],
-            args=[forwarded_identity, timeout],
+            keys=[prefixed_subman_index_key(base_key), prefixed_cache_generation_key(base_key)],
+            args=[forwarded_identity, timeout, str(cache_generation)],
         )
         return bool(registered)
     except Exception as exec:
@@ -172,14 +173,17 @@ def register_subman_cache_key(base_key: str, forwarded_identity: str, timeout: i
 
 def _delete_cached_system_keys_redis(base_key: str) -> None:
     try:
+        from app.common import inventory_config
+
         client = _get_redis_client()
+        scan_legacy = "1" if inventory_config().cache_subman_legacy_scan_enabled else "0"
         deleted_count = _get_invalidate_system_cache_keys_script(client)(
             keys=[
                 prefixed_subman_index_key(base_key),
                 prefixed_base_cache_key(base_key),
-                prefixed_invalidation_lock_key(base_key),
+                prefixed_cache_generation_key(base_key),
             ],
-            args=[legacy_subman_scan_pattern(base_key), prefixed_subman_key_prefix(base_key)],
+            args=[legacy_subman_scan_pattern(base_key), prefixed_subman_key_prefix(base_key), scan_legacy],
         )
         logger.info(
             "Deleted system cache keys for base_key=%s count=%s",

--- a/api/cache.py
+++ b/api/cache.py
@@ -6,8 +6,13 @@ import connexion
 from flask_caching import Cache
 from redis import Redis
 
-from api.system_cache_key import subman_cache_index_key
-from api.system_cache_key import subman_cache_key
+from api.system_cache_invalidation import INVALIDATE_SYSTEM_CACHE_KEYS_LUA
+from api.system_cache_invalidation import REGISTER_SUBMAN_CACHE_KEY_LUA
+from api.system_cache_invalidation import legacy_subman_scan_pattern
+from api.system_cache_invalidation import prefixed_base_cache_key
+from api.system_cache_invalidation import prefixed_invalidation_lock_key
+from api.system_cache_invalidation import prefixed_subman_index_key
+from api.system_cache_invalidation import prefixed_subman_key_prefix
 from api.system_cache_key import system_cache_key_base
 from app.logging import get_logger
 
@@ -19,6 +24,9 @@ CACHE_EXECUTOR = None
 REDIS_CLIENT = None
 STALENESS_L2_CACHE_ENABLED = False
 logger = get_logger("cache")
+
+_INVALIDATE_SYSTEM_CACHE_KEYS_SCRIPT = None
+_REGISTER_SUBMAN_CACHE_KEY_SCRIPT = None
 
 
 def init_cache(app_config, flask_app):
@@ -74,6 +82,31 @@ def _get_redis_client():
     return REDIS_CLIENT
 
 
+def _get_invalidate_system_cache_keys_script(client):
+    global _INVALIDATE_SYSTEM_CACHE_KEYS_SCRIPT
+    if _INVALIDATE_SYSTEM_CACHE_KEYS_SCRIPT is None:
+        _INVALIDATE_SYSTEM_CACHE_KEYS_SCRIPT = client.register_script(INVALIDATE_SYSTEM_CACHE_KEYS_LUA)
+    return _INVALIDATE_SYSTEM_CACHE_KEYS_SCRIPT
+
+
+def _get_register_subman_cache_key_script(client):
+    global _REGISTER_SUBMAN_CACHE_KEY_SCRIPT
+    if _REGISTER_SUBMAN_CACHE_KEY_SCRIPT is None:
+        _REGISTER_SUBMAN_CACHE_KEY_SCRIPT = client.register_script(REGISTER_SUBMAN_CACHE_KEY_LUA)
+    return _REGISTER_SUBMAN_CACHE_KEY_SCRIPT
+
+
+def subman_cache_invalidation_in_progress(base_key: str) -> bool:
+    if not (CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == CACHE_TYPE_REDIS_CACHE and base_key):
+        return False
+    try:
+        client = _get_redis_client()
+        return bool(client.exists(prefixed_invalidation_lock_key(base_key)))
+    except Exception as exec:
+        logger.exception("Failed to check subman cache invalidation lock", exc_info=exec)
+        return False
+
+
 def _delete_keys_redis(cache_key, wildcard=True):
     global CACHE_CONFIG
     try:
@@ -115,41 +148,44 @@ def delete_keys(cache_key, wildcard=True, spawn=False):
             logger.info(f"Not deleting cache: CACHE_TYPE '{cache_type}' != '{CACHE_TYPE_REDIS_CACHE}'")
 
 
-def register_subman_cache_key(base_key: str, forwarded_identity: str, timeout: int) -> None:
-    """Track a forwarded-identity cache key so invalidation can delete it without SCAN."""
+def register_subman_cache_key(base_key: str, forwarded_identity: str, timeout: int) -> bool:
+    """Track a forwarded-identity cache key so invalidation can delete it without SCAN.
+
+    Returns True when the forwarded identity was registered, False when registration was skipped
+    because invalidation is in progress for this base key.
+    """
     if not (
         CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == CACHE_TYPE_REDIS_CACHE and base_key and forwarded_identity
     ):
-        return
+        return False
     try:
         client = _get_redis_client()
-        index_key = f"{CACHE_PREFIX}{subman_cache_index_key(base_key)}"
-        client.sadd(index_key, forwarded_identity)
-        client.expire(index_key, timeout)
+        registered = _get_register_subman_cache_key_script(client)(
+            keys=[prefixed_subman_index_key(base_key), prefixed_invalidation_lock_key(base_key)],
+            args=[forwarded_identity, timeout],
+        )
+        return bool(registered)
     except Exception as exec:
         logger.exception("Failed to register subman cache key", exc_info=exec)
-
-
-def _redis_member_str(value) -> str:
-    return value.decode() if isinstance(value, bytes) else value
+        return False
 
 
 def _delete_cached_system_keys_redis(base_key: str) -> None:
     try:
         client = _get_redis_client()
-        keys_to_delete = [f"{CACHE_PREFIX}{base_key}"]
-
-        index_key = f"{CACHE_PREFIX}{subman_cache_index_key(base_key)}"
-        forwarded_ids = client.smembers(index_key)
-        if forwarded_ids:
-            keys_to_delete.extend(
-                f"{CACHE_PREFIX}{subman_cache_key(base_key, _redis_member_str(forwarded_id))}"
-                for forwarded_id in forwarded_ids
-            )
-            logger.info(f"Deleted subman cache keys count: {len(forwarded_ids)}")
-        keys_to_delete.append(index_key)
-        client.delete(*keys_to_delete)
-        logger.info(f"Deleted single cache key: {keys_to_delete[0]}")
+        deleted_count = _get_invalidate_system_cache_keys_script(client)(
+            keys=[
+                prefixed_subman_index_key(base_key),
+                prefixed_base_cache_key(base_key),
+                prefixed_invalidation_lock_key(base_key),
+            ],
+            args=[legacy_subman_scan_pattern(base_key), prefixed_subman_key_prefix(base_key)],
+        )
+        logger.info(
+            "Deleted system cache keys for base_key=%s count=%s",
+            base_key,
+            deleted_count,
+        )
     except Exception as exec:
         logger.exception("Cache deletion failed", exc_info=exec)
 

--- a/api/host.py
+++ b/api/host.py
@@ -13,8 +13,8 @@ from api import metrics
 from api import pagination_params
 from api.cache import CACHE
 from api.cache import delete_cached_system_keys
+from api.cache import get_system_cache_generation
 from api.cache import register_subman_cache_key
-from api.cache import subman_cache_invalidation_in_progress
 from api.cache_key import make_system_cache_key
 from api.filtering.db_filters import update_query_for_owner_id
 from api.host_query import build_paginated_host_list_response
@@ -189,7 +189,8 @@ def get_host_list(
     )
     if is_cached_insights_client_system_query and len(host_list) == 1:
         base_key = system_cache_key_base(insights_id, current_identity.org_id, owner_id)
-        if not subman_cache_invalidation_in_progress(base_key):
+        cache_generation = get_system_cache_generation(base_key)
+        if get_system_cache_generation(base_key) == cache_generation:
             system_key = make_system_cache_key(
                 insights_id, current_identity.org_id, owner_id, forwarded_identity=forwarded_identity
             )
@@ -197,7 +198,7 @@ def get_host_list(
             timeout = inventory_config().cache_insights_client_system_timeout_sec
             CACHE.set(key=system_key, value=output_host, timeout=timeout)
             if forwarded_identity:
-                register_subman_cache_key(base_key, forwarded_identity, timeout)
+                register_subman_cache_key(base_key, forwarded_identity, timeout, cache_generation)
 
     return flask_json_response(json_data)
 

--- a/api/host.py
+++ b/api/host.py
@@ -14,6 +14,7 @@ from api import pagination_params
 from api.cache import CACHE
 from api.cache import delete_cached_system_keys
 from api.cache import register_subman_cache_key
+from api.cache import subman_cache_invalidation_in_progress
 from api.cache_key import make_system_cache_key
 from api.filtering.db_filters import update_query_for_owner_id
 from api.host_query import build_paginated_host_list_response
@@ -187,18 +188,16 @@ def get_host_list(
         total, page, per_page, host_list, additional_fields, system_profile_fields
     )
     if is_cached_insights_client_system_query and len(host_list) == 1:
-        system_key = make_system_cache_key(
-            insights_id, current_identity.org_id, owner_id, forwarded_identity=forwarded_identity
-        )
-        output_host = serialize_host_with_params(host_list[0])
-        timeout = inventory_config().cache_insights_client_system_timeout_sec
-        CACHE.set(key=system_key, value=output_host, timeout=timeout)
-        if forwarded_identity:
-            register_subman_cache_key(
-                system_cache_key_base(insights_id, current_identity.org_id, owner_id),
-                forwarded_identity,
-                timeout,
+        base_key = system_cache_key_base(insights_id, current_identity.org_id, owner_id)
+        if not subman_cache_invalidation_in_progress(base_key):
+            system_key = make_system_cache_key(
+                insights_id, current_identity.org_id, owner_id, forwarded_identity=forwarded_identity
             )
+            output_host = serialize_host_with_params(host_list[0])
+            timeout = inventory_config().cache_insights_client_system_timeout_sec
+            CACHE.set(key=system_key, value=output_host, timeout=timeout)
+            if forwarded_identity:
+                register_subman_cache_key(base_key, forwarded_identity, timeout)
 
     return flask_json_response(json_data)
 

--- a/api/host.py
+++ b/api/host.py
@@ -13,6 +13,7 @@ from api import metrics
 from api import pagination_params
 from api.cache import CACHE
 from api.cache import delete_cached_system_keys
+from api.cache import register_subman_cache_key
 from api.cache_key import make_system_cache_key
 from api.filtering.db_filters import update_query_for_owner_id
 from api.host_query import build_paginated_host_list_response
@@ -25,6 +26,7 @@ from api.host_query_db import get_host_tags_list_by_id_list
 from api.host_query_db import get_sparse_system_profile
 from api.parsing import _normalize_workspace_filters
 from api.staleness_query import get_staleness_obj
+from api.system_cache_key import system_cache_key_base
 from app.auth import get_current_identity
 from app.auth.forwarded_identity import get_satellite_forwarded_identity
 from app.auth.identity import IdentityType
@@ -191,6 +193,12 @@ def get_host_list(
         output_host = serialize_host_with_params(host_list[0])
         timeout = inventory_config().cache_insights_client_system_timeout_sec
         CACHE.set(key=system_key, value=output_host, timeout=timeout)
+        if forwarded_identity:
+            register_subman_cache_key(
+                system_cache_key_base(insights_id, current_identity.org_id, owner_id),
+                forwarded_identity,
+                timeout,
+            )
 
     return flask_json_response(json_data)
 

--- a/api/system_cache_invalidation.py
+++ b/api/system_cache_invalidation.py
@@ -1,0 +1,119 @@
+"""Redis Lua scripts for atomic system-cache invalidation and registration."""
+
+from api.system_cache_key import SUBMAN_CACHE_KEY_DELIMITER
+from api.system_cache_key import subman_cache_index_key
+
+CACHE_PREFIX = "flask_cache_"
+INVALIDATION_LOCK_SUFFIX = ":invalidating"
+INDEX_DELETING_SUFFIX = ":deleting"
+
+# Atomically invalidate a system cache entry:
+# 1. Set a short-lived lock so concurrent registrations are skipped.
+# 2. RENAME the index set so in-flight SMEMBERS/delete cannot race with SADD.
+# 3. Delete indexed forwarded-identity keys.
+# 4. SCAN for legacy unindexed forwarded-identity keys (pre-index deployments).
+# 5. Delete any index recreated during invalidation and its members.
+# KEYS[1] = prefixed index key
+# KEYS[2] = prefixed base cache key
+# KEYS[3] = prefixed invalidation lock key
+# ARGV[1] = legacy SCAN match pattern
+# ARGV[2] = prefixed subman key prefix for indexed members
+INVALIDATE_SYSTEM_CACHE_KEYS_LUA = """
+local index_key = KEYS[1]
+local base_key = KEYS[2]
+local lock_key = KEYS[3]
+local scan_pattern = ARGV[1]
+local subman_prefix = ARGV[2]
+
+redis.call('SET', lock_key, '1', 'EX', 30)
+
+local keys_to_delete = {}
+local seen = {}
+local deleted_count = 0
+
+local function add_key(key)
+  if not seen[key] then
+    seen[key] = true
+    keys_to_delete[#keys_to_delete + 1] = key
+  end
+end
+
+add_key(base_key)
+
+if redis.call('EXISTS', index_key) == 1 then
+  local temp_index = index_key .. ':deleting'
+  redis.call('RENAME', index_key, temp_index)
+  for _, member in ipairs(redis.call('SMEMBERS', temp_index)) do
+    add_key(subman_prefix .. member)
+  end
+  add_key(temp_index)
+end
+
+local cursor = '0'
+repeat
+  local result = redis.call('SCAN', cursor, 'MATCH', scan_pattern, 'COUNT', 100)
+  cursor = result[1]
+  for _, key in ipairs(result[2]) do
+    add_key(key)
+  end
+until cursor == '0'
+
+if redis.call('EXISTS', index_key) == 1 then
+  for _, member in ipairs(redis.call('SMEMBERS', index_key)) do
+    add_key(subman_prefix .. member)
+  end
+  add_key(index_key)
+end
+
+redis.call('DEL', lock_key)
+
+if #keys_to_delete > 0 then
+  deleted_count = redis.call('UNLINK', unpack(keys_to_delete))
+end
+
+return deleted_count
+"""
+
+# Register a forwarded-identity cache key in the index unless invalidation is active.
+# KEYS[1] = prefixed index key
+# KEYS[2] = prefixed invalidation lock key
+# ARGV[1] = forwarded identity UUID
+# ARGV[2] = index TTL seconds
+REGISTER_SUBMAN_CACHE_KEY_LUA = """
+local index_key = KEYS[1]
+local lock_key = KEYS[2]
+local member = ARGV[1]
+local ttl = tonumber(ARGV[2])
+
+if redis.call('EXISTS', lock_key) == 1 then
+  return 0
+end
+
+redis.call('SADD', index_key, member)
+redis.call('EXPIRE', index_key, ttl)
+return 1
+"""
+
+
+def prefixed_base_cache_key(base_key: str) -> str:
+    return f"{CACHE_PREFIX}{base_key}"
+
+
+def prefixed_subman_cache_key(base_key: str, forwarded_identity: str) -> str:
+    return f"{CACHE_PREFIX}{base_key}{SUBMAN_CACHE_KEY_DELIMITER}{forwarded_identity}"
+
+
+def prefixed_subman_index_key(base_key: str) -> str:
+    return f"{CACHE_PREFIX}{subman_cache_index_key(base_key)}"
+
+
+def prefixed_subman_key_prefix(base_key: str) -> str:
+    return f"{CACHE_PREFIX}{base_key}{SUBMAN_CACHE_KEY_DELIMITER}"
+
+
+def prefixed_invalidation_lock_key(base_key: str) -> str:
+    return f"{prefixed_subman_index_key(base_key)}{INVALIDATION_LOCK_SUFFIX}"
+
+
+def legacy_subman_scan_pattern(base_key: str) -> str:
+    return f"{prefixed_subman_key_prefix(base_key)}*"

--- a/api/system_cache_invalidation.py
+++ b/api/system_cache_invalidation.py
@@ -4,28 +4,30 @@ from api.system_cache_key import SUBMAN_CACHE_KEY_DELIMITER
 from api.system_cache_key import subman_cache_index_key
 
 CACHE_PREFIX = "flask_cache_"
-INVALIDATION_LOCK_SUFFIX = ":invalidating"
-INDEX_DELETING_SUFFIX = ":deleting"
+GENERATION_SUFFIX = ":generation"
+UNLINK_BATCH_SIZE = 100
 
 # Atomically invalidate a system cache entry:
-# 1. Set a short-lived lock so concurrent registrations are skipped.
+# 1. INCR generation so in-flight writers cannot publish after invalidation completes.
 # 2. RENAME the index set so in-flight SMEMBERS/delete cannot race with SADD.
 # 3. Delete indexed forwarded-identity keys.
-# 4. SCAN for legacy unindexed forwarded-identity keys (pre-index deployments).
+# 4. Optionally SCAN for legacy unindexed forwarded-identity keys (migration only).
 # 5. Delete any index recreated during invalidation and its members.
 # KEYS[1] = prefixed index key
 # KEYS[2] = prefixed base cache key
-# KEYS[3] = prefixed invalidation lock key
-# ARGV[1] = legacy SCAN match pattern
+# KEYS[3] = prefixed generation key
+# ARGV[1] = legacy SCAN match pattern (used only when ARGV[3] == '1')
 # ARGV[2] = prefixed subman key prefix for indexed members
+# ARGV[3] = '1' to scan for legacy keys, '0' to skip
 INVALIDATE_SYSTEM_CACHE_KEYS_LUA = """
 local index_key = KEYS[1]
 local base_key = KEYS[2]
-local lock_key = KEYS[3]
+local generation_key = KEYS[3]
 local scan_pattern = ARGV[1]
 local subman_prefix = ARGV[2]
+local scan_legacy = ARGV[3]
 
-redis.call('SET', lock_key, '1', 'EX', 30)
+redis.call('INCR', generation_key)
 
 local keys_to_delete = {}
 local seen = {}
@@ -49,14 +51,16 @@ if redis.call('EXISTS', index_key) == 1 then
   add_key(temp_index)
 end
 
-local cursor = '0'
-repeat
-  local result = redis.call('SCAN', cursor, 'MATCH', scan_pattern, 'COUNT', 100)
-  cursor = result[1]
-  for _, key in ipairs(result[2]) do
-    add_key(key)
-  end
-until cursor == '0'
+if scan_legacy == '1' then
+  local cursor = '0'
+  repeat
+    local result = redis.call('SCAN', cursor, 'MATCH', scan_pattern, 'COUNT', 100)
+    cursor = result[1]
+    for _, key in ipairs(result[2]) do
+      add_key(key)
+    end
+  until cursor == '0'
+end
 
 if redis.call('EXISTS', index_key) == 1 then
   for _, member in ipairs(redis.call('SMEMBERS', index_key)) do
@@ -65,27 +69,34 @@ if redis.call('EXISTS', index_key) == 1 then
   add_key(index_key)
 end
 
-redis.call('DEL', lock_key)
-
 if #keys_to_delete > 0 then
-  deleted_count = redis.call('UNLINK', unpack(keys_to_delete))
+  local batch_size = 100
+  for start = 1, #keys_to_delete, batch_size do
+    local batch = {}
+    for i = start, math.min(start + batch_size - 1, #keys_to_delete) do
+      batch[#batch + 1] = keys_to_delete[i]
+    end
+    deleted_count = deleted_count + redis.call('UNLINK', unpack(batch))
+  end
 end
 
 return deleted_count
 """
 
-# Register a forwarded-identity cache key in the index unless invalidation is active.
+# Register a forwarded-identity cache key in the index when the generation is unchanged.
 # KEYS[1] = prefixed index key
-# KEYS[2] = prefixed invalidation lock key
+# KEYS[2] = prefixed generation key
 # ARGV[1] = forwarded identity UUID
 # ARGV[2] = index TTL seconds
+# ARGV[3] = expected generation token
 REGISTER_SUBMAN_CACHE_KEY_LUA = """
 local index_key = KEYS[1]
-local lock_key = KEYS[2]
+local generation_key = KEYS[2]
 local member = ARGV[1]
 local ttl = tonumber(ARGV[2])
+local expected_generation = ARGV[3]
 
-if redis.call('EXISTS', lock_key) == 1 then
+if redis.call('GET', generation_key) ~= expected_generation then
   return 0
 end
 
@@ -111,8 +122,8 @@ def prefixed_subman_key_prefix(base_key: str) -> str:
     return f"{CACHE_PREFIX}{base_key}{SUBMAN_CACHE_KEY_DELIMITER}"
 
 
-def prefixed_invalidation_lock_key(base_key: str) -> str:
-    return f"{prefixed_subman_index_key(base_key)}{INVALIDATION_LOCK_SUFFIX}"
+def prefixed_cache_generation_key(base_key: str) -> str:
+    return f"{prefixed_subman_index_key(base_key)}{GENERATION_SUFFIX}"
 
 
 def legacy_subman_scan_pattern(base_key: str) -> str:

--- a/api/system_cache_key.py
+++ b/api/system_cache_key.py
@@ -1,5 +1,14 @@
 SUBMAN_CACHE_KEY_DELIMITER = "_subman="
+SUBMAN_CACHE_INDEX_SUFFIX = "keys"
 
 
 def system_cache_key_base(insights_id, org_id, owner_id):
     return f"insights_id={insights_id}_org={org_id}_user=SYSTEM-{owner_id}"
+
+
+def subman_cache_index_key(base_key: str) -> str:
+    return f"{base_key}{SUBMAN_CACHE_KEY_DELIMITER}{SUBMAN_CACHE_INDEX_SUFFIX}"
+
+
+def subman_cache_key(base_key: str, forwarded_identity: str) -> str:
+    return f"{base_key}{SUBMAN_CACHE_KEY_DELIMITER}{forwarded_identity}"

--- a/app/config.py
+++ b/app/config.py
@@ -284,6 +284,9 @@ class Config:
             os.getenv("INVENTORY_CACHE_INSIGHTS_CLIENT_SYSTEM_TIMEOUT_SEC", "129600")
         )
         self.api_cache_max_thread_pool_workers = int(os.getenv("INVENTORY_CACHE_THREAD_POOL_MAX_WORKERS", "5"))
+        self.cache_subman_legacy_scan_enabled = (
+            os.getenv("INVENTORY_CACHE_SUBMAN_LEGACY_SCAN_ENABLED", "false").lower() == "true"
+        )
         self.staleness_cache_timeout = int(os.getenv("STALENESS_CACHE_TIMEOUT_SECONDS", "3600"))
         self.redis_socket_timeout = float(os.getenv("REDIS_SOCKET_TIMEOUT_SECONDS", "3"))
         self.redis_socket_connect_timeout = float(os.getenv("REDIS_SOCKET_CONNECT_TIMEOUT_SECONDS", "3"))

--- a/tests/test_system_cache_invalidation.py
+++ b/tests/test_system_cache_invalidation.py
@@ -1,5 +1,5 @@
 from api.system_cache_invalidation import legacy_subman_scan_pattern
-from api.system_cache_invalidation import prefixed_invalidation_lock_key
+from api.system_cache_invalidation import prefixed_cache_generation_key
 from api.system_cache_invalidation import prefixed_subman_index_key
 from api.system_cache_invalidation import prefixed_subman_key_prefix
 from api.system_cache_key import subman_cache_key
@@ -17,6 +17,6 @@ def test_legacy_subman_scan_pattern_matches_forwarded_identity_keys():
     assert subman_cache_key(base_key, forwarded_identity).endswith(forwarded_identity)
 
 
-def test_prefixed_invalidation_lock_key_uses_index_key():
+def test_prefixed_cache_generation_key_uses_index_key():
     base_key = system_cache_key_base(generate_uuid(), "test", "owner")
-    assert prefixed_invalidation_lock_key(base_key) == f"{prefixed_subman_index_key(base_key)}:invalidating"
+    assert prefixed_cache_generation_key(base_key) == f"{prefixed_subman_index_key(base_key)}:generation"

--- a/tests/test_system_cache_invalidation.py
+++ b/tests/test_system_cache_invalidation.py
@@ -1,0 +1,22 @@
+from api.system_cache_invalidation import legacy_subman_scan_pattern
+from api.system_cache_invalidation import prefixed_invalidation_lock_key
+from api.system_cache_invalidation import prefixed_subman_index_key
+from api.system_cache_invalidation import prefixed_subman_key_prefix
+from api.system_cache_key import subman_cache_key
+from api.system_cache_key import system_cache_key_base
+from tests.helpers.test_utils import generate_uuid
+
+
+def test_legacy_subman_scan_pattern_matches_forwarded_identity_keys():
+    base_key = system_cache_key_base(generate_uuid(), "test", "owner")
+    forwarded_identity = generate_uuid()
+
+    pattern = legacy_subman_scan_pattern(base_key)
+    assert pattern == f"{prefixed_subman_key_prefix(base_key)}*"
+    assert pattern.startswith(prefixed_subman_key_prefix(base_key))
+    assert subman_cache_key(base_key, forwarded_identity).endswith(forwarded_identity)
+
+
+def test_prefixed_invalidation_lock_key_uses_index_key():
+    base_key = system_cache_key_base(generate_uuid(), "test", "owner")
+    assert prefixed_invalidation_lock_key(base_key) == f"{prefixed_subman_index_key(base_key)}:invalidating"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,9 +11,13 @@ from yaml import safe_load
 from api.cache import _delete_cached_system_keys_redis
 from api.cache import delete_cached_system_keys
 from api.cache import register_subman_cache_key
+from api.cache import subman_cache_invalidation_in_progress
 from api.cache_key import make_system_cache_key
-from api.system_cache_key import subman_cache_index_key
-from api.system_cache_key import subman_cache_key
+from api.system_cache_invalidation import legacy_subman_scan_pattern
+from api.system_cache_invalidation import prefixed_base_cache_key
+from api.system_cache_invalidation import prefixed_invalidation_lock_key
+from api.system_cache_invalidation import prefixed_subman_index_key
+from api.system_cache_invalidation import prefixed_subman_key_prefix
 from api.system_cache_key import system_cache_key_base
 from lib.feature_flags import FLAG_FALLBACK_VALUES
 from lib.feature_flags import UNLEASH
@@ -207,44 +211,67 @@ def test_delete_cached_system_keys_deletes_base_and_subman_keys(delete_cached_sy
 
 
 @patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
+@patch("api.cache._get_register_subman_cache_key_script")
 @patch("api.cache.REDIS_CLIENT")
-def test_register_subman_cache_key_tracks_forwarded_identity(redis_client_mock):
+def test_register_subman_cache_key_tracks_forwarded_identity(_redis_client_mock, register_script_getter_mock):
     base_key = system_cache_key_base(generate_uuid(), "test", "owner")
     forwarded_identity = generate_uuid()
     timeout = 3600
+    register_script = MagicMock(return_value=1)
+    register_script_getter_mock.return_value = register_script
 
-    register_subman_cache_key(base_key, forwarded_identity, timeout)
+    registered = register_subman_cache_key(base_key, forwarded_identity, timeout)
 
-    index_key = f"flask_cache_{subman_cache_index_key(base_key)}"
-    redis_client_mock.sadd.assert_called_once_with(index_key, forwarded_identity)
-    redis_client_mock.expire.assert_called_once_with(index_key, timeout)
+    assert registered is True
+    register_script.assert_called_once_with(
+        keys=[prefixed_subman_index_key(base_key), prefixed_invalidation_lock_key(base_key)],
+        args=[forwarded_identity, timeout],
+    )
+
+
+@patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
+@patch("api.cache._get_register_subman_cache_key_script")
+@patch("api.cache.REDIS_CLIENT")
+def test_register_subman_cache_key_skips_during_invalidation(_redis_client_mock, register_script_getter_mock):
+    base_key = system_cache_key_base(generate_uuid(), "test", "owner")
+    register_script = MagicMock(return_value=0)
+    register_script_getter_mock.return_value = register_script
+
+    registered = register_subman_cache_key(base_key, generate_uuid(), 3600)
+
+    assert registered is False
+
+
+@patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
+@patch("api.cache._get_invalidate_system_cache_keys_script")
+@patch("api.cache.REDIS_CLIENT")
+def test_delete_cached_system_keys_redis_uses_atomic_invalidation_script(
+    _redis_client_mock, invalidate_script_getter_mock
+):
+    base_key = system_cache_key_base(generate_uuid(), "test", "owner")
+    invalidate_script = MagicMock(return_value=2)
+    invalidate_script_getter_mock.return_value = invalidate_script
+
+    _delete_cached_system_keys_redis(base_key)
+
+    invalidate_script.assert_called_once_with(
+        keys=[
+            prefixed_subman_index_key(base_key),
+            prefixed_base_cache_key(base_key),
+            prefixed_invalidation_lock_key(base_key),
+        ],
+        args=[legacy_subman_scan_pattern(base_key), prefixed_subman_key_prefix(base_key)],
+    )
 
 
 @patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
 @patch("api.cache.REDIS_CLIENT")
-def test_delete_cached_system_keys_redis_without_subman_index(redis_client_mock):
+def test_subman_cache_invalidation_in_progress(redis_client_mock):
     base_key = system_cache_key_base(generate_uuid(), "test", "owner")
-    redis_client_mock.smembers.return_value = []
+    redis_client_mock.exists.return_value = 1
 
-    _delete_cached_system_keys_redis(base_key)
-
-    index_key = f"flask_cache_{subman_cache_index_key(base_key)}"
-    redis_client_mock.smembers.assert_called_once_with(index_key)
-    redis_client_mock.delete.assert_called_once_with(f"flask_cache_{base_key}", index_key)
-
-
-@patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
-@patch("api.cache.REDIS_CLIENT")
-def test_delete_cached_system_keys_redis_with_subman_index(redis_client_mock):
-    base_key = system_cache_key_base(generate_uuid(), "test", "owner")
-    forwarded_identity = generate_uuid()
-    redis_client_mock.smembers.return_value = [forwarded_identity.encode()]
-
-    _delete_cached_system_keys_redis(base_key)
-
-    subman_key = f"flask_cache_{subman_cache_key(base_key, forwarded_identity)}"
-    index_key = f"flask_cache_{subman_cache_index_key(base_key)}"
-    redis_client_mock.delete.assert_called_once_with(f"flask_cache_{base_key}", subman_key, index_key)
+    assert subman_cache_invalidation_in_progress(base_key) is True
+    redis_client_mock.exists.assert_called_once_with(prefixed_invalidation_lock_key(base_key))
 
 
 @patch.dict(FLAG_FALLBACK_VALUES, {TEST_FEATURE_FLAG: False})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,12 +10,12 @@ from yaml import safe_load
 
 from api.cache import _delete_cached_system_keys_redis
 from api.cache import delete_cached_system_keys
+from api.cache import get_system_cache_generation
 from api.cache import register_subman_cache_key
-from api.cache import subman_cache_invalidation_in_progress
 from api.cache_key import make_system_cache_key
 from api.system_cache_invalidation import legacy_subman_scan_pattern
 from api.system_cache_invalidation import prefixed_base_cache_key
-from api.system_cache_invalidation import prefixed_invalidation_lock_key
+from api.system_cache_invalidation import prefixed_cache_generation_key
 from api.system_cache_invalidation import prefixed_subman_index_key
 from api.system_cache_invalidation import prefixed_subman_key_prefix
 from api.system_cache_key import system_cache_key_base
@@ -220,35 +220,37 @@ def test_register_subman_cache_key_tracks_forwarded_identity(_redis_client_mock,
     register_script = MagicMock(return_value=1)
     register_script_getter_mock.return_value = register_script
 
-    registered = register_subman_cache_key(base_key, forwarded_identity, timeout)
+    registered = register_subman_cache_key(base_key, forwarded_identity, timeout, cache_generation=3)
 
     assert registered is True
     register_script.assert_called_once_with(
-        keys=[prefixed_subman_index_key(base_key), prefixed_invalidation_lock_key(base_key)],
-        args=[forwarded_identity, timeout],
+        keys=[prefixed_subman_index_key(base_key), prefixed_cache_generation_key(base_key)],
+        args=[forwarded_identity, timeout, "3"],
     )
 
 
 @patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
 @patch("api.cache._get_register_subman_cache_key_script")
 @patch("api.cache.REDIS_CLIENT")
-def test_register_subman_cache_key_skips_during_invalidation(_redis_client_mock, register_script_getter_mock):
+def test_register_subman_cache_key_skips_when_generation_changed(_redis_client_mock, register_script_getter_mock):
     base_key = system_cache_key_base(generate_uuid(), "test", "owner")
     register_script = MagicMock(return_value=0)
     register_script_getter_mock.return_value = register_script
 
-    registered = register_subman_cache_key(base_key, generate_uuid(), 3600)
+    registered = register_subman_cache_key(base_key, generate_uuid(), 3600, cache_generation=3)
 
     assert registered is False
 
 
 @patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
+@patch("app.common.inventory_config")
 @patch("api.cache._get_invalidate_system_cache_keys_script")
 @patch("api.cache.REDIS_CLIENT")
 def test_delete_cached_system_keys_redis_uses_atomic_invalidation_script(
-    _redis_client_mock, invalidate_script_getter_mock
+    _redis_client_mock, invalidate_script_getter_mock, inventory_config_mock
 ):
     base_key = system_cache_key_base(generate_uuid(), "test", "owner")
+    inventory_config_mock.return_value.cache_subman_legacy_scan_enabled = False
     invalidate_script = MagicMock(return_value=2)
     invalidate_script_getter_mock.return_value = invalidate_script
 
@@ -258,20 +260,20 @@ def test_delete_cached_system_keys_redis_uses_atomic_invalidation_script(
         keys=[
             prefixed_subman_index_key(base_key),
             prefixed_base_cache_key(base_key),
-            prefixed_invalidation_lock_key(base_key),
+            prefixed_cache_generation_key(base_key),
         ],
-        args=[legacy_subman_scan_pattern(base_key), prefixed_subman_key_prefix(base_key)],
+        args=[legacy_subman_scan_pattern(base_key), prefixed_subman_key_prefix(base_key), "0"],
     )
 
 
 @patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
 @patch("api.cache.REDIS_CLIENT")
-def test_subman_cache_invalidation_in_progress(redis_client_mock):
+def test_get_system_cache_generation(redis_client_mock):
     base_key = system_cache_key_base(generate_uuid(), "test", "owner")
-    redis_client_mock.exists.return_value = 1
+    redis_client_mock.get.return_value = b"7"
 
-    assert subman_cache_invalidation_in_progress(base_key) is True
-    redis_client_mock.exists.assert_called_once_with(prefixed_invalidation_lock_key(base_key))
+    assert get_system_cache_generation(base_key) == 7
+    redis_client_mock.get.assert_called_once_with(prefixed_cache_generation_key(base_key))
 
 
 @patch.dict(FLAG_FALLBACK_VALUES, {TEST_FEATURE_FLAG: False})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,8 +8,12 @@ from pytest import mark
 from pytest import raises
 from yaml import safe_load
 
+from api.cache import _delete_cached_system_keys_redis
 from api.cache import delete_cached_system_keys
+from api.cache import register_subman_cache_key
 from api.cache_key import make_system_cache_key
+from api.system_cache_key import subman_cache_index_key
+from api.system_cache_key import subman_cache_key
 from api.system_cache_key import system_cache_key_base
 from lib.feature_flags import FLAG_FALLBACK_VALUES
 from lib.feature_flags import UNLEASH
@@ -190,8 +194,8 @@ def test_make_system_cache_key_with_forwarded_identity():
     assert key == (f"insights_id={insights_id}_org={org_id}_user=SYSTEM-{owner_id}_subman={forwarded_identity}")
 
 
-@patch("api.cache.delete_keys")
-def test_delete_cached_system_keys_uses_delimiter_aware_patterns(delete_keys_mock):
+@patch("api.cache._delete_cached_system_keys")
+def test_delete_cached_system_keys_deletes_base_and_subman_keys(delete_cached_system_keys_mock):
     insights_id = generate_uuid()
     org_id = "test"
     owner_id = "abc"
@@ -199,8 +203,48 @@ def test_delete_cached_system_keys_uses_delimiter_aware_patterns(delete_keys_moc
 
     delete_cached_system_keys(insights_id=insights_id, org_id=org_id, owner_id=owner_id)
 
-    delete_keys_mock.assert_any_call(base_key, wildcard=False, spawn=False)
-    delete_keys_mock.assert_any_call(f"{base_key}_subman=", wildcard=True, spawn=False)
+    delete_cached_system_keys_mock.assert_called_once_with(base_key, spawn=False)
+
+
+@patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
+@patch("api.cache.REDIS_CLIENT")
+def test_register_subman_cache_key_tracks_forwarded_identity(redis_client_mock):
+    base_key = system_cache_key_base(generate_uuid(), "test", "owner")
+    forwarded_identity = generate_uuid()
+    timeout = 3600
+
+    register_subman_cache_key(base_key, forwarded_identity, timeout)
+
+    index_key = f"flask_cache_{subman_cache_index_key(base_key)}"
+    redis_client_mock.sadd.assert_called_once_with(index_key, forwarded_identity)
+    redis_client_mock.expire.assert_called_once_with(index_key, timeout)
+
+
+@patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
+@patch("api.cache.REDIS_CLIENT")
+def test_delete_cached_system_keys_redis_without_subman_index(redis_client_mock):
+    base_key = system_cache_key_base(generate_uuid(), "test", "owner")
+    redis_client_mock.smembers.return_value = []
+
+    _delete_cached_system_keys_redis(base_key)
+
+    index_key = f"flask_cache_{subman_cache_index_key(base_key)}"
+    redis_client_mock.smembers.assert_called_once_with(index_key)
+    redis_client_mock.delete.assert_called_once_with(f"flask_cache_{base_key}", index_key)
+
+
+@patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
+@patch("api.cache.REDIS_CLIENT")
+def test_delete_cached_system_keys_redis_with_subman_index(redis_client_mock):
+    base_key = system_cache_key_base(generate_uuid(), "test", "owner")
+    forwarded_identity = generate_uuid()
+    redis_client_mock.smembers.return_value = [forwarded_identity.encode()]
+
+    _delete_cached_system_keys_redis(base_key)
+
+    subman_key = f"flask_cache_{subman_cache_key(base_key, forwarded_identity)}"
+    index_key = f"flask_cache_{subman_cache_index_key(base_key)}"
+    redis_client_mock.delete.assert_called_once_with(f"flask_cache_{base_key}", subman_key, index_key)
 
 
 @patch.dict(FLAG_FALLBACK_VALUES, {TEST_FEATURE_FLAG: False})


### PR DESCRIPTION
## Jira
Follows up on #4893 to address [RHINENG-30218](https://issues.redhat.com/browse/RHINENG-30218).

## What
Registers cache keys that include the subman ID, and deletes those specific keys when deleting the caches, rather than doing a Redis SCAN.

## Why
Redis SCANs can be CPU-intensive, and is the likely culprit for our recent elevated CPU usage on our service-writes pods in Prod.

## How

- Register the cache key for host-list queries only if `forwarded_identity` is provided
- Delete the registered cache keys rather than doing a SCAN

## Testing
Added tests to `test_utils.py`.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-30218]: https://redhat.atlassian.net/browse/RHINENG-30218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Eliminate routine Redis scans from system-cache invalidation by tracking forwarded-identity keys and deleting them atomically with generation-aware safeguards.

Bug Fixes:
- Replace routine Redis scans during system-cache invalidation with targeted deletion of registered forwarded-identity cache keys, reducing cache-deletion CPU overhead.

Enhancements:
- Add atomic cache invalidation and key registration with generation tracking to prevent stale in-flight writes from being retained.
- Register forwarded-identity host-list cache keys only when an identity is present, while retaining an opt-in legacy scan path for migration.
- Add cache-key helpers and coverage for key registration, generation handling, and targeted invalidation.

Tests:
- Add tests covering forwarded-identity key registration, generation reads, atomic invalidation arguments, and cache-key construction.