### PR TITLE
fix(RHINENG-30912): cache invalidation race condition

### DIFF
--- a/app/queue/host_mq.py
+++ b/app/queue/host_mq.py
@@ -1333,7 +1333,7 @@ def write_delete_event_message(event_producer: EventProducer, result: OperationR
     insights_id = serialize_uuid(result.row.insights_id)
     owner_id = serialize_uuid(result.row.static_system_profile.owner_id) if result.row.static_system_profile else None
     if insights_id and owner_id:
-        delete_cached_system_keys(insights_id=insights_id, org_id=result.row.org_id, owner_id=owner_id, spawn=True)
+        delete_cached_system_keys(insights_id=insights_id, org_id=result.row.org_id, owner_id=owner_id)
     result.success_logger()
 
 

--- a/tests/test_host_mq_service.py
+++ b/tests/test_host_mq_service.py
@@ -44,6 +44,7 @@ from app.queue.host_mq import SystemProfileMessageConsumer
 from app.queue.host_mq import WorkspaceMessageConsumer
 from app.queue.host_mq import _sanitize_json_object_for_postgres
 from app.queue.host_mq import write_add_update_event_message
+from app.queue.host_mq import write_delete_event_message
 from app.utils import Tag
 from inv_mq_service import build_topic_to_consumer_map
 from lib.host_repository import AddHostResult
@@ -3325,3 +3326,83 @@ def test_rhsm_with_containers_updates_normally(reporter, mq_create_or_update_hos
     workloads = returned_host.dynamic_system_profile.workloads
     assert workloads["ansible"]["controller_version"] == "2.0"
     assert workloads["ansible"]["containers"] == new_containers
+
+
+def test_write_delete_event_message_invalidates_cache_synchronously(mocker):
+    from uuid import UUID
+
+    mock_event_producer = mocker.Mock()
+    mock_success_logger = mocker.Mock()
+    mock_delete_cache = mocker.patch("app.queue.host_mq.delete_cached_system_keys")
+    mocker.patch("app.queue.host_mq.build_event", return_value="event")
+    mocker.patch(
+        "app.queue.host_mq.extract_system_profile_fields_for_headers",
+        return_value=(None, None, "False"),
+    )
+    mocker.patch("app.queue.host_mq.message_headers", return_value={})
+
+    insights_id = generate_uuid()
+    owner_id = generate_uuid()
+    org_id = "test-org"
+
+    static_sp = mocker.Mock()
+    static_sp.owner_id = UUID(owner_id)
+
+    host_row = mocker.NonCallableMock()
+    host_row.id = UUID(generate_uuid())
+    host_row.insights_id = UUID(insights_id)
+    host_row.org_id = org_id
+    host_row.reporter = "puptoo"
+    host_row.static_system_profile = static_sp
+
+    result = OperationResult(
+        row=host_row,
+        pm=None,
+        so=None,
+        et=EventType.delete,
+        sl=mock_success_logger,
+    )
+
+    write_delete_event_message(mock_event_producer, result, initiated_by_frontend=False)
+
+    mock_event_producer.write_event.assert_called_once()
+    mock_delete_cache.assert_called_once_with(insights_id=insights_id, org_id=org_id, owner_id=owner_id)
+    mock_success_logger.assert_called_once()
+
+
+def test_write_delete_event_message_without_owner_id_skips_cache_invalidation(mocker):
+    from uuid import UUID
+
+    mock_event_producer = mocker.Mock()
+    mock_success_logger = mocker.Mock()
+    mock_delete_cache = mocker.patch("app.queue.host_mq.delete_cached_system_keys")
+    mocker.patch("app.queue.host_mq.build_event", return_value="event")
+    mocker.patch(
+        "app.queue.host_mq.extract_system_profile_fields_for_headers",
+        return_value=(None, None, "False"),
+    )
+    mocker.patch("app.queue.host_mq.message_headers", return_value={})
+
+    insights_id = generate_uuid()
+    org_id = "test-org"
+
+    host_row = mocker.NonCallableMock(spec=["id", "insights_id", "org_id", "reporter", "static_system_profile"])
+    host_row.id = UUID(generate_uuid())
+    host_row.insights_id = UUID(insights_id)
+    host_row.org_id = org_id
+    host_row.reporter = "puptoo"
+    host_row.static_system_profile = None
+
+    result = OperationResult(
+        row=host_row,
+        pm=None,
+        so=None,
+        et=EventType.delete,
+        sl=mock_success_logger,
+    )
+
+    write_delete_event_message(mock_event_producer, result, initiated_by_frontend=False)
+
+    mock_event_producer.write_event.assert_called_once()
+    mock_delete_cache.assert_not_called()
+    mock_success_logger.assert_called_once()


### PR DESCRIPTION
## Jira
[RHINENG-30912](https://issues.redhat.com/browse/RHINENG-30912)

## What
Make system cache invalidation synchronous during host deletion to eliminate a race condition between deletion and subsequent API reads.

## Why
In `write_delete_event_message()`, cache invalidation was spawned asynchronously in a background thread pool (`spawn=True`) to avoid blocking on what used to be a slow keyspace `SCAN`. Under the new generational cache system, invalidation is a lightweight atomic `INCR` (~0.1ms). Backgrounding it introduced a race condition where subsequent API reads (such as cert-auth `GET /hosts` in IQE tests or real clients) reached Redis before the worker thread incremented the `:gen` counter, causing deleted hosts to be served from cache.

## How
- In `app/queue/host_mq.py` (`write_delete_event_message`):
  - Removed `spawn=True` from `delete_cached_system_keys()`, switching to the default synchronous execution (`spawn=False`).
  - The generation increment now completes before the deletion operation returns, guaranteeing subsequent reads observe the new generation.

## Testing
- Added unit tests in `tests/test_host_mq_service.py`:
  - `test_write_delete_event_message_invalidates_cache_synchronously`: verifies synchronous invalidation call with `insights_id`, `org_id`, and `owner_id`.
  - `test_write_delete_event_message_without_owner_id_skips_cache_invalidation`: verifies that invalidation is skipped when `owner_id` is absent, preventing unintended wildcard keyspace scans.
- Ran existing test suites: `tests/test_utils.py`, `tests/test_api_hosts_delete_by_id.py`, `tests/test_api_hosts_delete_bulk.py`, and `tests/test_host_mq_service.py` (all passed).
- Linted and formatted with `ruff check` and `ruff format`.

## PR Guidelines

You can find the documentation of the guidelines [here](https://redhat.atlassian.net/wiki/spaces/RHIN/pages/384311342/HBI+PR+Guideline)

## PR Guideline checks

- [x] Keep PRs under 400 lines of meaningful changes, including tests, excluding auto-generated files, config, etc.


[RHINENG-30218]: https://redhat.atlassian.net/browse/RHINENG-30218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure host deletion invalidates cached data before subsequent requests can read stale hosts.

Bug Fixes:
- Make host deletion cache invalidation synchronous to prevent deleted hosts from being returned by subsequent reads.

Tests:
- Add coverage for synchronous cache invalidation during host deletion and behavior when no owner ID is available.

[RHINENG-30912]: https://redhat.atlassian.net/browse/RHINENG-30912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ