### PR TITLE
fix(RHINENG-30218): lazy-init generation counter to stop CacheMiss flood

### DIFF
--- a/api/cache.py
+++ b/api/cache.py
@@ -80,16 +80,31 @@ def _generation_key(base_key: str) -> str:
 def get_system_cache_generation(insights_id, org_id, owner_id):
     """Read the current cache generation counter for a system cache entry.
 
-    Returns 0 when Redis is unavailable or the generation key does not exist,
-    which naturally makes readers construct a :g0 key (the initial generation).
+    Returns 0 when Redis is unavailable or the generation key does not exist.
+    When the key is absent, it is lazily initialised to 0 with the standard
+    cache TTL so that subsequent lookups are Redis cache-hits.
     """
     if not (CACHE_CONFIG and CACHE_CONFIG.get("CACHE_TYPE") == CACHE_TYPE_REDIS_CACHE):
         return 0
     try:
+        from app.common import inventory_config
+
         client = _get_redis_client()
         base_key = system_cache_key_base(insights_id, org_id, owner_id)
-        value = client.get(_generation_key(base_key))
-        return int(value) if value is not None else 0
+        gen_key = _generation_key(base_key)
+        value = client.get(gen_key)
+        if value is not None:
+            return int(value)
+        # Key does not exist — lazily initialise to 0 so future GETs are
+        # cache hits instead of misses.  NX prevents overwriting a counter
+        # that was just incremented by a concurrent invalidation.
+        gen_ttl = inventory_config().cache_insights_client_system_timeout_sec
+        if client.set(gen_key, 0, ex=gen_ttl, nx=True):
+            return 0
+        # SET NX failed — another process created the key (e.g. INCR from
+        # a concurrent invalidation).  Re-read to get the actual generation.
+        current_value = client.get(gen_key)
+        return int(current_value) if current_value is not None else 0
     except Exception as exc:
         logger.exception("Failed to read system cache generation", exc_info=exc)
         return 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,9 @@ from pytest import mark
 from pytest import raises
 from yaml import safe_load
 
+from api.cache import CACHE_PREFIX
+from api.cache import GENERATION_KEY_SUFFIX
+from api.cache import _invalidate_system_cache_redis
 from api.cache import delete_cached_system_keys
 from api.cache import get_system_cache_generation
 from api.cache_key import make_system_cache_key
@@ -239,14 +242,44 @@ def test_get_system_cache_generation_returns_stored_value(redis_client_mock):
     redis_client_mock.get.return_value = b"7"
 
     assert get_system_cache_generation(insights_id, org_id, owner_id) == 7
+    # Should NOT call set when key already exists
+    redis_client_mock.set.assert_not_called()
 
 
 @patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
 @patch("api.cache.REDIS_CLIENT")
-def test_get_system_cache_generation_returns_zero_when_key_missing(redis_client_mock):
+@patch("app.common.inventory_config")
+def test_get_system_cache_generation_inits_counter_when_key_missing(inventory_config_mock, redis_client_mock):
+    insights_id = generate_uuid()
+    org_id = "test"
+    owner_id = "abc"
     redis_client_mock.get.return_value = None
+    redis_client_mock.set.return_value = True
+    cache_ttl = 129600
+    inventory_config_mock.return_value.cache_insights_client_system_timeout_sec = cache_ttl
 
-    assert get_system_cache_generation(generate_uuid(), "test", "abc") == 0
+    assert get_system_cache_generation(insights_id, org_id, owner_id) == 0
+
+    base_key = system_cache_key_base(insights_id, org_id, owner_id)
+    expected_gen_key = f"{CACHE_PREFIX}{base_key}{GENERATION_KEY_SUFFIX}"
+    redis_client_mock.set.assert_called_once_with(expected_gen_key, 0, ex=cache_ttl, nx=True)
+
+
+@patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "RedisCache"})
+@patch("api.cache.REDIS_CLIENT")
+@patch("app.common.inventory_config")
+def test_get_system_cache_generation_rereads_on_concurrent_invalidation(inventory_config_mock, redis_client_mock):
+    """When SET NX fails because a concurrent INCR created the key, re-read the actual generation."""
+    insights_id = generate_uuid()
+    org_id = "test"
+    owner_id = "abc"
+    # First GET returns None (key missing), second GET returns the value set by concurrent INCR
+    redis_client_mock.get.side_effect = [None, b"1"]
+    redis_client_mock.set.return_value = False  # NX failed — key was just created by INCR
+    cache_ttl = 129600
+    inventory_config_mock.return_value.cache_insights_client_system_timeout_sec = cache_ttl
+
+    assert get_system_cache_generation(insights_id, org_id, owner_id) == 1
 
 
 @patch("api.cache.CACHE_CONFIG", {"CACHE_TYPE": "NullCache"})
@@ -258,10 +291,6 @@ def test_get_system_cache_generation_returns_zero_when_redis_disabled():
 @patch("app.common.inventory_config")
 @patch("api.cache.REDIS_CLIENT")
 def test_invalidate_system_cache_redis_increments_generation(redis_client_mock, inventory_config_mock):
-    from api.cache import CACHE_PREFIX
-    from api.cache import GENERATION_KEY_SUFFIX
-    from api.cache import _invalidate_system_cache_redis
-
     insights_id = generate_uuid()
     org_id = "test"
     owner_id = "abc"


### PR DESCRIPTION
## Jira
[RHINENG-30218](https://issues.redhat.com/browse/RHINENG-30218)

## What
Lazily initialise the generation counter key (`:gen`) to `0` on first read, so that subsequent Redis `GET` operations register as cache hits instead of misses.

## Why
After deploying PR [#4914](https://github.com/RedHatInsights/insights-host-inventory/pull/4914), the ElastiCache `CacheHitRate` dropped to lower numbers. The generation counter key is only created when an invalidation occurs (`INCR`), but >99% of hosts are never patched or deleted, their `:gen` key never exists. Every `GET :gen` from **MQ pods** and **API-read pods** returned `nil`, registering as a `keyspace_miss` in Redis. Millions of MQ misses per minute drowned out API hits in the hit-rate formula:

`$$\text{CacheHitRate} = \frac{\text{keyspace\_hits}}{\text{keyspace\_hits} + \text{keyspace\_misses}}$$`

The application-level cache was working correctly, but the Redis metrics were completely distorted.

## How
- When `get_system_cache_generation()` finds that the `:gen` key does not exist, it now calls `SET gen_key 0 EX <cache_ttl> NX` to lazily create it
- `NX` (set-if-not-exists) prevents overwriting a counter that was just incremented by a concurrent invalidation on another pod
- The TTL matches the cache entry TTL (36h) so the key is automatically cleaned up for inactive hosts
- When the key already exists, behavior is unchanged — just a `GET` returning the current value
- If SET NX returns False (lost race to a concurrent invalidation INCR), immediately re-read the key to return the updated generation.

## Testing
- Updated `test_get_system_cache_generation_returns_stored_value` to verify no `SET` is called when the key already exists
- Renamed `test_get_system_cache_generation_returns_zero_when_key_missing` → `test_get_system_cache_generation_inits_counter_when_key_missing` and added assertions that `SET NX` is called with the correct key, value (`0`), and TTL
- Existing test for Redis-disabled case (`NullCache`) unchanged — still returns `0` without any Redis call
- All 11 cache-related tests pass; ruff lint/format and mypy clean

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [ ] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-30218]: https://redhat.atlassian.net/browse/RHINENG-30218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Prevent Redis cache-miss metric inflation by lazily initializing absent system cache generation counters.

Bug Fixes:
- Lazily initialize missing system cache generation keys to reduce Redis keyspace misses while preserving concurrent invalidation updates.

Enhancements:
- Align generation-key expiration with the configured system cache TTL and verify existing-key, initialization, and concurrent-invalidation behavior.

Tests:
- Expand cache-generation tests to cover lazy initialization and concurrent invalidation rereads.