### PR TITLE
perf(RHINENG-30218): replace SCAN-based cache invalidation with generation-embedded keys

### DIFF
--- a/api/cache.py
+++ b/api/cache.py
@@ -6,7 +6,6 @@ import connexion
 from flask_caching import Cache
 from redis import Redis
 
-from api.system_cache_key import SUBMAN_CACHE_KEY_DELIMITER
 from api.system_cache_key import system_cache_key_base
 from app.logging import get_logger
 
@@ -17,6 +16,7 @@ CACHE_TYPE_REDIS_CACHE = "RedisCache"
 CACHE_EXECUTOR = None
 REDIS_CLIENT = None
 STALENESS_L2_CACHE_ENABLED = False
+GENERATION_KEY_SUFFIX = ":gen"
 logger = get_logger("cache")
 
 
@@ -73,6 +73,69 @@ def _get_redis_client():
     return REDIS_CLIENT
 
 
+def _generation_key(base_key: str) -> str:
+    return f"{CACHE_PREFIX}{base_key}{GENERATION_KEY_SUFFIX}"
+
+
+def get_system_cache_generation(insights_id, org_id, owner_id):
+    """Read the current cache generation counter for a system cache entry.
+
+    Returns 0 when Redis is unavailable or the generation key does not exist,
+    which naturally makes readers construct a :g0 key (the initial generation).
+    """
+    if not (CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == CACHE_TYPE_REDIS_CACHE):
+        return 0
+    try:
+        client = _get_redis_client()
+        base_key = system_cache_key_base(insights_id, org_id, owner_id)
+        value = client.get(_generation_key(base_key))
+        return int(value) if value is not None else 0
+    except Exception as exc:
+        logger.exception("Failed to read system cache generation", exc_info=exc)
+        return 0
+
+
+def _invalidate_system_cache_redis(insights_id, org_id, owner_id):
+    """Increment the generation counter, making all current cache entries unreachable.
+
+    Sets a TTL on the generation counter equal to the cache TTL so counters
+    for hosts that are no longer accessed are automatically cleaned up.
+    """
+    try:
+        from app.common import inventory_config
+
+        client = _get_redis_client()
+        base_key = system_cache_key_base(insights_id, org_id, owner_id)
+        gen_key = _generation_key(base_key)
+        gen_ttl = inventory_config().cache_insights_client_system_timeout_sec
+        pipe = client.pipeline(transaction=False)
+        pipe.incr(gen_key)
+        pipe.expire(gen_key, gen_ttl)
+        results = pipe.execute()
+        new_gen = results[0]
+        logger.info("Invalidated system cache for base_key=%s new_generation=%s", base_key, new_gen)
+    except Exception as exc:
+        logger.exception("System cache invalidation failed", exc_info=exc)
+
+
+def _invalidate_system_cache(insights_id, org_id, owner_id, spawn=False):
+    global CACHE_EXECUTOR
+
+    if not (CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == CACHE_TYPE_REDIS_CACHE):
+        if not CACHE_CONFIG:
+            logger.info("Not invalidating cache: CACHE_CONFIG is falsy")
+        else:
+            cache_type = CACHE_CONFIG.get("CACHE_TYPE")
+            logger.info(f"Not invalidating cache: CACHE_TYPE '{cache_type}' != '{CACHE_TYPE_REDIS_CACHE}'")
+        return
+
+    if spawn and CACHE_EXECUTOR:
+        logger.info("Submitted cache-invalidation callable to executor")
+        CACHE_EXECUTOR.submit(_invalidate_system_cache_redis, insights_id, org_id, owner_id)
+    else:
+        _invalidate_system_cache_redis(insights_id, org_id, owner_id)
+
+
 def _delete_keys_redis(cache_key, wildcard=True):
     global CACHE_CONFIG
     try:
@@ -116,9 +179,7 @@ def delete_keys(cache_key, wildcard=True, spawn=False):
 
 def delete_cached_system_keys(insights_id=None, org_id=None, owner_id=None, spawn=False):
     if insights_id and org_id and owner_id:
-        base_key = system_cache_key_base(insights_id, org_id, owner_id)
-        delete_keys(base_key, wildcard=False, spawn=spawn)
-        delete_keys(f"{base_key}{SUBMAN_CACHE_KEY_DELIMITER}", wildcard=True, spawn=spawn)
+        _invalidate_system_cache(insights_id, org_id, owner_id, spawn=spawn)
     elif insights_id and org_id and not owner_id:
         delete_keys(f"insights_id={insights_id}_org={org_id}", wildcard=True, spawn=spawn)
     elif not insights_id and org_id:

--- a/api/cache_key.py
+++ b/api/cache_key.py
@@ -27,11 +27,11 @@ def make_key():
     return key
 
 
-def make_system_cache_key(insights_id, org_id, owner_id, forwarded_identity=None):
+def make_system_cache_key(insights_id, org_id, owner_id, forwarded_identity=None, generation=0):
     if not insights_id or not org_id or not owner_id:
         message = f"Invalid cache key encountered; insights_id={insights_id} org_id={org_id}, owner_id={owner_id}."
         raise Exception(message)  # TODO: Raise a more specific exception
-    key = system_cache_key_base(insights_id, org_id, owner_id)
+    key = f"{system_cache_key_base(insights_id, org_id, owner_id)}:g{generation}"
     if forwarded_identity:
         key = f"{key}{SUBMAN_CACHE_KEY_DELIMITER}{forwarded_identity}"
     return key

--- a/api/host.py
+++ b/api/host.py
@@ -13,6 +13,7 @@ from api import metrics
 from api import pagination_params
 from api.cache import CACHE
 from api.cache import delete_cached_system_keys
+from api.cache import get_system_cache_generation
 from api.cache_key import make_system_cache_key
 from api.filtering.db_filters import update_query_for_owner_id
 from api.host_query import build_paginated_host_list_response
@@ -140,8 +141,13 @@ def get_host_list(
     if is_cached_insights_client_system_query:
         owner_id = current_identity.system.get("cn")
         forwarded_identity = get_satellite_forwarded_identity(current_identity)
+        generation = get_system_cache_generation(insights_id, current_identity.org_id, owner_id)
         system_key = make_system_cache_key(
-            insights_id, current_identity.org_id, owner_id, forwarded_identity=forwarded_identity
+            insights_id,
+            current_identity.org_id,
+            owner_id,
+            forwarded_identity=forwarded_identity,
+            generation=generation,
         )
         stored_system = CACHE.get(f"{system_key}")
         if stored_system:
@@ -185,9 +191,6 @@ def get_host_list(
         total, page, per_page, host_list, additional_fields, system_profile_fields
     )
     if is_cached_insights_client_system_query and len(host_list) == 1:
-        system_key = make_system_cache_key(
-            insights_id, current_identity.org_id, owner_id, forwarded_identity=forwarded_identity
-        )
         output_host = serialize_host_with_params(host_list[0])
         timeout = inventory_config().cache_insights_client_system_timeout_sec
         CACHE.set(key=system_key, value=output_host, timeout=timeout)

--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -39,6 +39,7 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.exc import StaleDataError
 
 from api.cache import delete_cached_system_keys
+from api.cache import get_system_cache_generation
 from api.cache import set_cached_system
 from api.cache_key import make_system_cache_key
 from api.staleness_query import get_staleness_obj
@@ -1391,7 +1392,8 @@ def write_add_update_event_message(
         try:
             owner_id = output_host.get("system_profile", {}).get("owner_id")
             if owner_id and insights_id and org_id:
-                system_key = make_system_cache_key(insights_id, org_id, owner_id)
+                generation = get_system_cache_generation(insights_id, org_id, owner_id)
+                system_key = make_system_cache_key(insights_id, org_id, owner_id, generation=generation)
                 if "tags" in output_host:
                     del output_host["tags"]
                 if "system_profile" in output_host:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from pytest import raises
 from yaml import safe_load
 
 from api.cache import delete_cached_system_keys
+from api.cache import get_system_cache_generation
 from api.cache_key import make_system_cache_key
 from api.system_cache_key import system_cache_key_base
 from lib.feature_flags import FLAG_FALLBACK_VALUES
@@ -178,7 +179,7 @@ def test_make_system_cache_key_valid():
     org_id = "101010191"
     owner_id = "1919388393"
     key = make_system_cache_key(insights_id, org_id, owner_id)
-    assert key == f"insights_id={insights_id}_org={org_id}_user=SYSTEM-{owner_id}"
+    assert key == f"insights_id={insights_id}_org={org_id}_user=SYSTEM-{owner_id}:g0"
 
 
 def test_make_system_cache_key_with_forwarded_identity():
@@ -187,20 +188,97 @@ def test_make_system_cache_key_with_forwarded_identity():
     owner_id = SYSTEM_IDENTITY["system"]["cn"]
     forwarded_identity = generate_uuid()
     key = make_system_cache_key(insights_id, org_id, owner_id, forwarded_identity=forwarded_identity)
-    assert key == (f"insights_id={insights_id}_org={org_id}_user=SYSTEM-{owner_id}_subman={forwarded_identity}")
+    assert key == (f"insights_id={insights_id}_org={org_id}_user=SYSTEM-{owner_id}:g0_subman={forwarded_identity}")
 
 
-@patch("api.cache.delete_keys")
-def test_delete_cached_system_keys_uses_delimiter_aware_patterns(delete_keys_mock):
+def test_make_system_cache_key_with_generation():
+    insights_id = generate_uuid()
+    org_id = "test"
+    owner_id = "abc"
+    key = make_system_cache_key(insights_id, org_id, owner_id, generation=5)
+    assert key == f"insights_id={insights_id}_org={org_id}_user=SYSTEM-{owner_id}:g5"
+
+
+def test_make_system_cache_key_with_generation_and_forwarded_identity():
+    insights_id = generate_uuid()
+    org_id = "test"
+    owner_id = "abc"
+    forwarded_identity = generate_uuid()
+    key = make_system_cache_key(insights_id, org_id, owner_id, forwarded_identity=forwarded_identity, generation=3)
+    assert key == (f"insights_id={insights_id}_org={org_id}_user=SYSTEM-{owner_id}:g3_subman={forwarded_identity}")
+
+
+@patch("api.cache._invalidate_system_cache")
+def test_delete_cached_system_keys_increments_generation(invalidate_mock):
+    insights_id = generate_uuid()
+    org_id = "test"
+    owner_id = "abc"
+
+    delete_cached_system_keys(insights_id=insights_id, org_id=org_id, owner_id=owner_id)
+
+    invalidate_mock.assert_called_once_with(insights_id, org_id, owner_id, spawn=False)
+
+
+@patch("api.cache._invalidate_system_cache")
+def test_delete_cached_system_keys_with_spawn(invalidate_mock):
+    insights_id = generate_uuid()
+    org_id = "test"
+    owner_id = "abc"
+
+    delete_cached_system_keys(insights_id=insights_id, org_id=org_id, owner_id=owner_id, spawn=True)
+
+    invalidate_mock.assert_called_once_with(insights_id, org_id, owner_id, spawn=True)
+
+
+@patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
+@patch("api.cache.REDIS_CLIENT")
+def test_get_system_cache_generation_returns_stored_value(redis_client_mock):
+    insights_id = generate_uuid()
+    org_id = "test"
+    owner_id = "abc"
+    redis_client_mock.get.return_value = b"7"
+
+    assert get_system_cache_generation(insights_id, org_id, owner_id) == 7
+
+
+@patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
+@patch("api.cache.REDIS_CLIENT")
+def test_get_system_cache_generation_returns_zero_when_key_missing(redis_client_mock):
+    redis_client_mock.get.return_value = None
+
+    assert get_system_cache_generation(generate_uuid(), "test", "abc") == 0
+
+
+@patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "NullCache"})
+def test_get_system_cache_generation_returns_zero_when_redis_disabled():
+    assert get_system_cache_generation(generate_uuid(), "test", "abc") == 0
+
+
+@patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
+@patch("app.common.inventory_config")
+@patch("api.cache.REDIS_CLIENT")
+def test_invalidate_system_cache_redis_increments_generation(redis_client_mock, inventory_config_mock):
+    from api.cache import CACHE_PREFIX
+    from api.cache import GENERATION_KEY_SUFFIX
+    from api.cache import _invalidate_system_cache_redis
+
     insights_id = generate_uuid()
     org_id = "test"
     owner_id = "abc"
     base_key = system_cache_key_base(insights_id, org_id, owner_id)
+    expected_gen_key = f"{CACHE_PREFIX}{base_key}{GENERATION_KEY_SUFFIX}"
 
-    delete_cached_system_keys(insights_id=insights_id, org_id=org_id, owner_id=owner_id)
+    cache_ttl = 129600
+    inventory_config_mock.return_value.cache_insights_client_system_timeout_sec = cache_ttl
 
-    delete_keys_mock.assert_any_call(base_key, wildcard=False, spawn=False)
-    delete_keys_mock.assert_any_call(f"{base_key}_subman=", wildcard=True, spawn=False)
+    pipe_mock = MagicMock()
+    pipe_mock.execute.return_value = [1, True]
+    redis_client_mock.pipeline.return_value = pipe_mock
+
+    _invalidate_system_cache_redis(insights_id, org_id, owner_id)
+
+    pipe_mock.incr.assert_called_once_with(expected_gen_key)
+    pipe_mock.expire.assert_called_once_with(expected_gen_key, cache_ttl)
 
 
 @patch.dict(FLAG_FALLBACK_VALUES, {TEST_FEATURE_FLAG: False})


### PR DESCRIPTION
## Jira
[RHINENG-30218](https://issues.redhat.com/browse/RHINENG-30218)

## What
Replace the Redis SCAN-based system-cache invalidation with generation-embedded cache keys, making invalidation a single `INCR` command instead of a full-keyspace scan.

## Why
Redis `SCAN` during system-cache invalidation is causing **83% engine CPU spikes** on the prod ElastiCache primary, which cascades into cache hit rate drops (99.9% → 86%) and increased DB load. This was introduced by the X-Forwarded-Identity cache scoping, which added per-satellite forwarded-identity cache keys that must be found and deleted on each host mutation.

## How
Instead of tracking and deleting individual cache keys, embed a generation counter (`:g{N}`) in every system cache key. On invalidation, increment the counter. Old-generation entries become unreachable and expire via their existing 36h TTL.

- **`api/cache_key.py`** — `make_system_cache_key` now accepts a `generation` param and embeds `:g{generation}` in the key
- **`api/cache.py`** — Add `get_system_cache_generation()` to read the counter; replace the `DELETE` + `SCAN` + `DELETE` invalidation path with a pipelined `INCR` + `EXPIRE` on a single generation counter key
- **`api/host.py`** — Read generation before cache lookup; reuse the same generation-embedded key for cache-miss writes (also eliminates a redundant `make_system_cache_key` call)
- **`app/queue/host_mq.py`** — MQ writer reads generation before constructing the cache key
- Generation counter TTL matches the cache TTL (auto-cleanup for inactive hosts)

### Performance comparison (benchmarked against local Redis with 50K keys)

| Fwd IDs / host | Current master (DELETE + SCAN) | PR #4913 Lua (no legacy scan) | PR #4913 Lua (with legacy scan) | **This PR — Generation (INCR)** |
|---|---|---|---|---|
| 0 | 22 inv/s | 14,468 inv/s (652×) | 133 inv/s (6×) | **19,688 inv/s (887×)** |
| 5 | 23 inv/s | 6,889 inv/s (305×) | 148 inv/s (7×) | **14,816 inv/s (655×)** |
| 20 | 22 inv/s | 8,189 inv/s (378×) | 142 inv/s (7×) | **11,751 inv/s (542×)** |
| 50 | 20 inv/s | 5,248 inv/s (265×) | 124 inv/s (6×) | **13,541 inv/s (685×)** |

The generation approach is consistently 2× faster than the Lua index approach and scales with constant cost regardless of forwarded-identity count (the Lua approach slows down with more indexed keys). The PR #4913 Lua approach with legacy scan enabled — needed during rollout to handle pre-existing unindexed keys — is only ~6× faster than master, since it still performs a SCAN inside the Lua script.

### Memory impact (prod ElastiCache analysis)

- Current: 2.9M keys, 7.2 GB, 34% capacity used
- Worst case with orphans: ~14 GB (68% capacity) — well within the ~21 GB limit, zero evictions
- Realistic case: 8–10 GB (38–48%) since most updates are MQ writes that don't create orphans

### Rolling deployment safety

Old pods write keys without `:g{N}`; new pods write with `:g0`. The two key namespaces don't interfere — old-format entries expire naturally via TTL with no migration steps needed.

## Testing
- Updated existing cache key tests for the new `:g0` generation segment
- Added tests for `make_system_cache_key` with generation and forwarded identity
- Added tests for `get_system_cache_generation` (stored value, missing key, Redis disabled)
- Added tests for `_invalidate_system_cache_redis` verifying `INCR` + `EXPIRE` pipeline
- Added tests for `delete_cached_system_keys` routing and spawn flag
- All 22 tests pass; ruff lint, ruff format, and mypy clean

This is an additional approach for PR #4913

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-30218]: https://redhat.atlassian.net/browse/RHINENG-30218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Use generation-embedded system-cache keys to make cache invalidation fast and avoid Redis keyspace scans.

Enhancements:
- Replace Redis SCAN-based system-cache invalidation with generation-based keys and constant-time counter increments.
- Propagate cache generations through host API reads and message-queue cache writes so stale entries become unreachable without key deletion.

Tests:
- Add coverage for generation-aware cache keys, generation retrieval and invalidation routing, including Redis and non-Redis configurations.